### PR TITLE
feat(payload): add Payload tagged union for widget output (#18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +359,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +443,8 @@ name = "splashboard"
 version = "0.1.0"
 dependencies = [
  "ratatui",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -591,3 +642,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 ratatui = "0.29"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use std::io::{self, stdout};
 
 use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend, widgets::Paragraph};
 
+mod payload;
+
 fn main() -> io::Result<()> {
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::with_options(

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,0 +1,214 @@
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Payload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<Status>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    #[serde(flatten)]
+    pub body: Body,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "render", content = "data", rename_all = "lowercase")]
+pub enum Body {
+    Text(TextData),
+    List(ListData),
+    Gauge(GaugeData),
+    Sparkline(SparklineData),
+    Chart(ChartData),
+    Bignum(BignumData),
+    Image(ImageData),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    Ok,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TextData {
+    pub lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ListData {
+    pub items: Vec<ListItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ListItem {
+    pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<Status>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GaugeData {
+    pub value: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SparklineData {
+    pub values: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChartData {
+    pub kind: ChartKind,
+    pub series: Vec<ChartSeries>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ChartKind {
+    Line,
+    Bar,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChartSeries {
+    pub name: String,
+    pub points: Vec<(f64, f64)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BignumData {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ImageData {
+    pub path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(payload: &Payload) -> Payload {
+        let json = serde_json::to_string(payload).unwrap();
+        serde_json::from_str(&json).unwrap()
+    }
+
+    fn bare(body: Body) -> Payload {
+        Payload {
+            title: None,
+            icon: None,
+            status: None,
+            format: None,
+            body,
+        }
+    }
+
+    #[test]
+    fn text_round_trips() {
+        let p = Payload {
+            title: Some("Git".into()),
+            icon: None,
+            status: None,
+            format: Some("{branch}".into()),
+            body: Body::Text(TextData {
+                lines: vec!["main".into()],
+            }),
+        };
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn text_parses_from_spec_example() {
+        let json = r#"{"render":"text","data":{"lines":["main"]},"title":"Git"}"#;
+        let p: Payload = serde_json::from_str(json).unwrap();
+        assert!(matches!(p.body, Body::Text(_)));
+        assert_eq!(p.title.as_deref(), Some("Git"));
+    }
+
+    #[test]
+    fn text_serializes_with_expected_shape() {
+        let p = bare(Body::Text(TextData {
+            lines: vec!["main".into()],
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["render"], "text");
+        assert_eq!(v["data"]["lines"][0], "main");
+    }
+
+    #[test]
+    fn list_round_trips() {
+        let p = bare(Body::List(ListData {
+            items: vec![ListItem {
+                key: "uptime".into(),
+                value: Some("3d".into()),
+                status: Some(Status::Ok),
+            }],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn gauge_round_trips() {
+        let p = bare(Body::Gauge(GaugeData {
+            value: 0.73,
+            label: Some("CPU".into()),
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn sparkline_round_trips() {
+        let p = bare(Body::Sparkline(SparklineData {
+            values: vec![1, 2, 3],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn chart_round_trips() {
+        let p = bare(Body::Chart(ChartData {
+            kind: ChartKind::Line,
+            series: vec![ChartSeries {
+                name: "temp".into(),
+                points: vec![(0.0, 20.0), (1.0, 21.5)],
+            }],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn bignum_round_trips() {
+        let p = bare(Body::Bignum(BignumData {
+            text: "12:34".into(),
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn image_round_trips() {
+        let p = bare(Body::Image(ImageData {
+            path: "/tmp/a.png".into(),
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn optional_fields_absent_in_serialization() {
+        let p = bare(Body::Text(TextData { lines: vec![] }));
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(!json.contains("title"));
+        assert!(!json.contains("icon"));
+    }
+}

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -17,13 +17,14 @@ pub struct Payload {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "render", content = "data", rename_all = "lowercase")]
+#[serde(tag = "render", content = "data", rename_all = "snake_case")]
 pub enum Body {
     Text(TextData),
     List(ListData),
     Gauge(GaugeData),
     Sparkline(SparklineData),
-    Chart(ChartData),
+    LineChart(LineChartData),
+    BarChart(BarChartData),
     Bignum(BignumData),
     Image(ImageData),
 }
@@ -57,7 +58,7 @@ pub struct ListItem {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GaugeData {
-    pub value: f32,
+    pub value: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
@@ -68,22 +69,25 @@ pub struct SparklineData {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ChartData {
-    pub kind: ChartKind,
-    pub series: Vec<ChartSeries>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ChartKind {
-    Line,
-    Bar,
+pub struct LineChartData {
+    pub series: Vec<LineSeries>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ChartSeries {
+pub struct LineSeries {
     pub name: String,
     pub points: Vec<(f64, f64)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BarChartData {
+    pub bars: Vec<Bar>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Bar {
+    pub label: String,
+    pub value: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -177,15 +181,38 @@ mod tests {
     }
 
     #[test]
-    fn chart_round_trips() {
-        let p = bare(Body::Chart(ChartData {
-            kind: ChartKind::Line,
-            series: vec![ChartSeries {
+    fn line_chart_round_trips() {
+        let p = bare(Body::LineChart(LineChartData {
+            series: vec![LineSeries {
                 name: "temp".into(),
                 points: vec![(0.0, 20.0), (1.0, 21.5)],
             }],
         }));
         assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn bar_chart_round_trips() {
+        let p = bare(Body::BarChart(BarChartData {
+            bars: vec![
+                Bar {
+                    label: "a".into(),
+                    value: 3,
+                },
+                Bar {
+                    label: "b".into(),
+                    value: 5,
+                },
+            ],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn bar_chart_tag_uses_snake_case() {
+        let p = bare(Body::BarChart(BarChartData { bars: vec![] }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["render"], "bar_chart");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Introduces `Payload` — the foundation type for the 3-axis (fetcher / render / layout) architecture. Every fetcher produces one, every renderer consumes one, and the same shape is the plugin subprocess JSON wire format.
- Eight render variants: `text` / `list` / `gauge` / `sparkline` / `line_chart` / `bar_chart` / `bignum` / `image`.
  - `line_chart` and `bar_chart` are kept separate because their underlying Ratatui widgets have fundamentally different data shapes (XY series vs labeled magnitudes).
- Common meta fields (`title`, `icon`, `status`, `format`) flattened alongside the render-tagged body.
- 12 tests: round-trip for each variant + spec-example-JSON parse + optional-fields-skipped + snake_case tag assertion.

Closes #18.

## Wire format example

```json
{ "render": "text", "data": { "lines": ["main"] }, "title": "Git" }
{ "render": "bar_chart", "data": { "bars": [{ "label": "a", "value": 3 }] } }
```

## Test plan

- [x] `cargo build`
- [x] `cargo test` (12 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)