### PR TITLE
ci: add GitHub Actions workflow (#15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --all-targets


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with three jobs: **format**, **clippy**, **test**.
- Test job runs across `ubuntu-latest` / `macos-latest` / `windows-latest` with `fail-fast: false` so one OS breaking doesn't cancel the rest.
- Caches cargo registry + target via `Swatinem/rust-cache@v2`.
- Triggers on push to `main` and on PRs targeting `main`.

Closes #15.

## Test plan

- [ ] First PR-level CI run exercises the workflow end-to-end (this PR).
- [ ] Verify format / clippy / test(×3) all pass against current `main`.
- [ ] Once merged, becomes the baseline gate for all subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)