### PR TITLE
feat(layout): declarative layout engine with nested rows/cols (#3)

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -38,6 +38,8 @@ pub enum Size {
     Fill(u16),
     Length(u16),
     Min(u16),
+    Max(u16),
+    Percentage(u16),
 }
 
 impl Layout {
@@ -86,6 +88,22 @@ impl Child {
             layout,
         }
     }
+
+    #[allow(dead_code)]
+    pub fn max(rows_or_cols: u16, layout: Layout) -> Self {
+        Self {
+            size: Size::Max(rows_or_cols),
+            layout,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn percentage(percent: u16, layout: Layout) -> Self {
+        Self {
+            size: Size::Percentage(percent),
+            layout,
+        }
+    }
 }
 
 pub fn draw(frame: &mut Frame, area: Rect, layout: &Layout, widgets: &HashMap<WidgetId, Payload>) {
@@ -125,6 +143,8 @@ fn to_constraint(size: Size) -> Constraint {
         Size::Fill(w) => Constraint::Fill(w),
         Size::Length(n) => Constraint::Length(n),
         Size::Min(n) => Constraint::Min(n),
+        Size::Max(n) => Constraint::Max(n),
+        Size::Percentage(p) => Constraint::Percentage(p),
     }
 }
 
@@ -205,6 +225,25 @@ mod tests {
             .join(" ");
         assert!(upper.contains("top-content"));
         assert!(lower.contains("bot-content"));
+    }
+
+    #[test]
+    fn percentage_and_max_constraints_render() {
+        let l = Layout::cols(vec![
+            Child::percentage(30, Layout::widget("a")),
+            Child::max(10, Layout::widget("b")),
+            Child::fill(1, Layout::widget("c")),
+        ]);
+        let w = widgets(&[
+            ("a", text_widget(&["a"])),
+            ("b", text_widget(&["b"])),
+            ("c", text_widget(&["c"])),
+        ]);
+        let buf = render_to_buffer_with(&l, &w, 40, 5);
+        let row = line_text(&buf, 1);
+        assert!(row.contains("a"));
+        assert!(row.contains("b"));
+        assert!(row.contains("c"));
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use ratatui::{
     Frame,
     layout::{Constraint, Direction as RatDir, Layout as RatLayout, Rect},
+    widgets::{Block, BorderType, Borders},
 };
 
 use crate::payload::Payload;
@@ -15,8 +16,12 @@ pub enum Layout {
     Stack {
         direction: Direction,
         children: Vec<Child>,
+        panel: Option<Panel>,
     },
-    Widget(WidgetId),
+    Widget {
+        id: WidgetId,
+        panel: Option<Panel>,
+    },
     #[allow(dead_code)]
     Empty,
 }
@@ -38,8 +43,28 @@ pub enum Size {
     Fill(u16),
     Length(u16),
     Min(u16),
+    #[allow(dead_code)]
     Max(u16),
+    #[allow(dead_code)]
     Percentage(u16),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Panel {
+    pub title: Option<String>,
+    pub border: BorderStyle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BorderStyle {
+    #[default]
+    Plain,
+    #[allow(dead_code)]
+    Rounded,
+    #[allow(dead_code)]
+    Thick,
+    #[allow(dead_code)]
+    Double,
 }
 
 impl Layout {
@@ -47,6 +72,7 @@ impl Layout {
         Self::Stack {
             direction: Direction::Vertical,
             children,
+            panel: None,
         }
     }
 
@@ -54,16 +80,63 @@ impl Layout {
         Self::Stack {
             direction: Direction::Horizontal,
             children,
+            panel: None,
         }
     }
 
     pub fn widget(id: impl Into<WidgetId>) -> Self {
-        Self::Widget(id.into())
+        Self::Widget {
+            id: id.into(),
+            panel: None,
+        }
     }
 
     #[allow(dead_code)]
     pub fn empty() -> Self {
         Self::Empty
+    }
+
+    pub fn titled(self, title: impl Into<String>) -> Self {
+        self.with_panel(|p| p.title(title))
+    }
+
+    #[allow(dead_code)]
+    pub fn bordered(self, border: BorderStyle) -> Self {
+        self.with_panel(|p| p.border(border))
+    }
+
+    fn with_panel(self, f: impl FnOnce(Panel) -> Panel) -> Self {
+        match self {
+            Self::Stack {
+                direction,
+                children,
+                panel,
+            } => {
+                let p = f(panel.unwrap_or_default());
+                Self::Stack {
+                    direction,
+                    children,
+                    panel: Some(p),
+                }
+            }
+            Self::Widget { id, panel } => {
+                let p = f(panel.unwrap_or_default());
+                Self::Widget { id, panel: Some(p) }
+            }
+            Self::Empty => Self::Empty,
+        }
+    }
+}
+
+impl Panel {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn border(mut self, border: BorderStyle) -> Self {
+        self.border = border;
+        self
     }
 }
 
@@ -111,13 +184,49 @@ pub fn draw(frame: &mut Frame, area: Rect, layout: &Layout, widgets: &HashMap<Wi
         Layout::Stack {
             direction,
             children,
-        } => draw_stack(frame, area, *direction, children, widgets),
-        Layout::Widget(id) => {
+            panel,
+        } => {
+            let inner = draw_panel(frame, area, panel);
+            draw_stack(frame, inner, *direction, children, widgets);
+        }
+        Layout::Widget { id, panel } => {
+            let inner = draw_panel(frame, area, panel);
             if let Some(payload) = widgets.get(id) {
-                render_payload(frame, area, payload);
+                render_payload(frame, inner, payload);
             }
         }
         Layout::Empty => {}
+    }
+}
+
+fn draw_panel(frame: &mut Frame, area: Rect, panel: &Option<Panel>) -> Rect {
+    match panel {
+        None => area,
+        Some(p) => {
+            let block = build_block(p);
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
+            inner
+        }
+    }
+}
+
+fn build_block(panel: &Panel) -> Block<'_> {
+    let mut b = Block::default()
+        .borders(Borders::ALL)
+        .border_type(to_border_type(panel.border));
+    if let Some(t) = panel.title.as_deref() {
+        b = b.title(t.to_string());
+    }
+    b
+}
+
+fn to_border_type(style: BorderStyle) -> BorderType {
+    match style {
+        BorderStyle::Plain => BorderType::Plain,
+        BorderStyle::Rounded => BorderType::Rounded,
+        BorderStyle::Thick => BorderType::Thick,
+        BorderStyle::Double => BorderType::Double,
     }
 }
 
@@ -165,7 +274,6 @@ mod tests {
 
     fn text_widget(lines: &[&str]) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,
@@ -183,11 +291,46 @@ mod tests {
     }
 
     #[test]
-    fn widget_leaf_renders() {
+    fn bare_widget_renders_content_at_top() {
         let l = Layout::widget("g");
         let w = widgets(&[("g", text_widget(&["hello"]))]);
         let buf = render_to_buffer_with(&l, &w, 20, 5);
+        assert!(line_text(&buf, 0).contains("hello"));
+    }
+
+    #[test]
+    fn widget_with_panel_draws_border_and_title() {
+        let l = Layout::widget("g").titled("Greeting");
+        let w = widgets(&[("g", text_widget(&["hello"]))]);
+        let buf = render_to_buffer_with(&l, &w, 20, 5);
+        let top = line_text(&buf, 0);
+        assert!(top.contains("Greeting"));
         assert!(line_text(&buf, 1).contains("hello"));
+    }
+
+    #[test]
+    fn stack_with_panel_wraps_children() {
+        let l = Layout::cols(vec![
+            Child::fill(1, Layout::widget("a")),
+            Child::fill(1, Layout::widget("b")),
+        ])
+        .titled("System");
+        let w = widgets(&[("a", text_widget(&["cpu"])), ("b", text_widget(&["mem"]))]);
+        let buf = render_to_buffer_with(&l, &w, 40, 5);
+        assert!(line_text(&buf, 0).contains("System"));
+        let inner = line_text(&buf, 1);
+        assert!(inner.contains("cpu"));
+        assert!(inner.contains("mem"));
+    }
+
+    #[test]
+    fn bordered_style_applies_rounded_corners() {
+        let l = Layout::widget("g")
+            .titled("T")
+            .bordered(BorderStyle::Rounded);
+        let w = widgets(&[("g", text_widget(&["x"]))]);
+        let buf = render_to_buffer_with(&l, &w, 20, 5);
+        assert!(line_text(&buf, 0).contains("╭"));
     }
 
     #[test]
@@ -240,7 +383,7 @@ mod tests {
             ("c", text_widget(&["c"])),
         ]);
         let buf = render_to_buffer_with(&l, &w, 40, 5);
-        let row = line_text(&buf, 1);
+        let row = line_text(&buf, 0);
         assert!(row.contains("a"));
         assert!(row.contains("b"));
         assert!(row.contains("c"));
@@ -260,7 +403,7 @@ mod tests {
             ("r", text_widget(&["right"])),
         ]);
         let buf = render_to_buffer_with(&l, &w, 40, 5);
-        let row1 = line_text(&buf, 1);
+        let row1 = line_text(&buf, 0);
         assert!(row1.contains("left"));
         assert!(row1.contains("right"));
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,228 @@
+use std::collections::HashMap;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction as RatDir, Layout as RatLayout, Rect},
+};
+
+use crate::payload::Payload;
+use crate::render::render_payload;
+
+pub type WidgetId = String;
+
+#[derive(Debug, Clone)]
+pub enum Layout {
+    Stack {
+        direction: Direction,
+        children: Vec<Child>,
+    },
+    Widget(WidgetId),
+    #[allow(dead_code)]
+    Empty,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Vertical,
+    Horizontal,
+}
+
+#[derive(Debug, Clone)]
+pub struct Child {
+    pub size: Size,
+    pub layout: Layout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Size {
+    Fill(u16),
+    Length(u16),
+    Min(u16),
+}
+
+impl Layout {
+    pub fn rows(children: Vec<Child>) -> Self {
+        Self::Stack {
+            direction: Direction::Vertical,
+            children,
+        }
+    }
+
+    pub fn cols(children: Vec<Child>) -> Self {
+        Self::Stack {
+            direction: Direction::Horizontal,
+            children,
+        }
+    }
+
+    pub fn widget(id: impl Into<WidgetId>) -> Self {
+        Self::Widget(id.into())
+    }
+
+    #[allow(dead_code)]
+    pub fn empty() -> Self {
+        Self::Empty
+    }
+}
+
+impl Child {
+    pub fn fill(weight: u16, layout: Layout) -> Self {
+        Self {
+            size: Size::Fill(weight),
+            layout,
+        }
+    }
+
+    pub fn length(rows_or_cols: u16, layout: Layout) -> Self {
+        Self {
+            size: Size::Length(rows_or_cols),
+            layout,
+        }
+    }
+
+    pub fn min(rows_or_cols: u16, layout: Layout) -> Self {
+        Self {
+            size: Size::Min(rows_or_cols),
+            layout,
+        }
+    }
+}
+
+pub fn draw(frame: &mut Frame, area: Rect, layout: &Layout, widgets: &HashMap<WidgetId, Payload>) {
+    match layout {
+        Layout::Stack {
+            direction,
+            children,
+        } => draw_stack(frame, area, *direction, children, widgets),
+        Layout::Widget(id) => {
+            if let Some(payload) = widgets.get(id) {
+                render_payload(frame, area, payload);
+            }
+        }
+        Layout::Empty => {}
+    }
+}
+
+fn draw_stack(
+    frame: &mut Frame,
+    area: Rect,
+    direction: Direction,
+    children: &[Child],
+    widgets: &HashMap<WidgetId, Payload>,
+) {
+    let constraints: Vec<Constraint> = children.iter().map(|c| to_constraint(c.size)).collect();
+    let rects = RatLayout::default()
+        .direction(to_ratatui_direction(direction))
+        .constraints(constraints)
+        .split(area);
+    for (child, rect) in children.iter().zip(rects.iter()) {
+        draw(frame, *rect, &child.layout, widgets);
+    }
+}
+
+fn to_constraint(size: Size) -> Constraint {
+    match size {
+        Size::Fill(w) => Constraint::Fill(w),
+        Size::Length(n) => Constraint::Length(n),
+        Size::Min(n) => Constraint::Min(n),
+    }
+}
+
+fn to_ratatui_direction(d: Direction) -> RatDir {
+    match d {
+        Direction::Vertical => RatDir::Vertical,
+        Direction::Horizontal => RatDir::Horizontal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::payload::{Body, Payload, TextData};
+    use crate::render::test_utils::{line_text, render_to_buffer_with};
+
+    fn text_widget(lines: &[&str]) -> Payload {
+        Payload {
+            title: None,
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                lines: lines.iter().map(|s| s.to_string()).collect(),
+            }),
+        }
+    }
+
+    fn widgets(pairs: &[(&str, Payload)]) -> HashMap<WidgetId, Payload> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn widget_leaf_renders() {
+        let l = Layout::widget("g");
+        let w = widgets(&[("g", text_widget(&["hello"]))]);
+        let buf = render_to_buffer_with(&l, &w, 20, 5);
+        assert!(line_text(&buf, 1).contains("hello"));
+    }
+
+    #[test]
+    fn missing_widget_id_renders_nothing() {
+        let l = Layout::widget("missing");
+        let w: HashMap<WidgetId, Payload> = HashMap::new();
+        let _ = render_to_buffer_with(&l, &w, 20, 5);
+    }
+
+    #[test]
+    fn empty_layout_renders_nothing() {
+        let l = Layout::empty();
+        let w: HashMap<WidgetId, Payload> = HashMap::new();
+        let _ = render_to_buffer_with(&l, &w, 20, 5);
+    }
+
+    #[test]
+    fn vertical_stack_splits_area() {
+        let l = Layout::rows(vec![
+            Child::fill(1, Layout::widget("top")),
+            Child::fill(1, Layout::widget("bot")),
+        ]);
+        let w = widgets(&[
+            ("top", text_widget(&["top-content"])),
+            ("bot", text_widget(&["bot-content"])),
+        ]);
+        let buf = render_to_buffer_with(&l, &w, 30, 10);
+        let upper: String = (0..5)
+            .map(|y| line_text(&buf, y))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let lower: String = (5..10)
+            .map(|y| line_text(&buf, y))
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(upper.contains("top-content"));
+        assert!(lower.contains("bot-content"));
+    }
+
+    #[test]
+    fn nested_rows_and_cols() {
+        let l = Layout::rows(vec![Child::fill(
+            1,
+            Layout::cols(vec![
+                Child::fill(1, Layout::widget("l")),
+                Child::fill(1, Layout::widget("r")),
+            ]),
+        )]);
+        let w = widgets(&[
+            ("l", text_widget(&["left"])),
+            ("r", text_widget(&["right"])),
+        ]);
+        let buf = render_to_buffer_with(&l, &w, 40, 5);
+        let row1 = line_text(&buf, 1);
+        assert!(row1.contains("left"));
+        assert!(row1.contains("right"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,15 @@
+use std::collections::HashMap;
 use std::io::{self, stdout};
 
-use ratatui::{
-    Frame, Terminal, TerminalOptions, Viewport,
-    backend::CrosstermBackend,
-    layout::{Constraint, Layout},
-};
+use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend};
 
+use crate::layout::{Child, Layout, WidgetId};
 use crate::payload::{
     Bar, BarChartData, BignumData, Body, GaugeData, ListData, ListItem, Payload, SparklineData,
     Status, TextData,
 };
 
+mod layout;
 mod payload;
 mod render;
 
@@ -22,35 +21,41 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Inline(16),
         },
     )?;
-    terminal.draw(draw_demo)?;
+    let root = demo_layout();
+    let widgets = demo_widgets();
+    terminal.draw(|frame| layout::draw(frame, frame.area(), &root, &widgets))?;
     println!();
     Ok(())
 }
 
-fn draw_demo(frame: &mut Frame) {
-    let widgets = demo_widgets();
-    let rows = Layout::vertical([
-        Constraint::Length(6),
-        Constraint::Length(5),
-        Constraint::Length(5),
+fn demo_layout() -> Layout {
+    Layout::rows(vec![
+        Child::min(6, row(&["greeting", "clock"])),
+        Child::length(5, row(&["disk", "commits"])),
+        Child::length(5, row(&["system", "prs"])),
     ])
-    .split(frame.area());
-    for (row_idx, row) in rows.iter().enumerate() {
-        let cols = Layout::horizontal([Constraint::Percentage(50); 2]).split(*row);
-        render::render_payload(frame, cols[0], &widgets[row_idx * 2]);
-        render::render_payload(frame, cols[1], &widgets[row_idx * 2 + 1]);
-    }
 }
 
-fn demo_widgets() -> [Payload; 6] {
+fn row(ids: &[&str]) -> Layout {
+    Layout::cols(
+        ids.iter()
+            .map(|id| Child::fill(1, Layout::widget(*id)))
+            .collect(),
+    )
+}
+
+fn demo_widgets() -> HashMap<WidgetId, Payload> {
     [
-        greeting(),
-        clock(),
-        disk_gauge(),
-        commits_sparkline(),
-        system_list(),
-        pr_counts(),
+        ("greeting", greeting()),
+        ("clock", clock()),
+        ("disk", disk_gauge()),
+        ("commits", commits_sparkline()),
+        ("system", system_list()),
+        ("prs", pr_counts()),
     ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect()
 }
 
 fn greeting() -> Payload {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,16 +30,17 @@ fn main() -> io::Result<()> {
 
 fn demo_layout() -> Layout {
     Layout::rows(vec![
-        Child::min(6, row(&["greeting", "clock"])),
-        Child::length(5, row(&["disk", "commits"])),
-        Child::length(5, row(&["system", "prs"])),
+        Child::min(6, row(&[("greeting", "Greeting"), ("clock", "Clock")])),
+        Child::length(5, row(&[("disk", "Disk /"), ("commits", "Commits (14d)")])),
+        Child::length(5, row(&[("system", "System"), ("prs", "Open PRs")])),
     ])
 }
 
-fn row(ids: &[&str]) -> Layout {
+fn row(widgets: &[(&str, &str)]) -> Layout {
     Layout::cols(
-        ids.iter()
-            .map(|id| Child::fill(1, Layout::widget(*id)))
+        widgets
+            .iter()
+            .map(|(id, title)| Child::fill(1, Layout::widget(*id).titled(*title)))
             .collect(),
     )
 }
@@ -59,93 +60,74 @@ fn demo_widgets() -> HashMap<WidgetId, Payload> {
 }
 
 fn greeting() -> Payload {
-    titled(
-        "Greeting",
-        Body::Text(TextData {
-            lines: vec!["Hello, splashboard!".into()],
-        }),
-    )
+    payload(Body::Text(TextData {
+        lines: vec!["Hello, splashboard!".into()],
+    }))
 }
 
 fn clock() -> Payload {
-    titled(
-        "Clock",
-        Body::Bignum(BignumData {
-            text: "12:34".into(),
-        }),
-    )
+    payload(Body::Bignum(BignumData {
+        text: "12:34".into(),
+    }))
 }
 
 fn disk_gauge() -> Payload {
-    titled(
-        "Disk /",
-        Body::Gauge(GaugeData {
-            value: 0.45,
-            label: Some("45% of 500 GB".into()),
-        }),
-    )
+    payload(Body::Gauge(GaugeData {
+        value: 0.45,
+        label: Some("45% of 500 GB".into()),
+    }))
 }
 
 fn commits_sparkline() -> Payload {
-    titled(
-        "Commits (14d)",
-        Body::Sparkline(SparklineData {
-            values: vec![2, 5, 0, 3, 7, 4, 1, 6, 9, 2, 3, 5, 8, 4],
-        }),
-    )
+    payload(Body::Sparkline(SparklineData {
+        values: vec![2, 5, 0, 3, 7, 4, 1, 6, 9, 2, 3, 5, 8, 4],
+    }))
 }
 
 fn system_list() -> Payload {
     let ok = Some(Status::Ok);
-    titled(
-        "System",
-        Body::List(ListData {
-            items: vec![
-                ListItem {
-                    key: "os".into(),
-                    value: Some("linux".into()),
-                    status: ok,
-                },
-                ListItem {
-                    key: "uptime".into(),
-                    value: Some("3d 2h".into()),
-                    status: ok,
-                },
-                ListItem {
-                    key: "load".into(),
-                    value: Some("0.28".into()),
-                    status: ok,
-                },
-            ],
-        }),
-    )
+    payload(Body::List(ListData {
+        items: vec![
+            ListItem {
+                key: "os".into(),
+                value: Some("linux".into()),
+                status: ok,
+            },
+            ListItem {
+                key: "uptime".into(),
+                value: Some("3d 2h".into()),
+                status: ok,
+            },
+            ListItem {
+                key: "load".into(),
+                value: Some("0.28".into()),
+                status: ok,
+            },
+        ],
+    }))
 }
 
 fn pr_counts() -> Payload {
-    titled(
-        "Open PRs",
-        Body::BarChart(BarChartData {
-            bars: vec![
-                Bar {
-                    label: "splsh".into(),
-                    value: 3,
-                },
-                Bar {
-                    label: "gtype".into(),
-                    value: 2,
-                },
-                Bar {
-                    label: "other".into(),
-                    value: 1,
-                },
-            ],
-        }),
-    )
+    payload(Body::BarChart(BarChartData {
+        bars: vec![
+            Bar {
+                label: "splsh".into(),
+                value: 3,
+            },
+            Bar {
+                label: "gtype".into(),
+                value: 2,
+            },
+            Bar {
+                label: "other".into(),
+                value: 1,
+            },
+        ],
+    }))
 }
 
-fn titled(title: &str, body: Body) -> Payload {
+fn payload(body: Body) -> Payload {
     Payload {
-        title: Some(title.into()),
         icon: None,
         status: None,
         format: None,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -5,8 +5,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Payload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<Status>,
@@ -111,7 +109,6 @@ mod tests {
 
     fn bare(body: Body) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,
@@ -122,7 +119,6 @@ mod tests {
     #[test]
     fn text_round_trips() {
         let p = Payload {
-            title: Some("Git".into()),
             icon: None,
             status: None,
             format: Some("{branch}".into()),
@@ -135,10 +131,9 @@ mod tests {
 
     #[test]
     fn text_parses_from_spec_example() {
-        let json = r#"{"render":"text","data":{"lines":["main"]},"title":"Git"}"#;
+        let json = r#"{"render":"text","data":{"lines":["main"]}}"#;
         let p: Payload = serde_json::from_str(json).unwrap();
         assert!(matches!(p.body, Body::Text(_)));
-        assert_eq!(p.title.as_deref(), Some("Git"));
     }
 
     #[test]
@@ -235,7 +230,7 @@ mod tests {
     fn optional_fields_absent_in_serialization() {
         let p = bare(Body::Text(TextData { lines: vec![] }));
         let json = serde_json::to_string(&p).unwrap();
-        assert!(!json.contains("title"));
         assert!(!json.contains("icon"));
+        assert!(!json.contains("status"));
     }
 }

--- a/src/render/bar_chart.rs
+++ b/src/render/bar_chart.rs
@@ -18,7 +18,6 @@ mod tests {
 
     fn payload(bars: Vec<Bar>) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,

--- a/src/render/bignum.rs
+++ b/src/render/bignum.rs
@@ -28,7 +28,6 @@ mod tests {
 
     fn payload(text: &str) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,

--- a/src/render/gauge.rs
+++ b/src/render/gauge.rs
@@ -18,7 +18,6 @@ mod tests {
 
     fn payload(value: f64, label: Option<&str>) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -48,7 +48,6 @@ mod tests {
 
     fn payload(path: &str) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,

--- a/src/render/line_chart.rs
+++ b/src/render/line_chart.rs
@@ -51,7 +51,6 @@ mod tests {
 
     fn payload(series: Vec<LineSeries>) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,

--- a/src/render/list.rs
+++ b/src/render/list.rs
@@ -39,7 +39,6 @@ mod tests {
 
     fn payload(items: Vec<ListItem>) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,
@@ -55,7 +54,7 @@ mod tests {
             status: Some(Status::Ok),
         }]);
         let buf = render_to_buffer(&p, 30, 5);
-        let row = line_text(&buf, 1);
+        let row = line_text(&buf, 0);
         assert!(row.contains("uptime"));
         assert!(row.contains("3d"));
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,8 +1,4 @@
-use ratatui::{
-    Frame,
-    layout::Rect,
-    widgets::{Block, Borders},
-};
+use ratatui::{Frame, layout::Rect};
 
 use crate::payload::{Body, Payload};
 
@@ -19,26 +15,14 @@ mod text;
 pub mod test_utils;
 
 pub fn render_payload(frame: &mut Frame, area: Rect, payload: &Payload) {
-    let block = build_block(payload);
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
     match &payload.body {
-        Body::Text(d) => text::render(frame, inner, d),
-        Body::List(d) => list::render(frame, inner, d),
-        Body::Gauge(d) => gauge::render(frame, inner, d),
-        Body::Sparkline(d) => sparkline::render(frame, inner, d),
-        Body::LineChart(d) => line_chart::render(frame, inner, d),
-        Body::BarChart(d) => bar_chart::render(frame, inner, d),
-        Body::Bignum(d) => bignum::render(frame, inner, d),
-        Body::Image(d) => image::render(frame, inner, d),
-    }
-}
-
-fn build_block(payload: &Payload) -> Block<'_> {
-    let b = Block::default().borders(Borders::ALL);
-    match payload.title.as_deref() {
-        Some(title) => b.title(title),
-        None => b,
+        Body::Text(d) => text::render(frame, area, d),
+        Body::List(d) => list::render(frame, area, d),
+        Body::Gauge(d) => gauge::render(frame, area, d),
+        Body::Sparkline(d) => sparkline::render(frame, area, d),
+        Body::LineChart(d) => line_chart::render(frame, area, d),
+        Body::BarChart(d) => bar_chart::render(frame, area, d),
+        Body::Bignum(d) => bignum::render(frame, area, d),
+        Body::Image(d) => image::render(frame, area, d),
     }
 }

--- a/src/render/sparkline.rs
+++ b/src/render/sparkline.rs
@@ -13,7 +13,6 @@ mod tests {
 
     fn payload(values: Vec<u64>) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,

--- a/src/render/test_utils.rs
+++ b/src/render/test_utils.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+
 use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
 
+use crate::layout::{self, Layout, WidgetId};
 use crate::payload::Payload;
 use crate::render::render_payload;
 
@@ -8,6 +11,20 @@ pub fn render_to_buffer(payload: &Payload, width: u16, height: u16) -> Buffer {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|f| render_payload(f, f.area(), payload))
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+pub fn render_to_buffer_with(
+    root: &Layout,
+    widgets: &HashMap<WidgetId, Payload>,
+    width: u16,
+    height: u16,
+) -> Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| layout::draw(f, f.area(), root, widgets))
         .unwrap();
     terminal.backend().buffer().clone()
 }

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -13,7 +13,6 @@ mod tests {
 
     fn payload(lines: &[&str]) -> Payload {
         Payload {
-            title: None,
             icon: None,
             status: None,
             format: None,
@@ -24,8 +23,8 @@ mod tests {
     }
 
     #[test]
-    fn renders_lines_inside_block() {
+    fn renders_lines_at_top() {
         let buf = render_to_buffer(&payload(&["hello world"]), 30, 5);
-        assert!(line_text(&buf, 1).contains("hello world"));
+        assert!(line_text(&buf, 0).contains("hello world"));
     }
 }


### PR DESCRIPTION
## Summary

Third axis of the 3-axis model. `layout::draw` walks a declarative `Layout` tree and hands each leaf rect to `render_payload`. Config (#2) will later drive the tree from TOML; for now `main.rs` constructs it programmatically.

## Layout primitives

\`\`\`rust
Layout::rows(vec![...])           // vertical stack
Layout::cols(vec![...])           // horizontal stack
Layout::widget(id)                // leaf referencing a widget by id
Layout::empty                     // explicit blank cell
\`\`\`

Size constraints (full mapping to Ratatui \`Constraint\`):
\`Child::fill(w) / length(n) / min(n) / max(n) / percentage(p)\`.

## Panels (titles + borders)

Both \`Widget\` and \`Stack\` nodes can carry an optional \`Panel\` that draws a \`Block\` with a title and border:

\`\`\`rust
Layout::widget(\"git\").titled(\"Git\").bordered(BorderStyle::Rounded)

Layout::cols(vec![
    Child::fill(1, Layout::widget(\"cpu\")),
    Child::fill(1, Layout::widget(\"mem\")),
    Child::fill(1, Layout::widget(\"disk\")),
]).titled(\"System\")
\`\`\`

BorderStyle covers Plain / Rounded / Thick / Double.

**Important redesign**: \`Payload.title\` was removed and \`render_payload\` no longer auto-wraps widgets in a \`Block\`. Decoration is now purely a layout concern — plugins and fetchers produce raw data, config decides how to dress it. This makes the Group pattern (shared outer border around multiple widgets) structurally possible without double-lining individual leaves.

## Design

- Nested ratio (`Fill`) instead of wtfutil's absolute grid — reflows cleanly on resize.
- Layout references widgets by id; payload map is provided separately so fetchers and layout decouple.
- Missing id is silently skipped (no panic); layout + widgets evolve independently.
- No Block is drawn unless a Panel is explicitly set — double borders are impossible.

## Test plan

- [x] `cargo build` (zero warnings)
- [x] `cargo test` (33 passed: 12 payload + 12 render + 9 layout)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] CI (ubuntu / macos / windows)

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a composable UI layout system enabling flexible stacking of components with vertical or horizontal arrangement.
  * Added configurable panel styling with optional titles and border options (plain, rounded, thick, double).

* **Refactor**
  * Migrated widget rendering to the new layout architecture.
  * Simplified widget rendering by eliminating redundant border layers.
  * Moved title management from individual widgets to layout panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->