### PR TITLE
feat(config): TOML config with per-directory discovery (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -389,6 +389,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +465,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -564,6 +591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +653,16 @@ name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "indoc"
@@ -711,10 +754,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -746,7 +804,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -882,6 +940,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1095,7 +1159,7 @@ dependencies = [
  "image",
  "rand 0.8.6",
  "ratatui",
- "rustix",
+ "rustix 0.38.44",
  "thiserror 1.0.69",
  "windows",
 ]
@@ -1180,6 +1244,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,8 +1269,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1260,6 +1348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,11 +1418,14 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "splashboard"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "image",
  "ratatui",
  "ratatui-image",
  "serde",
  "serde_json",
+ "tempfile",
+ "toml",
  "tui-big-text",
 ]
 
@@ -1381,6 +1481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1546,47 @@ dependencies = [
  "weezl",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tui-big-text"
@@ -1587,7 +1741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1600,7 +1754,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1637,7 +1791,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1647,7 +1801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1656,7 +1819,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1670,19 +1833,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1692,9 +1876,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1710,9 +1906,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1722,15 +1930,36 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ categories = ["command-line-utilities"]
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
+dirs = "5"
 tui-big-text = "0.7"
 ratatui-image = "4"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,319 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::layout::{BorderStyle, Child, Layout};
+
+const DEFAULT_CONFIG: &str = include_str!("default_config.toml");
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub general: General,
+    #[serde(default, rename = "widget")]
+    pub widgets: Vec<WidgetConfig>,
+    #[serde(default, rename = "row")]
+    pub rows: Vec<RowConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct General {
+    #[serde(default)]
+    pub wait_for_fresh: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WidgetConfig {
+    pub id: String,
+    pub fetcher: String,
+    pub render: RenderType,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub refresh_interval: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RenderType {
+    Text,
+    List,
+    Gauge,
+    Sparkline,
+    LineChart,
+    BarChart,
+    Bignum,
+    Image,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RowConfig {
+    #[serde(default)]
+    pub height: Option<SizeSpec>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub border: Option<BorderSpec>,
+    #[serde(default, rename = "child")]
+    pub children: Vec<ChildConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChildConfig {
+    pub widget: String,
+    #[serde(default)]
+    pub width: Option<SizeSpec>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub border: Option<BorderSpec>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SizeSpec {
+    Fill(u16),
+    Length(u16),
+    Min(u16),
+    Max(u16),
+    Percentage(u16),
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BorderSpec {
+    Plain,
+    Rounded,
+    Thick,
+    Double,
+}
+
+impl Config {
+    pub fn default_baked() -> Self {
+        toml::from_str(DEFAULT_CONFIG).expect("built-in default config must parse")
+    }
+
+    pub fn load_or_default(path: &Path) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Self::parse(&s).map_err(|e| format!("{}: {e}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default_baked()),
+            Err(e) => Err(format!("{}: {e}", path.display())),
+        }
+    }
+
+    pub fn parse(toml_str: &str) -> Result<Self, String> {
+        toml::from_str(toml_str).map_err(|e| e.to_string())
+    }
+
+    pub fn to_layout(&self) -> Layout {
+        Layout::rows(self.rows.iter().map(to_row_child).collect())
+    }
+}
+
+pub const LOCAL_CONFIG_FILENAME: &str = ".splashboard.toml";
+
+pub fn resolve_config_path() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_local(&cwd).or_else(default_global_path)
+}
+
+fn find_local(start: &Path) -> Option<PathBuf> {
+    let mut current = Some(start);
+    while let Some(dir) = current {
+        let candidate = dir.join(LOCAL_CONFIG_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+fn default_global_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("splashboard").join("config.toml"))
+}
+
+fn to_row_child(row: &RowConfig) -> Child {
+    let inner = Layout::cols(row.children.iter().map(to_col_child).collect());
+    let decorated = apply_panel(inner, row.title.as_deref(), row.border);
+    make_child(row.height, decorated)
+}
+
+fn to_col_child(c: &ChildConfig) -> Child {
+    let leaf = Layout::widget(c.widget.clone());
+    let decorated = apply_panel(leaf, c.title.as_deref(), c.border);
+    make_child(c.width, decorated)
+}
+
+fn make_child(size: Option<SizeSpec>, layout: Layout) -> Child {
+    match size {
+        Some(SizeSpec::Fill(w)) => Child::fill(w, layout),
+        Some(SizeSpec::Length(n)) => Child::length(n, layout),
+        Some(SizeSpec::Min(n)) => Child::min(n, layout),
+        Some(SizeSpec::Max(n)) => Child::max(n, layout),
+        Some(SizeSpec::Percentage(p)) => Child::percentage(p, layout),
+        None => Child::fill(1, layout),
+    }
+}
+
+fn apply_panel(layout: Layout, title: Option<&str>, border: Option<BorderSpec>) -> Layout {
+    let l = match title {
+        Some(t) => layout.titled(t),
+        None => layout,
+    };
+    match border {
+        Some(b) => l.bordered(to_border_style(b)),
+        None => l,
+    }
+}
+
+fn to_border_style(b: BorderSpec) -> BorderStyle {
+    match b {
+        BorderSpec::Plain => BorderStyle::Plain,
+        BorderSpec::Rounded => BorderStyle::Rounded,
+        BorderSpec::Thick => BorderStyle::Thick,
+        BorderSpec::Double => BorderStyle::Double,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_baked_config_parses() {
+        let _ = Config::default_baked();
+    }
+
+    #[test]
+    fn default_baked_has_expected_widgets() {
+        let c = Config::default_baked();
+        let ids: Vec<&str> = c.widgets.iter().map(|w| w.id.as_str()).collect();
+        assert!(ids.contains(&"greeting"));
+        assert!(ids.contains(&"clock"));
+        assert!(ids.contains(&"prs"));
+    }
+
+    #[test]
+    fn minimal_config_parses() {
+        let toml = r#"
+[[widget]]
+id = "x"
+fetcher = "static"
+render = "text"
+
+[[row]]
+height = { length = 3 }
+[[row.child]]
+widget = "x"
+"#;
+        let c = Config::parse(toml).unwrap();
+        assert_eq!(c.widgets.len(), 1);
+        assert_eq!(c.rows.len(), 1);
+        assert_eq!(c.rows[0].children.len(), 1);
+    }
+
+    #[test]
+    fn size_spec_accepts_variants() {
+        let toml = r#"
+[[widget]]
+id = "x"
+fetcher = "f"
+render = "text"
+
+[[row]]
+height = { fill = 2 }
+[[row.child]]
+widget = "x"
+width = { percentage = 50 }
+
+[[row]]
+height = { min = 6 }
+[[row.child]]
+widget = "x"
+width = { max = 30 }
+"#;
+        let c = Config::parse(toml).unwrap();
+        assert!(matches!(c.rows[0].height, Some(SizeSpec::Fill(2))));
+        assert!(matches!(
+            c.rows[0].children[0].width,
+            Some(SizeSpec::Percentage(50))
+        ));
+        assert!(matches!(c.rows[1].height, Some(SizeSpec::Min(6))));
+        assert!(matches!(
+            c.rows[1].children[0].width,
+            Some(SizeSpec::Max(30))
+        ));
+    }
+
+    #[test]
+    fn border_spec_parses_all_styles() {
+        for name in ["plain", "rounded", "thick", "double"] {
+            let toml = format!(
+                r#"
+[[widget]]
+id = "x"
+fetcher = "f"
+render = "text"
+
+[[row]]
+border = "{name}"
+[[row.child]]
+widget = "x"
+"#
+            );
+            Config::parse(&toml).unwrap();
+        }
+    }
+
+    #[test]
+    fn invalid_toml_returns_error() {
+        let r = Config::parse("this is not [valid toml");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn missing_file_falls_back_to_default() {
+        let path = Path::new("/does/not/exist.toml");
+        let c = Config::load_or_default(path).unwrap();
+        assert!(!c.widgets.is_empty());
+    }
+
+    #[test]
+    fn find_local_picks_up_file_in_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(LOCAL_CONFIG_FILENAME), "").unwrap();
+        let found = find_local(dir.path()).unwrap();
+        assert_eq!(found, dir.path().join(LOCAL_CONFIG_FILENAME));
+    }
+
+    #[test]
+    fn find_local_walks_up_to_ancestor() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(LOCAL_CONFIG_FILENAME), "").unwrap();
+        let nested = root.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&nested).unwrap();
+        let found = find_local(&nested).unwrap();
+        assert_eq!(found, root.path().join(LOCAL_CONFIG_FILENAME));
+    }
+
+    #[test]
+    fn find_local_returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_local(dir.path()).is_none());
+    }
+
+    #[test]
+    fn to_layout_builds_nested_rows_of_cols() {
+        let c = Config::default_baked();
+        let layout = c.to_layout();
+        match layout {
+            Layout::Stack { children, .. } => {
+                assert!(!children.is_empty());
+            }
+            _ => panic!("expected Stack at root"),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,7 +112,7 @@ impl Config {
     }
 }
 
-pub const LOCAL_CONFIG_FILENAME: &str = ".splashboard.toml";
+pub const LOCAL_CONFIG_CANDIDATES: &[&str] = &[".splashboard/config.toml", ".splashboard.toml"];
 
 pub fn resolve_config_path() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
@@ -122,9 +122,11 @@ pub fn resolve_config_path() -> Option<PathBuf> {
 fn find_local(start: &Path) -> Option<PathBuf> {
     let mut current = Some(start);
     while let Some(dir) = current {
-        let candidate = dir.join(LOCAL_CONFIG_FILENAME);
-        if candidate.is_file() {
-            return Some(candidate);
+        for name in LOCAL_CONFIG_CANDIDATES {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
         }
         current = dir.parent();
     }
@@ -282,21 +284,41 @@ widget = "x"
     }
 
     #[test]
-    fn find_local_picks_up_file_in_cwd() {
+    fn find_local_picks_up_flat_file() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join(LOCAL_CONFIG_FILENAME), "").unwrap();
-        let found = find_local(dir.path()).unwrap();
-        assert_eq!(found, dir.path().join(LOCAL_CONFIG_FILENAME));
+        let file = dir.path().join(".splashboard.toml");
+        std::fs::write(&file, "").unwrap();
+        assert_eq!(find_local(dir.path()).unwrap(), file);
+    }
+
+    #[test]
+    fn find_local_picks_up_directory_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let subdir = dir.path().join(".splashboard");
+        std::fs::create_dir(&subdir).unwrap();
+        let file = subdir.join("config.toml");
+        std::fs::write(&file, "").unwrap();
+        assert_eq!(find_local(dir.path()).unwrap(), file);
+    }
+
+    #[test]
+    fn find_local_prefers_directory_form_when_both_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".splashboard")).unwrap();
+        let dir_file = dir.path().join(".splashboard/config.toml");
+        std::fs::write(&dir_file, "").unwrap();
+        std::fs::write(dir.path().join(".splashboard.toml"), "").unwrap();
+        assert_eq!(find_local(dir.path()).unwrap(), dir_file);
     }
 
     #[test]
     fn find_local_walks_up_to_ancestor() {
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join(LOCAL_CONFIG_FILENAME), "").unwrap();
+        let file = root.path().join(".splashboard.toml");
+        std::fs::write(&file, "").unwrap();
         let nested = root.path().join("a").join("b").join("c");
         std::fs::create_dir_all(&nested).unwrap();
-        let found = find_local(&nested).unwrap();
-        assert_eq!(found, root.path().join(LOCAL_CONFIG_FILENAME));
+        assert_eq!(find_local(&nested).unwrap(), file);
     }
 
     #[test]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -1,0 +1,65 @@
+[general]
+wait_for_fresh = false
+
+[[widget]]
+id = "greeting"
+fetcher = "static"
+render = "text"
+
+[[widget]]
+id = "clock"
+fetcher = "clock"
+render = "bignum"
+
+[[widget]]
+id = "disk"
+fetcher = "disk"
+render = "gauge"
+
+[[widget]]
+id = "commits"
+fetcher = "git_commits"
+render = "sparkline"
+
+[[widget]]
+id = "system"
+fetcher = "system"
+render = "list"
+
+[[widget]]
+id = "prs"
+fetcher = "github_prs"
+render = "bar_chart"
+
+[[row]]
+height = { min = 6 }
+
+  [[row.child]]
+  widget = "greeting"
+  title = "Greeting"
+
+  [[row.child]]
+  widget = "clock"
+  title = "Clock"
+
+[[row]]
+height = { length = 5 }
+
+  [[row.child]]
+  widget = "disk"
+  title = "Disk /"
+
+  [[row.child]]
+  widget = "commits"
+  title = "Commits (14d)"
+
+[[row]]
+height = { length = 5 }
+
+  [[row.child]]
+  widget = "system"
+  title = "System"
+
+  [[row.child]]
+  widget = "prs"
+  title = "Open PRs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,23 @@ use std::io::{self, stdout};
 
 use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend};
 
-use crate::layout::{Child, Layout, WidgetId};
+use crate::config::Config;
+use crate::layout::WidgetId;
 use crate::payload::{
     Bar, BarChartData, BignumData, Body, GaugeData, ListData, ListItem, Payload, SparklineData,
     Status, TextData,
 };
 
+mod config;
 mod layout;
 mod payload;
 mod render;
 
 fn main() -> io::Result<()> {
+    let config = load_config();
+    let root = config.to_layout();
+    let widgets = widgets_for(&config);
+
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::with_options(
         backend,
@@ -21,42 +27,35 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Inline(16),
         },
     )?;
-    let root = demo_layout();
-    let widgets = demo_widgets();
     terminal.draw(|frame| layout::draw(frame, frame.area(), &root, &widgets))?;
     println!();
     Ok(())
 }
 
-fn demo_layout() -> Layout {
-    Layout::rows(vec![
-        Child::min(6, row(&[("greeting", "Greeting"), ("clock", "Clock")])),
-        Child::length(5, row(&[("disk", "Disk /"), ("commits", "Commits (14d)")])),
-        Child::length(5, row(&[("system", "System"), ("prs", "Open PRs")])),
-    ])
+fn load_config() -> Config {
+    config::resolve_config_path()
+        .and_then(|p| Config::load_or_default(&p).ok())
+        .unwrap_or_else(Config::default_baked)
 }
 
-fn row(widgets: &[(&str, &str)]) -> Layout {
-    Layout::cols(
-        widgets
-            .iter()
-            .map(|(id, title)| Child::fill(1, Layout::widget(*id).titled(*title)))
-            .collect(),
-    )
+fn widgets_for(config: &Config) -> HashMap<WidgetId, Payload> {
+    config
+        .widgets
+        .iter()
+        .filter_map(|w| stub_payload(&w.id).map(|p| (w.id.clone(), p)))
+        .collect()
 }
 
-fn demo_widgets() -> HashMap<WidgetId, Payload> {
-    [
-        ("greeting", greeting()),
-        ("clock", clock()),
-        ("disk", disk_gauge()),
-        ("commits", commits_sparkline()),
-        ("system", system_list()),
-        ("prs", pr_counts()),
-    ]
-    .into_iter()
-    .map(|(k, v)| (k.to_string(), v))
-    .collect()
+fn stub_payload(id: &str) -> Option<Payload> {
+    match id {
+        "greeting" => Some(greeting()),
+        "clock" => Some(clock()),
+        "disk" => Some(disk_gauge()),
+        "commits" => Some(commits_sparkline()),
+        "system" => Some(system_list()),
+        "prs" => Some(pr_counts()),
+        _ => None,
+    }
 }
 
 fn greeting() -> Payload {


### PR DESCRIPTION
## Summary

Declarative TOML config replaces the programmatic Layout in `main.rs`. Built-in default lives at `src/default_config.toml` (bundled via `include_str!`). Config covers all axes: widget definitions + layout tree + panel decoration.

## Schema (2-level: rows × cols)

```toml
[general]
wait_for_fresh = false

[[widget]]
id = "greeting"
fetcher = "static"
render = "text"

[[row]]
height = { min = 6 }

  [[row.child]]
  widget = "greeting"
  title = "Greeting"
  width = { fill = 1 }
  border = "rounded"
```

- `size` specs (`{ fill = 1 }` / `{ length = 6 }` / `{ min = 6 }` / `{ max = 30 }` / `{ percentage = 50 }`) map to the full Ratatui Constraint repertoire via #3's `Size`.
- `title` + `border` attach a `Panel` to that row or widget (group-style or per-widget).

## Discovery order

At each ancestor directory walking up from CWD, first match wins:

1. `./.splashboard/config.toml` — directory form (future companions: `plugins/`, `themes/`, `cache/`)
2. `./.splashboard.toml` — flat dotfile
3. `$XDG_CONFIG_HOME/splashboard/config.toml` — global
4. baked-in default

Drop either form at the root of any project and `splashboard` run inside that tree picks it up automatically. The cd-hook that triggers the splash without typing `splashboard` is scope for #6 shell integration.

## What's still hardcoded

Widget *payloads* are produced by `stub_*` functions in `main.rs` matched by id. Real fetchers (sysinfo, git log, HTTP clients, subprocess plugins) replace the stubs in #4 async/cache + the per-widget issues (#7–#14, #20).

## Test plan

- [x] `cargo build` (zero warnings)
- [x] `cargo test` (46 passed: 12 payload + 12 render + 9 layout + 13 config)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] CI (ubuntu / macos / windows)

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)