### PR TITLE
feat(trust): per-widget trust gate for project-local configs (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ splashboard init bash >> ~/.bashrc
 # splashboard init fish >> ~/.config/fish/config.fish
 ```
 
+## Security / threat model
+
+Per-directory configs (`.splashboard.toml` walked up from `cwd`) mean that `cd`-ing into an adversarial repo could auto-run a splash. To bound what that splash can do, widgets are classified by fetcher capability:
+
+| class | examples | runs on cd into unknown repo? |
+|---|---|---|
+| **Safe** — pure local read | clock, greeting, git status, disk | yes, always |
+| **Network** — HTTP | github, weather, rss, calendar | only after `splashboard trust` |
+| **Exec** — subprocess | plugin, command widget | only after `splashboard trust` |
+
+Until the local config is trusted, Network and Exec widgets render a `🔒 requires trust` placeholder — the layout stays intact so the user can preview what an unlock would enable. Global config (`~/.config/splashboard/config.toml`) and the baked-in default are implicitly trusted; only project-local configs need explicit consent.
+
+```
+splashboard trust          # trust the nearest project-local config (prints capability diff, prompts y/N)
+splashboard revoke         # revert
+splashboard list-trusted   # show all trusted configs
+```
+
+The trust store lives at `~/.local/share/splashboard/trusted.toml` keyed by `{ canonical_path, sha256 }`. Editing a trusted config invalidates trust — cd back into the repo and the gated slots return to placeholders until re-trusted.
+
+**What trust protects against:** arbitrary code execution from unknown repos, arbitrary URL exfil on `cd`.
+
+**What trust does not protect against:** data the user consciously opts into. A trusted `github` widget sends `GITHUB_TOKEN` to `api.github.com` — that's the whole point. Built-in network fetchers hardcode their hosts so a rubber-stamped trust can't redirect tokens elsewhere; plugins are referenced by name against the user-installed pool (`~/.local/share/splashboard/plugins/`) so a cloned repo can't introduce a new executable; the `command` widget is only accepted from the global config.
+
+Escape hatch: `SPLASHBOARD_TRUST_ALL=1` bypasses the check (CI use, documented as insecure).
+
 ## Status
 
 Early design phase. See [Issues](https://github.com/unhappychoice/splashboard/issues) for the roadmap.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -131,7 +131,10 @@ fn is_lock_stale(path: &Path, threshold: Duration) -> bool {
     mtime.elapsed().map(|d| d > threshold).unwrap_or(false)
 }
 
-fn tmp_path_for(final_path: &Path) -> PathBuf {
+/// Builds a per-invocation unique tmp path next to `final_path`. Pid keeps it distinct across
+/// processes; the atomic counter keeps it distinct across concurrent calls within one process.
+/// Exported so other modules (e.g. trust store) can share the write-tmp-then-rename idiom.
+pub(crate) fn tmp_path_for(final_path: &Path) -> PathBuf {
     let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
     let file_name = final_path

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,18 @@ pub fn resolve_cwd_only_path() -> Option<PathBuf> {
     find_local_at(&cwd)
 }
 
+/// Walks up from the current directory looking for a project-local config. Used by the trust
+/// commands so `splashboard trust` / `revoke` target the nearest `.splashboard.toml` the same
+/// way `splashboard` itself would pick one up.
+pub fn resolve_local_config_path() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_local(&cwd)
+}
+
+pub fn default_global_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("splashboard").join("config.toml"))
+}
+
 fn find_local(start: &Path) -> Option<PathBuf> {
     let mut current = Some(start);
     while let Some(dir) = current {
@@ -140,10 +152,6 @@ fn find_local_at(dir: &Path) -> Option<PathBuf> {
         .iter()
         .map(|name| dir.join(name))
         .find(|p| p.is_file())
-}
-
-fn default_global_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("splashboard").join("config.toml"))
 }
 
 fn to_row_child(row: &RowConfig) -> Child {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,11 +11,17 @@ use crate::runtime;
 /// config, drives the fetchers, writes the cache, and exits. The parent splashboard invocation
 /// either detaches from this child and exits, or (in `--wait` mode) blocks on it with a deadline.
 pub async fn run_fetch_only(config_path: Option<&Path>) -> io::Result<()> {
-    let config = match config_path {
-        Some(p) => Config::load_or_default(p).map_err(io::Error::other)?,
-        None => Config::default_baked(),
+    // Read config bytes once; compute hash + parse from that buffer so the trust check can't be
+    // TOCTOU'd between parse and hash.
+    let (config, ident) = match config_path {
+        Some(p) => {
+            let (c, h) = crate::trust::load_config_and_hash(p)?;
+            (c, Some((p, h)))
+        }
+        None => (Config::default_baked(), None),
     };
-    runtime::fetch_and_persist(&config, config_path).await;
+    let ident_ref = ident.as_ref().map(|(p, h)| (*p, h.as_str()));
+    runtime::fetch_and_persist(&config, ident_ref).await;
     Ok(())
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -15,7 +15,7 @@ pub async fn run_fetch_only(config_path: Option<&Path>) -> io::Result<()> {
         Some(p) => Config::load_or_default(p).map_err(io::Error::other)?,
         None => Config::default_baked(),
     };
-    runtime::fetch_and_persist(&config).await;
+    runtime::fetch_and_persist(&config, config_path).await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
-use std::io::{self, IsTerminal, stdin, stdout};
-use std::path::PathBuf;
+use std::io::{self, BufRead, IsTerminal, Write, stdin, stdout};
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 
-use crate::config::Config;
+use crate::config::{Config, WidgetConfig};
+use crate::fetcher::{Registry, Safety};
 use crate::shell::Shell;
+use crate::trust::{TrustStore, hash_file};
 
 mod cache;
 mod config;
@@ -15,6 +17,7 @@ mod payload;
 mod render;
 mod runtime;
 mod shell;
+mod trust;
 
 const OPT_OUT_ENV_VARS: &[&str] = &["CI", "SPLASHBOARD_SILENT", "NO_SPLASHBOARD"];
 const MIN_WIDTH: u16 = 40;
@@ -45,6 +48,21 @@ enum Command {
         #[arg(value_enum)]
         shell: Shell,
     },
+    /// Grant this project-local config permission to run Network and Exec widgets. Safe widgets
+    /// always run regardless; this is the consent step for anything that talks to the outside
+    /// world. Defaults to the nearest `.splashboard.toml` walking up from the current directory.
+    Trust {
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+    },
+    /// Remove trust for a project-local config. Network and Exec widgets in it will render the
+    /// "🔒 requires trust" placeholder until re-trusted.
+    Revoke {
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+    },
+    /// Print the currently trusted local configs.
+    ListTrusted,
     /// Internal: run fetchers and update the cache. Spawned as a detached child by the main
     /// splashboard invocation; not intended to be run directly.
     #[command(hide = true)]
@@ -63,6 +81,9 @@ async fn main() -> io::Result<()> {
             Ok(())
         }
         Some(Command::FetchOnly { config }) => daemon::run_fetch_only(config.as_deref()).await,
+        Some(Command::Trust { path }) => run_trust(path),
+        Some(Command::Revoke { path }) => run_revoke(path),
+        Some(Command::ListTrusted) => run_list_trusted(),
         None => {
             // Swallow render errors at the shell-facing boundary so a broken splash never breaks
             // the user's prompt. Internal paths (FetchOnly above) still propagate errors.
@@ -126,6 +147,93 @@ fn load_full_config() -> io::Result<(Config, Option<PathBuf>)> {
         None => Config::default_baked(),
     };
     Ok((config, path))
+}
+
+fn run_trust(path: Option<PathBuf>) -> io::Result<()> {
+    let Some(target) = resolve_trust_target(path) else {
+        eprintln!(
+            "no project-local config found (run from inside a directory with .splashboard.toml)"
+        );
+        return Ok(());
+    };
+    let config = Config::load_or_default(&target).map_err(io::Error::other)?;
+    let registry = Registry::with_builtins();
+    print_trust_summary(&target, &config.widgets, &registry)?;
+    if !prompt_yes_no("Trust this config?")? {
+        println!("not trusted");
+        return Ok(());
+    }
+    let mut store = TrustStore::load();
+    store.trust(&target)?;
+    println!("trusted: {}", target.display());
+    Ok(())
+}
+
+fn run_revoke(path: Option<PathBuf>) -> io::Result<()> {
+    let Some(target) = resolve_trust_target(path) else {
+        eprintln!("no project-local config found");
+        return Ok(());
+    };
+    let mut store = TrustStore::load();
+    if store.revoke(&target)? {
+        println!("revoked: {}", target.display());
+    } else {
+        println!("not trusted: {}", target.display());
+    }
+    Ok(())
+}
+
+fn run_list_trusted() -> io::Result<()> {
+    let store = TrustStore::load();
+    for entry in store.list() {
+        println!("{}  {}", entry.sha256, entry.path.display());
+    }
+    Ok(())
+}
+
+fn resolve_trust_target(override_path: Option<PathBuf>) -> Option<PathBuf> {
+    override_path.or_else(config::resolve_local_config_path)
+}
+
+fn print_trust_summary(
+    path: &Path,
+    widgets: &[WidgetConfig],
+    registry: &Registry,
+) -> io::Result<()> {
+    println!("Config: {}", path.display());
+    let hash = hash_file(path).unwrap_or_else(|_| "???".into());
+    println!("sha256: {hash}");
+    println!();
+
+    let mut declared = 0usize;
+    for w in widgets {
+        let Some(fetcher) = registry.get(&w.fetcher) else {
+            continue;
+        };
+        let label = match fetcher.safety() {
+            Safety::Safe => continue,
+            Safety::Network => "network",
+            Safety::Exec => "exec",
+        };
+        if declared == 0 {
+            println!("This config requests:");
+        }
+        println!("  - {label:<7}: {} ({})", w.id, w.fetcher);
+        declared += 1;
+    }
+    if declared == 0 {
+        println!("(no Network or Exec widgets — nothing to trust)");
+    }
+    println!();
+    Ok(())
+}
+
+fn prompt_yes_no(question: &str) -> io::Result<bool> {
+    print!("{question} [y/N] ");
+    stdout().flush()?;
+    let mut line = String::new();
+    stdin().lock().read_line(&mut line)?;
+    Ok(matches!(line.trim(), "y" | "Y" | "yes" | "Yes"))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use crate::config::{Config, WidgetConfig};
 use crate::fetcher::{Registry, Safety};
 use crate::shell::Shell;
-use crate::trust::{TrustStore, hash_file};
+use crate::trust::{TrustStore, load_config_and_hash};
 
 mod cache;
 mod config;
@@ -101,8 +101,9 @@ async fn render_splash(wait: bool) -> io::Result<()> {
     if !should_render() {
         return Ok(());
     }
-    let (config, path) = load_full_config()?;
-    runtime::run(&config, path.as_deref(), wait).await
+    let (config, ident) = load_full_config()?;
+    let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
+    runtime::run(&config, ident_ref, wait).await
 }
 
 async fn render_for_cd(wait: bool) -> io::Result<()> {
@@ -112,8 +113,8 @@ async fn render_for_cd(wait: bool) -> io::Result<()> {
     let Some(path) = config::resolve_cwd_only_path() else {
         return Ok(());
     };
-    let config = Config::load_or_default(&path).map_err(io::Error::other)?;
-    runtime::run(&config, Some(&path), wait).await
+    let (config, hash) = load_config_and_hash(&path).map_err(io::Error::other)?;
+    runtime::run(&config, Some((&path, &hash)), wait).await
 }
 
 fn should_render() -> bool {
@@ -140,13 +141,18 @@ fn is_large_enough(width: u16, height: u16) -> bool {
     width >= MIN_WIDTH && height >= MIN_HEIGHT
 }
 
-fn load_full_config() -> io::Result<(Config, Option<PathBuf>)> {
-    let path = config::resolve_config_path();
-    let config = match &path {
-        Some(p) => Config::load_or_default(p).map_err(io::Error::other)?,
-        None => Config::default_baked(),
-    };
-    Ok((config, path))
+/// Returns the resolved config plus an optional `(path, hash)` pair. Missing file / baked
+/// default produces `None` — trust gating treats that as implicitly trusted. When a file is
+/// present, reading and hashing happen in a single [`load_config_and_hash`] call so the trust
+/// check can't be TOCTOU'd between parse and hash.
+fn load_full_config() -> io::Result<(Config, Option<(PathBuf, String)>)> {
+    match config::resolve_config_path() {
+        Some(p) => {
+            let (config, hash) = load_config_and_hash(&p).map_err(io::Error::other)?;
+            Ok((config, Some((p, hash))))
+        }
+        None => Ok((Config::default_baked(), None)),
+    }
 }
 
 fn run_trust(path: Option<PathBuf>) -> io::Result<()> {
@@ -156,15 +162,17 @@ fn run_trust(path: Option<PathBuf>) -> io::Result<()> {
         );
         return Ok(());
     };
-    let config = Config::load_or_default(&target).map_err(io::Error::other)?;
+    // Read the bytes once so the hash we show the user matches the hash we store — and so an
+    // attacker can't swap the file between "here's what it asks for" and "ok I trust it".
+    let (config, hash) = load_config_and_hash(&target).map_err(io::Error::other)?;
     let registry = Registry::with_builtins();
-    print_trust_summary(&target, &config.widgets, &registry)?;
+    print_trust_summary(&target, &hash, &config.widgets, &registry)?;
     if !prompt_yes_no("Trust this config?")? {
         println!("not trusted");
         return Ok(());
     }
     let mut store = TrustStore::load();
-    store.trust(&target)?;
+    store.trust(&target, hash)?;
     println!("trusted: {}", target.display());
     Ok(())
 }
@@ -175,10 +183,11 @@ fn run_revoke(path: Option<PathBuf>) -> io::Result<()> {
         return Ok(());
     };
     let mut store = TrustStore::load();
+    let display = sanitize_for_display(&target.display().to_string());
     if store.revoke(&target)? {
-        println!("revoked: {}", target.display());
+        println!("revoked: {display}");
     } else {
-        println!("not trusted: {}", target.display());
+        println!("not trusted: {display}");
     }
     Ok(())
 }
@@ -186,7 +195,11 @@ fn run_revoke(path: Option<PathBuf>) -> io::Result<()> {
 fn run_list_trusted() -> io::Result<()> {
     let store = TrustStore::load();
     for entry in store.list() {
-        println!("{}  {}", entry.sha256, entry.path.display());
+        println!(
+            "{}  {}",
+            entry.sha256,
+            sanitize_for_display(&entry.path.display().to_string())
+        );
     }
     Ok(())
 }
@@ -197,11 +210,16 @@ fn resolve_trust_target(override_path: Option<PathBuf>) -> Option<PathBuf> {
 
 fn print_trust_summary(
     path: &Path,
+    hash: &str,
     widgets: &[WidgetConfig],
     registry: &Registry,
 ) -> io::Result<()> {
-    println!("Config: {}", path.display());
-    let hash = hash_file(path).unwrap_or_else(|_| "???".into());
+    // Paths and widget ids/fetchers flow into the terminal unmodified; sanitize control chars so
+    // a malicious config can't spoof the prompt with ANSI escape sequences.
+    println!(
+        "Config: {}",
+        sanitize_for_display(&path.display().to_string())
+    );
     println!("sha256: {hash}");
     println!();
 
@@ -218,7 +236,11 @@ fn print_trust_summary(
         if declared == 0 {
             println!("This config requests:");
         }
-        println!("  - {label:<7}: {} ({})", w.id, w.fetcher);
+        println!(
+            "  - {label:<7}: {} ({})",
+            sanitize_for_display(&w.id),
+            sanitize_for_display(&w.fetcher)
+        );
         declared += 1;
     }
     if declared == 0 {
@@ -226,6 +248,20 @@ fn print_trust_summary(
     }
     println!();
     Ok(())
+}
+
+/// Replaces control characters (including ANSI escape initiators) with U+FFFD so a hostile
+/// config can't draw over the trust prompt to make it look like something else.
+fn sanitize_for_display(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_control() {
+                char::REPLACEMENT_CHARACTER
+            } else {
+                c
+            }
+        })
+        .collect()
 }
 
 fn prompt_yes_no(question: &str) -> io::Result<bool> {
@@ -293,5 +329,25 @@ mod tests {
     #[test]
     fn below_min_height_fails() {
         assert!(!super::is_large_enough(80, 15));
+    }
+
+    #[test]
+    fn sanitize_replaces_control_chars() {
+        let evil = "legit\x1b[2Kspoof";
+        let safe = super::sanitize_for_display(evil);
+        assert!(!safe.contains('\x1b'));
+        assert!(safe.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn sanitize_preserves_normal_text() {
+        let s = super::sanitize_for_display("hello/world-dashboard_01");
+        assert_eq!(s, "hello/world-dashboard_01");
+    }
+
+    #[test]
+    fn sanitize_replaces_newline_and_tab() {
+        let s = super::sanitize_for_display("a\nb\tc");
+        assert_eq!(s.matches('\u{FFFD}').count(), 2);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,6 +15,7 @@ use crate::daemon;
 use crate::fetcher::{FetchContext, Registry};
 use crate::layout::{self, Layout, WidgetId};
 use crate::payload::Payload;
+use crate::trust::{self, TrustStore};
 
 const DEFAULT_REFRESH_SECS: u64 = 60;
 const FAST_DEADLINE: Duration = Duration::from_millis(1500);
@@ -28,14 +29,23 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
     let cache = Cache::open_default();
     let registry = Registry::with_builtins();
 
-    let entries = load_entries(cache.as_ref(), &registry, &config.widgets);
+    // Split widgets into what we can fetch vs what we must gate behind trust. Gated slots render
+    // a canned "🔒 requires trust" placeholder so the layout stays intact and the user can see
+    // what needs unlocking.
+    let decision = TrustStore::load().decide(config_path);
+    let (fetchable, gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
+
+    let entries = load_entries(cache.as_ref(), &registry, &fetchable);
     let mut payloads = entries_to_payloads(&entries);
+    for w in &gated {
+        payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+    }
 
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = make_terminal(backend)?;
 
-    // Cache-first: unless --wait, paint what we have from disk immediately so the shell prompt
-    // is never blocked on fetch I/O.
+    // Cache-first: unless --wait, paint what we have from disk (plus trust placeholders)
+    // immediately so the shell prompt is never blocked on fetch I/O.
     let drew_cached = !wait && !payloads.is_empty();
     if drew_cached {
         draw(&mut terminal, &layout, &payloads)?;
@@ -47,8 +57,11 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
                 // Block on the daemon (with a hard ceiling) and then redraw with whatever it
                 // managed to write before the deadline.
                 let _ = wait_for_daemon(child, WAIT_DEADLINE).await;
-                let entries = load_entries(cache.as_ref(), &registry, &config.widgets);
+                let entries = load_entries(cache.as_ref(), &registry, &fetchable);
                 payloads = entries_to_payloads(&entries);
+                for w in &gated {
+                    payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+                }
                 draw(&mut terminal, &layout, &payloads)?;
             }
             // Default path: the child is detached; it keeps fetching after we exit. Next
@@ -58,14 +71,7 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
             // Failing to spawn the daemon is rare (OOM, exec permission). Fall back to inline
             // fetch so the user still gets fresh data this invocation.
             let deadline = if wait { WAIT_DEADLINE } else { FAST_DEADLINE };
-            let fresh = fetch_all(
-                &registry,
-                cache.as_ref(),
-                &config.widgets,
-                &entries,
-                deadline,
-            )
-            .await;
+            let fresh = fetch_all(&registry, cache.as_ref(), &fetchable, &entries, deadline).await;
             let changed = !fresh.is_empty();
             for (id, payload) in fresh {
                 payloads.insert(id, payload);
@@ -82,15 +88,19 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
 
 /// Runs fetchers and persists the results. Called by the detached `fetch-only` subcommand so the
 /// main invocation can exit without waiting for I/O. Errors from individual fetchers are logged
-/// nowhere (daemon has no stdio) and simply leave stale cache in place.
-pub async fn fetch_and_persist(config: &Config) {
+/// nowhere (daemon has no stdio) and simply leave stale cache in place. The daemon re-checks
+/// trust itself because it loads config via its own command-line argument, not from shared
+/// state.
+pub async fn fetch_and_persist(config: &Config, config_path: Option<&Path>) {
     let cache = Cache::open_default();
     let registry = Registry::with_builtins();
-    let entries = load_entries(cache.as_ref(), &registry, &config.widgets);
+    let decision = TrustStore::load().decide(config_path);
+    let (fetchable, _gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
+    let entries = load_entries(cache.as_ref(), &registry, &fetchable);
     let _ = fetch_all(
         &registry,
         cache.as_ref(),
-        &config.widgets,
+        &fetchable,
         &entries,
         DAEMON_DEADLINE,
     )

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -23,7 +23,11 @@ const WAIT_DEADLINE: Duration = Duration::from_secs(5);
 const DAEMON_DEADLINE: Duration = Duration::from_secs(30);
 const VIEWPORT_LINES: u16 = 16;
 
-pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io::Result<()> {
+pub async fn run(
+    config: &Config,
+    config_ident: Option<(&Path, &str)>,
+    wait: bool,
+) -> io::Result<()> {
     let wait = wait || config.general.wait_for_fresh;
     let layout = config.to_layout();
     let cache = Cache::open_default();
@@ -32,7 +36,7 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
     // Split widgets into what we can fetch vs what we must gate behind trust. Gated slots render
     // a canned "🔒 requires trust" placeholder so the layout stays intact and the user can see
     // what needs unlocking.
-    let decision = TrustStore::load().decide(config_path);
+    let decision = TrustStore::load().decide(config_ident);
     let (fetchable, gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
 
     let entries = load_entries(cache.as_ref(), &registry, &fetchable);
@@ -51,7 +55,7 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
         draw(&mut terminal, &layout, &payloads)?;
     }
 
-    match daemon::spawn_fetch_daemon(config_path) {
+    match daemon::spawn_fetch_daemon(config_ident.map(|(p, _)| p)) {
         Ok(child) => {
             if wait {
                 // Block on the daemon (with a hard ceiling) and then redraw with whatever it
@@ -91,10 +95,10 @@ pub async fn run(config: &Config, config_path: Option<&Path>, wait: bool) -> io:
 /// nowhere (daemon has no stdio) and simply leave stale cache in place. The daemon re-checks
 /// trust itself because it loads config via its own command-line argument, not from shared
 /// state.
-pub async fn fetch_and_persist(config: &Config, config_path: Option<&Path>) {
+pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &str)>) {
     let cache = Cache::open_default();
     let registry = Registry::with_builtins();
-    let decision = TrustStore::load().decide(config_path);
+    let decision = TrustStore::load().decide(config_ident);
     let (fetchable, _gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
     let entries = load_entries(cache.as_ref(), &registry, &fetchable);
     let _ = fetch_all(

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -1,0 +1,355 @@
+#![allow(dead_code)]
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::{WidgetConfig, default_global_path};
+use crate::fetcher::{Registry, Safety};
+use crate::payload::{Body, Payload, TextData};
+
+const TRUST_ALL_ENV: &str = "SPLASHBOARD_TRUST_ALL";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustDecision {
+    /// Global config, baked-in default, or `SPLASHBOARD_TRUST_ALL` set. No store entry needed.
+    ImplicitlyTrusted,
+    /// Local config whose hash matches an entry in the trust store.
+    Trusted,
+    /// Local config with no entry, or an entry whose hash no longer matches (config edited).
+    Untrusted,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TrustStore {
+    #[serde(default, rename = "entry")]
+    entries: Vec<TrustEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustEntry {
+    pub path: PathBuf,
+    pub sha256: String,
+}
+
+impl TrustStore {
+    /// Loads the on-disk store, or returns an empty store if it's missing or corrupt. We
+    /// deliberately do not surface corruption errors: a broken trust store must not cause the
+    /// splash to misbehave. Worst case: user re-runs `splashboard trust`.
+    pub fn load() -> Self {
+        store_path()
+            .and_then(|p| std::fs::read_to_string(&p).ok())
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) -> io::Result<()> {
+        let Some(path) = store_path() else {
+            return Err(io::Error::other("could not resolve trust store path"));
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let toml = toml::to_string(self).map_err(io::Error::other)?;
+        std::fs::write(&path, toml)
+    }
+
+    pub fn decide(&self, config_path: Option<&Path>) -> TrustDecision {
+        if trust_all_override() {
+            return TrustDecision::ImplicitlyTrusted;
+        }
+        let Some(path) = config_path else {
+            return TrustDecision::ImplicitlyTrusted;
+        };
+        if is_global(path) {
+            return TrustDecision::ImplicitlyTrusted;
+        }
+        let Ok(hash) = hash_file(path) else {
+            return TrustDecision::Untrusted;
+        };
+        let canon = canonicalize_or(path);
+        for entry in &self.entries {
+            if canonicalize_or(&entry.path) == canon && entry.sha256 == hash {
+                return TrustDecision::Trusted;
+            }
+        }
+        TrustDecision::Untrusted
+    }
+
+    pub fn trust(&mut self, path: &Path) -> io::Result<()> {
+        let hash = hash_file(path)?;
+        let canon = path.canonicalize()?;
+        self.entries.retain(|e| canonicalize_or(&e.path) != canon);
+        self.entries.push(TrustEntry {
+            path: canon,
+            sha256: hash,
+        });
+        self.save()
+    }
+
+    pub fn revoke(&mut self, path: &Path) -> io::Result<bool> {
+        let canon = canonicalize_or(path);
+        let before = self.entries.len();
+        self.entries.retain(|e| canonicalize_or(&e.path) != canon);
+        let removed = self.entries.len() < before;
+        if removed {
+            self.save()?;
+        }
+        Ok(removed)
+    }
+
+    pub fn list(&self) -> &[TrustEntry] {
+        &self.entries
+    }
+}
+
+/// Partitions widgets into (fetchable, gated). Widgets whose fetcher requires trust
+/// (Network or Exec) are moved to `gated` when the config is untrusted; callers should render
+/// `requires_trust_placeholder()` for those slots instead of fetching.
+pub fn partition_by_trust(
+    widgets: &[WidgetConfig],
+    registry: &Registry,
+    decision: TrustDecision,
+) -> (Vec<WidgetConfig>, Vec<WidgetConfig>) {
+    if !matches!(decision, TrustDecision::Untrusted) {
+        return (widgets.to_vec(), Vec::new());
+    }
+    widgets
+        .iter()
+        .cloned()
+        .partition(|w| match registry.get(&w.fetcher) {
+            Some(f) => matches!(f.safety(), Safety::Safe),
+            None => true,
+        })
+}
+
+pub fn requires_trust_placeholder() -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body: Body::Text(TextData {
+            lines: vec!["🔒 requires trust".into(), "run `splashboard trust`".into()],
+        }),
+    }
+}
+
+pub fn hash_file(path: &Path) -> io::Result<String> {
+    let data = std::fs::read(path)?;
+    let digest = Sha256::digest(&data);
+    Ok(digest.iter().map(|b| format!("{b:02x}")).collect())
+}
+
+fn trust_all_override() -> bool {
+    matches!(
+        std::env::var(TRUST_ALL_ENV).ok().as_deref(),
+        Some("1") | Some("true")
+    )
+}
+
+fn is_global(path: &Path) -> bool {
+    let Some(global) = default_global_path() else {
+        return false;
+    };
+    canonicalize_or(path) == canonicalize_or(&global)
+}
+
+fn canonicalize_or(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn store_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join("splashboard").join("trusted.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RenderType;
+    use crate::fetcher::{FetchContext, FetchError, Fetcher};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct FakeFetcher {
+        name: &'static str,
+        safety: Safety,
+    }
+
+    #[async_trait]
+    impl Fetcher for FakeFetcher {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn safety(&self) -> Safety {
+            self.safety
+        }
+        async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
+            unimplemented!("fake fetcher not invoked in tests")
+        }
+    }
+
+    fn registry_with(fetchers: &[(&'static str, Safety)]) -> Registry {
+        let mut r = Registry::default();
+        for (name, safety) in fetchers {
+            r.register(Arc::new(FakeFetcher {
+                name,
+                safety: *safety,
+            }));
+        }
+        r
+    }
+
+    fn widget(id: &str, fetcher: &str) -> WidgetConfig {
+        WidgetConfig {
+            id: id.into(),
+            fetcher: fetcher.into(),
+            render: RenderType::Text,
+            format: None,
+            refresh_interval: None,
+        }
+    }
+
+    #[test]
+    fn hash_file_is_deterministic() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("c.toml");
+        std::fs::write(&p, "hello").unwrap();
+        let a = hash_file(&p).unwrap();
+        let b = hash_file(&p).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn hash_file_changes_when_contents_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("c.toml");
+        std::fs::write(&p, "hello").unwrap();
+        let before = hash_file(&p).unwrap();
+        std::fs::write(&p, "world").unwrap();
+        let after = hash_file(&p).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn decide_none_path_is_implicitly_trusted() {
+        let store = TrustStore::default();
+        assert_eq!(store.decide(None), TrustDecision::ImplicitlyTrusted);
+    }
+
+    #[test]
+    fn decide_unlisted_local_config_is_untrusted() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(".splashboard.toml");
+        std::fs::write(&p, "").unwrap();
+        let store = TrustStore::default();
+        assert_eq!(store.decide(Some(&p)), TrustDecision::Untrusted);
+    }
+
+    #[test]
+    fn decide_trusted_after_explicit_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(".splashboard.toml");
+        std::fs::write(&p, "hello").unwrap();
+        let hash = hash_file(&p).unwrap();
+        let canon = p.canonicalize().unwrap();
+        let store = TrustStore {
+            entries: vec![TrustEntry {
+                path: canon,
+                sha256: hash,
+            }],
+        };
+        assert_eq!(store.decide(Some(&p)), TrustDecision::Trusted);
+    }
+
+    #[test]
+    fn decide_detects_modification_after_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(".splashboard.toml");
+        std::fs::write(&p, "original").unwrap();
+        let hash = hash_file(&p).unwrap();
+        let store = TrustStore {
+            entries: vec![TrustEntry {
+                path: p.canonicalize().unwrap(),
+                sha256: hash,
+            }],
+        };
+        std::fs::write(&p, "tampered").unwrap();
+        assert_eq!(store.decide(Some(&p)), TrustDecision::Untrusted);
+    }
+
+    #[test]
+    fn partition_keeps_everything_when_trusted() {
+        let registry = registry_with(&[
+            ("static", Safety::Safe),
+            ("github_prs", Safety::Network),
+            ("plugin", Safety::Exec),
+        ]);
+        let widgets = vec![
+            widget("g", "static"),
+            widget("p", "github_prs"),
+            widget("x", "plugin"),
+        ];
+        let (fetchable, gated) = partition_by_trust(&widgets, &registry, TrustDecision::Trusted);
+        assert_eq!(fetchable.len(), 3);
+        assert!(gated.is_empty());
+    }
+
+    #[test]
+    fn partition_gates_network_and_exec_when_untrusted() {
+        let registry = registry_with(&[
+            ("static", Safety::Safe),
+            ("github_prs", Safety::Network),
+            ("plugin", Safety::Exec),
+        ]);
+        let widgets = vec![
+            widget("g", "static"),
+            widget("p", "github_prs"),
+            widget("x", "plugin"),
+        ];
+        let (fetchable, gated) = partition_by_trust(&widgets, &registry, TrustDecision::Untrusted);
+        let fetchable_ids: Vec<String> = fetchable.iter().map(|w| w.id.clone()).collect();
+        let gated_ids: Vec<String> = gated.iter().map(|w| w.id.clone()).collect();
+        assert_eq!(fetchable_ids, vec!["g".to_string()]);
+        assert!(gated_ids.iter().any(|s| s == "p"));
+        assert!(gated_ids.iter().any(|s| s == "x"));
+    }
+
+    #[test]
+    fn partition_keeps_unknown_fetchers_in_fetchable_when_untrusted() {
+        // Unknown fetchers will simply be skipped at fetch time; gating them away isn't useful
+        // since they can't actually reach anything anyway.
+        let registry = registry_with(&[("static", Safety::Safe)]);
+        let widgets = vec![widget("x", "mystery")];
+        let (fetchable, gated) = partition_by_trust(&widgets, &registry, TrustDecision::Untrusted);
+        assert_eq!(fetchable.len(), 1);
+        assert!(gated.is_empty());
+    }
+
+    #[test]
+    fn trust_store_round_trips_via_toml() {
+        let store = TrustStore {
+            entries: vec![TrustEntry {
+                path: PathBuf::from("/tmp/x/.splashboard.toml"),
+                sha256: "a".repeat(64),
+            }],
+        };
+        let s = toml::to_string(&store).unwrap();
+        let back: TrustStore = toml::from_str(&s).unwrap();
+        assert_eq!(back.entries, store.entries);
+    }
+
+    #[test]
+    fn placeholder_has_lock_icon_in_first_line() {
+        let p = requires_trust_placeholder();
+        match p.body {
+            Body::Text(t) => {
+                assert!(t.lines[0].contains("🔒"));
+                assert!(t.lines[1].contains("splashboard trust"));
+            }
+            _ => panic!("expected text body"),
+        }
+    }
+}

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -6,7 +6,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::config::{WidgetConfig, default_global_path};
+use crate::cache::tmp_path_for;
+use crate::config::{Config, WidgetConfig, default_global_path};
 use crate::fetcher::{Registry, Safety};
 use crate::payload::{Body, Payload, TextData};
 
@@ -35,9 +36,9 @@ pub struct TrustEntry {
 }
 
 impl TrustStore {
-    /// Loads the on-disk store, or returns an empty store if it's missing or corrupt. We
-    /// deliberately do not surface corruption errors: a broken trust store must not cause the
-    /// splash to misbehave. Worst case: user re-runs `splashboard trust`.
+    /// Loads the on-disk store, or returns an empty store if it's missing or corrupt. A broken
+    /// trust store must never cause the splash to misbehave; the worst case is that the user
+    /// needs to re-run `splashboard trust`.
     pub fn load() -> Self {
         store_path()
             .and_then(|p| std::fs::read_to_string(&p).ok())
@@ -45,6 +46,8 @@ impl TrustStore {
             .unwrap_or_default()
     }
 
+    /// Atomic write so a concurrent invocation or crashed write never leaves the store empty
+    /// (which would silently untrust every entry). Same tmp+rename idiom as the payload cache.
     pub fn save(&self) -> io::Result<()> {
         let Some(path) = store_path() else {
             return Err(io::Error::other("could not resolve trust store path"));
@@ -52,23 +55,37 @@ impl TrustStore {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let toml = toml::to_string(self).map_err(io::Error::other)?;
-        std::fs::write(&path, toml)
+        let body = toml::to_string(self).map_err(io::Error::other)?;
+        let tmp = tmp_path_for(&path);
+        std::fs::write(&tmp, body)?;
+        std::fs::rename(tmp, path)?;
+        Ok(())
     }
 
-    pub fn decide(&self, config_path: Option<&Path>) -> TrustDecision {
+    /// Caller is expected to have already read the config bytes and hashed them (via
+    /// [`load_config_and_hash`]). Re-hashing here would open a TOCTOU window: a trusted file
+    /// could be swapped for an attacker-crafted one between the caller's load and our hash.
+    pub fn decide(&self, ident: Option<(&Path, &str)>) -> TrustDecision {
+        self.decide_with_global(ident, default_global_path().as_deref())
+    }
+
+    fn decide_with_global(
+        &self,
+        ident: Option<(&Path, &str)>,
+        global: Option<&Path>,
+    ) -> TrustDecision {
         if trust_all_override() {
             return TrustDecision::ImplicitlyTrusted;
         }
-        let Some(path) = config_path else {
+        let Some((path, hash)) = ident else {
             return TrustDecision::ImplicitlyTrusted;
         };
-        if is_global(path) {
+        // Literal equality only. A symlink that resolves to the global config is NOT the global
+        // config — the attacker controls the cwd it runs in, which subverts the whole point of
+        // trusting global configs.
+        if global == Some(path) {
             return TrustDecision::ImplicitlyTrusted;
         }
-        let Ok(hash) = hash_file(path) else {
-            return TrustDecision::Untrusted;
-        };
         let canon = canonicalize_or(path);
         for entry in &self.entries {
             if canonicalize_or(&entry.path) == canon && entry.sha256 == hash {
@@ -78,8 +95,7 @@ impl TrustStore {
         TrustDecision::Untrusted
     }
 
-    pub fn trust(&mut self, path: &Path) -> io::Result<()> {
-        let hash = hash_file(path)?;
+    pub fn trust(&mut self, path: &Path, hash: String) -> io::Result<()> {
         let canon = path.canonicalize()?;
         self.entries.retain(|e| canonicalize_or(&e.path) != canon);
         self.entries.push(TrustEntry {
@@ -103,6 +119,28 @@ impl TrustStore {
     pub fn list(&self) -> &[TrustEntry] {
         &self.entries
     }
+}
+
+/// Reads the config bytes once and returns both the parsed `Config` and its sha256. All
+/// trust-sensitive callers MUST use this instead of `Config::load_or_default` + `hash_file` —
+/// two separate reads would let an attacker swap the file between the load and the hash.
+pub fn load_config_and_hash(path: &Path) -> io::Result<(Config, String)> {
+    let bytes = std::fs::read(path)?;
+    let hash = hash_bytes(&bytes);
+    let text = std::str::from_utf8(&bytes).map_err(io::Error::other)?;
+    let config = Config::parse(text).map_err(io::Error::other)?;
+    Ok((config, hash))
+}
+
+pub fn hash_file(path: &Path) -> io::Result<String> {
+    Ok(hash_bytes(&std::fs::read(path)?))
+}
+
+pub fn hash_bytes(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Partitions widgets into (fetchable, gated). Widgets whose fetcher requires trust
@@ -136,24 +174,11 @@ pub fn requires_trust_placeholder() -> Payload {
     }
 }
 
-pub fn hash_file(path: &Path) -> io::Result<String> {
-    let data = std::fs::read(path)?;
-    let digest = Sha256::digest(&data);
-    Ok(digest.iter().map(|b| format!("{b:02x}")).collect())
-}
-
 fn trust_all_override() -> bool {
     matches!(
         std::env::var(TRUST_ALL_ENV).ok().as_deref(),
         Some("1") | Some("true")
     )
-}
-
-fn is_global(path: &Path) -> bool {
-    let Some(global) = default_global_path() else {
-        return false;
-    };
-    canonicalize_or(path) == canonicalize_or(&global)
 }
 
 fn canonicalize_or(path: &Path) -> PathBuf {
@@ -234,7 +259,16 @@ mod tests {
     }
 
     #[test]
-    fn decide_none_path_is_implicitly_trusted() {
+    fn load_config_and_hash_returns_matching_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(".splashboard.toml");
+        std::fs::write(&p, "").unwrap();
+        let (_cfg, hash) = load_config_and_hash(&p).unwrap();
+        assert_eq!(hash, hash_file(&p).unwrap());
+    }
+
+    #[test]
+    fn decide_none_ident_is_implicitly_trusted() {
         let store = TrustStore::default();
         assert_eq!(store.decide(None), TrustDecision::ImplicitlyTrusted);
     }
@@ -244,8 +278,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join(".splashboard.toml");
         std::fs::write(&p, "").unwrap();
+        let hash = hash_file(&p).unwrap();
         let store = TrustStore::default();
-        assert_eq!(store.decide(Some(&p)), TrustDecision::Untrusted);
+        assert_eq!(store.decide(Some((&p, &hash))), TrustDecision::Untrusted);
     }
 
     #[test]
@@ -258,26 +293,59 @@ mod tests {
         let store = TrustStore {
             entries: vec![TrustEntry {
                 path: canon,
-                sha256: hash,
+                sha256: hash.clone(),
             }],
         };
-        assert_eq!(store.decide(Some(&p)), TrustDecision::Trusted);
+        assert_eq!(store.decide(Some((&p, &hash))), TrustDecision::Trusted);
     }
 
     #[test]
-    fn decide_detects_modification_after_trust() {
+    fn decide_rejects_mismatched_hash_even_if_path_matches() {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join(".splashboard.toml");
         std::fs::write(&p, "original").unwrap();
-        let hash = hash_file(&p).unwrap();
+        let stored_hash = hash_file(&p).unwrap();
         let store = TrustStore {
             entries: vec![TrustEntry {
                 path: p.canonicalize().unwrap(),
-                sha256: hash,
+                sha256: stored_hash,
             }],
         };
-        std::fs::write(&p, "tampered").unwrap();
-        assert_eq!(store.decide(Some(&p)), TrustDecision::Untrusted);
+        // Simulate attacker swapping the file: caller passes a hash that doesn't match the entry.
+        let attacker_hash = "f".repeat(64);
+        assert_eq!(
+            store.decide(Some((&p, &attacker_hash))),
+            TrustDecision::Untrusted
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_global_is_not_implicitly_trusted() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let fake_global = dir.path().join("global.toml");
+        std::fs::write(&fake_global, "content").unwrap();
+        let local = dir.path().join(".splashboard.toml");
+        symlink(&fake_global, &local).unwrap();
+        // Sanity: the symlink canonicalizes to the global path.
+        assert_eq!(canonicalize_or(&local), canonicalize_or(&fake_global));
+        // But decide must NOT treat the symlink as the global config.
+        let store = TrustStore::default();
+        let hash = hash_file(&local).unwrap();
+        let decision = store.decide_with_global(Some((&local, &hash)), Some(&fake_global));
+        assert_eq!(decision, TrustDecision::Untrusted);
+    }
+
+    #[test]
+    fn literal_global_path_is_implicitly_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = dir.path().join("global.toml");
+        std::fs::write(&global, "x").unwrap();
+        let hash = hash_file(&global).unwrap();
+        let store = TrustStore::default();
+        let decision = store.decide_with_global(Some((&global, &hash)), Some(&global));
+        assert_eq!(decision, TrustDecision::ImplicitlyTrusted);
     }
 
     #[test]
@@ -319,8 +387,6 @@ mod tests {
 
     #[test]
     fn partition_keeps_unknown_fetchers_in_fetchable_when_untrusted() {
-        // Unknown fetchers will simply be skipped at fetch time; gating them away isn't useful
-        // since they can't actually reach anything anyway.
         let registry = registry_with(&[("static", Safety::Safe)]);
         let widgets = vec![widget("x", "mystery")];
         let (fetchable, gated) = partition_by_trust(&widgets, &registry, TrustDecision::Untrusted);


### PR DESCRIPTION
Shipping the trust scaffolding now so #5 (plugins), #20 (command widget), and #11-14 (network fetchers) land on a consent layer that already exists — not bolted on after the fact.

## Design

- \`Safety\` classification on the \`Fetcher\` trait drives the gate. Safe widgets always run; Network + Exec run only when the config is trusted.
- Global config + baked-in default are implicitly trusted. Project-local configs need explicit consent.
- Trust store at \`\$XDG_DATA_HOME/splashboard/trusted.toml\`, \`{ canonical_path, sha256 }\` per entry. Editing the config invalidates trust (hash no longer matches) — no manual re-prompt logic.
- Untrusted Network/Exec widgets render a \`🔒 requires trust\` placeholder rather than being skipped, so the layout stays intact and the user can preview what an unlock would enable.

## CLI

- \`splashboard trust [path]\` — prints a capability diff (only Network/Exec widgets) and prompts y/N.
- \`splashboard revoke [path]\` — removes the entry.
- \`splashboard list-trusted\` — dumps entries.
- \`SPLASHBOARD_TRUST_ALL=1\` — escape hatch.

## Out of scope (lands with each dependent feature)

- Plugin name-ref enforcement → #5
- Command widget rejected from local config → #20
- Network fetcher host allowlists + no-token-forwarding → #11-14

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` (112 passed, incl. hash determinism, modification invalidates trust, partition gates Network/Exec when untrusted, TOML round-trip)
- [ ] Manual: \`splashboard trust\` on a repo config, verify capability diff matches the fetchers, y/N writes / doesn't write entry
- [ ] Manual: modify the trusted config, verify next \`splashboard\` run shows the 🔒 placeholder again
- [ ] Manual: \`SPLASHBOARD_TRUST_ALL=1 splashboard\` bypasses gating

README grows a Security / threat model section documenting exactly what trust does and doesn't protect against.

Closes #27 (scaffolding portion). Hardening tickets stay open and land with #5 / #20 / #11-14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trust management system with new commands: `trust` (grant permission), `revoke` (remove permission), and `list-trusted` (view trusted configs)
  * Network and Exec widgets now require explicit trust, displaying a placeholder until permission is granted
  * Trust checks can be bypassed with `SPLASHBOARD_TRUST_ALL=1` environment variable

* **Documentation**
  * Added Security/threat model section to README explaining the trust-based gating mechanism for local configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->