### PR TITLE
feat(fetcher): real clock + multi-line static text (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +289,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +364,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -764,6 +790,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icy_sixel"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +946,16 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1609,6 +1669,7 @@ name = "splashboard"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "clap",
  "dirs",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process"] }
 async-trait = "0.1"
 sha2 = "0.10"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/fetcher/clock.rs
+++ b/src/fetcher/clock.rs
@@ -1,0 +1,114 @@
+use std::fmt::Write;
+
+use async_trait::async_trait;
+use chrono::Local;
+
+use crate::payload::{BignumData, Body, Payload};
+
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+const DEFAULT_FORMAT: &str = "%H:%M";
+
+/// Renders the current local time. `format` follows chrono's strftime conventions; default is
+/// `%H:%M` (24h clock). Emits a Bignum payload so the default layout can lean on the big-text
+/// renderer for visual weight.
+pub struct ClockFetcher;
+
+#[async_trait]
+impl Fetcher for ClockFetcher {
+    fn name(&self) -> &str {
+        "clock"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let fmt = ctx.format.as_deref().unwrap_or(DEFAULT_FORMAT);
+        let text = format_now(fmt);
+        Ok(Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Bignum(BignumData { text }),
+        })
+    }
+}
+
+/// Formats the current local time using `fmt`. An invalid strftime directive would cause
+/// chrono's `DelayedFormat::to_string()` to panic (`Display::fmt` returns `Err`, and
+/// `ToString::to_string` panics on that). We capture the error via `write!` and fall back to
+/// the default format so a typo in a user's config can never crash the splash.
+fn format_now(fmt: &str) -> String {
+    let now = Local::now();
+    let mut buf = String::new();
+    if write!(&mut buf, "{}", now.format(fmt)).is_ok() {
+        return buf;
+    }
+    // The partial write on error may leave buf in an unusable state; discard it.
+    let mut fallback = String::new();
+    // `write!` on the default format is infallible; `unwrap_or_default` keeps it panic-free
+    // even if some future version of chrono changes that invariant.
+    let _ = write!(&mut fallback, "{}", now.format(DEFAULT_FORMAT));
+    fallback
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(format: Option<&str>) -> FetchContext {
+        FetchContext {
+            widget_id: "clock".into(),
+            format: format.map(String::from),
+            timeout: Duration::from_secs(1),
+        }
+    }
+
+    #[tokio::test]
+    async fn default_format_is_hh_mm() {
+        let p = ClockFetcher.fetch(&ctx(None)).await.unwrap();
+        match p.body {
+            Body::Bignum(d) => {
+                assert_eq!(d.text.len(), 5, "{:?} should be HH:MM", d.text);
+                assert_eq!(d.text.chars().nth(2), Some(':'));
+            }
+            _ => panic!("expected bignum body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_format_is_honored() {
+        let p = ClockFetcher.fetch(&ctx(Some("%Y"))).await.unwrap();
+        match p.body {
+            Body::Bignum(d) => assert_eq!(d.text.len(), 4, "{:?} should be YYYY", d.text),
+            _ => panic!("expected bignum body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_format_falls_back_without_panicking() {
+        // `%Q` is not a recognised strftime directive; chrono's formatter returns `fmt::Error`
+        // for it, which would panic through `to_string()`. Our wrapper must return a valid
+        // default-formatted string instead.
+        let p = ClockFetcher.fetch(&ctx(Some("%Q"))).await.unwrap();
+        match p.body {
+            Body::Bignum(d) => {
+                assert_eq!(d.text.len(), 5, "expected fallback HH:MM, got {:?}", d.text);
+                assert_eq!(d.text.chars().nth(2), Some(':'));
+            }
+            _ => panic!("expected bignum body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn literal_percent_in_format_does_not_crash() {
+        // Plain literals are fine.
+        let p = ClockFetcher.fetch(&ctx(Some("now: %H:%M"))).await.unwrap();
+        match p.body {
+            Body::Bignum(d) => assert!(d.text.starts_with("now: ")),
+            _ => panic!("expected bignum body"),
+        }
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -9,6 +9,8 @@ use async_trait::async_trait;
 
 use crate::payload::Payload;
 
+pub mod clock;
+pub mod static_text;
 pub mod stub;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,7 +73,9 @@ pub struct Registry {
 impl Registry {
     pub fn with_builtins() -> Self {
         let mut r = Self::default();
-        for f in stub::builtins() {
+        r.register(Arc::new(static_text::StaticText));
+        r.register(Arc::new(clock::ClockFetcher));
+        for f in stub::stubs() {
             r.register(f);
         }
         r

--- a/src/fetcher/static_text.rs
+++ b/src/fetcher/static_text.rs
@@ -1,0 +1,99 @@
+use async_trait::async_trait;
+
+use crate::payload::{Body, Payload, TextData};
+
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+/// Emits `format` verbatim, splitting on `\n` so users can ship multi-line fixed text blocks
+/// ("welcome to this project", setup notes, etc.) without needing a dedicated fetcher. Empty
+/// or missing format produces an empty line list — the widget renders nothing rather than a
+/// spurious blank line.
+pub struct StaticText;
+
+#[async_trait]
+impl Fetcher for StaticText {
+    fn name(&self) -> &str {
+        "static"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let source = ctx.format.as_deref().unwrap_or("");
+        let lines = if source.is_empty() {
+            Vec::new()
+        } else {
+            source.split('\n').map(String::from).collect()
+        };
+        Ok(Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData { lines }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(format: Option<&str>) -> FetchContext {
+        FetchContext {
+            widget_id: "x".into(),
+            format: format.map(String::from),
+            timeout: Duration::from_secs(1),
+        }
+    }
+
+    fn text_lines(p: Payload) -> Vec<String> {
+        match p.body {
+            Body::Text(t) => t.lines,
+            _ => panic!("expected text body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn single_line_format() {
+        let p = StaticText.fetch(&ctx(Some("Hello!"))).await.unwrap();
+        assert_eq!(text_lines(p), vec!["Hello!".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn newline_separates_into_lines() {
+        let p = StaticText
+            .fetch(&ctx(Some("line one\nline two\nline three")))
+            .await
+            .unwrap();
+        assert_eq!(
+            text_lines(p),
+            vec![
+                "line one".to_string(),
+                "line two".to_string(),
+                "line three".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_format_yields_empty_list() {
+        let p = StaticText.fetch(&ctx(None)).await.unwrap();
+        assert!(text_lines(p).is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_format_yields_empty_list() {
+        let p = StaticText.fetch(&ctx(Some(""))).await.unwrap();
+        assert!(text_lines(p).is_empty());
+    }
+
+    #[tokio::test]
+    async fn trailing_newline_preserves_blank_line() {
+        // Users who don't want the trailing blank shouldn't trail a \n; we preserve split
+        // semantics so the rendered output matches the format string byte-for-byte.
+        let p = StaticText.fetch(&ctx(Some("a\n"))).await.unwrap();
+        assert_eq!(text_lines(p), vec!["a".to_string(), "".to_string()]);
+    }
+}

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -1,68 +1,25 @@
+//! Placeholder fetchers that still return canned data. Each of these is blocked on a dedicated
+//! issue (#8 git, #9 system, #11 github) and will be replaced one-by-one. Keeping them in a
+//! single module makes it obvious at a glance which parts of the default dashboard aren't real
+//! yet.
+
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::payload::{
-    Bar, BarChartData, BignumData, Body, GaugeData, ListData, ListItem, Payload, SparklineData,
-    Status, TextData,
+    Bar, BarChartData, Body, GaugeData, ListData, ListItem, Payload, SparklineData, Status,
 };
 
 use super::{FetchContext, FetchError, Fetcher, Safety};
 
-pub fn builtins() -> Vec<Arc<dyn Fetcher>> {
+pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
     vec![
-        Arc::new(StaticText),
-        Arc::new(ClockFetcher),
         Arc::new(DiskStub),
         Arc::new(GitCommitsStub),
         Arc::new(SystemStub),
         Arc::new(GithubPrsStub),
     ]
-}
-
-/// Emits `format` verbatim, splitting on `\n` so users can ship multi-line fixed text blocks
-/// ("welcome to this project", setup notes, etc.) without needing a dedicated fetcher.
-pub struct StaticText;
-
-#[async_trait]
-impl Fetcher for StaticText {
-    fn name(&self) -> &str {
-        "static"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Safe
-    }
-    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let source = ctx.format.as_deref().unwrap_or("");
-        let lines = if source.is_empty() {
-            Vec::new()
-        } else {
-            source.split('\n').map(String::from).collect()
-        };
-        Ok(payload(Body::Text(TextData { lines })))
-    }
-}
-
-/// Renders the current local time. `format` follows chrono's strftime conventions; default is
-/// `%H:%M` (24h clock). Emits a Bignum payload so the default layout can lean on the big-text
-/// renderer for visual weight.
-pub struct ClockFetcher;
-
-const CLOCK_DEFAULT_FORMAT: &str = "%H:%M";
-
-#[async_trait]
-impl Fetcher for ClockFetcher {
-    fn name(&self) -> &str {
-        "clock"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Safe
-    }
-    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let fmt = ctx.format.as_deref().unwrap_or(CLOCK_DEFAULT_FORMAT);
-        let text = chrono::Local::now().format(fmt).to_string();
-        Ok(payload(Body::Bignum(BignumData { text })))
-    }
 }
 
 pub struct DiskStub;
@@ -175,118 +132,22 @@ fn payload(body: Body) -> Payload {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use super::*;
 
-    fn ctx(format: Option<&str>) -> FetchContext {
-        FetchContext {
-            widget_id: "w".into(),
-            format: format.map(String::from),
-            timeout: Duration::from_secs(1),
-        }
-    }
-
-    #[tokio::test]
-    async fn static_text_single_line() {
-        let p = StaticText.fetch(&ctx(Some("Hello!"))).await.unwrap();
-        match p.body {
-            Body::Text(t) => assert_eq!(t.lines, vec!["Hello!".to_string()]),
-            _ => panic!("expected text body"),
-        }
-    }
-
-    #[tokio::test]
-    async fn static_text_splits_on_newline() {
-        let p = StaticText
-            .fetch(&ctx(Some("line one\nline two\nline three")))
-            .await
-            .unwrap();
-        match p.body {
-            Body::Text(t) => {
-                assert_eq!(
-                    t.lines,
-                    vec![
-                        "line one".to_string(),
-                        "line two".to_string(),
-                        "line three".to_string(),
-                    ]
-                );
-            }
-            _ => panic!("expected text body"),
-        }
-    }
-
-    #[tokio::test]
-    async fn static_text_missing_format_is_empty() {
-        let p = StaticText.fetch(&ctx(None)).await.unwrap();
-        match p.body {
-            Body::Text(t) => assert!(t.lines.is_empty()),
-            _ => panic!("expected text body"),
-        }
-    }
-
-    #[tokio::test]
-    async fn static_text_empty_format_is_empty() {
-        let p = StaticText.fetch(&ctx(Some(""))).await.unwrap();
-        match p.body {
-            Body::Text(t) => assert!(t.lines.is_empty()),
-            _ => panic!("expected text body"),
-        }
-    }
-
-    #[tokio::test]
-    async fn static_text_trailing_newline_keeps_empty_line() {
-        // Users who don't want the trailing blank shouldn't trail a \n; we preserve split
-        // semantics so the rendered output matches the format string byte-for-byte.
-        let p = StaticText.fetch(&ctx(Some("a\n"))).await.unwrap();
-        match p.body {
-            Body::Text(t) => assert_eq!(t.lines, vec!["a".to_string(), "".to_string()]),
-            _ => panic!("expected text body"),
-        }
-    }
-
-    #[tokio::test]
-    async fn clock_default_format_is_hh_mm() {
-        let p = ClockFetcher.fetch(&ctx(None)).await.unwrap();
-        match p.body {
-            Body::Bignum(d) => {
-                assert_eq!(d.text.len(), 5, "{:?} should be HH:MM", d.text);
-                assert_eq!(d.text.chars().nth(2), Some(':'));
-            }
-            _ => panic!("expected bignum body"),
-        }
-    }
-
-    #[tokio::test]
-    async fn clock_honors_custom_format() {
-        let p = ClockFetcher.fetch(&ctx(Some("%Y"))).await.unwrap();
-        match p.body {
-            Body::Bignum(d) => assert_eq!(d.text.len(), 4, "{:?} should be 4-digit year", d.text),
-            _ => panic!("expected bignum body"),
-        }
-    }
-
     #[test]
-    fn builtins_cover_default_config_fetchers() {
-        let fetchers = builtins();
-        let names: Vec<&str> = fetchers.iter().map(|f| f.name()).collect();
-        for expected in [
-            "static",
-            "clock",
-            "disk",
-            "git_commits",
-            "system",
-            "github_prs",
-        ] {
-            assert!(names.contains(&expected), "missing builtin: {expected}");
-        }
-    }
-
-    #[test]
-    fn safety_classification_marks_exec_and_network() {
+    fn safety_classification_matches_feature_surface() {
+        assert_eq!(DiskStub.safety(), Safety::Safe);
+        assert_eq!(SystemStub.safety(), Safety::Safe);
         assert_eq!(GitCommitsStub.safety(), Safety::Exec);
         assert_eq!(GithubPrsStub.safety(), Safety::Network);
-        assert_eq!(StaticText.safety(), Safety::Safe);
+    }
+
+    #[test]
+    fn all_stubs_are_registered() {
+        let fetchers = stubs();
+        let names: Vec<&str> = fetchers.iter().map(|f| f.name()).collect();
+        for expected in ["disk", "git_commits", "system", "github_prs"] {
+            assert!(names.contains(&expected), "missing stub: {expected}");
+        }
     }
 }

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -12,7 +12,7 @@ use super::{FetchContext, FetchError, Fetcher, Safety};
 pub fn builtins() -> Vec<Arc<dyn Fetcher>> {
     vec![
         Arc::new(StaticText),
-        Arc::new(ClockStub),
+        Arc::new(ClockFetcher),
         Arc::new(DiskStub),
         Arc::new(GitCommitsStub),
         Arc::new(SystemStub),
@@ -20,6 +20,8 @@ pub fn builtins() -> Vec<Arc<dyn Fetcher>> {
     ]
 }
 
+/// Emits `format` verbatim, splitting on `\n` so users can ship multi-line fixed text blocks
+/// ("welcome to this project", setup notes, etc.) without needing a dedicated fetcher.
 pub struct StaticText;
 
 #[async_trait]
@@ -31,25 +33,35 @@ impl Fetcher for StaticText {
         Safety::Safe
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let line = ctx.format.clone().unwrap_or_default();
-        Ok(payload(Body::Text(TextData { lines: vec![line] })))
+        let source = ctx.format.as_deref().unwrap_or("");
+        let lines = if source.is_empty() {
+            Vec::new()
+        } else {
+            source.split('\n').map(String::from).collect()
+        };
+        Ok(payload(Body::Text(TextData { lines })))
     }
 }
 
-pub struct ClockStub;
+/// Renders the current local time. `format` follows chrono's strftime conventions; default is
+/// `%H:%M` (24h clock). Emits a Bignum payload so the default layout can lean on the big-text
+/// renderer for visual weight.
+pub struct ClockFetcher;
+
+const CLOCK_DEFAULT_FORMAT: &str = "%H:%M";
 
 #[async_trait]
-impl Fetcher for ClockStub {
+impl Fetcher for ClockFetcher {
     fn name(&self) -> &str {
         "clock"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
     }
-    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
-        Ok(payload(Body::Bignum(BignumData {
-            text: "12:34".into(),
-        })))
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let fmt = ctx.format.as_deref().unwrap_or(CLOCK_DEFAULT_FORMAT);
+        let text = chrono::Local::now().format(fmt).to_string();
+        Ok(payload(Body::Bignum(BignumData { text })))
     }
 }
 
@@ -176,7 +188,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn static_text_uses_format_field() {
+    async fn static_text_single_line() {
         let p = StaticText.fetch(&ctx(Some("Hello!"))).await.unwrap();
         match p.body {
             Body::Text(t) => assert_eq!(t.lines, vec!["Hello!".to_string()]),
@@ -185,9 +197,74 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clock_stub_emits_bignum() {
-        let p = ClockStub.fetch(&ctx(None)).await.unwrap();
-        assert!(matches!(p.body, Body::Bignum(_)));
+    async fn static_text_splits_on_newline() {
+        let p = StaticText
+            .fetch(&ctx(Some("line one\nline two\nline three")))
+            .await
+            .unwrap();
+        match p.body {
+            Body::Text(t) => {
+                assert_eq!(
+                    t.lines,
+                    vec![
+                        "line one".to_string(),
+                        "line two".to_string(),
+                        "line three".to_string(),
+                    ]
+                );
+            }
+            _ => panic!("expected text body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn static_text_missing_format_is_empty() {
+        let p = StaticText.fetch(&ctx(None)).await.unwrap();
+        match p.body {
+            Body::Text(t) => assert!(t.lines.is_empty()),
+            _ => panic!("expected text body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn static_text_empty_format_is_empty() {
+        let p = StaticText.fetch(&ctx(Some(""))).await.unwrap();
+        match p.body {
+            Body::Text(t) => assert!(t.lines.is_empty()),
+            _ => panic!("expected text body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn static_text_trailing_newline_keeps_empty_line() {
+        // Users who don't want the trailing blank shouldn't trail a \n; we preserve split
+        // semantics so the rendered output matches the format string byte-for-byte.
+        let p = StaticText.fetch(&ctx(Some("a\n"))).await.unwrap();
+        match p.body {
+            Body::Text(t) => assert_eq!(t.lines, vec!["a".to_string(), "".to_string()]),
+            _ => panic!("expected text body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn clock_default_format_is_hh_mm() {
+        let p = ClockFetcher.fetch(&ctx(None)).await.unwrap();
+        match p.body {
+            Body::Bignum(d) => {
+                assert_eq!(d.text.len(), 5, "{:?} should be HH:MM", d.text);
+                assert_eq!(d.text.chars().nth(2), Some(':'));
+            }
+            _ => panic!("expected bignum body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn clock_honors_custom_format() {
+        let p = ClockFetcher.fetch(&ctx(Some("%Y"))).await.unwrap();
+        match p.body {
+            Body::Bignum(d) => assert_eq!(d.text.len(), 4, "{:?} should be 4-digit year", d.text),
+            _ => panic!("expected bignum body"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Replaces two placeholder fetchers with their v1 implementations and reorganizes the fetcher module so future widget PRs (#8 git, #9 system, #10 todo, #11 github) can slot in without further churn.

## What changes

- **\`clock\`**: \`chrono::Local::now().format(fmt)\` with default \`%H:%M\`. Invalid strftime directives no longer panic — chrono's \`to_string()\` escalates \`fmt::Error\` into a \`.expect()\` panic, so the fetch is wrapped in \`write!\` and falls back to the default format on error. Output stays as Bignum so the default layout's big-text renderer gets used.
- **\`static\`**: \`format\` splits on \`\\n\` into multiple Text lines. Empty / missing format emits an empty line list (widget renders nothing rather than a spurious blank). Trailing \`\\n\` preserves the trailing blank to match split semantics.
- **Module split**: \`src/fetcher/clock.rs\` and \`src/fetcher/static_text.rs\` each own their fetcher + tests. \`stub.rs\` is trimmed to the remaining placeholder fetchers (disk / git_commits / system / github_prs) and renames its aggregator from \`builtins()\` to \`stubs()\`. \`Registry::with_builtins\` composes from all three.

\`greeting\` was considered and dropped: time-of-day salutations in splash screens are filler. Users who want fixed text can use \`static\`.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` (125 passed, incl. default clock format is HH:MM, custom format, invalid-format fallback without panic, static single-line / multi-line / empty / trailing-newline)
- [ ] Manual: run \`splashboard\` and confirm the clock slot shows the real time
- [ ] Manual: \`format = "line one\\nline two"\` in a widget config and confirm two-line render

Closes #7.