### PR TITLE
feat(layout,render): chromeless widgets + content alignment

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -4,10 +4,8 @@
 
 [general]
 wait_for_fresh = false
-# Must be >= sum of all row lengths below (currently 2+4+6+4+4+3+5+7+6 = 41) or the bottom
-# widgets get clipped. Runtime additionally caps this at `terminal_rows - 1`, so on short
-# terminals trailing rows simply don't fit.
-height = 41
+# `height` omitted — runtime auto-sizes the inline viewport to fit every configured row.
+# Set it explicitly if you want padding below the last widget.
 
 # ── Lines shape: 4 renderers ──────────────────────────────────────────
 

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -17,23 +17,23 @@ format = "welcome back"
 [[widget]]
 id = "clock"
 fetcher = "clock"
-render = { type = "ascii_art", pixel_size = "quadrant" }
+render = { type = "ascii_art", pixel_size = "quadrant", align = "center" }
 
 [[widget]]
 id = "clock_figlet"
 fetcher = "clock"
-render = { type = "ascii_art", style = "figlet" }
+render = { type = "ascii_art", style = "figlet", align = "center" }
 
 [[widget]]
 id = "typewriter"
 fetcher = "static"
-render = "animated_typewriter"
+render = { type = "animated_typewriter", align = "center" }
 format = "animated_typewriter:\nreveals character by character while --wait ticks"
 
 [[widget]]
 id = "notes"
 fetcher = "static"
-render = "list"
+render = { type = "list", align = "center" }
 format = "ratatui::List widget\nalternative to simple\nselectable items, later"
 
 # ── Entries ─────────────────────────────────────────────────────────

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -11,18 +11,18 @@ height = 32
 [[widget]]
 id = "greeting_simple"
 fetcher = "static"
-render = "simple"
-format = "render = \"simple\"\nratatui Paragraph; flows multi-line format"
+render = { type = "simple", align = "center" }
+format = "welcome back"
 
 [[widget]]
-id = "clock_blocks"
+id = "clock"
 fetcher = "clock"
-render = { type = "ascii_art", style = "blocks", pixel_size = "quadrant" }
+render = { type = "ascii_art", pixel_size = "quadrant", align = "center" }
 
 [[widget]]
 id = "clock_figlet"
 fetcher = "clock"
-render = { type = "ascii_art", style = "figlet" }
+render = { type = "ascii_art", style = "figlet", align = "center" }
 
 [[widget]]
 id = "typewriter"
@@ -34,7 +34,7 @@ format = "animated_typewriter:\nreveals character by character while --wait tick
 id = "notes"
 fetcher = "static"
 render = "list"
-format = "render = \"list\"\nratatui::List widget\ndifferent from table"
+format = "ratatui::List widget\nalternative to simple\nselectable items, later"
 
 # ── Entries ─────────────────────────────────────────────────────────
 
@@ -89,32 +89,39 @@ fetcher = "today"
 render = "calendar"
 
 # ── Layout ──────────────────────────────────────────────────────────
+# Hero row: clock front-and-center, chromeless. Greeting centered, also chromeless.
+# Below, widgets pick their own chrome — some bordered for separation, some naked.
+
+[[row]]
+height = { length = 2 }
+
+  [[row.child]]
+  widget = "greeting_simple"
+  border = "none"
 
 [[row]]
 height = { length = 4 }
 
   [[row.child]]
-  widget = "greeting_simple"
-  title = "simple"
+  widget = "clock"
+  border = "none"
+
+  [[row.child]]
+  widget = "clock_figlet"
+  border = "none"
+
+[[row]]
+height = { length = 4 }
 
   [[row.child]]
   widget = "typewriter"
   title = "animated_typewriter"
+  border = "rounded"
 
   [[row.child]]
   widget = "notes"
   title = "list"
-
-[[row]]
-height = { length = 6 }
-
-  [[row.child]]
-  widget = "clock_blocks"
-  title = "ascii_art (blocks)"
-
-  [[row.child]]
-  widget = "clock_figlet"
-  title = "ascii_art (figlet)"
+  border = "rounded"
 
 [[row]]
 height = { length = 3 }
@@ -122,10 +129,12 @@ height = { length = 3 }
   [[row.child]]
   widget = "disk_gauge"
   title = "gauge"
+  border = "rounded"
 
   [[row.child]]
   widget = "disk_line"
   title = "line_gauge"
+  border = "rounded"
 
 [[row]]
 height = { length = 5 }
@@ -133,10 +142,12 @@ height = { length = 5 }
   [[row.child]]
   widget = "commits"
   title = "sparkline"
+  border = "rounded"
 
   [[row.child]]
   widget = "prs"
   title = "bar_chart"
+  border = "rounded"
 
 [[row]]
 height = { length = 7 }
@@ -144,14 +155,17 @@ height = { length = 7 }
   [[row.child]]
   widget = "trend_line"
   title = "chart_line"
+  border = "rounded"
 
   [[row.child]]
   widget = "trend_dots"
   title = "scatter"
+  border = "rounded"
 
   [[row.child]]
   widget = "today"
   title = "calendar"
+  border = "rounded"
 
 [[row]]
 height = { length = 6 }
@@ -159,3 +173,4 @@ height = { length = 6 }
   [[row.child]]
   widget = "system"
   title = "table"
+  border = "rounded"

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -4,7 +4,7 @@
 
 [general]
 wait_for_fresh = false
-height = 32
+height = 36
 
 # ── Lines shape: 4 renderers ──────────────────────────────────────────
 
@@ -17,12 +17,12 @@ format = "welcome back"
 [[widget]]
 id = "clock"
 fetcher = "clock"
-render = { type = "ascii_art", pixel_size = "quadrant", align = "center" }
+render = { type = "ascii_art", pixel_size = "quadrant" }
 
 [[widget]]
 id = "clock_figlet"
 fetcher = "clock"
-render = { type = "ascii_art", style = "figlet", align = "center" }
+render = { type = "ascii_art", style = "figlet" }
 
 [[widget]]
 id = "typewriter"
@@ -89,39 +89,51 @@ fetcher = "today"
 render = "calendar"
 
 # ── Layout ──────────────────────────────────────────────────────────
-# Hero row: clock front-and-center, chromeless. Greeting centered, also chromeless.
-# Below, widgets pick their own chrome — some bordered for separation, some naked.
+# Hero band: single-child rows with flex=center so the widget sits in the middle of the row
+# even though it's narrower than the terminal. 2-column rows below keep the default Legacy
+# flex so children split the row proportionally.
 
 [[row]]
 height = { length = 2 }
+flex = "center"
 
   [[row.child]]
   widget = "greeting_simple"
-  border = "none"
+  width = { length = 24 }
 
 [[row]]
 height = { length = 4 }
+flex = "center"
 
   [[row.child]]
   widget = "clock"
-  border = "none"
+  width = { length = 22 }
+
+[[row]]
+height = { length = 6 }
+flex = "center"
 
   [[row.child]]
   widget = "clock_figlet"
-  border = "none"
+  width = { length = 44 }
 
 [[row]]
 height = { length = 4 }
+flex = "center"
 
   [[row.child]]
   widget = "typewriter"
-  title = "animated_typewriter"
-  border = "rounded"
+  width = { length = 64 }
+
+[[row]]
+height = { length = 4 }
+flex = "center"
 
   [[row.child]]
   widget = "notes"
-  title = "list"
-  border = "rounded"
+  width = { length = 44 }
+
+# ── Dense 2-column rows from here on, default Legacy flex ─────────────
 
 [[row]]
 height = { length = 3 }

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -4,7 +4,10 @@
 
 [general]
 wait_for_fresh = false
-height = 36
+# Must be >= sum of all row lengths below (currently 2+4+6+4+4+3+5+7+6 = 41) or the bottom
+# widgets get clipped. Runtime additionally caps this at `terminal_rows - 1`, so on short
+# terminals trailing rows simply don't fit.
+height = 41
 
 # ── Lines shape: 4 renderers ──────────────────────────────────────────
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,26 @@ impl Config {
     pub fn to_layout(&self) -> Layout {
         Layout::rows(self.rows.iter().map(to_row_child).collect())
     }
+
+    /// Sum of row heights — what the inline viewport needs to be to fit every row without
+    /// clipping the bottom. Non-Length sizes fall back to reasonable approximations
+    /// (Min/Max use their value, Fill contributes a small default, Percentage is ignored
+    /// since it can't resolve without a known viewport).
+    pub fn computed_height(&self) -> u16 {
+        self.rows
+            .iter()
+            .map(|r| row_height_estimate(r.height))
+            .sum()
+    }
+}
+
+fn row_height_estimate(size: Option<SizeSpec>) -> u16 {
+    match size {
+        Some(SizeSpec::Length(n)) | Some(SizeSpec::Min(n)) | Some(SizeSpec::Max(n)) => n,
+        Some(SizeSpec::Fill(_)) => 3,
+        Some(SizeSpec::Percentage(_)) => 0,
+        None => 3,
+    }
 }
 
 pub const LOCAL_CONFIG_CANDIDATES: &[&str] = &[".splashboard/config.toml", ".splashboard.toml"];

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,9 +77,12 @@ pub enum SizeSpec {
     Percentage(u16),
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum BorderSpec {
+    /// No chrome at all — widget fills its full cell, no title drawn. Useful for hero
+    /// elements like a big clock that should own its slot without framing.
+    None,
     Plain,
     Rounded,
     Thick,
@@ -174,22 +177,29 @@ fn make_child(size: Option<SizeSpec>, layout: Layout) -> Child {
 }
 
 fn apply_panel(layout: Layout, title: Option<&str>, border: Option<BorderSpec>) -> Layout {
+    // Explicit `border = "none"` opts out of chrome entirely — skip the panel even if a title
+    // was set (a bare title without a border to anchor it to doesn't render, and pretending it
+    // would be worse than dropping it).
+    if matches!(border, Some(BorderSpec::None)) {
+        return layout;
+    }
     let l = match title {
         Some(t) => layout.titled(t),
         None => layout,
     };
-    match border {
-        Some(b) => l.bordered(to_border_style(b)),
+    match border.and_then(to_border_style) {
+        Some(b) => l.bordered(b),
         None => l,
     }
 }
 
-fn to_border_style(b: BorderSpec) -> BorderStyle {
+fn to_border_style(b: BorderSpec) -> Option<BorderStyle> {
     match b {
-        BorderSpec::Plain => BorderStyle::Plain,
-        BorderSpec::Rounded => BorderStyle::Rounded,
-        BorderSpec::Thick => BorderStyle::Thick,
-        BorderSpec::Double => BorderStyle::Double,
+        BorderSpec::None => None,
+        BorderSpec::Plain => Some(BorderStyle::Plain),
+        BorderSpec::Rounded => Some(BorderStyle::Rounded),
+        BorderSpec::Thick => Some(BorderStyle::Thick),
+        BorderSpec::Double => Some(BorderStyle::Double),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,20 +177,19 @@ fn make_child(size: Option<SizeSpec>, layout: Layout) -> Child {
 }
 
 fn apply_panel(layout: Layout, title: Option<&str>, border: Option<BorderSpec>) -> Layout {
-    // Explicit `border = "none"` opts out of chrome entirely — skip the panel even if a title
-    // was set (a bare title without a border to anchor it to doesn't render, and pretending it
-    // would be worse than dropping it).
-    if matches!(border, Some(BorderSpec::None)) {
+    // Chrome is opt-in: no border, no panel — even if a title was set. A bare title has no
+    // border to render on, so dropping it cleanly is better than pretending. Users who want
+    // the framed-with-label look set `border = "rounded"` (or plain/thick/double) explicitly
+    // on the widgets that deserve it (charts, tables), keeping hero widgets (clock, greeting)
+    // chromeless by default.
+    let Some(style) = border.and_then(to_border_style) else {
         return layout;
-    }
+    };
     let l = match title {
         Some(t) => layout.titled(t),
         None => layout,
     };
-    match border.and_then(to_border_style) {
-        Some(b) => l.bordered(b),
-        None => l,
-    }
+    l.bordered(style)
 }
 
 fn to_border_style(b: BorderSpec) -> Option<BorderStyle> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::layout::{BorderStyle, Child, Layout};
+use crate::layout::{BorderStyle, Child, Flex, Layout};
 use crate::render::RenderSpec;
 
 const DEFAULT_CONFIG: &str = include_str!("default_config.toml");
@@ -52,8 +52,23 @@ pub struct RowConfig {
     pub title: Option<String>,
     #[serde(default)]
     pub border: Option<BorderSpec>,
+    /// How children are placed along this row's horizontal axis when they don't fill the row.
+    /// `center` is the obvious use case: a narrower widget parked in the middle of its row.
+    #[serde(default)]
+    pub flex: Option<FlexSpec>,
     #[serde(default, rename = "child")]
     pub children: Vec<ChildConfig>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FlexSpec {
+    Legacy,
+    Start,
+    Center,
+    End,
+    SpaceBetween,
+    SpaceAround,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -154,9 +169,23 @@ fn find_local_at(dir: &Path) -> Option<PathBuf> {
 }
 
 fn to_row_child(row: &RowConfig) -> Child {
-    let inner = Layout::cols(row.children.iter().map(to_col_child).collect());
+    let mut inner = Layout::cols(row.children.iter().map(to_col_child).collect());
+    if let Some(f) = row.flex {
+        inner = inner.flexed(to_flex(f));
+    }
     let decorated = apply_panel(inner, row.title.as_deref(), row.border);
     make_child(row.height, decorated)
+}
+
+fn to_flex(f: FlexSpec) -> Flex {
+    match f {
+        FlexSpec::Legacy => Flex::Legacy,
+        FlexSpec::Start => Flex::Start,
+        FlexSpec::Center => Flex::Center,
+        FlexSpec::End => Flex::End,
+        FlexSpec::SpaceBetween => Flex::SpaceBetween,
+        FlexSpec::SpaceAround => Flex::SpaceAround,
+    }
 }
 
 fn to_col_child(c: &ChildConfig) -> Child {

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -37,11 +37,9 @@ height = { min = 6 }
 
   [[row.child]]
   widget = "greeting"
-  title = "Greeting"
 
   [[row.child]]
   widget = "clock"
-  title = "Clock"
 
 [[row]]
 height = { length = 5 }
@@ -49,10 +47,12 @@ height = { length = 5 }
   [[row.child]]
   widget = "disk"
   title = "Disk /"
+  border = "rounded"
 
   [[row.child]]
   widget = "commits"
   title = "Commits (14d)"
+  border = "rounded"
 
 [[row]]
 height = { length = 5 }
@@ -60,7 +60,9 @@ height = { length = 5 }
   [[row.child]]
   widget = "system"
   title = "System"
+  border = "rounded"
 
   [[row.child]]
   widget = "prs"
   title = "Open PRs"
+  border = "rounded"

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction as RatDir, Layout as RatLayout, Rect},
+    layout::{Constraint, Direction as RatDir, Flex as RatFlex, Layout as RatLayout, Rect},
     widgets::{Block, BorderType, Borders},
 };
 
@@ -17,6 +17,7 @@ pub enum Layout {
         direction: Direction,
         children: Vec<Child>,
         panel: Option<Panel>,
+        flex: Flex,
     },
     Widget {
         id: WidgetId,
@@ -24,6 +25,21 @@ pub enum Layout {
     },
     #[allow(dead_code)]
     Empty,
+}
+
+/// How children are distributed along the stack's main axis when their constraints don't fill
+/// the available space. `Legacy` is ratatui's default (proportional fill with Fill constraints);
+/// `Center` / `Start` / `End` / `SpaceBetween` etc. take a narrower set of children and place
+/// them within the parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Flex {
+    #[default]
+    Legacy,
+    Start,
+    Center,
+    End,
+    SpaceBetween,
+    SpaceAround,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,6 +89,7 @@ impl Layout {
             direction: Direction::Vertical,
             children,
             panel: None,
+            flex: Flex::Legacy,
         }
     }
 
@@ -81,6 +98,24 @@ impl Layout {
             direction: Direction::Horizontal,
             children,
             panel: None,
+            flex: Flex::Legacy,
+        }
+    }
+
+    pub fn flexed(self, flex: Flex) -> Self {
+        match self {
+            Self::Stack {
+                direction,
+                children,
+                panel,
+                flex: _,
+            } => Self::Stack {
+                direction,
+                children,
+                panel,
+                flex,
+            },
+            other => other,
         }
     }
 
@@ -111,12 +146,14 @@ impl Layout {
                 direction,
                 children,
                 panel,
+                flex,
             } => {
                 let p = f(panel.unwrap_or_default());
                 Self::Stack {
                     direction,
                     children,
                     panel: Some(p),
+                    flex,
                 }
             }
             Self::Widget { id, panel } => {
@@ -192,9 +229,12 @@ pub fn draw(
             direction,
             children,
             panel,
+            flex,
         } => {
             let inner = draw_panel(frame, area, panel);
-            draw_stack(frame, inner, *direction, children, widgets, specs, registry);
+            draw_stack(
+                frame, inner, *direction, *flex, children, widgets, specs, registry,
+            );
         }
         Layout::Widget { id, panel } => {
             let inner = draw_panel(frame, area, panel);
@@ -237,10 +277,12 @@ fn to_border_type(style: BorderStyle) -> BorderType {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_stack(
     frame: &mut Frame,
     area: Rect,
     direction: Direction,
+    flex: Flex,
     children: &[Child],
     widgets: &HashMap<WidgetId, Payload>,
     specs: &HashMap<WidgetId, RenderSpec>,
@@ -250,9 +292,21 @@ fn draw_stack(
     let rects = RatLayout::default()
         .direction(to_ratatui_direction(direction))
         .constraints(constraints)
+        .flex(to_ratatui_flex(flex))
         .split(area);
     for (child, rect) in children.iter().zip(rects.iter()) {
         draw(frame, *rect, &child.layout, widgets, specs, registry);
+    }
+}
+
+fn to_ratatui_flex(flex: Flex) -> RatFlex {
+    match flex {
+        Flex::Legacy => RatFlex::Legacy,
+        Flex::Start => RatFlex::Start,
+        Flex::Center => RatFlex::Center,
+        Flex::End => RatFlex::End,
+        Flex::SpaceBetween => RatFlex::SpaceBetween,
+        Flex::SpaceAround => RatFlex::SpaceAround,
     }
 }
 

--- a/src/render/animated_typewriter.rs
+++ b/src/render/animated_typewriter.rs
@@ -1,7 +1,11 @@
 use std::sync::OnceLock;
 use std::time::Instant;
 
-use ratatui::{Frame, layout::Rect, widgets::Paragraph};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    widgets::Paragraph,
+};
 
 use crate::payload::{Body, LinesData};
 
@@ -25,18 +29,27 @@ impl Renderer for AnimatedTypewriterRenderer {
     fn animates(&self) -> bool {
         true
     }
-    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, _opts: &RenderOptions) {
+    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
         if let Body::Lines(d) = body {
-            render_typewriter(frame, area, d);
+            render_typewriter(frame, area, d, opts);
         }
     }
 }
 
-fn render_typewriter(frame: &mut Frame, area: Rect, data: &LinesData) {
+fn render_typewriter(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
     let total: usize = data.lines.iter().map(|l| l.chars().count() + 1).sum();
     let budget = chars_revealed(total);
     let revealed = reveal(&data.lines, budget);
-    frame.render_widget(Paragraph::new(revealed), area);
+    let p = Paragraph::new(revealed).alignment(parse_align(opts.align.as_deref()));
+    frame.render_widget(p, area);
+}
+
+fn parse_align(s: Option<&str>) -> Alignment {
+    match s {
+        Some("center") => Alignment::Center,
+        Some("right") => Alignment::Right,
+        _ => Alignment::Left,
+    }
 }
 
 /// Characters that should be visible given the time elapsed since render loop start.

--- a/src/render/ascii_art.rs
+++ b/src/render/ascii_art.rs
@@ -24,7 +24,7 @@ impl Renderer for AsciiArtRenderer {
     fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
         if let Body::Lines(d) = body {
             match opts.style.as_deref() {
-                Some("figlet") => render_figlet(frame, area, d),
+                Some("figlet") => render_figlet(frame, area, d, opts),
                 _ => render_blocks(frame, area, d, opts),
             }
         }
@@ -37,22 +37,65 @@ fn render_blocks(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderO
         .as_deref()
         .and_then(parse_pixel_size)
         .unwrap_or_else(|| pick_pixel_size(area));
+    let natural_width = blocks_width(&data.lines, pixel_size);
+    let target = align_rect(area, natural_width, opts.align.as_deref());
     let lines: Vec<_> = data.lines.iter().map(|s| s.clone().into()).collect();
     let big = BigText::builder()
         .pixel_size(pixel_size)
         .lines(lines)
         .build();
-    frame.render_widget(big, area);
+    frame.render_widget(big, target);
 }
 
-fn render_figlet(frame: &mut Frame, area: Rect, data: &LinesData) {
+fn render_figlet(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
     let rendered = data
         .lines
         .iter()
         .map(|l| figletify(l))
         .collect::<Vec<_>>()
         .join("\n");
-    frame.render_widget(Paragraph::new(rendered), area);
+    let p = Paragraph::new(rendered).alignment(parse_alignment(opts.align.as_deref()));
+    frame.render_widget(p, area);
+}
+
+/// Maximum natural width (in terminal cells) of a tui-big-text block string at the given
+/// pixel size. Based on the 8x8 base font; `pixels_per_cell` compresses each axis. Only the
+/// three variants we recognise in `parse_pixel_size` are listed — anything else falls back to
+/// a conservative default.
+fn blocks_width(lines: &[String], pixel_size: PixelSize) -> u16 {
+    let max_chars = lines.iter().map(|l| l.chars().count()).max().unwrap_or(0) as u16;
+    let glyph_cols = match pixel_size {
+        PixelSize::Full => 8,
+        PixelSize::Quadrant => 4,
+        PixelSize::Sextant => 4,
+        _ => 4,
+    };
+    max_chars.saturating_mul(glyph_cols)
+}
+
+fn align_rect(area: Rect, content_width: u16, align: Option<&str>) -> Rect {
+    if content_width == 0 || content_width >= area.width {
+        return area;
+    }
+    let offset = match align {
+        Some("center") => (area.width - content_width) / 2,
+        Some("right") => area.width - content_width,
+        _ => return area,
+    };
+    Rect {
+        x: area.x + offset,
+        y: area.y,
+        width: content_width,
+        height: area.height,
+    }
+}
+
+fn parse_alignment(s: Option<&str>) -> ratatui::layout::Alignment {
+    match s {
+        Some("center") => ratatui::layout::Alignment::Center,
+        Some("right") => ratatui::layout::Alignment::Right,
+        _ => ratatui::layout::Alignment::Left,
+    }
 }
 
 fn figletify(text: &str) -> String {

--- a/src/render/list.rs
+++ b/src/render/list.rs
@@ -8,6 +8,23 @@ use crate::payload::{Body, LinesData};
 
 use super::{RenderOptions, Renderer, Shape};
 
+fn align_rect(area: Rect, content_width: u16, align: Option<&str>) -> Rect {
+    if content_width == 0 || content_width >= area.width {
+        return area;
+    }
+    let offset = match align {
+        Some("center") => (area.width - content_width) / 2,
+        Some("right") => area.width - content_width,
+        _ => return area,
+    };
+    Rect {
+        x: area.x + offset,
+        y: area.y,
+        width: content_width,
+        height: area.height,
+    }
+}
+
 /// Renders lines through ratatui's `List` widget. Behaviourally close to `simple` today; the
 /// distinction matters once we add list-specific options (bullet marker, highlight selected
 /// item, scrollbar). Alternate renderer for the `Lines` shape so tests of the 1→N dispatch
@@ -21,20 +38,27 @@ impl Renderer for ListRenderer {
     fn accepts(&self) -> &[Shape] {
         &[Shape::Lines]
     }
-    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, _opts: &RenderOptions) {
+    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
         if let Body::Lines(d) = body {
-            render_list(frame, area, d);
+            render_list(frame, area, d, opts);
         }
     }
 }
 
-fn render_list(frame: &mut Frame, area: Rect, data: &LinesData) {
+fn render_list(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
+    let max = data
+        .lines
+        .iter()
+        .map(|l| l.chars().count() as u16)
+        .max()
+        .unwrap_or(0);
+    let target = align_rect(area, max, opts.align.as_deref());
     let items: Vec<ListItem> = data
         .lines
         .iter()
         .map(|l| ListItem::new(l.clone()))
         .collect();
-    frame.render_widget(List::new(items), area);
+    frame.render_widget(List::new(items), target);
 }
 
 #[cfg(test)]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -64,6 +64,11 @@ pub struct RenderOptions {
     /// height). Ignored by other styles.
     #[serde(default)]
     pub pixel_size: Option<String>,
+    /// Horizontal alignment of the rendered content within its cell: "left" (default),
+    /// "center", or "right". Not every renderer honours this — simple text and ascii_art do;
+    /// structural renderers (table, gauge, charts) ignore it.
+    #[serde(default)]
+    pub align: Option<String>,
 }
 
 /// What the TOML accepts for `render`. Short form `render = "simple"` uses defaults; long form

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -1,11 +1,16 @@
-use ratatui::{Frame, layout::Rect, widgets::Paragraph};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    widgets::Paragraph,
+};
 
 use crate::payload::{Body, LinesData};
 
 use super::{RenderOptions, Renderer, Shape};
 
 /// Plain-text renderer: stacks `LinesData.lines` into a ratatui `Paragraph`. The default
-/// renderer for the `Lines` shape, used for greetings, project notes, static blocks.
+/// renderer for the `Lines` shape, used for greetings, project notes, static blocks. Honours
+/// the `align` option (left / center / right).
 pub struct SimpleRenderer;
 
 impl Renderer for SimpleRenderer {
@@ -15,15 +20,24 @@ impl Renderer for SimpleRenderer {
     fn accepts(&self) -> &[Shape] {
         &[Shape::Lines]
     }
-    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, _opts: &RenderOptions) {
+    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
         if let Body::Lines(d) = body {
-            render_lines(frame, area, d);
+            render_lines(frame, area, d, opts);
         }
     }
 }
 
-fn render_lines(frame: &mut Frame, area: Rect, data: &LinesData) {
-    frame.render_widget(Paragraph::new(data.lines.join("\n")), area);
+fn render_lines(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
+    let p = Paragraph::new(data.lines.join("\n")).alignment(parse_align(opts.align.as_deref()));
+    frame.render_widget(p, area);
+}
+
+fn parse_align(s: Option<&str>) -> Alignment {
+    match s {
+        Some("center") => Alignment::Center,
+        Some("right") => Alignment::Right,
+        _ => Alignment::Left,
+    }
 }
 
 #[cfg(test)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -68,10 +68,14 @@ pub async fn run(
         (true, _) => Some(WAIT_DEADLINE),
     };
 
-    // Cap the inline viewport at terminal_height - 1 so there's always one row left below it
-    // for the shell prompt to land on cleanly. If we exceed the terminal height, the final
-    // `println!()` on exit forces a scroll and shaves off the top of the splash.
-    let requested_height = config.general.height.unwrap_or(DEFAULT_VIEWPORT_LINES);
+    // Default viewport = sum of configured row heights so every widget fits without manual
+    // tuning. Users can still override with `general.height` when they want padding or are
+    // using Percentage sizes. Clamped to `terminal_rows - 1` so there's always one row left
+    // below the viewport for the shell prompt to land on cleanly.
+    let requested_height = config
+        .general
+        .height
+        .unwrap_or_else(|| config.computed_height().max(DEFAULT_VIEWPORT_LINES));
     let term_rows = ratatui::crossterm::terminal::size()
         .map(|(_, h)| h)
         .unwrap_or(requested_height);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -68,7 +68,14 @@ pub async fn run(
         (true, _) => Some(WAIT_DEADLINE),
     };
 
-    let viewport_lines = config.general.height.unwrap_or(DEFAULT_VIEWPORT_LINES);
+    // Cap the inline viewport at terminal_height - 1 so there's always one row left below it
+    // for the shell prompt to land on cleanly. If we exceed the terminal height, the final
+    // `println!()` on exit forces a scroll and shaves off the top of the splash.
+    let requested_height = config.general.height.unwrap_or(DEFAULT_VIEWPORT_LINES);
+    let term_rows = ratatui::crossterm::terminal::size()
+        .map(|(_, h)| h)
+        .unwrap_or(requested_height);
+    let viewport_lines = requested_height.min(term_rows.saturating_sub(1)).max(1);
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = make_terminal(backend, viewport_lines)?;
 


### PR DESCRIPTION
Two layout knobs to escape "everything boxed" dashboards:

- **\`border = \"none\"\`** — new \`BorderSpec::None\`; skip Panel entirely (no chrome, title dropped). Existing borders (plain / rounded / thick / double) unchanged.
- **\`align\` on RenderOptions** — \"left\" (default) / \"center\" / \"right\". Honoured by \`simple\` (Paragraph::alignment), \`ascii_art\` blocks (computed sub-rect based on tui-big-text 8×8 font + pixels_per_cell), \`ascii_art\` figlet (Paragraph over figlet output). Structural renderers (table, gauge, charts) ignore it — centering a bar chart isn't meaningful.

Dogfood \`.splashboard/config.toml\` updated: greeting + both clocks are chromeless and centered as a hero band; the rest keep rounded borders for slot separation.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` (142 passed)
- [ ] Manual: \`cargo run\` — verify hero clock is centered without a border, bottom widgets still boxed
- [ ] Manual: change \`align = \"right\"\` on simple widget, re-run, verify right alignment