### PR TITLE
feat(fetcher): introduce RealtimeFetcher trait for clock-like widgets

### DIFF
--- a/src/fetcher/clock.rs
+++ b/src/fetcher/clock.rs
@@ -1,36 +1,35 @@
 use std::fmt::Write;
 
-use async_trait::async_trait;
 use chrono::Local;
 
 use crate::payload::{Body, LinesData, Payload};
 
-use super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{FetchContext, RealtimeFetcher, Safety};
 
 const DEFAULT_FORMAT: &str = "%H:%M";
 
 /// Renders the current local time. `format` follows chrono's strftime conventions; default is
-/// `%H:%M` (24h clock). Emits a Bignum payload so the default layout can lean on the big-text
-/// renderer for visual weight.
+/// `%H:%M` (24h clock). Classified as [`RealtimeFetcher`] so the value is recomputed on every
+/// frame instead of being pulled from a stale cache entry.
 pub struct ClockFetcher;
 
-#[async_trait]
-impl Fetcher for ClockFetcher {
+impl RealtimeFetcher for ClockFetcher {
     fn name(&self) -> &str {
         "clock"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
     }
-    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+    fn compute(&self, ctx: &FetchContext) -> Payload {
         let fmt = ctx.format.as_deref().unwrap_or(DEFAULT_FORMAT);
-        let text = format_now(fmt);
-        Ok(Payload {
+        Payload {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData { lines: vec![text] }),
-        })
+            body: Body::Lines(LinesData {
+                lines: vec![format_now(fmt)],
+            }),
+        }
     }
 }
 
@@ -44,10 +43,7 @@ fn format_now(fmt: &str) -> String {
     if write!(&mut buf, "{}", now.format(fmt)).is_ok() {
         return buf;
     }
-    // The partial write on error may leave buf in an unusable state; discard it.
     let mut fallback = String::new();
-    // `write!` on the default format is infallible; `unwrap_or_default` keeps it panic-free
-    // even if some future version of chrono changes that invariant.
     let _ = write!(&mut fallback, "{}", now.format(DEFAULT_FORMAT));
     fallback
 }
@@ -73,32 +69,32 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn default_format_is_hh_mm() {
-        let text = first_line(ClockFetcher.fetch(&ctx(None)).await.unwrap());
+    #[test]
+    fn default_format_is_hh_mm() {
+        let text = first_line(ClockFetcher.compute(&ctx(None)));
         assert_eq!(text.len(), 5, "{text:?} should be HH:MM");
         assert_eq!(text.chars().nth(2), Some(':'));
     }
 
-    #[tokio::test]
-    async fn custom_format_is_honored() {
-        let text = first_line(ClockFetcher.fetch(&ctx(Some("%Y"))).await.unwrap());
+    #[test]
+    fn custom_format_is_honored() {
+        let text = first_line(ClockFetcher.compute(&ctx(Some("%Y"))));
         assert_eq!(text.len(), 4, "{text:?} should be YYYY");
     }
 
-    #[tokio::test]
-    async fn invalid_format_falls_back_without_panicking() {
+    #[test]
+    fn invalid_format_falls_back_without_panicking() {
         // `%Q` is not a recognised strftime directive; chrono's formatter returns `fmt::Error`
         // for it, which would panic through `to_string()`. Our wrapper must return a valid
         // default-formatted string instead.
-        let text = first_line(ClockFetcher.fetch(&ctx(Some("%Q"))).await.unwrap());
+        let text = first_line(ClockFetcher.compute(&ctx(Some("%Q"))));
         assert_eq!(text.len(), 5, "expected fallback HH:MM, got {text:?}");
         assert_eq!(text.chars().nth(2), Some(':'));
     }
 
-    #[tokio::test]
-    async fn literal_percent_in_format_does_not_crash() {
-        let text = first_line(ClockFetcher.fetch(&ctx(Some("now: %H:%M"))).await.unwrap());
+    #[test]
+    fn literal_percent_in_format_does_not_crash() {
+        let text = first_line(ClockFetcher.compute(&ctx(Some("now: %H:%M"))));
         assert!(text.starts_with("now: "));
     }
 }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -57,6 +57,16 @@ pub trait Fetcher: Send + Sync {
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError>;
 }
 
+/// Fetchers whose value is intrinsically "right now" — wall clock, instantaneous system counters,
+/// countdowns. Contract: computed in <1ms, infallible, no I/O. Bypasses the disk cache entirely
+/// and is recomputed by the runtime on every frame. If a prospective fetcher can't meet that
+/// contract, it belongs on [`Fetcher`] instead.
+pub trait RealtimeFetcher: Send + Sync {
+    fn name(&self) -> &str;
+    fn safety(&self) -> Safety;
+    fn compute(&self, ctx: &FetchContext) -> Payload;
+}
+
 pub fn default_cache_key(name: &str, ctx: &FetchContext) -> String {
     use sha2::{Digest, Sha256};
     let raw = format!("{}|{}", name, ctx.format.as_deref().unwrap_or(""));
@@ -65,28 +75,81 @@ pub fn default_cache_key(name: &str, ctx: &FetchContext) -> String {
     format!("{name}-{hex}")
 }
 
+/// Registry entry — either a cache-backed async fetcher or a recompute-each-frame realtime one.
+/// The trust gate and name lookup work against this unified type; runtime unwraps to the specific
+/// kind only when it needs the kind-specific behavior (cache I/O vs. per-frame compute).
+#[derive(Clone)]
+pub enum RegisteredFetcher {
+    Cached(Arc<dyn Fetcher>),
+    Realtime(Arc<dyn RealtimeFetcher>),
+}
+
+impl RegisteredFetcher {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Cached(f) => f.name(),
+            Self::Realtime(f) => f.name(),
+        }
+    }
+    pub fn safety(&self) -> Safety {
+        match self {
+            Self::Cached(f) => f.safety(),
+            Self::Realtime(f) => f.safety(),
+        }
+    }
+    pub fn as_cached(&self) -> Option<Arc<dyn Fetcher>> {
+        match self {
+            Self::Cached(f) => Some(f.clone()),
+            Self::Realtime(_) => None,
+        }
+    }
+    pub fn as_realtime(&self) -> Option<Arc<dyn RealtimeFetcher>> {
+        match self {
+            Self::Realtime(f) => Some(f.clone()),
+            Self::Cached(_) => None,
+        }
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct Registry {
-    fetchers: HashMap<String, Arc<dyn Fetcher>>,
+    fetchers: HashMap<String, RegisteredFetcher>,
 }
 
 impl Registry {
     pub fn with_builtins() -> Self {
         let mut r = Self::default();
         r.register(Arc::new(static_text::StaticText));
-        r.register(Arc::new(clock::ClockFetcher));
+        r.register_realtime(Arc::new(clock::ClockFetcher));
         for f in stub::stubs() {
             r.register(f);
+        }
+        for f in stub::realtime_stubs() {
+            r.register_realtime(f);
         }
         r
     }
 
     pub fn register(&mut self, f: Arc<dyn Fetcher>) {
-        self.fetchers.insert(f.name().to_string(), f);
+        self.fetchers
+            .insert(f.name().to_string(), RegisteredFetcher::Cached(f));
     }
 
-    pub fn get(&self, name: &str) -> Option<Arc<dyn Fetcher>> {
+    pub fn register_realtime(&mut self, f: Arc<dyn RealtimeFetcher>) {
+        self.fetchers
+            .insert(f.name().to_string(), RegisteredFetcher::Realtime(f));
+    }
+
+    pub fn get(&self, name: &str) -> Option<RegisteredFetcher> {
         self.fetchers.get(name).cloned()
+    }
+
+    pub fn get_cached(&self, name: &str) -> Option<Arc<dyn Fetcher>> {
+        self.get(name).and_then(|f| f.as_cached())
+    }
+
+    pub fn get_realtime(&self, name: &str) -> Option<Arc<dyn RealtimeFetcher>> {
+        self.get(name).and_then(|f| f.as_realtime())
     }
 
     pub fn names(&self) -> Vec<&str> {
@@ -119,6 +182,25 @@ mod tests {
         }
     }
 
+    struct DummyRealtime(&'static str, Safety);
+
+    impl RealtimeFetcher for DummyRealtime {
+        fn name(&self) -> &str {
+            self.0
+        }
+        fn safety(&self) -> Safety {
+            self.1
+        }
+        fn compute(&self, _: &FetchContext) -> Payload {
+            Payload {
+                icon: None,
+                status: None,
+                format: None,
+                body: Body::Lines(LinesData { lines: vec![] }),
+            }
+        }
+    }
+
     #[test]
     fn registry_register_and_get() {
         let mut r = Registry::default();
@@ -128,9 +210,46 @@ mod tests {
     }
 
     #[test]
+    fn registry_register_realtime_and_get() {
+        let mut r = Registry::default();
+        r.register_realtime(Arc::new(DummyRealtime("rt", Safety::Safe)));
+        let entry = r.get("rt").expect("must be present");
+        assert!(matches!(entry, RegisteredFetcher::Realtime(_)));
+        assert_eq!(entry.safety(), Safety::Safe);
+    }
+
+    #[test]
+    fn registry_name_collision_replaces() {
+        // Registering the same name twice — second wins. Prevents both-kinds-of-fetcher confusion.
+        let mut r = Registry::default();
+        r.register(Arc::new(Dummy("x", Safety::Safe)));
+        r.register_realtime(Arc::new(DummyRealtime("x", Safety::Network)));
+        let entry = r.get("x").unwrap();
+        assert!(matches!(entry, RegisteredFetcher::Realtime(_)));
+        assert_eq!(entry.safety(), Safety::Network);
+    }
+
+    #[test]
+    fn as_cached_and_as_realtime_are_mutually_exclusive() {
+        let cached = RegisteredFetcher::Cached(Arc::new(Dummy("c", Safety::Safe)));
+        assert!(cached.as_cached().is_some());
+        assert!(cached.as_realtime().is_none());
+        let rt = RegisteredFetcher::Realtime(Arc::new(DummyRealtime("r", Safety::Safe)));
+        assert!(rt.as_realtime().is_some());
+        assert!(rt.as_cached().is_none());
+    }
+
+    #[test]
     fn with_builtins_registers_static_fetcher() {
         let r = Registry::with_builtins();
         assert!(r.get("static").is_some());
+    }
+
+    #[test]
+    fn with_builtins_registers_clock_as_realtime() {
+        let r = Registry::with_builtins();
+        let entry = r.get("clock").expect("clock must be registered");
+        assert!(matches!(entry, RegisteredFetcher::Realtime(_)));
     }
 
     #[tokio::test]

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -12,7 +12,7 @@ use crate::payload::{
     PointSeriesData, RatioData, Status,
 };
 
-use super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{FetchContext, FetchError, Fetcher, RealtimeFetcher, Safety};
 
 pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
     vec![
@@ -21,8 +21,11 @@ pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(SystemStub),
         Arc::new(GithubPrsStub),
         Arc::new(TrendStub),
-        Arc::new(TodayStub),
     ]
+}
+
+pub fn realtime_stubs() -> Vec<Arc<dyn RealtimeFetcher>> {
+    vec![Arc::new(TodayStub)]
 }
 
 pub struct DiskStub;
@@ -154,23 +157,22 @@ impl Fetcher for TrendStub {
 
 pub struct TodayStub;
 
-#[async_trait]
-impl Fetcher for TodayStub {
+impl RealtimeFetcher for TodayStub {
     fn name(&self) -> &str {
         "today"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
     }
-    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
+    fn compute(&self, _: &FetchContext) -> Payload {
         use chrono::Datelike;
         let now = chrono::Local::now().date_naive();
-        Ok(payload(Body::Calendar(CalendarData {
+        payload(Body::Calendar(CalendarData {
             year: now.year(),
             month: now.month() as u8,
             day: Some(now.day() as u8),
             events: Vec::new(),
-        })))
+        }))
     }
 }
 
@@ -193,21 +195,24 @@ mod tests {
         assert_eq!(SystemStub.safety(), Safety::Safe);
         assert_eq!(GitCommitsStub.safety(), Safety::Exec);
         assert_eq!(GithubPrsStub.safety(), Safety::Network);
+        assert_eq!(RealtimeFetcher::safety(&TodayStub), Safety::Safe);
     }
 
     #[test]
-    fn all_stubs_are_registered() {
+    fn all_cached_stubs_are_registered() {
         let fetchers = stubs();
         let names: Vec<&str> = fetchers.iter().map(|f| f.name()).collect();
-        for expected in [
-            "disk",
-            "git_commits",
-            "system",
-            "github_prs",
-            "trend",
-            "today",
-        ] {
+        for expected in ["disk", "git_commits", "system", "github_prs", "trend"] {
             assert!(names.contains(&expected), "missing stub: {expected}");
         }
+    }
+
+    #[test]
+    fn realtime_stubs_includes_today() {
+        let names: Vec<String> = realtime_stubs()
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        assert!(names.iter().any(|n| n == "today"));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,6 +18,33 @@ use crate::payload::Payload;
 use crate::render::{self, RenderSpec};
 use crate::trust::{self, TrustStore};
 
+/// Split trust-passed widgets into cached (disk-backed, fetched async via daemon) and realtime
+/// (recomputed on every frame, no disk I/O). Keeps the rest of the runtime simple: cache-aware
+/// code only sees cached widgets, per-frame code only sees realtime widgets.
+fn split_by_fetcher_kind(
+    widgets: &[WidgetConfig],
+    registry: &Registry,
+) -> (Vec<WidgetConfig>, Vec<WidgetConfig>) {
+    widgets
+        .iter()
+        .cloned()
+        .partition(|w| registry.get_cached(&w.fetcher).is_some())
+}
+
+fn compute_realtime_payloads(
+    registry: &Registry,
+    widgets: &[WidgetConfig],
+) -> HashMap<WidgetId, Payload> {
+    widgets
+        .iter()
+        .filter_map(|w| {
+            let fetcher = registry.get_realtime(&w.fetcher)?;
+            let ctx = fetch_context(w, Duration::from_secs(0));
+            Some((w.id.clone(), fetcher.compute(&ctx)))
+        })
+        .collect()
+}
+
 const DEFAULT_REFRESH_SECS: u64 = 60;
 const FAST_DEADLINE: Duration = Duration::from_millis(1500);
 const WAIT_DEADLINE: Duration = Duration::from_secs(5);
@@ -48,15 +75,23 @@ pub async fn run(
     let decision = TrustStore::load().decide(config_ident);
     let (fetchable, gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
 
-    let entries = load_entries(cache.as_ref(), &registry, &fetchable);
+    // Cached widgets go through disk cache + async daemon. Realtime widgets recompute each
+    // frame and never touch disk.
+    let (cached_widgets, realtime_widgets) = split_by_fetcher_kind(&fetchable, &registry);
+
+    let entries = load_entries(cache.as_ref(), &registry, &cached_widgets);
     let mut payloads = entries_to_payloads(&entries);
+    payloads.extend(compute_realtime_payloads(&registry, &realtime_widgets));
     for w in &gated {
         payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
     }
 
-    // Load axis: decide whether to block on fresh data. Empty cache gets promoted to wait
-    // so we don't exit with a blank terminal on first run.
-    let wait = wait || config.general.wait_for_fresh || entries.is_empty();
+    // Load axis: decide whether to block on fresh data. If there are any cached widgets with no
+    // entry yet, promote to wait so we don't exit with a blank terminal on first run. Realtime
+    // widgets don't count — they're always fresh.
+    let wait = wait
+        || config.general.wait_for_fresh
+        || (!cached_widgets.is_empty() && entries.is_empty());
 
     // Render axis: decide whether any configured renderer needs repeat frames. Independent of
     // the load decision — an animated widget must animate regardless of cache state.
@@ -99,7 +134,14 @@ pub async fn run(
             // daemon finishes (if we were waiting for it) or the window expires.
             let deadline = std::time::Instant::now() + window;
             loop {
-                refresh_payloads(&cache, &registry, &fetchable, &gated, &mut payloads);
+                refresh_payloads(
+                    &cache,
+                    &registry,
+                    &cached_widgets,
+                    &realtime_widgets,
+                    &gated,
+                    &mut payloads,
+                );
                 draw(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                 if remaining.is_zero() {
@@ -118,7 +160,14 @@ pub async fn run(
                     tokio::time::sleep(tick).await;
                 }
             }
-            refresh_payloads(&cache, &registry, &fetchable, &gated, &mut payloads);
+            refresh_payloads(
+                &cache,
+                &registry,
+                &cached_widgets,
+                &realtime_widgets,
+                &gated,
+                &mut payloads,
+            );
             draw_final(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
         }
         Err(_) => {
@@ -128,7 +177,7 @@ pub async fn run(
             let fresh = fetch_all(
                 &registry,
                 cache.as_ref(),
-                &fetchable,
+                &cached_widgets,
                 &entries,
                 fetch_deadline,
             )
@@ -136,6 +185,8 @@ pub async fn run(
             for (id, payload) in fresh {
                 payloads.insert(id, payload);
             }
+            // Realtime values in the fallback path are still fresh at this point — the compute
+            // above was microseconds ago. No refresh needed before the single final draw.
             draw_final(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
         }
     }
@@ -154,29 +205,33 @@ pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &st
     let registry = Registry::with_builtins();
     let decision = TrustStore::load().decide(config_ident);
     let (fetchable, _gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
-    let entries = load_entries(cache.as_ref(), &registry, &fetchable);
+    // Daemon only persists cached-fetcher output. Realtime widgets have no disk representation.
+    let (cached_widgets, _realtime) = split_by_fetcher_kind(&fetchable, &registry);
+    let entries = load_entries(cache.as_ref(), &registry, &cached_widgets);
     let _ = fetch_all(
         &registry,
         cache.as_ref(),
-        &fetchable,
+        &cached_widgets,
         &entries,
         DAEMON_DEADLINE,
     )
     .await;
 }
 
-/// Rebuilds the payload map after the daemon has run: pulls fresh entries from the cache and
-/// re-applies the trust-gate placeholders on top. Used by both the `--wait` path and the
-/// first-run fallback so the two stay in sync.
+/// Rebuilds the payload map after the daemon has run: pulls fresh entries from the cache for
+/// cached widgets, recomputes realtime widgets, and re-applies the trust-gate placeholders on
+/// top. Used by both the `--wait` path and the first-run fallback so the two stay in sync.
 fn refresh_payloads(
     cache: &Option<Cache>,
     registry: &Registry,
-    fetchable: &[WidgetConfig],
+    cached_widgets: &[WidgetConfig],
+    realtime_widgets: &[WidgetConfig],
     gated: &[WidgetConfig],
     payloads: &mut HashMap<WidgetId, Payload>,
 ) {
-    let entries = load_entries(cache.as_ref(), registry, fetchable);
+    let entries = load_entries(cache.as_ref(), registry, cached_widgets);
     *payloads = entries_to_payloads(&entries);
+    payloads.extend(compute_realtime_payloads(registry, realtime_widgets));
     for w in gated {
         payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
     }
@@ -201,7 +256,7 @@ fn load_entries(
     widgets
         .iter()
         .filter_map(|w| {
-            let fetcher = registry.get(&w.fetcher)?;
+            let fetcher = registry.get_cached(&w.fetcher)?;
             let key = fetcher.cache_key(&fetch_context(w, Duration::from_secs(0)));
             c.load(&key).map(|e| (w.id.clone(), e))
         })
@@ -227,7 +282,7 @@ async fn fetch_all(
         if !should_refresh(cached, w) {
             continue;
         }
-        let Some(fetcher) = registry.get(&w.fetcher) else {
+        let Some(fetcher) = registry.get_cached(&w.fetcher) else {
             continue;
         };
         let ctx = fetch_context(w, deadline);
@@ -415,7 +470,7 @@ mod tests {
 
         assert!(fresh.contains_key("greeting"));
         let key = registry
-            .get("static")
+            .get_cached("static")
             .unwrap()
             .cache_key(&fetch_context(&widgets[0], Duration::from_secs(0)));
         let loaded = cache.load(&key).unwrap();
@@ -513,7 +568,7 @@ mod tests {
         let registry = Registry::with_builtins();
         let widgets = vec![static_widget("greeting", "Hi!")];
         let key = registry
-            .get("static")
+            .get_cached("static")
             .unwrap()
             .cache_key(&fetch_context(&widgets[0], Duration::from_secs(0)));
         let _held = cache.try_lock(&key).expect("first acquire");

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -192,7 +192,7 @@ fn store_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fetcher::{FetchContext, FetchError, Fetcher};
+    use crate::fetcher::{FetchContext, FetchError, Fetcher, RealtimeFetcher};
     use async_trait::async_trait;
     use std::sync::Arc;
 
@@ -211,6 +211,23 @@ mod tests {
         }
         async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
             unimplemented!("fake fetcher not invoked in tests")
+        }
+    }
+
+    struct FakeRealtime {
+        name: &'static str,
+        safety: Safety,
+    }
+
+    impl RealtimeFetcher for FakeRealtime {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn safety(&self) -> Safety {
+            self.safety
+        }
+        fn compute(&self, _: &FetchContext) -> Payload {
+            unimplemented!("fake realtime not invoked in tests")
         }
     }
 
@@ -382,6 +399,21 @@ mod tests {
         assert_eq!(fetchable_ids, vec!["g".to_string()]);
         assert!(gated_ids.iter().any(|s| s == "p"));
         assert!(gated_ids.iter().any(|s| s == "x"));
+    }
+
+    #[test]
+    fn partition_treats_realtime_safe_fetcher_as_fetchable_when_untrusted() {
+        // A realtime fetcher exposes safety via the unified Registry entry; a Safe realtime
+        // fetcher must not be gated just because it isn't the async Fetcher kind.
+        let mut registry = Registry::default();
+        registry.register_realtime(Arc::new(FakeRealtime {
+            name: "clock",
+            safety: Safety::Safe,
+        }));
+        let widgets = vec![widget("c", "clock")];
+        let (fetchable, gated) = partition_by_trust(&widgets, &registry, TrustDecision::Untrusted);
+        assert_eq!(fetchable.len(), 1);
+        assert!(gated.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #36

## Summary
- Add sync \`RealtimeFetcher\` trait — contract is <1ms, infallible, no I/O. Bypasses the disk cache entirely and recomputes every frame.
- Teach \`Registry\` to hold both \`Fetcher\` (cached) and \`RealtimeFetcher\` under one name-keyed lookup. \`RegisteredFetcher\` enum exposes unified \`name()\` / \`safety()\` so the trust gate needs no branching.
- Migrate \`ClockFetcher\` and \`TodayStub\` to the new trait. Both are pure \`Local::now()\` calls — caching them was always wrong (cache-warm splash would show a minute-old clock).
- \`runtime.rs\` splits trust-passed widgets by kind: cached path goes through the existing daemon + disk cache, realtime path computes each frame and is overlaid into the payload map in \`refresh_payloads\`.
- Daemon's \`fetch_and_persist\` skips realtime widgets. First-run wait promotion only triggers when there are cached widgets expecting data, so a clock-only config doesn't force the full wait window.

## Why not \`CachePolicy\` on the existing trait?
A realtime fetcher that accidentally does \`reqwest\` inside \`async fetch\` would silently block the frame loop. Separate sync trait makes the \"no I/O, fast\" contract type-enforced.

## Test plan
- [x] \`cargo test\` (148 passing, +1 new for realtime-fetcher partition gating)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] manual: cd into a repo, confirm clock shows current time (not cached-from-previous-invocation)
- [ ] manual: \`--wait\` mode, confirm clock ticks during the animation window if format includes \`%S\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Separated real-time and cached data sources within the system architecture.
  * Clock and date information now update dynamically on each frame instead of relying on cached values, improving data freshness and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->