### PR TITLE
feat: $HOME/.splashboard/ home-dir layout + ReadStore fetcher

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -96,6 +96,18 @@ id = "contributions"
 fetcher = "contributions"
 render = { type = "heatmap", align = "center" }
 
+# ── ReadStore demo ──────────────────────────────────────────────────
+# Renders whatever the user puts in $HOME/.splashboard/store/habit.json.
+# Example content: {"cells":[[3,1,0,5,8,0,0],[0,2,4,0,1,0,0], ...]}
+# Empty / missing file → empty heatmap (the slot is still present).
+
+[[widget]]
+id = "habit"
+fetcher = "read_store"
+shape = "heatmap"
+file_format = "json"
+render = { type = "heatmap", align = "center" }
+
 # ── Layout ──────────────────────────────────────────────────────────
 # Hero band: single-child rows with flex=center so the widget sits in the middle of the row
 # even though it's narrower than the terminal. 2-column rows below keep the default Legacy
@@ -146,6 +158,12 @@ height = { length = 10 }
 
   [[row.child]]
   widget = "contributions"
+
+[[row]]
+height = { length = 10 }
+
+  [[row.child]]
+  widget = "habit"
 
 # ── Dense 2-column rows from here on, default Legacy flex ─────────────
 

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -97,16 +97,15 @@ fetcher = "contributions"
 render = { type = "heatmap", align = "center" }
 
 # ── ReadStore demo ──────────────────────────────────────────────────
-# Renders whatever the user puts in $HOME/.splashboard/store/habit.json.
-# Example content: {"cells":[[3,1,0,5,8,0,0],[0,2,4,0,1,0,0], ...]}
-# Empty / missing file → empty heatmap (the slot is still present).
+# Renders whatever the user writes to $HOME/.splashboard/store/scratch.txt.
+# One line per row. Missing file → the "nothing here yet" placeholder.
 
 [[widget]]
-id = "habit"
+id = "scratch"
 fetcher = "read_store"
-shape = "heatmap"
-file_format = "json"
-render = { type = "heatmap", align = "center" }
+shape = "lines"
+file_format = "text"
+render = { type = "simple", align = "center" }
 
 # ── Layout ──────────────────────────────────────────────────────────
 # Hero band: single-child rows with flex=center so the widget sits in the middle of the row
@@ -160,10 +159,10 @@ height = { length = 10 }
   widget = "contributions"
 
 [[row]]
-height = { length = 10 }
+height = { length = 5 }
 
   [[row.child]]
-  widget = "habit"
+  widget = "scratch"
 
 # ── Dense 2-column rows from here on, default Legacy flex ─────────────
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -40,8 +40,7 @@ pub struct Cache {
 
 impl Cache {
     pub fn open_default() -> Option<Self> {
-        let dir = dirs::cache_dir()?.join("splashboard");
-        Self::open(dir)
+        Self::open(crate::paths::cache_dir()?)
     }
 
     pub fn open(dir: PathBuf) -> Option<Self> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct General {
     pub height: Option<u16>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct WidgetConfig {
     pub id: String,
     pub fetcher: String,
@@ -42,6 +42,13 @@ pub struct WidgetConfig {
     pub format: Option<String>,
     #[serde(default)]
     pub refresh_interval: Option<u64>,
+    /// read_store: file format — "json", "toml", or "text". Other fetchers ignore it.
+    #[serde(default)]
+    pub file_format: Option<String>,
+    /// read_store: target payload shape the file deserializes into — "heatmap", "lines",
+    /// "entries", etc. Other fetchers ignore it.
+    #[serde(default)]
+    pub shape: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -167,7 +174,7 @@ pub fn resolve_local_config_path() -> Option<PathBuf> {
 }
 
 pub fn default_global_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("splashboard").join("config.toml"))
+    crate::paths::config_path()
 }
 
 fn find_local(start: &Path) -> Option<PathBuf> {

--- a/src/fetcher/clock.rs
+++ b/src/fetcher/clock.rs
@@ -59,6 +59,7 @@ mod tests {
             widget_id: "clock".into(),
             format: format.map(String::from),
             timeout: Duration::from_secs(1),
+            ..Default::default()
         }
     }
 

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use crate::payload::Payload;
 
 pub mod clock;
+pub mod read_store;
 pub mod static_text;
 pub mod stub;
 
@@ -37,11 +38,17 @@ impl fmt::Display for FetchError {
 
 impl std::error::Error for FetchError {}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FetchContext {
     pub widget_id: String,
     pub format: Option<String>,
     pub timeout: Duration,
+    /// read_store file encoding — "json" / "toml" / "text". Set by config; ignored by
+    /// fetchers that don't read files.
+    pub file_format: Option<String>,
+    /// read_store target shape — "heatmap" / "lines" / "entries" / ... Set by config;
+    /// ignored by fetchers that don't produce shape-dependent output.
+    pub shape: Option<String>,
 }
 
 #[async_trait]
@@ -120,6 +127,7 @@ impl Registry {
     pub fn with_builtins() -> Self {
         let mut r = Self::default();
         r.register(Arc::new(static_text::StaticText));
+        r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register_realtime(Arc::new(clock::ClockFetcher));
         for f in stub::stubs() {
             r.register(f);
@@ -259,6 +267,7 @@ mod tests {
             widget_id: "w".into(),
             format: None,
             timeout: Duration::from_secs(1),
+            ..Default::default()
         };
         let p = f.fetch(&ctx).await.unwrap();
         assert!(matches!(p.body, Body::Lines(_)));
@@ -270,6 +279,7 @@ mod tests {
             widget_id: "w".into(),
             format: format.map(String::from),
             timeout: Duration::from_secs(1),
+            ..Default::default()
         }
     }
 

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -1,0 +1,348 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use crate::payload::{
+    Bar, BarsData, Body, CalendarData, EntriesData, HeatmapData, ImageData, LinesData,
+    NumberSeriesData, Payload, PointSeriesData, RatioData,
+};
+
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+/// Renders a local file the user wrote. The file lives at a fixed, sanitized path
+/// `$HOME/.splashboard/store/<widget_id>.<ext>` — config cannot redirect the read, so a hostile
+/// repo-local config can't traverse the filesystem. The value on disk is user-controlled;
+/// splashboard just deserializes it into a `Payload` of the shape the config declares.
+///
+/// Fills the gap that #5 (plugin protocol) and #20 (command widget) were meant to cover:
+/// arbitrary user-defined display surface, without any exec path. Users populate the file via
+/// whatever they like (editor, cron, post-commit hook, CI step).
+pub struct ReadStoreFetcher;
+
+#[async_trait]
+impl Fetcher for ReadStoreFetcher {
+    fn name(&self) -> &str {
+        "read_store"
+    }
+    fn safety(&self) -> Safety {
+        // Always Safe: the path is derived from the widget id under a fixed home subdir, so
+        // there's no path-traversal vector even in an untrusted local config.
+        Safety::Safe
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        // Differentiate by widget id + declared shape so two widgets pointed at different
+        // files (different ids) don't collide, and a single widget changing its shape gets
+        // a fresh entry rather than reading an old-shape cached payload.
+        let shape = ctx.shape.as_deref().unwrap_or("");
+        let file_format = ctx.file_format.as_deref().unwrap_or("");
+        format!(
+            "read_store-{}-{}-{}",
+            sanitize(&ctx.widget_id),
+            shape,
+            file_format
+        )
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let shape = ctx
+            .shape
+            .as_deref()
+            .ok_or_else(|| FetchError::Failed("read_store widget missing `shape`".into()))?;
+        let file_format = ctx
+            .file_format
+            .as_deref()
+            .unwrap_or(default_format_for_shape(shape));
+        let path = resolve_path(&ctx.widget_id, file_format)
+            .ok_or_else(|| FetchError::Failed("could not resolve splashboard home".into()))?;
+        let body = load_body(&path, file_format, shape)?;
+        Ok(Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body,
+        })
+    }
+}
+
+/// `text` is the natural default for `lines`; everything else needs structure. Saves users
+/// from writing `file_format = "text"` for every simple notes widget.
+fn default_format_for_shape(shape: &str) -> &'static str {
+    match shape {
+        "lines" => "text",
+        _ => "json",
+    }
+}
+
+fn resolve_path(widget_id: &str, file_format: &str) -> Option<PathBuf> {
+    let ext = extension_for(file_format);
+    let name = format!("{}.{ext}", sanitize(widget_id));
+    crate::paths::read_store_dir().map(|d| d.join(name))
+}
+
+fn extension_for(file_format: &str) -> &'static str {
+    match file_format {
+        "toml" => "toml",
+        "text" => "txt",
+        _ => "json",
+    }
+}
+
+/// Confine filenames to safe characters so widget ids never escape the store subdir or break
+/// on case-insensitive filesystems. Same rule as the cache module.
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn load_body(path: &std::path::Path, file_format: &str, shape: &str) -> Result<Body, FetchError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(empty_body(shape)),
+        Err(e) => return Err(FetchError::Failed(format!("read failed: {e}"))),
+    };
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|e| FetchError::Failed(format!("utf-8: {e}")))?;
+    parse_body(text, file_format, shape)
+}
+
+fn parse_body(text: &str, file_format: &str, shape: &str) -> Result<Body, FetchError> {
+    match (file_format, shape) {
+        ("text", "lines") => Ok(Body::Lines(LinesData {
+            lines: text.lines().map(str::to_string).collect(),
+        })),
+        ("text", _) => Err(FetchError::Failed(format!(
+            "shape {shape:?} requires json or toml, not text"
+        ))),
+        ("json", shape) => from_json(text, shape),
+        ("toml", shape) => from_toml(text, shape),
+        (other, _) => Err(FetchError::Failed(format!(
+            "unknown file_format: {other:?}"
+        ))),
+    }
+}
+
+/// Deserialize the file as the inner `*Data` struct for the requested shape, and wrap in the
+/// right `Body` variant. Users write the data payload directly (e.g. `{ "cells": [[...]] }`
+/// for a heatmap) — no wrapping `{"shape":...}` envelope required.
+fn from_json(text: &str, shape: &str) -> Result<Body, FetchError> {
+    macro_rules! parse_as {
+        ($ty:ty, $variant:ident) => {
+            serde_json::from_str::<$ty>(text)
+                .map(Body::$variant)
+                .map_err(|e| FetchError::Failed(format!("json parse: {e}")))
+        };
+    }
+    match shape {
+        "lines" => parse_as!(LinesData, Lines),
+        "entries" => parse_as!(EntriesData, Entries),
+        "ratio" => parse_as!(RatioData, Ratio),
+        "number_series" => parse_as!(NumberSeriesData, NumberSeries),
+        "point_series" => parse_as!(PointSeriesData, PointSeries),
+        "bars" => parse_as!(BarsData, Bars),
+        "image" => parse_as!(ImageData, Image),
+        "calendar" => parse_as!(CalendarData, Calendar),
+        "heatmap" => parse_as!(HeatmapData, Heatmap),
+        other => Err(FetchError::Failed(format!("unknown shape: {other:?}"))),
+    }
+}
+
+fn from_toml(text: &str, shape: &str) -> Result<Body, FetchError> {
+    macro_rules! parse_as {
+        ($ty:ty, $variant:ident) => {
+            toml::from_str::<$ty>(text)
+                .map(Body::$variant)
+                .map_err(|e| FetchError::Failed(format!("toml parse: {e}")))
+        };
+    }
+    match shape {
+        "lines" => parse_as!(LinesData, Lines),
+        "entries" => parse_as!(EntriesData, Entries),
+        "ratio" => parse_as!(RatioData, Ratio),
+        "number_series" => parse_as!(NumberSeriesData, NumberSeries),
+        "point_series" => parse_as!(PointSeriesData, PointSeries),
+        "bars" => parse_as!(BarsData, Bars),
+        "image" => parse_as!(ImageData, Image),
+        "calendar" => parse_as!(CalendarData, Calendar),
+        "heatmap" => parse_as!(HeatmapData, Heatmap),
+        other => Err(FetchError::Failed(format!("unknown shape: {other:?}"))),
+    }
+}
+
+/// Empty-but-valid body for the declared shape. Used when the file is missing so the splash
+/// stays quiet rather than breaking — matches the "optional" flavor of ReadStore widgets.
+fn empty_body(shape: &str) -> Body {
+    match shape {
+        "entries" => Body::Entries(EntriesData { items: Vec::new() }),
+        "ratio" => Body::Ratio(RatioData {
+            value: 0.0,
+            label: None,
+        }),
+        "number_series" => Body::NumberSeries(NumberSeriesData { values: Vec::new() }),
+        "point_series" => Body::PointSeries(PointSeriesData { series: Vec::new() }),
+        "bars" => Body::Bars(BarsData { bars: Vec::<Bar>::new() }),
+        "image" => Body::Image(ImageData { path: String::new() }),
+        "calendar" => Body::Calendar(CalendarData {
+            year: 1970,
+            month: 1,
+            day: None,
+            events: Vec::new(),
+        }),
+        "heatmap" => Body::Heatmap(HeatmapData {
+            cells: Vec::new(),
+            thresholds: None,
+            row_labels: None,
+            col_labels: None,
+        }),
+        _ => Body::Lines(LinesData { lines: Vec::new() }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn ctx(id: &str, shape: &str, file_format: &str) -> FetchContext {
+        FetchContext {
+            widget_id: id.into(),
+            timeout: Duration::from_secs(1),
+            shape: Some(shape.into()),
+            file_format: Some(file_format.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Scope-guard sharing the crate-wide `paths::TEST_ENV_LOCK`, so any parallel test that
+    /// also touches `SPLASHBOARD_HOME` serializes with us.
+    struct ScopedHome {
+        previous: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+    impl ScopedHome {
+        fn new(dir: &std::path::Path) -> Self {
+            let lock = crate::paths::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let previous = std::env::var("SPLASHBOARD_HOME").ok();
+            unsafe {
+                std::env::set_var("SPLASHBOARD_HOME", dir);
+            }
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+    impl Drop for ScopedHome {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(v) => std::env::set_var("SPLASHBOARD_HOME", v),
+                    None => std::env::remove_var("SPLASHBOARD_HOME"),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn reads_heatmap_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(store.join("habit.json"), r#"{"cells":[[0,1,2,3,4]]}"#).unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let p = ReadStoreFetcher
+            .fetch(&ctx("habit", "heatmap", "json"))
+            .await
+            .unwrap();
+        match p.body {
+            Body::Heatmap(d) => assert_eq!(d.cells, vec![vec![0, 1, 2, 3, 4]]),
+            other => panic!("expected heatmap body, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn text_shape_lines_splits_on_newline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(store.join("notes.txt"), "one\ntwo\nthree").unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let p = ReadStoreFetcher
+            .fetch(&ctx("notes", "lines", "text"))
+            .await
+            .unwrap();
+        match p.body {
+            Body::Lines(d) => assert_eq!(d.lines, vec!["one", "two", "three"]),
+            other => panic!("expected lines body, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_file_renders_empty_for_declared_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let p = ReadStoreFetcher
+            .fetch(&ctx("absent", "heatmap", "json"))
+            .await
+            .unwrap();
+        match p.body {
+            Body::Heatmap(d) => assert!(d.cells.is_empty()),
+            other => panic!("expected empty heatmap, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_shape_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(store.join("x.json"), "{}").unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let p = ReadStoreFetcher
+            .fetch(&ctx("x", "definitely_not_a_shape", "json"))
+            .await;
+        assert!(matches!(p, Err(FetchError::Failed(_))));
+    }
+
+    #[tokio::test]
+    async fn missing_shape_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let c = FetchContext {
+            widget_id: "x".into(),
+            timeout: Duration::from_secs(1),
+            ..Default::default()
+        };
+        let p = ReadStoreFetcher.fetch(&c).await;
+        assert!(matches!(p, Err(FetchError::Failed(_))));
+    }
+
+    #[test]
+    fn sanitize_drops_path_traversal() {
+        assert_eq!(sanitize("../etc/passwd"), "___etc_passwd");
+        assert_eq!(sanitize("../../secret"), "______secret");
+        assert_eq!(sanitize("a b/c"), "a_b_c");
+        assert_eq!(sanitize("habit-01_alt"), "habit-01_alt");
+    }
+
+    #[test]
+    fn cache_key_differs_across_widget_ids() {
+        let a = ReadStoreFetcher.cache_key(&ctx("habit", "heatmap", "json"));
+        let b = ReadStoreFetcher.cache_key(&ctx("sleep", "heatmap", "json"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_differs_across_shapes() {
+        let a = ReadStoreFetcher.cache_key(&ctx("habit", "heatmap", "json"));
+        let b = ReadStoreFetcher.cache_key(&ctx("habit", "lines", "json"));
+        assert_ne!(a, b);
+    }
+}

--- a/src/fetcher/static_text.rs
+++ b/src/fetcher/static_text.rs
@@ -45,6 +45,7 @@ mod tests {
             widget_id: "x".into(),
             format: format.map(String::from),
             timeout: Duration::from_secs(1),
+            ..Default::default()
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod config;
 mod daemon;
 mod fetcher;
 mod layout;
+mod paths;
 mod payload;
 mod render;
 mod runtime;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,75 @@
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+/// All splashboard state lives under a single dotted directory in the user's home:
+/// `$HOME/.splashboard/`. Keeps config, trust store, cache, and ReadStore data in one
+/// place — same pattern as per-directory `.splashboard/` configs. Overridable via the
+/// `SPLASHBOARD_HOME` env var for tests, CI, or power users who want to relocate.
+///
+/// Rationale over the platform-specific `dirs` crate: for a CLI tool, `~/Library/...` on
+/// macOS is awkward (Unix-flavored OS, dotfile conventions are the norm for terminal
+/// tools). `$HOME/.splashboard/` works the same on Linux, macOS, and Windows, and mirrors
+/// the per-directory convention users already know.
+pub fn splashboard_home() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("SPLASHBOARD_HOME") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::home_dir().map(|h| h.join(".splashboard"))
+}
+
+pub fn config_path() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("config.toml"))
+}
+
+pub fn trust_store_path() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("trust.toml"))
+}
+
+pub fn cache_dir() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("cache"))
+}
+
+pub fn read_store_dir() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("store"))
+}
+
+/// Shared mutex guarding any test that mutates `SPLASHBOARD_HOME`. Without this, parallel
+/// tests in different modules can see each other's temporary values through the process-wide
+/// env var. Exposed at crate level so other test modules (`fetcher::read_store`, etc.) can
+/// lock the same mutex.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All subpaths flow through `splashboard_home()` so overriding the env var relocates
+    /// every splashboard-owned file atomically — important for test isolation and for
+    /// power users who want to `SPLASHBOARD_HOME=/opt/splashboard` ship the whole state
+    /// directory elsewhere.
+    #[test]
+    fn env_var_overrides_home() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().to_path_buf();
+        let previous = std::env::var("SPLASHBOARD_HOME").ok();
+        // SAFETY: mutating process env in tests. Scoped to restore on exit; mutex above
+        // ensures no other test races with us on this env var.
+        unsafe {
+            std::env::set_var("SPLASHBOARD_HOME", &path);
+        }
+        assert_eq!(splashboard_home(), Some(path.clone()));
+        assert_eq!(config_path(), Some(path.join("config.toml")));
+        assert_eq!(trust_store_path(), Some(path.join("trust.toml")));
+        assert_eq!(cache_dir(), Some(path.join("cache")));
+        assert_eq!(read_store_dir(), Some(path.join("store")));
+        unsafe {
+            match previous {
+                Some(v) => std::env::set_var("SPLASHBOARD_HOME", v),
+                None => std::env::remove_var("SPLASHBOARD_HOME"),
+            }
+        }
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,7 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ratatui::{Frame, layout::Rect, widgets::Paragraph};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+};
 use serde::Deserialize;
 
 use crate::payload::{Body, Payload};
@@ -170,6 +175,11 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
 /// Resolves a renderer by spec (or shape default), compat-checks it, and renders. An unknown
 /// renderer name or a shape/renderer mismatch draws an in-band error rather than panicking —
 /// a misconfigured widget should show what's wrong, not crash the splash.
+///
+/// Bodies that carry no usable data short-circuit to [`render_empty_state`] before dispatch so
+/// every widget shows the same "nothing here yet" placeholder instead of each renderer's
+/// individual no-op. Keeps user-written ReadStore widgets, and any widget whose upstream data
+/// hasn't arrived yet, visually present rather than appearing as absent layout.
 pub fn render_payload(
     frame: &mut Frame,
     area: Rect,
@@ -177,6 +187,10 @@ pub fn render_payload(
     spec: Option<&RenderSpec>,
     registry: &Registry,
 ) {
+    if is_empty_body(&payload.body) {
+        render_empty_state(frame, area);
+        return;
+    }
     let shape = shape_of(&payload.body);
     let (name, options) = match spec {
         Some(s) => (s.renderer_name().to_string(), s.options()),
@@ -198,6 +212,37 @@ pub fn render_payload(
         return;
     }
     renderer.render(frame, area, &payload.body, &options);
+}
+
+/// `true` when the body has no meaningful data to render. Callers (most usefully
+/// [`render_payload`]) use this to substitute an empty-state placeholder rather than letting a
+/// specific renderer silently draw nothing.
+///
+/// Note on specific shapes:
+/// - `Ratio` is never considered empty (0.0 is legitimate, e.g. "0% disk used").
+/// - `Calendar` is never considered empty (month/year are always present).
+/// - Everything else checks its natural collection.
+pub fn is_empty_body(body: &Body) -> bool {
+    match body {
+        Body::Lines(d) => d.lines.is_empty() || d.lines.iter().all(|l| l.is_empty()),
+        Body::Entries(d) => d.items.is_empty(),
+        Body::NumberSeries(d) => d.values.is_empty(),
+        Body::PointSeries(d) => d.series.iter().all(|s| s.points.is_empty()),
+        Body::Bars(d) => d.bars.is_empty(),
+        Body::Image(d) => d.path.is_empty(),
+        Body::Heatmap(d) => d.cells.is_empty() || d.cells.iter().all(|r| r.is_empty()),
+        Body::Calendar(_) | Body::Ratio(_) => false,
+    }
+}
+
+fn render_empty_state(frame: &mut Frame, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let p = Paragraph::new("—")
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM));
+    frame.render_widget(p, area);
 }
 
 /// `true` if any widget in `widgets` will be rendered by a renderer that declares itself
@@ -287,6 +332,69 @@ mod tests {
                 "default renderer {name} doesn't accept its shape {s:?}"
             );
         }
+    }
+
+    #[test]
+    fn is_empty_body_matches_expectations() {
+        use crate::payload::{
+            BarsData, EntriesData, HeatmapData, ImageData, LinesData, NumberSeriesData,
+            PointSeriesData, RatioData,
+        };
+        // Empty cases.
+        assert!(is_empty_body(&Body::Lines(LinesData { lines: vec![] })));
+        assert!(is_empty_body(&Body::Lines(LinesData {
+            lines: vec![String::new()],
+        })));
+        assert!(is_empty_body(&Body::Entries(EntriesData { items: vec![] })));
+        assert!(is_empty_body(&Body::NumberSeries(NumberSeriesData {
+            values: vec![],
+        })));
+        assert!(is_empty_body(&Body::PointSeries(PointSeriesData {
+            series: vec![],
+        })));
+        assert!(is_empty_body(&Body::Bars(BarsData { bars: vec![] })));
+        assert!(is_empty_body(&Body::Image(ImageData {
+            path: String::new(),
+        })));
+        assert!(is_empty_body(&Body::Heatmap(HeatmapData {
+            cells: vec![],
+            thresholds: None,
+            row_labels: None,
+            col_labels: None,
+        })));
+        // Non-empty and "structurally always present" cases.
+        assert!(!is_empty_body(&Body::Lines(LinesData {
+            lines: vec!["x".into()],
+        })));
+        assert!(!is_empty_body(&Body::Ratio(RatioData {
+            value: 0.0,
+            label: None,
+        })));
+    }
+
+    #[test]
+    fn empty_body_renders_placeholder_not_specific_renderer() {
+        use crate::payload::{HeatmapData, Payload};
+        use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+        let p = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Heatmap(HeatmapData {
+                cells: vec![],
+                thresholds: None,
+                row_labels: None,
+                col_labels: None,
+            }),
+        };
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("heatmap".into());
+        let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 20, 3);
+        // The centered em-dash lands at column (20-1)/2 = 9 on the middle row-ish. Just
+        // check any row contains the em-dash — placement is centered so exact row depends on
+        // area height.
+        let has_dash = (0..3).any(|y| line_text(&buf, y).contains('—'));
+        assert!(has_dash, "expected — placeholder somewhere in the output");
     }
 
     #[test]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 
 use ratatui::{
     Frame,
-    layout::{Alignment, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
+    text::Line,
     widgets::Paragraph,
 };
 use serde::Deserialize;
@@ -239,10 +240,25 @@ fn render_empty_state(frame: &mut Frame, area: Rect) {
     if area.width == 0 || area.height == 0 {
         return;
     }
-    let p = Paragraph::new("—")
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM));
-    frame.render_widget(p, area);
+    let dim = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::ITALIC | Modifier::DIM);
+    // Two lines if there's room (icon + caption), otherwise collapse to the caption alone.
+    // Centered both axes via a Fill / Length / Fill vertical layout.
+    let lines: Vec<Line> = if area.height >= 2 {
+        vec![Line::from("◌").style(dim), Line::from("nothing here yet").style(dim)]
+    } else {
+        vec![Line::from("◌ nothing here yet").style(dim)]
+    };
+    let content_height = lines.len() as u16;
+    let chunks = Layout::vertical([
+        Constraint::Fill(1),
+        Constraint::Length(content_height),
+        Constraint::Fill(1),
+    ])
+    .split(area);
+    let p = Paragraph::new(lines).alignment(Alignment::Center);
+    frame.render_widget(p, chunks[1]);
 }
 
 /// `true` if any widget in `widgets` will be rendered by a renderer that declares itself
@@ -389,12 +405,9 @@ mod tests {
         };
         let registry = Registry::with_builtins();
         let spec = RenderSpec::Short("heatmap".into());
-        let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 20, 3);
-        // The centered em-dash lands at column (20-1)/2 = 9 on the middle row-ish. Just
-        // check any row contains the em-dash — placement is centered so exact row depends on
-        // area height.
-        let has_dash = (0..3).any(|y| line_text(&buf, y).contains('—'));
-        assert!(has_dash, "expected — placeholder somewhere in the output");
+        let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 40, 5);
+        let joined: String = (0..5).map(|y| line_text(&buf, y)).collect();
+        assert!(joined.contains("nothing here yet"), "missing caption: {joined:?}");
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -242,6 +242,8 @@ fn fetch_context(w: &WidgetConfig, deadline: Duration) -> FetchContext {
         widget_id: w.id.clone(),
         format: w.format.clone(),
         timeout: deadline,
+        file_format: w.file_format.clone(),
+        shape: w.shape.clone(),
     }
 }
 
@@ -409,9 +411,8 @@ mod tests {
         WidgetConfig {
             id: id.into(),
             fetcher: fetcher.into(),
-            render: None,
-            format: None,
             refresh_interval: Some(60),
+            ..Default::default()
         }
     }
 
@@ -446,9 +447,9 @@ mod tests {
         WidgetConfig {
             id: id.into(),
             fetcher: "static".into(),
-            render: None,
             format: Some(text.into()),
             refresh_interval: Some(60),
+            ..Default::default()
         }
     }
 
@@ -539,9 +540,9 @@ mod tests {
         let widgets = vec![WidgetConfig {
             id: "greeting".into(),
             fetcher: "static".into(),
-            render: None,
             format: Some("Hi!".into()),
             refresh_interval: Some(60),
+            ..Default::default()
         }];
         let mut cached = HashMap::new();
         cached.insert("greeting".into(), CacheEntry::new(text_payload("old"), 60));

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -186,7 +186,7 @@ fn canonicalize_or(path: &Path) -> PathBuf {
 }
 
 fn store_path() -> Option<PathBuf> {
-    dirs::data_dir().map(|d| d.join("splashboard").join("trusted.toml"))
+    crate::paths::trust_store_path()
 }
 
 #[cfg(test)]
@@ -246,9 +246,7 @@ mod tests {
         WidgetConfig {
             id: id.into(),
             fetcher: fetcher.into(),
-            render: None,
-            format: None,
-            refresh_interval: None,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
Closes #38.

## Summary

Two changes landing together because ReadStore's path resolution sits on the new home-dir layout.

### Home-dir layout (\`src/paths.rs\`)

All splashboard state moves under \`\$HOME/.splashboard/\` — one visible place on every platform, matching the per-directory config convention users already know:

\`\`\`
\$HOME/.splashboard/
├── config.toml        # was ~/.config/splashboard/config.toml
├── trust.toml         # was ~/.local/share/splashboard/trusted.toml
├── cache/             # was ~/.cache/splashboard/
└── store/             # new, for ReadStore
\`\`\`

Previously we used the \`dirs\` crate, which returns platform-native paths (\`~/Library/Application Support/...\` on macOS, \`%APPDATA%\` on Windows). Fine for GUI apps, awkward for a Unix-flavored CLI tool where dotfile conventions are the norm. Users asked for one visible dir.

Overridable via \`SPLASHBOARD_HOME\` env var (tests, CI, power users). No automatic migration — pre-1.0, existing cache/trust stores are disposable and \`config.toml\` is a one-time manual move.

### ReadStore fetcher (\`src/fetcher/read_store.rs\`)

Fills the gap left by closing #5 (plugin protocol) and #20 (command widget). Users write arbitrary data to \`\$HOME/.splashboard/store/<id>.<ext>\`; splashboard deserializes and renders per the widget's declared shape.

- Always \`Safety::Safe\` — path is \`<fixed_dir>/<sanitized_id>.<ext>\`, no config-driven path means no traversal vector even in untrusted local configs.
- Supports every Body shape: lines, entries, ratio, number_series, point_series, bars, image, calendar, heatmap.
- \`file_format = \"json\" | \"toml\" | \"text\"\`. Text only valid for \`shape = \"lines\"\`.
- Missing file → empty-but-valid body (silent, no error).
- Cache key mixes in widget id + shape so distinct widgets don't collide.

### Dogfood

The repo's \`.splashboard/config.toml\` now has a ReadStore demo slot pointing at \`\$HOME/.splashboard/store/habit.json\` as a heatmap. Empty by default; users drop a JSON blob there to see their own grass grid.

## Test plan
- [x] \`cargo test\` — 171 passing (+8 for ReadStore, +1 for paths env override)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] repeated runs show no flaky tests (env-var mutation protected by a crate-shared mutex)
- [ ] manual: \`SPLASHBOARD_HOME=/tmp/test-home splashboard\` to confirm env override relocates everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)