### PR TITLE
feat(render): add badge renderer

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -44,6 +44,26 @@ id = "system"
 fetcher = "system"
 render = "table"
 
+# ── Badge: one status per fetcher; a row of badges is a layout concern ─
+# Per-widget align converges the trio visually: the left slot right-aligns so its text hugs
+# the centre, the centre slot centres, the right slot left-aligns so its text hugs the
+# centre — the three labels cluster together inside a centred row.
+
+[[widget]]
+id = "ci"
+fetcher = "ci_status"
+render = { type = "badge", align = "right" }
+
+[[widget]]
+id = "deploy"
+fetcher = "deploy_status"
+render = { type = "badge", align = "center" }
+
+[[widget]]
+id = "oncall"
+fetcher = "oncall_status"
+render = { type = "badge", align = "left" }
+
 # ── Ratio: 2 renderers ──────────────────────────────────────────────
 
 [[widget]]
@@ -140,6 +160,22 @@ flex = "center"
   [[row.child]]
   widget = "notes"
   width = { length = 44 }
+
+[[row]]
+height = { length = 2 }
+flex = "center"
+
+  [[row.child]]
+  widget = "ci"
+  width = { length = 20 }
+
+  [[row.child]]
+  widget = "deploy"
+  width = { length = 20 }
+
+  [[row.child]]
+  widget = "oncall"
+  width = { length = 20 }
 
 [[row]]
 height = { length = 10 }

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::payload::{
-    Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData, NumberSeriesData, Payload,
-    PointSeries, PointSeriesData, RatioData, Status,
+    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData,
+    NumberSeriesData, Payload, PointSeries, PointSeriesData, RatioData, Status,
 };
 
 use super::{FetchContext, FetchError, Fetcher, RealtimeFetcher, Safety};
@@ -22,6 +22,9 @@ pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(GithubPrsStub),
         Arc::new(TrendStub),
         Arc::new(ContributionsStub),
+        Arc::new(CiStatusStub),
+        Arc::new(DeployStatusStub),
+        Arc::new(OncallStatusStub),
     ]
 }
 
@@ -246,6 +249,62 @@ fn short_month(m: u32) -> String {
     .to_string()
 }
 
+/// Single-badge stubs — each pairs with the badge renderer one-to-one. Split into three
+/// fetchers on purpose: a badge widget is "one indicator per fetcher". Mixing multiple
+/// statuses into a single payload is the `combined_status_row` concern, handled at the
+/// layout level, not in the data shape.
+pub struct CiStatusStub;
+
+#[async_trait]
+impl Fetcher for CiStatusStub {
+    fn name(&self) -> &str {
+        "ci_status"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
+        Ok(badge(Status::Ok, "build passing"))
+    }
+}
+
+pub struct DeployStatusStub;
+
+#[async_trait]
+impl Fetcher for DeployStatusStub {
+    fn name(&self) -> &str {
+        "deploy_status"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
+        Ok(badge(Status::Warn, "deploy degraded"))
+    }
+}
+
+pub struct OncallStatusStub;
+
+#[async_trait]
+impl Fetcher for OncallStatusStub {
+    fn name(&self) -> &str {
+        "oncall_status"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
+        Ok(badge(Status::Error, "oncall paging"))
+    }
+}
+
+fn badge(status: Status, label: &str) -> Payload {
+    payload(Body::Badge(BadgeData {
+        status,
+        label: label.into(),
+    }))
+}
+
 pub struct TodayStub;
 
 impl RealtimeFetcher for TodayStub {
@@ -300,6 +359,9 @@ mod tests {
             "github_prs",
             "trend",
             "contributions",
+            "ci_status",
+            "deploy_status",
+            "oncall_status",
         ] {
             assert!(names.contains(&expected), "missing stub: {expected}");
         }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -42,6 +42,10 @@ pub enum Body {
     /// 2D grid of intensities. Used by the GitHub-style contribution graph, habit trackers, any
     /// daily-metric heatmap. Renderer maps each cell into a bucketed color.
     Heatmap(HeatmapData),
+    /// Single traffic-light status + short label. Used by CI, deploy, SLO, oncall — one
+    /// indicator per fetcher. Rows of badges are a composition concern handled by the nested
+    /// layout (`combined_status_row`), not by a multi-entry payload.
+    Badge(BadgeData),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -122,6 +126,12 @@ pub struct HeatmapData {
     pub row_labels: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub col_labels: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BadgeData {
+    pub status: Status,
+    pub label: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -259,6 +269,27 @@ mod tests {
             lines: vec!["12:34".into()],
         }));
         assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn badge_round_trips() {
+        let p = bare(Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: "deploy degraded".into(),
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn badge_serializes_with_expected_shape_tag() {
+        let p = bare(Body::Badge(BadgeData {
+            status: Status::Error,
+            label: "oncall paging".into(),
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["shape"], "badge");
+        assert_eq!(v["data"]["status"], "error");
+        assert_eq!(v["data"]["label"], "oncall paging");
     }
 
     #[test]

--- a/src/render/badge.rs
+++ b/src/render/badge.rs
@@ -1,0 +1,120 @@
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::payload::{BadgeData, Body, Status};
+
+use super::{RenderOptions, Renderer, Shape};
+
+/// Traffic-light / badge renderer: a single coloured dot (● green / yellow / red) driven by
+/// `BadgeData.status`, followed by `BadgeData.label`. One indicator per widget — CI, deploy,
+/// SLO, oncall. Rows of badges are a composition concern, handled by the nested layout
+/// (`combined_status_row`), not by stuffing multiple statuses into one payload.
+pub struct BadgeRenderer;
+
+const DOT: &str = "●";
+
+impl Renderer for BadgeRenderer {
+    fn name(&self) -> &str {
+        "badge"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::Badge]
+    }
+    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
+        if let Body::Badge(d) = body {
+            render_badge(frame, area, d, opts);
+        }
+    }
+}
+
+fn render_badge(frame: &mut Frame, area: Rect, data: &BadgeData, opts: &RenderOptions) {
+    let line = Line::from(vec![
+        Span::styled(DOT, Style::default().fg(status_color(data.status))),
+        Span::raw(" "),
+        Span::raw(data.label.clone()),
+    ]);
+    let p = Paragraph::new(line).alignment(parse_align(opts.align.as_deref()));
+    frame.render_widget(p, area);
+}
+
+fn status_color(status: Status) -> Color {
+    match status {
+        Status::Ok => Color::Green,
+        Status::Warn => Color::Yellow,
+        Status::Error => Color::Red,
+    }
+}
+
+fn parse_align(s: Option<&str>) -> Alignment {
+    match s {
+        Some("center") => Alignment::Center,
+        Some("right") => Alignment::Right,
+        _ => Alignment::Left,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{BadgeData, Payload, Status};
+    use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+    use crate::render::{Registry, RenderSpec};
+
+    fn payload(status: Status, label: &str) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Badge(BadgeData {
+                status,
+                label: label.into(),
+            }),
+        }
+    }
+
+    fn render(status: Status, label: &str, w: u16, h: u16) -> ratatui::buffer::Buffer {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("badge".into());
+        render_to_buffer_with_spec(&payload(status, label), Some(&spec), &registry, w, h)
+    }
+
+    #[test]
+    fn renders_dot_and_label() {
+        let buf = render(Status::Ok, "build passing", 30, 1);
+        let row = line_text(&buf, 0);
+        assert!(row.starts_with(DOT), "expected dot prefix: {row:?}");
+        assert!(row.contains("build passing"));
+    }
+
+    #[test]
+    fn ok_maps_to_green() {
+        let buf = render(Status::Ok, "x", 10, 1);
+        assert_eq!(buf.cell((0, 0)).unwrap().fg, Color::Green);
+    }
+
+    #[test]
+    fn warn_maps_to_yellow() {
+        let buf = render(Status::Warn, "x", 10, 1);
+        assert_eq!(buf.cell((0, 0)).unwrap().fg, Color::Yellow);
+    }
+
+    #[test]
+    fn error_maps_to_red() {
+        let buf = render(Status::Error, "x", 10, 1);
+        assert_eq!(buf.cell((0, 0)).unwrap().fg, Color::Red);
+    }
+
+    #[test]
+    fn badge_is_the_default_renderer_for_badge_shape() {
+        // A widget with no explicit `render =` still picks `badge`, since the shape has exactly
+        // one natural renderer.
+        let registry = Registry::with_builtins();
+        let buf = render_to_buffer_with_spec(&payload(Status::Ok, "ci"), None, &registry, 10, 1);
+        assert!(line_text(&buf, 0).contains("ci"));
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,6 +8,7 @@ use crate::payload::{Body, Payload};
 
 mod animated_typewriter;
 mod ascii_art;
+mod badge;
 mod bar_chart;
 mod calendar;
 mod gauge;
@@ -38,6 +39,7 @@ pub enum Shape {
     Image,
     Calendar,
     Heatmap,
+    Badge,
 }
 
 pub fn shape_of(body: &Body) -> Shape {
@@ -51,6 +53,7 @@ pub fn shape_of(body: &Body) -> Shape {
         Body::Image(_) => Shape::Image,
         Body::Calendar(_) => Shape::Calendar,
         Body::Heatmap(_) => Shape::Heatmap,
+        Body::Badge(_) => Shape::Badge,
     }
 }
 
@@ -130,6 +133,7 @@ impl Registry {
         r.register(Arc::new(text::SimpleRenderer));
         r.register(Arc::new(ascii_art::AsciiArtRenderer));
         r.register(Arc::new(animated_typewriter::AnimatedTypewriterRenderer));
+        r.register(Arc::new(badge::BadgeRenderer));
         r.register(Arc::new(list::ListRenderer));
         r.register(Arc::new(table::TableRenderer));
         r.register(Arc::new(gauge::GaugeRenderer));
@@ -164,6 +168,7 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
         Shape::Image => "image",
         Shape::Calendar => "calendar",
         Shape::Heatmap => "heatmap",
+        Shape::Badge => "badge",
     }
 }
 
@@ -250,6 +255,7 @@ mod tests {
             "simple",
             "ascii_art",
             "animated_typewriter",
+            "badge",
             "list",
             "table",
             "gauge",
@@ -278,6 +284,7 @@ mod tests {
             Shape::Image,
             Shape::Calendar,
             Shape::Heatmap,
+            Shape::Badge,
         ] {
             let name = default_renderer_for(s);
             let r = Registry::with_builtins();


### PR DESCRIPTION
## Summary
- New `Body::Badge { status, label }` shape + `BadgeRenderer` — single coloured dot (green/yellow/red) + label per payload. CI / deploy / SLO / oncall.
- Keeps "row of badges" as a layout concern (`combined_status_row`), not a data-shape concern.
- Three demo stubs (`ci_status`, `deploy_status`, `oncall_status`) wired into the dogfood config with per-widget alignment so the trio clusters visually at screen centre.

Addresses the **badge / traffic light** checkbox in #41.

## Test plan
- [x] `cargo test` — 169 pass (2 new payload round-trip tests, 5 new renderer tests)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo run` in repo root — three badges render at centre above the heatmap, green/yellow/red respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)