### PR TITLE
feat(render): add timeline renderer for timestamped event lists

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -116,6 +116,13 @@ id = "contributions"
 fetcher = "contributions"
 render = { type = "heatmap", align = "center" }
 
+# ── Timeline ────────────────────────────────────────────────────────
+
+[[widget]]
+id = "recent_commits"
+fetcher = "git_recent_commits"
+render = "timeline"
+
 # ── ReadStore demo ──────────────────────────────────────────────────
 # Renders whatever the user writes to $HOME/.splashboard/store/scratch.txt.
 # One line per row. Missing file → the "nothing here yet" placeholder.
@@ -252,5 +259,10 @@ height = { length = 6 }
   [[row.child]]
   widget = "system"
   title = "table"
+  border = "rounded"
+
+  [[row.child]]
+  widget = "recent_commits"
+  title = "timeline"
   border = "rounded"
 

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -106,8 +106,8 @@ fn load_body(path: &std::path::Path, file_format: &str, shape: &str) -> Result<B
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(empty_body(shape)),
         Err(e) => return Err(FetchError::Failed(format!("read failed: {e}"))),
     };
-    let text = std::str::from_utf8(&bytes)
-        .map_err(|e| FetchError::Failed(format!("utf-8: {e}")))?;
+    let text =
+        std::str::from_utf8(&bytes).map_err(|e| FetchError::Failed(format!("utf-8: {e}")))?;
     parse_body(text, file_format, shape)
 }
 
@@ -185,8 +185,12 @@ fn empty_body(shape: &str) -> Body {
         }),
         "number_series" => Body::NumberSeries(NumberSeriesData { values: Vec::new() }),
         "point_series" => Body::PointSeries(PointSeriesData { series: Vec::new() }),
-        "bars" => Body::Bars(BarsData { bars: Vec::<Bar>::new() }),
-        "image" => Body::Image(ImageData { path: String::new() }),
+        "bars" => Body::Bars(BarsData {
+            bars: Vec::<Bar>::new(),
+        }),
+        "image" => Body::Image(ImageData {
+            path: String::new(),
+        }),
         "calendar" => Body::Calendar(CalendarData {
             year: 1970,
             month: 1,

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 
 use crate::payload::{
     BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData,
-    NumberSeriesData, Payload, PointSeries, PointSeriesData, RatioData, Status,
+    NumberSeriesData, Payload, PointSeries, PointSeriesData, RatioData, Status, TimelineData,
+    TimelineEvent,
 };
 
 use super::{FetchContext, FetchError, Fetcher, RealtimeFetcher, Safety};
@@ -25,6 +26,7 @@ pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(CiStatusStub),
         Arc::new(DeployStatusStub),
         Arc::new(OncallStatusStub),
+        Arc::new(GitRecentCommitsStub),
     ]
 }
 
@@ -305,6 +307,41 @@ fn badge(status: Status, label: &str) -> Payload {
     }))
 }
 
+/// Demo-quality recent-commit timeline. Offsets from `now` so the relative labels stay fresh
+/// (`Nm` / `Nh` / `Nd` / `Nw`) without the renderer caching stale "ago" strings. Stands in for
+/// the future `git_recent_commits` fetcher.
+pub struct GitRecentCommitsStub;
+
+#[async_trait]
+impl Fetcher for GitRecentCommitsStub {
+    fn name(&self) -> &str {
+        "git_recent_commits"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
+        let now = chrono::Utc::now().timestamp();
+        let events = vec![
+            event(now - 7 * 60, "feat(render): timeline renderer", None, Some(Status::Ok)),
+            event(now - 2 * 3600, "feat(render): badge renderer", None, Some(Status::Ok)),
+            event(now - 26 * 3600, "docs: AGENTS.md", None, None),
+            event(now - 4 * 86_400, "feat: readstore home layout", None, None),
+            event(now - 9 * 86_400, "chore: bump deps", None, Some(Status::Warn)),
+        ];
+        Ok(payload(Body::Timeline(TimelineData { events })))
+    }
+}
+
+fn event(timestamp: i64, title: &str, detail: Option<&str>, status: Option<Status>) -> TimelineEvent {
+    TimelineEvent {
+        timestamp,
+        title: title.into(),
+        detail: detail.map(|s| s.into()),
+        status,
+    }
+}
+
 pub struct TodayStub;
 
 impl RealtimeFetcher for TodayStub {
@@ -362,6 +399,7 @@ mod tests {
             "ci_status",
             "deploy_status",
             "oncall_status",
+            "git_recent_commits",
         ] {
             assert!(names.contains(&expected), "missing stub: {expected}");
         }

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -199,11 +199,7 @@ fn fake_contributions() -> Vec<Vec<u32>> {
                 .map(|_| {
                     let weekday_peak = if (1..=5).contains(&day) { 8 } else { 3 };
                     let roll = next(10);
-                    if roll < 3 {
-                        0
-                    } else {
-                        next(weekday_peak) + 1
-                    }
+                    if roll < 3 { 0 } else { next(weekday_peak) + 1 }
                 })
                 .collect()
         })
@@ -323,17 +319,37 @@ impl Fetcher for GitRecentCommitsStub {
     async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
         let now = chrono::Utc::now().timestamp();
         let events = vec![
-            event(now - 7 * 60, "feat(render): timeline renderer", None, Some(Status::Ok)),
-            event(now - 2 * 3600, "feat(render): badge renderer", None, Some(Status::Ok)),
+            event(
+                now - 7 * 60,
+                "feat(render): timeline renderer",
+                None,
+                Some(Status::Ok),
+            ),
+            event(
+                now - 2 * 3600,
+                "feat(render): badge renderer",
+                None,
+                Some(Status::Ok),
+            ),
             event(now - 26 * 3600, "docs: AGENTS.md", None, None),
             event(now - 4 * 86_400, "feat: readstore home layout", None, None),
-            event(now - 9 * 86_400, "chore: bump deps", None, Some(Status::Warn)),
+            event(
+                now - 9 * 86_400,
+                "chore: bump deps",
+                None,
+                Some(Status::Warn),
+            ),
         ];
         Ok(payload(Body::Timeline(TimelineData { events })))
     }
 }
 
-fn event(timestamp: i64, title: &str, detail: Option<&str>, status: Option<Status>) -> TimelineEvent {
+fn event(
+    timestamp: i64,
+    title: &str,
+    detail: Option<&str>,
+    status: Option<Status>,
+) -> TimelineEvent {
     TimelineEvent {
         timestamp,
         title: title.into(),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -46,6 +46,10 @@ pub enum Body {
     /// indicator per fetcher. Rows of badges are a composition concern handled by the nested
     /// layout (`combined_status_row`), not by a multi-entry payload.
     Badge(BadgeData),
+    /// Time-stamped events, newest first. Used by git_recent_commits, deploy history, ci
+    /// history. Timestamps are raw unix seconds so the renderer computes the `"3h ago"` label
+    /// at draw time — keeping cached payloads from going stale.
+    Timeline(TimelineData),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -132,6 +136,25 @@ pub struct HeatmapData {
 pub struct BadgeData {
     pub status: Status,
     pub label: String,
+}
+
+/// Time-stamped events for the timeline renderer. Timestamps are unix seconds UTC; the renderer
+/// formats a relative label (`"3h ago"`, `"yesterday"`, `"Apr 5"`) at draw time so cached
+/// payloads don't freeze stale relative strings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TimelineData {
+    pub events: Vec<TimelineEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TimelineEvent {
+    /// Unix seconds UTC.
+    pub timestamp: i64,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<Status>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -290,6 +313,45 @@ mod tests {
         assert_eq!(v["shape"], "badge");
         assert_eq!(v["data"]["status"], "error");
         assert_eq!(v["data"]["label"], "oncall paging");
+    }
+
+    #[test]
+    fn timeline_round_trips() {
+        let p = bare(Body::Timeline(TimelineData {
+            events: vec![
+                TimelineEvent {
+                    timestamp: 1_700_000_000,
+                    title: "merged #42".into(),
+                    detail: Some("feat(render): heatmap".into()),
+                    status: Some(Status::Ok),
+                },
+                TimelineEvent {
+                    timestamp: 1_699_990_000,
+                    title: "opened #41".into(),
+                    detail: None,
+                    status: None,
+                },
+            ],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn timeline_serializes_with_expected_shape_tag() {
+        let p = bare(Body::Timeline(TimelineData {
+            events: vec![TimelineEvent {
+                timestamp: 1_700_000_000,
+                title: "x".into(),
+                detail: None,
+                status: None,
+            }],
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["shape"], "timeline");
+        assert_eq!(v["data"]["events"][0]["timestamp"], 1_700_000_000_i64);
+        assert_eq!(v["data"]["events"][0]["title"], "x");
+        assert!(v["data"]["events"][0].get("detail").is_none());
+        assert!(v["data"]["events"][0].get("status").is_none());
     }
 
     #[test]

--- a/src/render/heatmap.rs
+++ b/src/render/heatmap.rs
@@ -79,7 +79,13 @@ fn render_heatmap(frame: &mut Frame, area: Rect, data: &HeatmapData, opts: &Rend
         ..area
     };
     if label_row {
-        paint_col_labels(frame.buffer_mut(), label_area, data, visible_cols, col_offset);
+        paint_col_labels(
+            frame.buffer_mut(),
+            label_area,
+            data,
+            visible_cols,
+            col_offset,
+        );
     }
     paint_cells(
         frame.buffer_mut(),
@@ -275,7 +281,9 @@ mod tests {
 
     #[test]
     fn renders_grid_without_panicking() {
-        let cells: Vec<Vec<u32>> = (0..7).map(|r| (0..20).map(|c| (r * c) as u32).collect()).collect();
+        let cells: Vec<Vec<u32>> = (0..7)
+            .map(|r| (0..20).map(|c| (r * c) as u32).collect())
+            .collect();
         let _ = render(cells, 40, 7);
     }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -27,6 +27,7 @@ mod scatter;
 mod sparkline;
 mod table;
 mod text;
+mod timeline;
 
 #[cfg(test)]
 pub mod test_utils;
@@ -46,6 +47,7 @@ pub enum Shape {
     Calendar,
     Heatmap,
     Badge,
+    Timeline,
 }
 
 pub fn shape_of(body: &Body) -> Shape {
@@ -60,6 +62,7 @@ pub fn shape_of(body: &Body) -> Shape {
         Body::Calendar(_) => Shape::Calendar,
         Body::Heatmap(_) => Shape::Heatmap,
         Body::Badge(_) => Shape::Badge,
+        Body::Timeline(_) => Shape::Timeline,
     }
 }
 
@@ -151,6 +154,7 @@ impl Registry {
         r.register(Arc::new(image::ImageRenderer));
         r.register(Arc::new(calendar::CalendarRenderer));
         r.register(Arc::new(heatmap::HeatmapRenderer));
+        r.register(Arc::new(timeline::TimelineRenderer));
         r
     }
 
@@ -175,6 +179,7 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
         Shape::Calendar => "calendar",
         Shape::Heatmap => "heatmap",
         Shape::Badge => "badge",
+        Shape::Timeline => "timeline",
     }
 }
 
@@ -237,7 +242,8 @@ pub fn is_empty_body(body: &Body) -> bool {
         Body::Bars(d) => d.bars.is_empty(),
         Body::Image(d) => d.path.is_empty(),
         Body::Heatmap(d) => d.cells.is_empty() || d.cells.iter().all(|r| r.is_empty()),
-        Body::Calendar(_) | Body::Ratio(_) => false,
+        Body::Timeline(d) => d.events.is_empty(),
+        Body::Badge(_) | Body::Calendar(_) | Body::Ratio(_) => false,
     }
 }
 
@@ -328,6 +334,7 @@ mod tests {
             "image",
             "calendar",
             "heatmap",
+            "timeline",
         ] {
             assert!(r.get(name).is_some(), "missing builtin renderer: {name}");
         }
@@ -346,6 +353,7 @@ mod tests {
             Shape::Calendar,
             Shape::Heatmap,
             Shape::Badge,
+            Shape::Timeline,
         ] {
             let name = default_renderer_for(s);
             let r = Registry::with_builtins();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -257,7 +257,10 @@ fn render_empty_state(frame: &mut Frame, area: Rect) {
     // Two lines if there's room (icon + caption), otherwise collapse to the caption alone.
     // Centered both axes via a Fill / Length / Fill vertical layout.
     let lines: Vec<Line> = if area.height >= 2 {
-        vec![Line::from("◌").style(dim), Line::from("nothing here yet").style(dim)]
+        vec![
+            Line::from("◌").style(dim),
+            Line::from("nothing here yet").style(dim),
+        ]
     } else {
         vec![Line::from("◌ nothing here yet").style(dim)]
     };
@@ -422,7 +425,10 @@ mod tests {
         let spec = RenderSpec::Short("heatmap".into());
         let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 40, 5);
         let joined: String = (0..5).map(|y| line_text(&buf, y)).collect();
-        assert!(joined.contains("nothing here yet"), "missing caption: {joined:?}");
+        assert!(
+            joined.contains("nothing here yet"),
+            "missing caption: {joined:?}"
+        );
     }
 
     #[test]

--- a/src/render/timeline.rs
+++ b/src/render/timeline.rs
@@ -1,0 +1,377 @@
+use chrono::{Datelike, TimeZone, Utc};
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::payload::{Body, Status, TimelineData};
+
+use super::{RenderOptions, Renderer, Shape};
+
+/// Time-stamped event list. Each row shows a compact relative prefix (`"3h"`, `"2d"`, `"Apr 5"`)
+/// computed at draw time against the current clock — cached payloads never freeze a stale
+/// "ago" string. Optional `detail` hangs under the title; `status` colours the title.
+pub struct TimelineRenderer;
+
+const SEPARATOR: &str = " │ ";
+
+impl Renderer for TimelineRenderer {
+    fn name(&self) -> &str {
+        "timeline"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::Timeline]
+    }
+    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
+        if let Body::Timeline(d) = body {
+            render_timeline_at(frame, area, d, opts, Utc::now().timestamp());
+        }
+    }
+}
+
+fn render_timeline_at(
+    frame: &mut Frame,
+    area: Rect,
+    data: &TimelineData,
+    opts: &RenderOptions,
+    now: i64,
+) {
+    let prefixes: Vec<String> = data
+        .events
+        .iter()
+        .map(|e| format_relative(e.timestamp, now))
+        .collect();
+    let prefix_width = prefixes
+        .iter()
+        .map(|p| p.chars().count())
+        .max()
+        .unwrap_or(0);
+    let dim = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::DIM);
+
+    let mut lines: Vec<Line> = Vec::with_capacity(data.events.len() * 2);
+    let mut content_width: usize = 0;
+    for (prefix, event) in prefixes.iter().zip(data.events.iter()) {
+        let head = format!("{}{SEPARATOR}", pad_left(prefix, prefix_width));
+        content_width = content_width.max(head.chars().count() + event.title.chars().count());
+        lines.push(Line::from(vec![
+            Span::styled(head, dim),
+            Span::styled(event.title.clone(), status_style(event.status)),
+        ]));
+        if let Some(detail) = &event.detail {
+            let indent = format!("{}{SEPARATOR}", " ".repeat(prefix_width));
+            content_width = content_width.max(indent.chars().count() + detail.chars().count());
+            lines.push(Line::from(vec![
+                Span::styled(indent, dim),
+                Span::styled(detail.clone(), Style::default().fg(Color::Gray)),
+            ]));
+        }
+    }
+
+    let target = align_rect(area, content_width as u16, opts.align.as_deref());
+    frame.render_widget(Paragraph::new(lines), target);
+}
+
+fn align_rect(area: Rect, content_width: u16, align: Option<&str>) -> Rect {
+    if content_width == 0 || content_width >= area.width {
+        return area;
+    }
+    let offset = match align {
+        Some("center") => (area.width - content_width) / 2,
+        Some("right") => area.width - content_width,
+        _ => return area,
+    };
+    Rect {
+        x: area.x + offset,
+        y: area.y,
+        width: content_width,
+        height: area.height,
+    }
+}
+
+fn pad_left(s: &str, width: usize) -> String {
+    let n = s.chars().count();
+    if n >= width {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(width);
+    out.extend(std::iter::repeat_n(' ', width - n));
+    out.push_str(s);
+    out
+}
+
+fn status_style(status: Option<Status>) -> Style {
+    match status {
+        Some(Status::Ok) => Style::default().fg(Color::Green),
+        Some(Status::Warn) => Style::default().fg(Color::Yellow),
+        Some(Status::Error) => Style::default().fg(Color::Red),
+        None => Style::default(),
+    }
+}
+
+/// Relative label for `ts` seen from `now`. Past events shrink to `Ns`/`Nm`/`Nh`/`Nd`/`Nw`;
+/// anything older than ~4 weeks falls back to an absolute date so the label stays short. Future
+/// events get an `in …` prefix. Same clock for past and future keeps the column width stable.
+fn format_relative(ts: i64, now: i64) -> String {
+    let delta = now - ts;
+    if delta.abs() < 45 {
+        return "now".into();
+    }
+    let abs = delta.abs();
+    let compact = compact_delta(abs);
+    match compact {
+        Some(s) => {
+            if delta >= 0 {
+                s
+            } else {
+                format!("in {s}")
+            }
+        }
+        None => format_absolute(ts, now),
+    }
+}
+
+fn compact_delta(abs: i64) -> Option<String> {
+    const MIN: i64 = 60;
+    const HOUR: i64 = 60 * 60;
+    const DAY: i64 = 60 * 60 * 24;
+    const WEEK: i64 = DAY * 7;
+    if abs < HOUR {
+        Some(format!("{}m", (abs + MIN / 2) / MIN))
+    } else if abs < DAY {
+        Some(format!("{}h", abs / HOUR))
+    } else if abs < WEEK {
+        Some(format!("{}d", abs / DAY))
+    } else if abs < WEEK * 4 {
+        Some(format!("{}w", abs / WEEK))
+    } else {
+        None
+    }
+}
+
+fn format_absolute(ts: i64, now: i64) -> String {
+    let Some(event) = Utc.timestamp_opt(ts, 0).single() else {
+        return "—".into();
+    };
+    let Some(now_dt) = Utc.timestamp_opt(now, 0).single() else {
+        return event.format("%Y-%m-%d").to_string();
+    };
+    if event.year() == now_dt.year() {
+        event.format("%b %-d").to_string()
+    } else {
+        event.format("%Y-%m-%d").to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Body, Payload, Status, TimelineData, TimelineEvent};
+    use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+    use crate::render::{Registry, RenderSpec};
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    fn render_at(data: &TimelineData, now: i64, w: u16, h: u16) -> Buffer {
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| render_timeline_at(f, f.area(), data, &RenderOptions::default(), now))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn row_text(buf: &Buffer, y: u16) -> String {
+        (0..buf.area.width)
+            .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn format_relative_seconds_is_now() {
+        assert_eq!(format_relative(1_000, 1_030), "now");
+    }
+
+    #[test]
+    fn format_relative_minutes() {
+        assert_eq!(format_relative(0, 120), "2m");
+    }
+
+    #[test]
+    fn format_relative_minutes_rounds_half_up() {
+        assert_eq!(format_relative(0, 45), "1m");
+    }
+
+    #[test]
+    fn format_relative_hours() {
+        assert_eq!(format_relative(0, 3 * 3600), "3h");
+    }
+
+    #[test]
+    fn format_relative_days() {
+        assert_eq!(format_relative(0, 2 * 86_400), "2d");
+    }
+
+    #[test]
+    fn format_relative_weeks() {
+        assert_eq!(format_relative(0, 8 * 86_400), "1w");
+    }
+
+    #[test]
+    fn format_relative_falls_back_to_absolute_date_after_four_weeks() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 4, 22, 0, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp();
+        let ts = now - 60 * 86_400; // → 2026-02-21
+        assert_eq!(format_relative(ts, now), "Feb 21");
+    }
+
+    #[test]
+    fn format_relative_absolute_includes_year_across_boundary() {
+        // now = 2026-02-15, event 2025-11-20 → different year, ISO date.
+        let now = Utc
+            .with_ymd_and_hms(2026, 2, 15, 0, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp();
+        let ts = Utc
+            .with_ymd_and_hms(2025, 11, 20, 0, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp();
+        assert_eq!(format_relative(ts, now), "2025-11-20");
+    }
+
+    #[test]
+    fn format_relative_future_gets_in_prefix() {
+        assert_eq!(format_relative(3_600, 0), "in 1h");
+    }
+
+    #[test]
+    fn renders_event_title_with_relative_prefix() {
+        let data = TimelineData {
+            events: vec![TimelineEvent {
+                timestamp: 0,
+                title: "merged #42".into(),
+                detail: None,
+                status: None,
+            }],
+        };
+        let buf = render_at(&data, 3 * 3600, 40, 1);
+        let line = row_text(&buf, 0);
+        assert!(line.contains("3h"), "missing relative prefix: {line:?}");
+        assert!(line.contains("merged #42"), "missing title: {line:?}");
+    }
+
+    #[test]
+    fn detail_lands_on_next_row_indented() {
+        let data = TimelineData {
+            events: vec![TimelineEvent {
+                timestamp: 0,
+                title: "opened #41".into(),
+                detail: Some("widget catalog".into()),
+                status: None,
+            }],
+        };
+        let buf = render_at(&data, 3 * 3600, 40, 2);
+        let row0 = row_text(&buf, 0);
+        let row1 = row_text(&buf, 1);
+        assert!(row0.contains("opened #41"));
+        assert!(row1.contains("widget catalog"));
+        // Detail row starts with spaces, not with "3h".
+        assert!(!row1.trim_start().starts_with("3h"));
+    }
+
+    #[test]
+    fn status_colours_the_title() {
+        let data = TimelineData {
+            events: vec![TimelineEvent {
+                timestamp: 0,
+                title: "build failed".into(),
+                detail: None,
+                status: Some(Status::Error),
+            }],
+        };
+        let buf = render_at(&data, 60, 40, 1);
+        // Title follows the separator " │ " — scan for the 'b' of "build".
+        let row = row_text(&buf, 0);
+        let col = row.find("build").expect("title should appear") as u16;
+        assert_eq!(buf.cell((col, 0)).unwrap().fg, Color::Red);
+    }
+
+    #[test]
+    fn prefixes_share_a_column_width() {
+        let data = TimelineData {
+            events: vec![
+                TimelineEvent {
+                    timestamp: 0,
+                    title: "old".into(),
+                    detail: None,
+                    status: None,
+                },
+                TimelineEvent {
+                    timestamp: 10 * 86_400 - 60, // still under 28d → "1w"
+                    title: "recent".into(),
+                    detail: None,
+                    status: None,
+                },
+            ],
+        };
+        // now = 10d past epoch: first event is "10d", second is "1w". Widths 3 and 2 — the
+        // "1w" row should be right-padded so the " │ " separator lines up with the "10d" row.
+        let buf = render_at(&data, 10 * 86_400, 40, 2);
+        let row0 = row_text(&buf, 0);
+        let row1 = row_text(&buf, 1);
+        let col0 = row0.find('│').unwrap();
+        let col1 = row1.find('│').unwrap();
+        assert_eq!(col0, col1, "separators misaligned: {row0:?} vs {row1:?}");
+    }
+
+    #[test]
+    fn timeline_is_the_default_renderer_for_timeline_shape() {
+        // Uses real Utc::now() through the public path — we only assert the title lands, not
+        // the prefix, since the relative label is clock-dependent.
+        let p = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Timeline(TimelineData {
+                events: vec![TimelineEvent {
+                    timestamp: Utc::now().timestamp(),
+                    title: "right now".into(),
+                    detail: None,
+                    status: None,
+                }],
+            }),
+        };
+        let registry = Registry::with_builtins();
+        let buf = render_to_buffer_with_spec(&p, None, &registry, 40, 1);
+        assert!(line_text(&buf, 0).contains("right now"));
+    }
+
+    #[test]
+    fn timeline_renders_via_short_spec() {
+        let p = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Timeline(TimelineData {
+                events: vec![TimelineEvent {
+                    timestamp: Utc::now().timestamp() - 120,
+                    title: "x".into(),
+                    detail: None,
+                    status: None,
+                }],
+            }),
+        };
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("timeline".into());
+        let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 20, 1);
+        assert!(line_text(&buf, 0).contains("x"));
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -89,9 +89,8 @@ pub async fn run(
     // Load axis: decide whether to block on fresh data. If there are any cached widgets with no
     // entry yet, promote to wait so we don't exit with a blank terminal on first run. Realtime
     // widgets don't count — they're always fresh.
-    let wait = wait
-        || config.general.wait_for_fresh
-        || (!cached_widgets.is_empty() && entries.is_empty());
+    let wait =
+        wait || config.general.wait_for_fresh || (!cached_widgets.is_empty() && entries.is_empty());
 
     // Render axis: decide whether any configured renderer needs repeat frames. Independent of
     // the load decision — an animated widget must animate regardless of cache state.


### PR DESCRIPTION
## Summary

- New `Body::Timeline { events }` shape + `TimelineRenderer` that feeds git_recent_commits, deploy history, ci history — any \"events over time\" widget.
- Timestamps are raw unix seconds UTC; the renderer formats the relative label (`\"3h\"`, `\"Apr 5\"`) at draw time so cached payloads never freeze a stale \"ago\" string.
- Status-aware title colouring (Ok/Warn/Error) matches the badge renderer's palette so badges + timeline share a visual vocabulary.
- Ships a `git_recent_commits` demo stub and wires it into the dogfood config next to the `system` table.

Addresses the `timeline` checkbox in #41.

## Visual

Each row is `<relative> │ <title>`, with an optional indented detail line under it. Relative column is right-padded to the widest label so separators line up. Honours `align` like the list renderer.

Relative format buckets:
- `< 45s` → `now`
- `< 1h` → `Nm` (rounded)
- `< 1d` → `Nh`
- `< 1w` → `Nd`
- `< 4w` → `Nw`
- older → absolute (`Apr 5` same year, `2025-11-20` across)
- future → `in …` prefix

## Test plan

- [x] \`cargo test\` — 197 passed (15 new tests in `render::timeline`, incl. relative-format buckets, column-width padding, status colour, default renderer wiring, year-boundary absolute date)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [ ] Eyeball the dogfood splash in a real TTY (`cargo run`) — relative labels look right, status colours stand out, column alignment holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)