### PR TITLE
feat(render): add pie_chart renderer over Bars shape

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -95,12 +95,17 @@ id = "trend_dots"
 fetcher = "trend"
 render = "scatter"
 
-# ── Bars ────────────────────────────────────────────────────────────
+# ── Bars: 2 renderers ───────────────────────────────────────────────
 
 [[widget]]
 id = "prs"
 fetcher = "github_prs"
 render = "bar_chart"
+
+[[widget]]
+id = "prs_pie"
+fetcher = "github_prs"
+render = "pie_chart"
 
 # ── Calendar ────────────────────────────────────────────────────────
 
@@ -222,7 +227,7 @@ height = { length = 3 }
   border = "rounded"
 
 [[row]]
-height = { length = 5 }
+height = { length = 7 }
 
   [[row.child]]
   widget = "commits"
@@ -232,6 +237,11 @@ height = { length = 5 }
   [[row.child]]
   widget = "prs"
   title = "bar_chart"
+  border = "rounded"
+
+  [[row.child]]
+  widget = "prs_pie"
+  title = "pie_chart"
   border = "rounded"
 
 [[row]]

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -219,7 +219,7 @@ height = { length = 3 }
   border = "rounded"
 
 [[row]]
-height = { length = 11 }
+height = { length = 12 }
 
   [[row.child]]
   widget = "prs"

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -21,11 +21,6 @@ fetcher = "clock"
 render = { type = "ascii_art", pixel_size = "quadrant", align = "center" }
 
 [[widget]]
-id = "clock_figlet"
-fetcher = "clock"
-render = { type = "ascii_art", style = "figlet", align = "center" }
-
-[[widget]]
 id = "typewriter"
 fetcher = "static"
 render = { type = "animated_typewriter", align = "center" }
@@ -158,14 +153,6 @@ flex = "center"
   [[row.child]]
   widget = "clock"
   width = { length = 22 }
-
-[[row]]
-height = { length = 6 }
-flex = "center"
-
-  [[row.child]]
-  widget = "clock_figlet"
-  width = { length = 44 }
 
 [[row]]
 height = { length = 4 }

--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -226,13 +226,13 @@ height = { length = 3 }
   title = "line_gauge"
   border = "rounded"
 
-[[row]]
-height = { length = 7 }
-
   [[row.child]]
   widget = "commits"
   title = "sparkline"
   border = "rounded"
+
+[[row]]
+height = { length = 11 }
 
   [[row.child]]
   widget = "prs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "tokio",
  "toml",
  "tui-big-text",
+ "tui-piechart",
 ]
 
 [[package]]
@@ -1938,6 +1939,15 @@ dependencies = [
  "derive_builder",
  "font8x8",
  "itertools 0.14.0",
+ "ratatui",
+]
+
+[[package]]
+name = "tui-piechart"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e197188d264d07b41f11939c5273e5b516c6fd951726861714a890ea2a065b7b"
+dependencies = [
  "ratatui",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.8"
 dirs = "5"
 clap = { version = "4", features = ["derive"] }
 tui-big-text = "0.7"
+tui-piechart = "=0.2.8"
 ratatui-image = "4"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process"] }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -23,6 +23,7 @@ mod image;
 mod line_chart;
 mod line_gauge;
 mod list;
+mod pie_chart;
 mod scatter;
 mod sparkline;
 mod table;
@@ -171,6 +172,7 @@ impl Registry {
         r.register(Arc::new(line_chart::LineChartRenderer));
         r.register(Arc::new(scatter::ScatterRenderer));
         r.register(Arc::new(bar_chart::BarChartRenderer));
+        r.register(Arc::new(pie_chart::PieChartRenderer));
         r.register(Arc::new(image::ImageRenderer));
         r.register(Arc::new(calendar::CalendarRenderer));
         r.register(Arc::new(heatmap::HeatmapRenderer));
@@ -354,6 +356,7 @@ mod tests {
             "chart_line",
             "scatter",
             "bar_chart",
+            "pie_chart",
             "image",
             "calendar",
             "heatmap",

--- a/src/render/pie_chart.rs
+++ b/src/render/pie_chart.rs
@@ -1,0 +1,132 @@
+use ratatui::{Frame, layout::Rect, style::Color};
+use tui_piechart::{PieChart, PieSlice};
+
+use crate::payload::{BarsData, Body};
+
+use super::{RenderOptions, Renderer, Shape};
+
+/// Pie-chart renderer. Consumes the same `Bars` shape as `bar_chart`, so one fetcher feeds
+/// either — `render = "pie_chart"` vs `render = "bar_chart"` is a config choice. Slice colours
+/// cycle through a fixed palette in input order; labels and percentages come from the widget.
+pub struct PieChartRenderer;
+
+const PALETTE: &[Color] = &[
+    Color::Red,
+    Color::Blue,
+    Color::Green,
+    Color::Yellow,
+    Color::Magenta,
+    Color::Cyan,
+    Color::LightRed,
+    Color::LightBlue,
+    Color::LightGreen,
+    Color::LightYellow,
+];
+
+impl Renderer for PieChartRenderer {
+    fn name(&self) -> &str {
+        "pie_chart"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::Bars]
+    }
+    fn render(&self, frame: &mut Frame, area: Rect, body: &Body, _opts: &RenderOptions) {
+        if let Body::Bars(d) = body {
+            render_pie(frame, area, d);
+        }
+    }
+}
+
+fn render_pie(frame: &mut Frame, area: Rect, data: &BarsData) {
+    let slices: Vec<PieSlice> = data
+        .bars
+        .iter()
+        .enumerate()
+        .map(|(i, b)| PieSlice::new(b.label.as_str(), b.value as f64, PALETTE[i % PALETTE.len()]))
+        .collect();
+    frame.render_widget(
+        PieChart::new(slices)
+            .show_legend(true)
+            .show_percentages(true),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Bar, BarsData, Payload};
+    use crate::render::test_utils::render_to_buffer_with_spec;
+    use crate::render::{Registry, RenderSpec};
+
+    fn payload(bars: Vec<Bar>) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Bars(BarsData { bars }),
+        }
+    }
+
+    fn render(bars: Vec<Bar>, w: u16, h: u16) -> ratatui::buffer::Buffer {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("pie_chart".into());
+        render_to_buffer_with_spec(&payload(bars), Some(&spec), &registry, w, h)
+    }
+
+    fn bar(label: &str, value: u64) -> Bar {
+        Bar {
+            label: label.into(),
+            value,
+        }
+    }
+
+    #[test]
+    fn renders_without_panicking() {
+        let _ = render(
+            vec![bar("rust", 45), bar("go", 30), bar("python", 25)],
+            40,
+            15,
+        );
+    }
+
+    #[test]
+    fn empty_bars_short_circuit_to_placeholder() {
+        use crate::render::test_utils::line_text;
+        let buf = render(vec![], 40, 5);
+        let joined: String = (0..5).map(|y| line_text(&buf, y)).collect();
+        assert!(
+            joined.contains("nothing here yet"),
+            "missing empty-state caption: {joined:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_only_bars_shape() {
+        let r = PieChartRenderer;
+        assert_eq!(r.accepts(), &[Shape::Bars]);
+    }
+
+    #[test]
+    fn registered_under_pie_chart_name() {
+        let r = Registry::with_builtins();
+        assert!(r.get("pie_chart").is_some(), "pie_chart not registered");
+    }
+
+    #[test]
+    fn legend_labels_appear_in_buffer() {
+        use crate::render::test_utils::line_text;
+        let buf = render(vec![bar("alpha", 10), bar("beta", 20)], 60, 20);
+        let joined: String = (0..20).map(|y| line_text(&buf, y)).collect();
+        assert!(joined.contains("alpha"), "alpha label missing: {joined:?}");
+        assert!(joined.contains("beta"), "beta label missing: {joined:?}");
+    }
+
+    #[test]
+    fn more_bars_than_palette_does_not_panic() {
+        let many: Vec<Bar> = (0..PALETTE.len() + 3)
+            .map(|i| bar(&format!("b{i}"), (i as u64) + 1))
+            .collect();
+        let _ = render(many, 80, 30);
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,8 +4,12 @@ use std::path::Path;
 use std::time::Duration;
 
 use ratatui::{
-    Terminal, TerminalOptions, Viewport,
+    Frame, Terminal, TerminalOptions, Viewport,
     backend::{Backend, CrosstermBackend},
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::Paragraph,
 };
 use tokio::task::JoinSet;
 
@@ -187,7 +191,9 @@ pub async fn run(
     // Default viewport = sum of configured row heights so every widget fits without manual
     // tuning. Users can still override with `general.height` when they want padding or are
     // using Percentage sizes. Clamped to `terminal_rows - 1` so there's always one row left
-    // below the viewport for the shell prompt to land on cleanly.
+    // below the viewport for the shell prompt. When the configured height doesn't fit, the
+    // bottom row of the visible viewport is sacrificed for a `… +N rows` clip hint so users
+    // aren't silently missing widgets.
     let requested_height = config
         .general
         .height
@@ -195,13 +201,32 @@ pub async fn run(
     let term_rows = ratatui::crossterm::terminal::size()
         .map(|(_, h)| h)
         .unwrap_or(requested_height);
-    let viewport_lines = requested_height.min(term_rows.saturating_sub(1)).max(1);
+    let max_inline = term_rows.saturating_sub(1).max(1);
+    let clipping = requested_height > max_inline;
+    let viewport_lines = if clipping {
+        max_inline
+    } else {
+        requested_height
+    }
+    .max(1);
+    let hidden_rows = if clipping {
+        requested_height.saturating_sub(viewport_lines.saturating_sub(1))
+    } else {
+        0
+    };
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = make_terminal(backend, viewport_lines)?;
 
     // Cache-first one-shot: no looping needed, paint what we have and exit.
     if loop_window.is_none() {
-        draw_final(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
+        draw_final(
+            &mut terminal,
+            &layout,
+            &payloads,
+            &specs,
+            &render_registry,
+            hidden_rows,
+        )?;
         let _ = daemon::spawn_fetch_daemon(config_ident.map(|(p, _)| p));
         finalize_splash(&mut terminal);
         return Ok(());
@@ -222,7 +247,14 @@ pub async fn run(
             let deadline = std::time::Instant::now() + window;
             loop {
                 refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
-                draw(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
+                draw(
+                    &mut terminal,
+                    &layout,
+                    &payloads,
+                    &specs,
+                    &render_registry,
+                    hidden_rows,
+                )?;
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                 if remaining.is_zero() {
                     if wait {
@@ -241,7 +273,14 @@ pub async fn run(
                 }
             }
             refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
-            draw_final(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
+            draw_final(
+                &mut terminal,
+                &layout,
+                &payloads,
+                &specs,
+                &render_registry,
+                hidden_rows,
+            )?;
         }
         Err(_) => {
             // Spawning the daemon failed (OOM, exec permission) — rare. Fall back to inline
@@ -261,7 +300,14 @@ pub async fn run(
             }
             // Realtime values in the fallback path are still fresh at this point — the compute
             // above was microseconds ago. No refresh needed before the single final draw.
-            draw_final(&mut terminal, &layout, &payloads, &specs, &render_registry)?;
+            draw_final(
+                &mut terminal,
+                &layout,
+                &payloads,
+                &specs,
+                &render_registry,
+                hidden_rows,
+            )?;
         }
     }
 
@@ -442,8 +488,19 @@ fn draw<B: Backend>(
     payloads: &HashMap<WidgetId, Payload>,
     specs: &HashMap<WidgetId, RenderSpec>,
     registry: &render::Registry,
+    hidden_rows: u16,
 ) -> io::Result<()> {
-    terminal.draw(|frame| layout::draw(frame, frame.area(), root, payloads, specs, registry))?;
+    terminal.draw(|frame| {
+        draw_frame(
+            frame,
+            frame.area(),
+            root,
+            payloads,
+            specs,
+            registry,
+            hidden_rows,
+        )
+    })?;
     Ok(())
 }
 
@@ -458,12 +515,13 @@ fn draw_final<B: Backend>(
     payloads: &HashMap<WidgetId, Payload>,
     specs: &HashMap<WidgetId, RenderSpec>,
     registry: &render::Registry,
+    hidden_rows: u16,
 ) -> io::Result<()> {
-    let mut captured: Option<ratatui::layout::Rect> = None;
+    let mut captured: Option<Rect> = None;
     terminal.draw(|frame| {
         let area = frame.area();
         captured = Some(area);
-        layout::draw(frame, area, root, payloads, specs, registry);
+        draw_frame(frame, area, root, payloads, specs, registry, hidden_rows);
     })?;
     if let Some(area) = captured
         && area.height > 0
@@ -474,6 +532,43 @@ fn draw_final<B: Backend>(
         })?;
     }
     Ok(())
+}
+
+/// Renders the layout into the given area, sacrificing the bottom row for a `… +N rows` hint
+/// when the configured height doesn't fit and the viewport had to be clamped to the terminal.
+fn draw_frame(
+    frame: &mut Frame,
+    area: Rect,
+    root: &Layout,
+    payloads: &HashMap<WidgetId, Payload>,
+    specs: &HashMap<WidgetId, RenderSpec>,
+    registry: &render::Registry,
+    hidden_rows: u16,
+) {
+    if hidden_rows > 0 && area.height > 1 {
+        let layout_area = Rect {
+            height: area.height - 1,
+            ..area
+        };
+        let hint_area = Rect {
+            y: area.y + area.height - 1,
+            height: 1,
+            ..area
+        };
+        layout::draw(frame, layout_area, root, payloads, specs, registry);
+        render_clip_hint(frame, hint_area, hidden_rows);
+    } else {
+        layout::draw(frame, area, root, payloads, specs, registry);
+    }
+}
+
+fn render_clip_hint(frame: &mut Frame, area: Rect, hidden_rows: u16) {
+    let text = format!("… +{hidden_rows} rows (terminal too short)");
+    let style = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::DIM | Modifier::ITALIC);
+    let p = Paragraph::new(Line::from(text).style(style)).alignment(Alignment::Right);
+    frame.render_widget(p, area);
 }
 
 /// Hand back to the shell: show the cursor (ratatui hid it during drawing) and emit the
@@ -493,7 +588,9 @@ fn render_specs(widgets: &[WidgetConfig]) -> HashMap<WidgetId, RenderSpec> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::layout::Layout as LayoutTree;
     use crate::payload::{Body, LinesData};
+    use ratatui::{Terminal, backend::TestBackend};
 
     fn text_payload(line: &str) -> Payload {
         Payload {
@@ -504,6 +601,70 @@ mod tests {
                 lines: vec![line.into()],
             }),
         }
+    }
+
+    fn single_widget_tree(id: &str) -> LayoutTree {
+        LayoutTree::Widget {
+            id: id.into(),
+            panel: None,
+        }
+    }
+
+    fn row_text(buf: &ratatui::buffer::Buffer, y: u16) -> String {
+        (0..buf.area.width)
+            .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn draw_frame_hint_lands_on_bottom_row_when_clipping() {
+        let root = single_widget_tree("x");
+        let mut payloads = HashMap::new();
+        payloads.insert("x".into(), text_payload("top"));
+        let specs = HashMap::new();
+        let registry = render::Registry::with_builtins();
+        let backend = TestBackend::new(50, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw_frame(f, f.area(), &root, &payloads, &specs, &registry, 7))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let bottom = row_text(&buf, 3);
+        assert!(
+            bottom.contains("…") && bottom.contains("+7"),
+            "expected clip hint in bottom row: {bottom:?}"
+        );
+        assert!(row_text(&buf, 0).contains("top"), "layout still rendered");
+    }
+
+    #[test]
+    fn draw_frame_without_clipping_paints_no_hint() {
+        let root = single_widget_tree("x");
+        let mut payloads = HashMap::new();
+        payloads.insert("x".into(), text_payload("only"));
+        let specs = HashMap::new();
+        let registry = render::Registry::with_builtins();
+        let backend = TestBackend::new(50, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw_frame(f, f.area(), &root, &payloads, &specs, &registry, 0))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let joined: String = (0..3).map(|y| row_text(&buf, y)).collect();
+        assert!(!joined.contains("…"), "no marker expected: {joined:?}");
+        assert!(!joined.contains("terminal too short"));
+    }
+
+    #[test]
+    fn clip_hint_includes_marker_and_count() {
+        let backend = TestBackend::new(60, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| render_clip_hint(f, f.area(), 42))
+            .unwrap();
+        let row = row_text(&terminal.backend().buffer().clone(), 0);
+        assert!(row.contains("…"), "marker missing: {row:?}");
+        assert!(row.contains("+42"), "count missing: {row:?}");
     }
 
     fn widget(id: &str, fetcher: &str) -> WidgetConfig {


### PR DESCRIPTION
## Summary

### Renderer: pie_chart
- New `PieChartRenderer` wrapping `tui-piechart` 0.2.8, registered as `pie_chart`. Accepts `Shape::Bars`, so the same `Bars` payload can be rendered as `bar_chart` or `pie_chart` purely via config.
- Slice colours cycle through a fixed 10-entry palette in input order; legend + percentages come from the widget itself.
- `tui-piechart` is pinned to `=0.2.8` — 0.2.9 bumped the upstream dep to `ratatui ^0.30` while we're on 0.29, so loose semver silently resolves into a compile error.
- Empty `Bars` short-circuits through the shared empty-state placeholder in `render_payload`.

Addresses the `pie_chart` checkbox in #41.

### Runtime: clip hint
- Adding `pie_chart` to the dogfood config pushed total row height past ~60, exposing a pre-existing footgun: configured heights taller than the terminal were silently clipped by ratatui/crossterm — widgets below the fold just disappeared.
- Runtime now clamps the inline viewport to `term_rows - 1` and, when clipping would occur, sacrifices the bottom row for a right-aligned `… +N rows (terminal too short)` hint in dim italic. When everything fits, rendering is unchanged.

### Dogfood layout
- `bar_chart` + `pie_chart` get their own 2-col row at height 11 so the pie has readable dimensions.
- `sparkline` joins the disk row as a 3rd column — gauges + sparklines coexist fine at height 3.

## Test plan

- [x] `cargo test` — 206 passed (6 new in `render::pie_chart`, 3 new in `runtime::tests` for clip hint)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Eyeball in a real TTY — pie renders, clip hint appears at the bottom when the terminal is too short

🤖 Generated with [Claude Code](https://claude.com/claude-code)