### PR TITLE
feat(fetcher): cross-platform system fetchers via sysinfo

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -133,6 +133,34 @@ fetcher = "read_store"
 file_format = "text"
 render = { type = "simple", align = "center" }
 
+# ── System fetchers (sysinfo-backed, cross-platform) ─────────────────
+# Each fetcher is multi-shape; the renderer pick below is one valid pairing.
+
+[[widget]]
+id = "cpu"
+fetcher = "cpu_load"
+render = "gauge"
+
+[[widget]]
+id = "memory"
+fetcher = "memory"
+render = "line_gauge"
+
+[[widget]]
+id = "uptime"
+fetcher = "uptime"
+render = { type = "simple", align = "center" }
+
+[[widget]]
+id = "load_avg"
+fetcher = "load_average"
+render = { type = "simple", align = "center" }
+
+[[widget]]
+id = "processes"
+fetcher = "process_top"
+render = "table"
+
 # ── Layout ──────────────────────────────────────────────────────────
 # Hero band: single-child rows with flex=center so the widget sits in the middle of the row
 # even though it's narrower than the terminal. 2-column rows below keep the default Legacy
@@ -263,5 +291,39 @@ height = { length = 6 }
   [[row.child]]
   widget = "recent_commits"
   title = "timeline"
+  border = "rounded"
+
+[[row]]
+height = { length = 3 }
+
+  [[row.child]]
+  widget = "cpu"
+  title = "cpu_load"
+  border = "rounded"
+
+  [[row.child]]
+  widget = "memory"
+  title = "memory"
+  border = "rounded"
+
+[[row]]
+height = { length = 3 }
+
+  [[row.child]]
+  widget = "uptime"
+  title = "uptime"
+  border = "rounded"
+
+  [[row.child]]
+  widget = "load_avg"
+  title = "load_average"
+  border = "rounded"
+
+[[row]]
+height = { length = 7 }
+
+  [[row.child]]
+  widget = "processes"
+  title = "process_top"
   border = "rounded"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -1128,6 +1128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1199,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1437,7 +1465,7 @@ dependencies = [
  "ratatui",
  "rustix 0.38.44",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1716,6 +1744,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sysinfo",
  "tempfile",
  "time",
  "tokio",
@@ -1772,6 +1801,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2099,8 +2142,29 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2109,11 +2173,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2121,6 +2209,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2139,10 +2238,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2154,13 +2274,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2219,6 +2357,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "proce
 async-trait = "0.1"
 sha2 = "0.10"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+sysinfo = "0.38.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -14,6 +14,7 @@ pub mod clock;
 pub mod read_store;
 pub mod static_text;
 pub mod stub;
+pub mod system;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Safety {
@@ -182,6 +183,12 @@ impl Registry {
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register_realtime(Arc::new(clock::ClockFetcher));
+        for f in system::realtime_fetchers() {
+            r.register_realtime(f);
+        }
+        for f in system::cached_fetchers() {
+            r.register(f);
+        }
         for f in stub::stubs() {
             r.register(f);
         }

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -1,15 +1,14 @@
 //! Placeholder fetchers that still return canned data. Each of these is blocked on a dedicated
-//! issue (#8 git, #9 system, #11 github) and will be replaced one-by-one. Keeping them in a
-//! single module makes it obvious at a glance which parts of the default dashboard aren't real
-//! yet.
+//! issue (#8 git, #11 github) and will be replaced one-by-one. Keeping them in a single module
+//! makes it obvious at a glance which parts of the default dashboard aren't real yet.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::payload::{
-    BadgeData, Bar, BarsData, Body, EntriesData, Entry, HeatmapData, NumberSeriesData, Payload,
-    PointSeries, PointSeriesData, RatioData, Status, TimelineData, TimelineEvent,
+    BadgeData, Bar, BarsData, Body, HeatmapData, NumberSeriesData, Payload, PointSeries,
+    PointSeriesData, Status, TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 
@@ -17,9 +16,7 @@ use super::{FetchContext, FetchError, Fetcher, Safety};
 
 pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
     vec![
-        Arc::new(DiskStub),
         Arc::new(GitCommitsStub),
-        Arc::new(SystemStub),
         Arc::new(GithubPrsStub),
         Arc::new(TrendStub),
         Arc::new(ContributionsStub),
@@ -28,27 +25,6 @@ pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(OncallStatusStub),
         Arc::new(GitRecentCommitsStub),
     ]
-}
-
-pub struct DiskStub;
-
-#[async_trait]
-impl Fetcher for DiskStub {
-    fn name(&self) -> &str {
-        "disk"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Safe
-    }
-    fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio]
-    }
-    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
-        Ok(payload(Body::Ratio(RatioData {
-            value: 0.45,
-            label: Some("45% of 500 GB".into()),
-        })))
-    }
 }
 
 pub struct GitCommitsStub;
@@ -67,43 +43,6 @@ impl Fetcher for GitCommitsStub {
     async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
         Ok(payload(Body::NumberSeries(NumberSeriesData {
             values: vec![2, 5, 0, 3, 7, 4, 1, 6, 9, 2, 3, 5, 8, 4],
-        })))
-    }
-}
-
-pub struct SystemStub;
-
-#[async_trait]
-impl Fetcher for SystemStub {
-    fn name(&self) -> &str {
-        "system"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Safe
-    }
-    fn shapes(&self) -> &[Shape] {
-        &[Shape::Entries]
-    }
-    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
-        let ok = Some(Status::Ok);
-        Ok(payload(Body::Entries(EntriesData {
-            items: vec![
-                Entry {
-                    key: "os".into(),
-                    value: Some("linux".into()),
-                    status: ok,
-                },
-                Entry {
-                    key: "uptime".into(),
-                    value: Some("3d 2h".into()),
-                    status: ok,
-                },
-                Entry {
-                    key: "load".into(),
-                    value: Some("0.28".into()),
-                    status: ok,
-                },
-            ],
         })))
     }
 }
@@ -399,8 +338,6 @@ mod tests {
 
     #[test]
     fn safety_classification_matches_feature_surface() {
-        assert_eq!(DiskStub.safety(), Safety::Safe);
-        assert_eq!(SystemStub.safety(), Safety::Safe);
         assert_eq!(GitCommitsStub.safety(), Safety::Exec);
         assert_eq!(GithubPrsStub.safety(), Safety::Network);
     }
@@ -410,9 +347,7 @@ mod tests {
         let fetchers = stubs();
         let names: Vec<&str> = fetchers.iter().map(|f| f.name()).collect();
         for expected in [
-            "disk",
             "git_commits",
-            "system",
             "github_prs",
             "trend",
             "contributions",

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -282,10 +282,7 @@ impl RealtimeFetcher for ProcessTopFetcher {
         let rows = top_processes(&sys, PROCESS_TOP_COUNT);
         match ctx.shape.unwrap_or(Shape::Entries) {
             Shape::Lines => payload(Body::Lines(LinesData {
-                lines: rows
-                    .iter()
-                    .map(|(n, c)| format!("{n}  {c:.1}%"))
-                    .collect(),
+                lines: rows.iter().map(|(n, c)| format!("{n}  {c:.1}%")).collect(),
             })),
             _ => payload(Body::Entries(EntriesData {
                 items: rows
@@ -319,9 +316,11 @@ impl Fetcher for DiskFetcher {
                 bars: disk_bars(&disks),
             })),
             Shape::Lines => payload(Body::Lines(LinesData {
-                lines: vec![primary_disk(&disks)
-                    .map(|(t, a)| disk_label(t, a))
-                    .unwrap_or_else(|| "no disks detected".into())],
+                lines: vec![
+                    primary_disk(&disks)
+                        .map(|(t, a)| disk_label(t, a))
+                        .unwrap_or_else(|| "no disks detected".into()),
+                ],
             })),
             _ => primary_disk(&disks)
                 .map(|(total, available)| {

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -1,0 +1,601 @@
+//! Cross-platform system fetchers backed by `sysinfo`.
+//!
+//! All are `Safety::Safe` — local kernel counters only, no network or exec. Realtime fetchers
+//! cache a `Mutex<System>` and refresh only the fields they need per frame, so the `<1ms
+//! infallible` contract holds even as many widgets sample the same source.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use sysinfo::{Disks, ProcessesToUpdate, System};
+
+use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, LinesData, Payload, RatioData};
+use crate::render::Shape;
+
+use super::{FetchContext, FetchError, Fetcher, RealtimeFetcher, Safety};
+
+pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
+    vec![
+        Arc::new(SystemFetcher::new()),
+        Arc::new(CpuLoadFetcher::new()),
+        Arc::new(MemoryFetcher::new()),
+        Arc::new(UptimeFetcher),
+        Arc::new(LoadAverageFetcher),
+        Arc::new(ProcessTopFetcher::new()),
+    ]
+}
+
+pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(DiskFetcher)]
+}
+
+/// `os / host / uptime / load / cpu / memory` rollup. Entries by default; `Lines` collapses each
+/// row to `"key: value"` so the same fetcher can feed the `text` / `ascii_art` renderers.
+pub struct SystemFetcher {
+    state: Mutex<System>,
+    os: String,
+    host: String,
+}
+
+impl SystemFetcher {
+    pub fn new() -> Self {
+        let mut sys = System::new();
+        sys.refresh_cpu_usage();
+        sys.refresh_memory();
+        Self {
+            state: Mutex::new(sys),
+            os: os_label(),
+            host: System::host_name().unwrap_or_else(|| "unknown".into()),
+        }
+    }
+}
+
+impl Default for SystemFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RealtimeFetcher for SystemFetcher {
+    fn name(&self) -> &str {
+        "system"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Entries, Shape::Lines]
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let mut sys = self.state.lock().expect("system state mutex poisoned");
+        sys.refresh_cpu_usage();
+        sys.refresh_memory();
+        let rows = [
+            ("os", self.os.clone()),
+            ("host", self.host.clone()),
+            ("uptime", format_uptime(System::uptime())),
+            ("load", format!("{:.2}", System::load_average().one)),
+            ("cpu", format!("{:.0}%", sys.global_cpu_usage())),
+            ("memory", format!("{:.0}%", memory_ratio(&sys) * 100.0)),
+        ];
+        match ctx.shape.unwrap_or(Shape::Entries) {
+            Shape::Lines => payload(Body::Lines(LinesData {
+                lines: rows.iter().map(|(k, v)| format!("{k}: {v}")).collect(),
+            })),
+            _ => payload(Body::Entries(EntriesData {
+                items: rows.iter().map(|(k, v)| entry(k, v)).collect(),
+            })),
+        }
+    }
+}
+
+/// Aggregated CPU usage across all cores. `Ratio` (0..=1) for gauges, `Lines` for plain text.
+pub struct CpuLoadFetcher {
+    state: Mutex<System>,
+}
+
+impl CpuLoadFetcher {
+    pub fn new() -> Self {
+        let mut sys = System::new();
+        sys.refresh_cpu_usage();
+        Self {
+            state: Mutex::new(sys),
+        }
+    }
+}
+
+impl Default for CpuLoadFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RealtimeFetcher for CpuLoadFetcher {
+    fn name(&self) -> &str {
+        "cpu_load"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Ratio, Shape::Lines]
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let mut sys = self.state.lock().expect("cpu state mutex poisoned");
+        sys.refresh_cpu_usage();
+        let pct = sys.global_cpu_usage();
+        let ratio = (f64::from(pct) / 100.0).clamp(0.0, 1.0);
+        let label = format!("{pct:.0}%");
+        match ctx.shape.unwrap_or(Shape::Ratio) {
+            Shape::Lines => payload(Body::Lines(LinesData { lines: vec![label] })),
+            _ => payload(Body::Ratio(RatioData {
+                value: ratio,
+                label: Some(label),
+            })),
+        }
+    }
+}
+
+/// RAM usage. `Ratio` by default, `Lines` as `"3.2 GB / 16 GB"`, `Entries` as used/total/free rows.
+pub struct MemoryFetcher {
+    state: Mutex<System>,
+}
+
+impl MemoryFetcher {
+    pub fn new() -> Self {
+        let mut sys = System::new();
+        sys.refresh_memory();
+        Self {
+            state: Mutex::new(sys),
+        }
+    }
+}
+
+impl Default for MemoryFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RealtimeFetcher for MemoryFetcher {
+    fn name(&self) -> &str {
+        "memory"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Ratio, Shape::Lines, Shape::Entries]
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let mut sys = self.state.lock().expect("memory state mutex poisoned");
+        sys.refresh_memory();
+        let total = sys.total_memory();
+        let used = sys.used_memory();
+        let ratio = ratio_of(used, total);
+        let label = format!("{} / {}", format_bytes(used), format_bytes(total));
+        match ctx.shape.unwrap_or(Shape::Ratio) {
+            Shape::Lines => payload(Body::Lines(LinesData { lines: vec![label] })),
+            Shape::Entries => payload(Body::Entries(EntriesData {
+                items: vec![
+                    entry("used", &format_bytes(used)),
+                    entry("total", &format_bytes(total)),
+                    entry("free", &format_bytes(total.saturating_sub(used))),
+                ],
+            })),
+            _ => payload(Body::Ratio(RatioData {
+                value: ratio,
+                label: Some(label),
+            })),
+        }
+    }
+}
+
+/// Time since boot as a compact `"3d 4h"` / `"2h 15m"` / `"45m"` string.
+pub struct UptimeFetcher;
+
+impl RealtimeFetcher for UptimeFetcher {
+    fn name(&self) -> &str {
+        "uptime"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Lines]
+    }
+    fn compute(&self, _: &FetchContext) -> Payload {
+        payload(Body::Lines(LinesData {
+            lines: vec![format_uptime(System::uptime())],
+        }))
+    }
+}
+
+/// 1 / 5 / 15-minute load average. `Lines` default; `Entries` splits the three windows.
+/// Windows doesn't expose load average — shown as `"n/a (windows)"` there.
+pub struct LoadAverageFetcher;
+
+impl RealtimeFetcher for LoadAverageFetcher {
+    fn name(&self) -> &str {
+        "load_average"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Lines, Shape::Entries]
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let la = System::load_average();
+        match ctx.shape.unwrap_or(Shape::Lines) {
+            Shape::Entries => payload(Body::Entries(EntriesData {
+                items: vec![
+                    entry("1min", &format_load(la.one)),
+                    entry("5min", &format_load(la.five)),
+                    entry("15min", &format_load(la.fifteen)),
+                ],
+            })),
+            _ => payload(Body::Lines(LinesData {
+                lines: vec![load_line(la.one, la.five, la.fifteen)],
+            })),
+        }
+    }
+}
+
+/// Top N processes by CPU usage. `Entries` default (`"python": "42.1%"`), `Lines` collapses to
+/// one process per row.
+pub struct ProcessTopFetcher {
+    state: Mutex<System>,
+}
+
+const PROCESS_TOP_COUNT: usize = 5;
+
+impl ProcessTopFetcher {
+    pub fn new() -> Self {
+        let mut sys = System::new();
+        sys.refresh_processes(ProcessesToUpdate::All, true);
+        Self {
+            state: Mutex::new(sys),
+        }
+    }
+}
+
+impl Default for ProcessTopFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RealtimeFetcher for ProcessTopFetcher {
+    fn name(&self) -> &str {
+        "process_top"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Entries, Shape::Lines]
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let mut sys = self.state.lock().expect("process state mutex poisoned");
+        sys.refresh_processes(ProcessesToUpdate::All, true);
+        let rows = top_processes(&sys, PROCESS_TOP_COUNT);
+        match ctx.shape.unwrap_or(Shape::Entries) {
+            Shape::Lines => payload(Body::Lines(LinesData {
+                lines: rows
+                    .iter()
+                    .map(|(n, c)| format!("{n}  {c:.1}%"))
+                    .collect(),
+            })),
+            _ => payload(Body::Entries(EntriesData {
+                items: rows
+                    .iter()
+                    .map(|(n, c)| entry(n, &format!("{c:.1}%")))
+                    .collect(),
+            })),
+        }
+    }
+}
+
+/// Disk usage. Cached (mount scan on each refresh is a syscall, not <1ms). Defaults to the
+/// largest disk as `Ratio`; `Lines` renders `"45% of 500 GB"`; `Bars` lists every mount.
+pub struct DiskFetcher;
+
+#[async_trait]
+impl Fetcher for DiskFetcher {
+    fn name(&self) -> &str {
+        "disk"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Ratio, Shape::Lines, Shape::Bars]
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let disks = Disks::new_with_refreshed_list();
+        Ok(match ctx.shape.unwrap_or(Shape::Ratio) {
+            Shape::Bars => payload(Body::Bars(BarsData {
+                bars: disk_bars(&disks),
+            })),
+            Shape::Lines => payload(Body::Lines(LinesData {
+                lines: vec![primary_disk(&disks)
+                    .map(|(t, a)| disk_label(t, a))
+                    .unwrap_or_else(|| "no disks detected".into())],
+            })),
+            _ => primary_disk(&disks)
+                .map(|(total, available)| {
+                    let used = total.saturating_sub(available);
+                    payload(Body::Ratio(RatioData {
+                        value: ratio_of(used, total),
+                        label: Some(disk_label(total, available)),
+                    }))
+                })
+                .unwrap_or_else(|| {
+                    payload(Body::Lines(LinesData {
+                        lines: vec!["no disks detected".into()],
+                    }))
+                }),
+        })
+    }
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+fn entry(key: &str, value: &str) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.into()),
+        status: None,
+    }
+}
+
+fn os_label() -> String {
+    System::long_os_version()
+        .or_else(System::name)
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn memory_ratio(sys: &System) -> f64 {
+    ratio_of(sys.used_memory(), sys.total_memory())
+}
+
+fn ratio_of(numer: u64, denom: u64) -> f64 {
+    if denom == 0 {
+        0.0
+    } else {
+        (numer as f64 / denom as f64).clamp(0.0, 1.0)
+    }
+}
+
+fn top_processes(sys: &System, count: usize) -> Vec<(String, f32)> {
+    let mut rows: Vec<(String, f32)> = sys
+        .processes()
+        .values()
+        .map(|p| (p.name().to_string_lossy().into_owned(), p.cpu_usage()))
+        .collect();
+    rows.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    rows.truncate(count);
+    rows
+}
+
+fn primary_disk(disks: &Disks) -> Option<(u64, u64)> {
+    disks
+        .iter()
+        .filter(|d| d.total_space() > 0)
+        .max_by_key(|d| d.total_space())
+        .map(|d| (d.total_space(), d.available_space()))
+}
+
+fn disk_bars(disks: &Disks) -> Vec<Bar> {
+    disks
+        .iter()
+        .filter(|d| d.total_space() > 0)
+        .map(|d| Bar {
+            label: d.mount_point().to_string_lossy().into_owned(),
+            value: d.total_space().saturating_sub(d.available_space()),
+        })
+        .collect()
+}
+
+fn disk_label(total: u64, available: u64) -> String {
+    let used = total.saturating_sub(available);
+    format!(
+        "{:.0}% of {}",
+        ratio_of(used, total) * 100.0,
+        format_bytes(total)
+    )
+}
+
+fn format_uptime(secs: u64) -> String {
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3600;
+    let minutes = (secs % 3600) / 60;
+    match (days, hours, minutes) {
+        (0, 0, m) => format!("{m}m"),
+        (0, h, m) => format!("{h}h {m}m"),
+        (d, h, _) => format!("{d}d {h}h"),
+    }
+}
+
+fn format_load(v: f64) -> String {
+    if cfg!(windows) {
+        "n/a".into()
+    } else {
+        format!("{v:.2}")
+    }
+}
+
+#[cfg(windows)]
+fn load_line(_: f64, _: f64, _: f64) -> String {
+    "n/a (windows)".into()
+}
+
+#[cfg(not(windows))]
+fn load_line(one: f64, five: f64, fifteen: f64) -> String {
+    format!("{one:.2} {five:.2} {fifteen:.2}")
+}
+
+const KB: u64 = 1024;
+const MB: u64 = 1024 * KB;
+const GB: u64 = 1024 * MB;
+const TB: u64 = 1024 * GB;
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes >= TB {
+        format!("{:.1} TB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.0} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.0} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn ctx_with_shape(shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn format_uptime_covers_minute_hour_day_ranges() {
+        assert_eq!(format_uptime(0), "0m");
+        assert_eq!(format_uptime(45 * 60), "45m");
+        assert_eq!(format_uptime(2 * 3600 + 15 * 60), "2h 15m");
+        assert_eq!(format_uptime(3 * 86_400 + 4 * 3600 + 30 * 60), "3d 4h");
+    }
+
+    #[test]
+    fn format_bytes_buckets_by_unit() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(4 * KB), "4 KB");
+        assert_eq!(format_bytes(250 * MB), "250 MB");
+        assert_eq!(format_bytes(2 * GB + GB / 2), "2.5 GB");
+        assert_eq!(format_bytes(3 * TB), "3.0 TB");
+    }
+
+    #[test]
+    fn ratio_of_handles_zero_denominator() {
+        assert_eq!(ratio_of(10, 0), 0.0);
+        assert_eq!(ratio_of(5, 10), 0.5);
+        assert_eq!(ratio_of(20, 10), 1.0);
+    }
+
+    #[test]
+    fn cpu_load_defaults_to_ratio() {
+        let p = CpuLoadFetcher::new().compute(&ctx_with_shape(None));
+        assert!(matches!(p.body, Body::Ratio(_)));
+    }
+
+    #[test]
+    fn cpu_load_emits_lines_when_requested() {
+        let p = CpuLoadFetcher::new().compute(&ctx_with_shape(Some(Shape::Lines)));
+        assert!(matches!(p.body, Body::Lines(_)));
+    }
+
+    #[test]
+    fn memory_defaults_to_ratio() {
+        let p = MemoryFetcher::new().compute(&ctx_with_shape(None));
+        let Body::Ratio(r) = p.body else {
+            panic!("expected ratio");
+        };
+        assert!((0.0..=1.0).contains(&r.value));
+    }
+
+    #[test]
+    fn memory_entries_shape_has_three_rows() {
+        let p = MemoryFetcher::new().compute(&ctx_with_shape(Some(Shape::Entries)));
+        let Body::Entries(e) = p.body else {
+            panic!("expected entries");
+        };
+        let keys: Vec<_> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(keys, ["used", "total", "free"]);
+    }
+
+    #[test]
+    fn uptime_emits_single_line() {
+        let p = UptimeFetcher.compute(&ctx_with_shape(None));
+        let Body::Lines(l) = p.body else {
+            panic!("expected lines");
+        };
+        assert_eq!(l.lines.len(), 1);
+    }
+
+    #[test]
+    fn load_average_defaults_to_lines() {
+        let p = LoadAverageFetcher.compute(&ctx_with_shape(None));
+        assert!(matches!(p.body, Body::Lines(_)));
+    }
+
+    #[test]
+    fn load_average_entries_shape_has_three_windows() {
+        let p = LoadAverageFetcher.compute(&ctx_with_shape(Some(Shape::Entries)));
+        let Body::Entries(e) = p.body else {
+            panic!("expected entries");
+        };
+        let keys: Vec<_> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(keys, ["1min", "5min", "15min"]);
+    }
+
+    #[test]
+    fn system_rollup_emits_six_rows() {
+        let p = SystemFetcher::new().compute(&ctx_with_shape(None));
+        let Body::Entries(e) = p.body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 6);
+    }
+
+    #[test]
+    fn system_lines_shape_returns_key_value_strings() {
+        let p = SystemFetcher::new().compute(&ctx_with_shape(Some(Shape::Lines)));
+        let Body::Lines(l) = p.body else {
+            panic!("expected lines");
+        };
+        assert_eq!(l.lines.len(), 6);
+        assert!(l.lines.iter().all(|s| s.contains(": ")));
+    }
+
+    #[test]
+    fn process_top_respects_count_cap() {
+        let p = ProcessTopFetcher::new().compute(&ctx_with_shape(None));
+        let Body::Entries(e) = p.body else {
+            panic!("expected entries");
+        };
+        assert!(e.items.len() <= PROCESS_TOP_COUNT);
+    }
+
+    #[tokio::test]
+    async fn disk_defaults_to_ratio_or_lines_fallback() {
+        let ctx = ctx_with_shape(None);
+        let p = DiskFetcher.fetch(&ctx).await.unwrap();
+        assert!(matches!(p.body, Body::Ratio(_) | Body::Lines(_)));
+    }
+
+    #[tokio::test]
+    async fn disk_bars_shape_emits_bars_body() {
+        let ctx = ctx_with_shape(Some(Shape::Bars));
+        let p = DiskFetcher.fetch(&ctx).await.unwrap();
+        assert!(matches!(p.body, Body::Bars(_)));
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -215,7 +215,6 @@ pub async fn run(
             // daemon finishes (if we were waiting for it) or the window expires.
             let buckets = WidgetBuckets {
                 cached: &cached_widgets,
-                realtime: &realtime_widgets,
                 gated: &gated,
                 shape_invalid: &shape_invalid,
             };
@@ -303,14 +302,15 @@ pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &st
 /// categories explicit at call sites.
 struct WidgetBuckets<'a> {
     cached: &'a [WidgetConfig],
-    realtime: &'a [WidgetConfig],
     gated: &'a [WidgetConfig],
     shape_invalid: &'a [(WidgetConfig, ShapeMismatch)],
 }
 
-/// Rebuilds the payload map after the daemon has run: pulls fresh entries from the cache for
-/// cached widgets, recomputes realtime widgets, and re-applies the trust-gate placeholders on
-/// top. Used by both the `--wait` path and the first-run fallback so the two stay in sync.
+/// Merges fresh daemon-written cache entries into the payload map between frames. Realtime
+/// payloads stay exactly as they were computed once before the loop — the animation window is
+/// short (2s) and recomputing per frame would make expensive fetchers like `process_top`
+/// scale badly. Trust-gate and shape-mismatch placeholders are re-applied defensively so a
+/// daemon-written entry can't leak into a gated slot.
 fn refresh_payloads(
     cache: &Option<Cache>,
     registry: &Registry,
@@ -319,12 +319,9 @@ fn refresh_payloads(
     payloads: &mut HashMap<WidgetId, Payload>,
 ) {
     let entries = load_entries(cache.as_ref(), registry, buckets.cached, shapes);
-    *payloads = entries_to_payloads(&entries);
-    payloads.extend(compute_realtime_payloads(
-        registry,
-        buckets.realtime,
-        shapes,
-    ));
+    for (id, payload) in entries_to_payloads(&entries) {
+        payloads.insert(id, payload);
+    }
     for w in buckets.gated {
         payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
     }


### PR DESCRIPTION
## Summary

- Seven `sysinfo`-backed fetchers replace the `disk`/`system` stubs and fill the realtime system block in the #41 catalog: `system`, `cpu_load`, `memory`, `uptime`, `load_average`, `process_top` (realtime), plus `disk` (cached). All `Safety::Safe`, cross-platform (Linux / macOS / Windows), multi-shape so each fetcher feeds several renderers.
- `refresh_payloads` no longer recomputes realtime fetchers each frame — the pre-loop compute persists through the 2s animation window. Fixes the footgun where `process_top`'s `/proc/*/stat` walk would run up to 40× per splash invocation.
- Dogfood `.splashboard/config.toml` adds cpu/memory/uptime/load/process widgets so the dev splash exercises every new fetcher end-to-end.

## Catalog (#41)

Ticks:
- [x] system (realtime rollup)
- [x] cpu_load
- [x] memory
- [x] disk (replace stub)
- [x] uptime
- [x] load_average (new entry)
- [x] process_top

Explicitly out-of-scope (each would need per-OS native APIs or delta tracking that breaks the realtime <1ms contract): `battery`, `network_speed`, `wifi_ssid`, `gpu`, `sensor_temperatures`, `ip_addresses`, `mounted_volumes`.

## Test plan

- [x] `cargo test` — 220 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo run` in this repo renders without panics, every new widget displays real data
- [ ] Verify on macOS (load_average, process_top, disks from /Volumes)
- [ ] Verify on Windows (load_average shows `n/a (windows)`, disk picks system drive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)