### PR TITLE
feat(fetcher): gix-backed git fetchers (8 widgets)

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -75,7 +75,7 @@ render = "line_gauge"
 
 [[widget]]
 id = "commits"
-fetcher = "git_commits"
+fetcher = "git_commits_activity"
 render = "sparkline"
 
 # ── PointSeries: 2 renderers ────────────────────────────────────────

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +280,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cassowary"
@@ -340,6 +372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -525,6 +575,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,10 +660,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equator"
@@ -653,6 +732,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +783,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4742a071cd9694fc86f9fa1a08fa3e53d40cc899d7ee532295da2d085639fbc5"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +820,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font8x8"
@@ -771,6 +877,873 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.81.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "winnow",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39acf819aa9fee65e4838a2eec5cb2506e47ebb89e02a5ab9918196e491571ea"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff 0.1.8",
+ "imara-diff 0.2.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+dependencies = [
+ "bytes",
+ "bytesize",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix 1.1.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "imara-diff 0.1.8",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be19313dcdb7dff75a3ce2f99be00878458295bcc3b6c7f0005591597573345c"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f"
+dependencies = [
+ "bitflags",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+
+[[package]]
+name = "gix-transport"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +1755,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,7 +1777,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -799,10 +1798,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "human_format"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
 
 [[package]]
 name = "iana-time-zone"
@@ -875,6 +1890,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1998,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +2056,15 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -1001,7 +2095,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1050,6 +2147,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +2172,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1120,6 +2237,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "noop_proc_macro"
@@ -1256,7 +2379,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1274,10 +2397,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -1290,6 +2425,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1314,6 +2464,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "bytesize",
+ "human_format",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1548,6 +2709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +2727,12 @@ dependencies = [
  "libredox",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 
 [[package]]
 name = "rgb"
@@ -1601,6 +2777,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1661,6 +2846,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +2876,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1738,6 +2950,7 @@ dependencies = [
  "clap",
  "dirs",
  "figlet-rs",
+ "gix",
  "image",
  "ratatui",
  "ratatui-image",
@@ -1907,6 +3120,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,10 +3229,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2057,6 +3309,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2139,6 +3401,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2508,6 +3779,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = "0.1"
 sha2 = "0.10"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 sysinfo = "0.38.4"
+gix = { version = "0.81", default-features = false, features = ["revision", "status", "blob-diff", "max-performance-safe", "comfort", "sha1"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -19,7 +19,7 @@ render = "gauge"
 
 [[widget]]
 id = "commits"
-fetcher = "git_commits"
+fetcher = "git_commits_activity"
 render = "sparkline"
 
 [[widget]]

--- a/src/fetcher/git/blame_heatmap.rs
+++ b/src/fetcher/git/blame_heatmap.rs
@@ -1,0 +1,289 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::ops::ControlFlow;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
+use gix::object::tree::diff::Change;
+use gix::revision::walk::Sorting;
+use gix::traverse::commit::simple::CommitTimeOrder;
+
+use crate::payload::{Body, HeatmapData, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::Lines];
+const WEEKS: usize = 52;
+const TOP_FILES: usize = 7;
+const MAX_COMMITS: usize = 500;
+
+/// Per-file churn over the last 52 weeks. Rows are the top 7 most-touched files (truncated path),
+/// columns are weeks (rightmost = this week), cell = commits in that week touching that file.
+/// `Lines` emits a top-N summary `"src/main.rs (42), src/lib.rs (31), …"`.
+pub struct GitBlameHeatmap;
+
+#[async_trait]
+impl Fetcher for GitBlameHeatmap {
+    fn name(&self) -> &str {
+        "git_blame_heatmap"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Heatmap
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let today = Local::now().date_naive();
+        let churn = churn(&repo, today)?;
+        Ok(payload(render_body(churn, ctx.shape.unwrap_or(Shape::Heatmap))))
+    }
+}
+
+struct Churn {
+    files: Vec<String>,
+    totals: Vec<u32>,
+    grid: Vec<Vec<u32>>,
+}
+
+fn churn(repo: &gix::Repository, today: NaiveDate) -> Result<Churn, FetchError> {
+    let Ok(head_id) = repo.head_id() else {
+        return Ok(Churn {
+            files: Vec::new(),
+            totals: Vec::new(),
+            grid: Vec::new(),
+        });
+    };
+    let start = grid_start_date(today);
+    let cutoff = start.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+    let walker = repo
+        .rev_walk([head_id.detach()])
+        .sorting(Sorting::ByCommitTimeCutoff {
+            seconds: cutoff,
+            order: CommitTimeOrder::NewestFirst,
+        })
+        .all()
+        .map_err(fail)?;
+
+    let empty_tree = repo.empty_tree();
+    let mut per_file_week: HashMap<String, Vec<u32>> = HashMap::new();
+    let mut totals: HashMap<String, u32> = HashMap::new();
+
+    for info in walker.take(MAX_COMMITS) {
+        let Ok(info) = info else { continue };
+        let Ok(commit) = repo.find_commit(info.id) else {
+            continue;
+        };
+        let Ok(time) = commit.time() else { continue };
+        let Some(dt) = DateTime::<Utc>::from_timestamp(time.seconds, 0) else {
+            continue;
+        };
+        let date = dt.with_timezone(&Local).date_naive();
+        let Some(col) = week_col(date, start) else {
+            continue;
+        };
+        let Ok(tree) = commit.tree() else { continue };
+        let parent_tree = commit
+            .parent_ids()
+            .next()
+            .and_then(|id| repo.find_commit(id.detach()).ok())
+            .and_then(|c| c.tree().ok())
+            .unwrap_or_else(|| empty_tree.clone());
+
+        let Ok(mut changes) = parent_tree.changes() else {
+            continue;
+        };
+        let _ = changes.for_each_to_obtain_tree(&tree, |change| {
+            if let Some(path) = changed_path(&change) {
+                *totals.entry(path.clone()).or_insert(0) += 1;
+                let weeks = per_file_week
+                    .entry(path)
+                    .or_insert_with(|| vec![0u32; WEEKS]);
+                if let Some(slot) = weeks.get_mut(col) {
+                    *slot = slot.saturating_add(1);
+                }
+            }
+            Ok::<_, Infallible>(ControlFlow::Continue(()))
+        });
+    }
+
+    let mut ranked: Vec<_> = totals.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked.truncate(TOP_FILES);
+
+    let files: Vec<String> = ranked.iter().map(|(f, _)| f.clone()).collect();
+    let totals: Vec<u32> = ranked.iter().map(|(_, c)| *c).collect();
+    let grid: Vec<Vec<u32>> = files
+        .iter()
+        .map(|f| {
+            per_file_week
+                .remove(f)
+                .unwrap_or_else(|| vec![0u32; WEEKS])
+        })
+        .collect();
+    Ok(Churn {
+        files,
+        totals,
+        grid,
+    })
+}
+
+fn changed_path(change: &Change<'_, '_, '_>) -> Option<String> {
+    let (loc, mode) = match change {
+        Change::Addition {
+            location,
+            entry_mode,
+            ..
+        }
+        | Change::Deletion {
+            location,
+            entry_mode,
+            ..
+        }
+        | Change::Modification {
+            location,
+            entry_mode,
+            ..
+        }
+        | Change::Rewrite {
+            location,
+            entry_mode,
+            ..
+        } => (*location, entry_mode),
+    };
+    if loc.is_empty() || mode.is_tree() {
+        None
+    } else {
+        Some(loc.to_string())
+    }
+}
+
+fn grid_start_date(today: NaiveDate) -> NaiveDate {
+    use chrono::Datelike;
+    let offset_from_sunday = today.weekday().num_days_from_sunday() as i64;
+    today - Duration::days((WEEKS as i64 - 1) * 7 + offset_from_sunday)
+}
+
+fn week_col(date: NaiveDate, start: NaiveDate) -> Option<usize> {
+    let days = (date - start).num_days();
+    if days < 0 {
+        return None;
+    }
+    let col = (days / 7) as usize;
+    if col >= WEEKS { None } else { Some(col) }
+}
+
+fn render_body(churn: Churn, shape: Shape) -> Body {
+    match shape {
+        Shape::Lines => {
+            if churn.files.is_empty() {
+                lines_body(Vec::new())
+            } else {
+                let line = churn
+                    .files
+                    .iter()
+                    .zip(churn.totals.iter())
+                    .map(|(f, c)| format!("{} ({c})", short_path(f)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                lines_body(vec![line])
+            }
+        }
+        _ => Body::Heatmap(HeatmapData {
+            cells: churn.grid,
+            thresholds: None,
+            row_labels: Some(churn.files.into_iter().map(|f| short_path(&f)).collect()),
+            col_labels: None,
+        }),
+    }
+}
+
+/// Truncate a long path to its basename so the heatmap row label stays readable.
+fn short_path(path: &str) -> String {
+    path.rsplit('/').next().unwrap_or(path).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit_touching, make_repo};
+    use super::*;
+
+    #[test]
+    fn empty_repo_returns_empty() {
+        let (_tmp, repo) = make_repo();
+        let c = churn(&repo, NaiveDate::from_ymd_opt(2026, 4, 22).unwrap()).unwrap();
+        assert!(c.files.is_empty());
+    }
+
+    #[test]
+    fn top_files_ranked_by_commit_count() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "a.rs", "a1");
+        commit_touching(&repo, "a.rs", "a2");
+        commit_touching(&repo, "a.rs", "a3");
+        commit_touching(&repo, "b.rs", "b1");
+        let c = churn(&repo, Local::now().date_naive()).unwrap();
+        assert_eq!(c.files[0], "a.rs");
+        assert_eq!(c.totals[0], 3);
+        assert_eq!(c.files[1], "b.rs");
+        assert_eq!(c.totals[1], 1);
+    }
+
+    #[test]
+    fn current_week_lands_in_rightmost_column() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "a.rs", "a");
+        let c = churn(&repo, Local::now().date_naive()).unwrap();
+        assert_eq!(c.grid[0][WEEKS - 1], 1);
+    }
+
+    #[test]
+    fn lines_shape_summarises_with_counts() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "dir/deep/name.rs", "x");
+        let body = render_body(churn(&repo, Local::now().date_naive()).unwrap(), Shape::Lines);
+        match body {
+            Body::Lines(d) => {
+                assert_eq!(d.lines.len(), 1);
+                assert!(
+                    d.lines[0].starts_with("name.rs ("),
+                    "unexpected line: {:?}",
+                    d.lines[0]
+                );
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn heatmap_shape_carries_row_labels() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "x.rs", "x");
+        let body = render_body(
+            churn(&repo, Local::now().date_naive()).unwrap(),
+            Shape::Heatmap,
+        );
+        match body {
+            Body::Heatmap(d) => {
+                assert_eq!(d.row_labels.as_ref().unwrap(), &vec!["x.rs".to_string()]);
+                assert_eq!(d.cells[0].len(), WEEKS);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn short_path_returns_basename() {
+        assert_eq!(short_path("a.rs"), "a.rs");
+        assert_eq!(short_path("src/foo/bar.rs"), "bar.rs");
+    }
+}

--- a/src/fetcher/git/blame_heatmap.rs
+++ b/src/fetcher/git/blame_heatmap.rs
@@ -45,7 +45,10 @@ impl Fetcher for GitBlameHeatmap {
         let repo = open_repo()?;
         let today = Local::now().date_naive();
         let churn = churn(&repo, today)?;
-        Ok(payload(render_body(churn, ctx.shape.unwrap_or(Shape::Heatmap))))
+        Ok(payload(render_body(
+            churn,
+            ctx.shape.unwrap_or(Shape::Heatmap),
+        )))
     }
 }
 
@@ -124,11 +127,7 @@ fn churn(repo: &gix::Repository, today: NaiveDate) -> Result<Churn, FetchError> 
     let totals: Vec<u32> = ranked.iter().map(|(_, c)| *c).collect();
     let grid: Vec<Vec<u32>> = files
         .iter()
-        .map(|f| {
-            per_file_week
-                .remove(f)
-                .unwrap_or_else(|| vec![0u32; WEEKS])
-        })
+        .map(|f| per_file_week.remove(f).unwrap_or_else(|| vec![0u32; WEEKS]))
         .collect();
     Ok(Churn {
         files,
@@ -250,7 +249,10 @@ mod tests {
     fn lines_shape_summarises_with_counts() {
         let (_tmp, repo) = make_repo();
         commit_touching(&repo, "dir/deep/name.rs", "x");
-        let body = render_body(churn(&repo, Local::now().date_naive()).unwrap(), Shape::Lines);
+        let body = render_body(
+            churn(&repo, Local::now().date_naive()).unwrap(),
+            Shape::Lines,
+        );
         match body {
             Body::Lines(d) => {
                 assert_eq!(d.lines.len(), 1);

--- a/src/fetcher/git/commits_activity.rs
+++ b/src/fetcher/git/commits_activity.rs
@@ -1,0 +1,249 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, Utc};
+use gix::revision::walk::Sorting;
+use gix::traverse::commit::simple::CommitTimeOrder;
+
+use crate::payload::{Body, HeatmapData, NumberSeriesData, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::NumberSeries, Shape::Lines];
+const WEEKS: usize = 52;
+const DAYS_PER_WEEK: usize = 7;
+
+/// Commit count per day over the last 52 weeks, anchored like GitHub: rightmost column contains
+/// today's week, rows are weekdays (0 = Sunday .. 6 = Saturday). `Heatmap` is the default; the
+/// `NumberSeries` alt flattens the grid into a 364-point array for sparkline rendering;
+/// `Lines` emits a one-line summary.
+pub struct GitCommitsActivity;
+
+#[async_trait]
+impl Fetcher for GitCommitsActivity {
+    fn name(&self) -> &str {
+        "git_commits_activity"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Heatmap
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let today = Local::now().date_naive();
+        let grid = commits_grid(&repo, today)?;
+        Ok(payload(render_body(
+            grid,
+            today,
+            ctx.shape.unwrap_or(Shape::Heatmap),
+        )))
+    }
+}
+
+fn commits_grid(repo: &gix::Repository, today: NaiveDate) -> Result<Vec<Vec<u32>>, FetchError> {
+    let mut grid = vec![vec![0u32; WEEKS]; DAYS_PER_WEEK];
+    let Ok(head_id) = repo.head_id() else {
+        return Ok(grid);
+    };
+    let start = grid_start_date(today);
+    let cutoff = start.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+    let walker = repo
+        .rev_walk([head_id.detach()])
+        .sorting(Sorting::ByCommitTimeCutoff {
+            seconds: cutoff,
+            order: CommitTimeOrder::NewestFirst,
+        })
+        .all()
+        .map_err(fail)?;
+    for info in walker {
+        let Ok(info) = info else { continue };
+        let Ok(commit) = repo.find_commit(info.id) else {
+            continue;
+        };
+        let Ok(time) = commit.time() else { continue };
+        let Some(dt) = DateTime::<Utc>::from_timestamp(time.seconds, 0) else {
+            continue;
+        };
+        let date = dt.with_timezone(&Local).date_naive();
+        if let Some((row, col)) = cell_of(date, start, today) {
+            grid[row][col] = grid[row][col].saturating_add(1);
+        }
+    }
+    Ok(grid)
+}
+
+/// Sunday of the leftmost column so `today`'s week lands in column 51.
+fn grid_start_date(today: NaiveDate) -> NaiveDate {
+    let offset_from_sunday = today.weekday().num_days_from_sunday() as i64;
+    today - Duration::days((WEEKS as i64 - 1) * 7 + offset_from_sunday)
+}
+
+fn cell_of(date: NaiveDate, start: NaiveDate, today: NaiveDate) -> Option<(usize, usize)> {
+    if date < start || date > today {
+        return None;
+    }
+    let days_from_start = (date - start).num_days();
+    let col = (days_from_start / 7) as usize;
+    let row = date.weekday().num_days_from_sunday() as usize;
+    if col >= WEEKS || row >= DAYS_PER_WEEK {
+        return None;
+    }
+    Some((row, col))
+}
+
+fn month_labels(start: NaiveDate) -> Vec<String> {
+    let mut last_month = 0u32;
+    (0..WEEKS)
+        .map(|week| {
+            let week_start = start + Duration::days((week as i64) * 7);
+            for d in 0..DAYS_PER_WEEK {
+                let day = week_start + Duration::days(d as i64);
+                if day.day() == 1 && day.month() != last_month {
+                    last_month = day.month();
+                    return short_month(day.month());
+                }
+            }
+            String::new()
+        })
+        .collect()
+}
+
+fn short_month(m: u32) -> String {
+    ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+        .get(m as usize)
+        .copied()
+        .unwrap_or("")
+        .to_string()
+}
+
+fn render_body(grid: Vec<Vec<u32>>, today: NaiveDate, shape: Shape) -> Body {
+    match shape {
+        Shape::NumberSeries => Body::NumberSeries(NumberSeriesData {
+            values: flatten_by_day(&grid),
+        }),
+        Shape::Lines => {
+            let total: u64 = grid.iter().flatten().map(|v| *v as u64).sum();
+            if total == 0 {
+                lines_body(Vec::new())
+            } else {
+                lines_body(vec![format!(
+                    "{total} commits in the last {WEEKS} weeks"
+                )])
+            }
+        }
+        _ => Body::Heatmap(HeatmapData {
+            cells: grid,
+            thresholds: None,
+            row_labels: None,
+            col_labels: Some(month_labels(grid_start_date(today))),
+        }),
+    }
+}
+
+/// Flattens a 7×52 grid into a 364-entry daily series in chronological order (oldest → newest).
+fn flatten_by_day(grid: &[Vec<u32>]) -> Vec<u64> {
+    (0..WEEKS)
+        .flat_map(|col| (0..DAYS_PER_WEEK).map(move |row| grid[row][col] as u64))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit, make_repo};
+    use super::*;
+
+    fn any_weekday() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 4, 22).unwrap()
+    }
+
+    #[test]
+    fn empty_repo_grid_is_all_zero() {
+        let (_tmp, repo) = make_repo();
+        let grid = commits_grid(&repo, any_weekday()).unwrap();
+        assert_eq!(grid.len(), DAYS_PER_WEEK);
+        assert!(grid.iter().all(|row| row.len() == WEEKS));
+        assert!(grid.iter().flatten().all(|v| *v == 0));
+    }
+
+    #[test]
+    fn today_commit_lands_in_rightmost_column() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "today");
+        let today = Local::now().date_naive();
+        let grid = commits_grid(&repo, today).unwrap();
+        let row = today.weekday().num_days_from_sunday() as usize;
+        assert_eq!(grid[row][WEEKS - 1], 1, "today should be in last column");
+    }
+
+    #[test]
+    fn grid_start_is_a_sunday() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 22).unwrap(); // Wednesday
+        let start = grid_start_date(today);
+        assert_eq!(start.weekday().num_days_from_sunday(), 0);
+        assert_eq!((today - start).num_days(), (WEEKS as i64 - 1) * 7 + 3);
+    }
+
+    #[test]
+    fn cell_of_past_anchor_in_first_column() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 22).unwrap();
+        let start = grid_start_date(today);
+        // The start date itself should be (row=0 Sun, col=0)
+        assert_eq!(cell_of(start, start, today), Some((0, 0)));
+    }
+
+    #[test]
+    fn cell_of_out_of_range_returns_none() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 22).unwrap();
+        let start = grid_start_date(today);
+        assert!(cell_of(start - Duration::days(1), start, today).is_none());
+        assert!(cell_of(today + Duration::days(1), start, today).is_none());
+    }
+
+    #[test]
+    fn number_series_flatten_is_chronological() {
+        let mut grid = vec![vec![0u32; WEEKS]; DAYS_PER_WEEK];
+        grid[0][0] = 1; // Sunday, first week
+        grid[1][0] = 2; // Monday, first week
+        grid[0][1] = 3; // Sunday, second week
+        let series = flatten_by_day(&grid);
+        assert_eq!(series.len(), WEEKS * DAYS_PER_WEEK);
+        assert_eq!(series[0], 1);
+        assert_eq!(series[1], 2);
+        assert_eq!(series[7], 3);
+    }
+
+    #[test]
+    fn lines_shape_summary() {
+        let mut grid = vec![vec![0u32; WEEKS]; DAYS_PER_WEEK];
+        grid[0][0] = 5;
+        let body = render_body(grid, any_weekday(), Shape::Lines);
+        match body {
+            Body::Lines(d) => {
+                assert_eq!(d.lines.len(), 1);
+                assert!(d.lines[0].contains("5 commits"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn heatmap_shape_carries_month_labels() {
+        let grid = vec![vec![0u32; WEEKS]; DAYS_PER_WEEK];
+        let body = render_body(grid, any_weekday(), Shape::Heatmap);
+        match body {
+            Body::Heatmap(d) => {
+                assert_eq!(d.cells.len(), DAYS_PER_WEEK);
+                assert_eq!(d.col_labels.as_ref().unwrap().len(), WEEKS);
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/src/fetcher/git/commits_activity.rs
+++ b/src/fetcher/git/commits_activity.rs
@@ -117,11 +117,13 @@ fn month_labels(start: NaiveDate) -> Vec<String> {
 }
 
 fn short_month(m: u32) -> String {
-    ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-        .get(m as usize)
-        .copied()
-        .unwrap_or("")
-        .to_string()
+    [
+        "", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ]
+    .get(m as usize)
+    .copied()
+    .unwrap_or("")
+    .to_string()
 }
 
 fn render_body(grid: Vec<Vec<u32>>, today: NaiveDate, shape: Shape) -> Body {
@@ -134,9 +136,7 @@ fn render_body(grid: Vec<Vec<u32>>, today: NaiveDate, shape: Shape) -> Body {
             if total == 0 {
                 lines_body(Vec::new())
             } else {
-                lines_body(vec![format!(
-                    "{total} commits in the last {WEEKS} weeks"
-                )])
+                lines_body(vec![format!("{total} commits in the last {WEEKS} weeks")])
             }
         }
         _ => Body::Heatmap(HeatmapData {

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -41,7 +41,10 @@ impl Fetcher for GitContributors {
         let repo = open_repo()?;
         let days = parse_days(ctx.format.as_deref());
         let ranked = contributors(&repo, days)?;
-        Ok(payload(render_body(ranked, ctx.shape.unwrap_or(Shape::Bars))))
+        Ok(payload(render_body(
+            ranked,
+            ctx.shape.unwrap_or(Shape::Bars),
+        )))
     }
 }
 
@@ -64,7 +67,9 @@ fn contributors(repo: &gix::Repository, days: u64) -> Result<Vec<(String, u64)>,
         let Ok(commit) = repo.find_commit(info.id) else {
             continue;
         };
-        let Ok(author) = commit.author() else { continue };
+        let Ok(author) = commit.author() else {
+            continue;
+        };
         let name = author.name.to_string();
         *counts.entry(name).or_insert(0) += 1;
     }
@@ -136,10 +141,7 @@ mod tests {
         commit_as(&repo, "a2", "alice", "a@example.com");
         commit_as(&repo, "a3", "alice", "a@example.com");
         let ranked = contributors(&repo, 30).unwrap();
-        assert_eq!(
-            ranked,
-            vec![("alice".into(), 3u64), ("bob".into(), 1u64)]
-        );
+        assert_eq!(ranked, vec![("alice".into(), 3u64), ("bob".into(), 1u64)]);
     }
 
     #[test]

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -1,0 +1,182 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use gix::revision::walk::Sorting;
+use gix::traverse::commit::simple::CommitTimeOrder;
+
+use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries, Shape::Lines];
+const DEFAULT_DAYS: u64 = 30;
+const MAX_ENTRIES: usize = 10;
+
+/// Commit authors over the last N days (default 30, configurable via `format = "N"`). Ranked
+/// by commit count, truncated to the top 10 so a busy repo doesn't blow up the widget. `Bars`
+/// is the default (visual ranking); `Entries` emits `name: count` rows; `Lines` collapses to
+/// `"alice (23), bob (11)"` style.
+pub struct GitContributors;
+
+#[async_trait]
+impl Fetcher for GitContributors {
+    fn name(&self) -> &str {
+        "git_contributors"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Bars
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let days = parse_days(ctx.format.as_deref());
+        let ranked = contributors(&repo, days)?;
+        Ok(payload(render_body(ranked, ctx.shape.unwrap_or(Shape::Bars))))
+    }
+}
+
+fn contributors(repo: &gix::Repository, days: u64) -> Result<Vec<(String, u64)>, FetchError> {
+    let Ok(head_id) = repo.head_id() else {
+        return Ok(Vec::new());
+    };
+    let cutoff = chrono::Utc::now().timestamp() - (days as i64) * 86_400;
+    let walker = repo
+        .rev_walk([head_id.detach()])
+        .sorting(Sorting::ByCommitTimeCutoff {
+            seconds: cutoff,
+            order: CommitTimeOrder::NewestFirst,
+        })
+        .all()
+        .map_err(fail)?;
+    let mut counts: HashMap<String, u64> = HashMap::new();
+    for info in walker {
+        let Ok(info) = info else { continue };
+        let Ok(commit) = repo.find_commit(info.id) else {
+            continue;
+        };
+        let Ok(author) = commit.author() else { continue };
+        let name = author.name.to_string();
+        *counts.entry(name).or_insert(0) += 1;
+    }
+    let mut ranked: Vec<_> = counts.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked.truncate(MAX_ENTRIES);
+    Ok(ranked)
+}
+
+fn parse_days(format: Option<&str>) -> u64 {
+    format
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_DAYS)
+}
+
+fn render_body(ranked: Vec<(String, u64)>, shape: Shape) -> Body {
+    match shape {
+        Shape::Entries => Body::Entries(EntriesData {
+            items: ranked
+                .into_iter()
+                .map(|(name, count)| Entry {
+                    key: name,
+                    value: Some(count.to_string()),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Lines => {
+            if ranked.is_empty() {
+                lines_body(Vec::new())
+            } else {
+                let line = ranked
+                    .into_iter()
+                    .map(|(name, count)| format!("{name} ({count})"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                lines_body(vec![line])
+            }
+        }
+        _ => Body::Bars(BarsData {
+            bars: ranked
+                .into_iter()
+                .map(|(name, count)| Bar {
+                    label: name,
+                    value: count,
+                })
+                .collect(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit_as, make_repo};
+    use super::*;
+
+    #[test]
+    fn empty_repo_returns_empty() {
+        let (_tmp, repo) = make_repo();
+        assert!(contributors(&repo, 30).unwrap().is_empty());
+    }
+
+    #[test]
+    fn tallies_authors_in_rank_order() {
+        let (_tmp, repo) = make_repo();
+        commit_as(&repo, "a1", "alice", "a@example.com");
+        commit_as(&repo, "b1", "bob", "b@example.com");
+        commit_as(&repo, "a2", "alice", "a@example.com");
+        commit_as(&repo, "a3", "alice", "a@example.com");
+        let ranked = contributors(&repo, 30).unwrap();
+        assert_eq!(
+            ranked,
+            vec![("alice".into(), 3u64), ("bob".into(), 1u64)]
+        );
+    }
+
+    #[test]
+    fn bars_shape_from_ranking() {
+        let body = render_body(vec![("alice".into(), 3), ("bob".into(), 1)], Shape::Bars);
+        match body {
+            Body::Bars(d) => {
+                assert_eq!(d.bars.len(), 2);
+                assert_eq!(d.bars[0].label, "alice");
+                assert_eq!(d.bars[0].value, 3);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn lines_shape_empty_when_empty() {
+        let body = render_body(Vec::new(), Shape::Lines);
+        match body {
+            Body::Lines(d) => assert!(d.lines.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn lines_shape_joins_with_counts() {
+        let body = render_body(vec![("alice".into(), 3), ("bob".into(), 1)], Shape::Lines);
+        match body {
+            Body::Lines(d) => assert_eq!(d.lines, vec!["alice (3), bob (1)".to_string()]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_days_defaults_and_parses() {
+        assert_eq!(parse_days(None), DEFAULT_DAYS);
+        assert_eq!(parse_days(Some("0")), DEFAULT_DAYS);
+        assert_eq!(parse_days(Some("7")), 7);
+    }
+}

--- a/src/fetcher/git/latest_tag.rs
+++ b/src/fetcher/git/latest_tag.rs
@@ -1,0 +1,147 @@
+use async_trait::async_trait;
+
+use crate::payload::{Body, EntriesData, Entry, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+
+/// Most recent annotated-or-lightweight tag by committer time of the peeled commit. `Lines` emits
+/// just the tag name; `Entries` adds the target short hash and the commit time as ISO date so a
+/// two-line "latest release" widget has somewhere to put the date.
+pub struct GitLatestTag;
+
+#[async_trait]
+impl Fetcher for GitLatestTag {
+    fn name(&self) -> &str {
+        "git_latest_tag"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Lines
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        build(&repo, ctx.shape.unwrap_or(Shape::Lines))
+    }
+}
+
+fn build(repo: &gix::Repository, shape: Shape) -> Result<Payload, FetchError> {
+    let Some(tag) = latest_tag(repo)? else {
+        return Ok(payload(lines_body(Vec::new())));
+    };
+    let body = match shape {
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("tag", &tag.name),
+                entry("commit", &tag.short_hash),
+                entry("date", &tag.iso_date),
+            ],
+        }),
+        _ => lines_body(vec![tag.name]),
+    };
+    Ok(payload(body))
+}
+
+struct TagInfo {
+    name: String,
+    short_hash: String,
+    iso_date: String,
+}
+
+fn latest_tag(repo: &gix::Repository) -> Result<Option<TagInfo>, FetchError> {
+    let refs = repo.references().map_err(fail)?;
+    let tags = refs.tags().map_err(fail)?;
+    let mut best: Option<(TagInfo, i64)> = None;
+    for tag in tags {
+        let mut tag = tag.map_err(fail)?;
+        let name = tag.name().shorten().to_string();
+        let id = tag.peel_to_id().map_err(fail)?;
+        let short_hash = id.shorten().map_err(fail)?.to_string();
+        let Ok(commit) = id.object().map_err(fail)?.try_into_commit() else {
+            continue;
+        };
+        let time = commit.time().map_err(fail)?.seconds;
+        let info = TagInfo {
+            name,
+            short_hash,
+            iso_date: iso_date(time),
+        };
+        match best {
+            Some((_, t)) if t >= time => {}
+            _ => best = Some((info, time)),
+        }
+    }
+    Ok(best.map(|(info, _)| info))
+}
+
+fn iso_date(unix_seconds: i64) -> String {
+    use chrono::{DateTime, Utc};
+    DateTime::<Utc>::from_timestamp(unix_seconds, 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_default()
+}
+
+fn entry(key: &str, value: &str) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.into()),
+        status: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::make_repo;
+    use super::*;
+
+    #[test]
+    fn returns_none_when_no_tags() {
+        let (_tmp, repo) = make_repo();
+        let p = build(&repo, Shape::Lines).unwrap();
+        match p.body {
+            Body::Lines(d) => assert!(d.lines.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn lines_shape_emits_tag_name() {
+        let (_tmp, repo) = make_repo();
+        super::super::test_support::commit(&repo, "initial");
+        super::super::test_support::tag(&repo, "v0.1.0");
+        let p = build(&repo, Shape::Lines).unwrap();
+        match p.body {
+            Body::Lines(d) => assert_eq!(d.lines, vec!["v0.1.0".to_string()]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn entries_shape_has_tag_commit_date() {
+        let (_tmp, repo) = make_repo();
+        super::super::test_support::commit(&repo, "initial");
+        super::super::test_support::tag(&repo, "v1.2.3");
+        let p = build(&repo, Shape::Entries).unwrap();
+        match p.body {
+            Body::Entries(d) => {
+                let keys: Vec<_> = d.items.iter().map(|e| e.key.as_str()).collect();
+                assert_eq!(keys, ["tag", "commit", "date"]);
+                assert_eq!(d.items[0].value.as_deref(), Some("v1.2.3"));
+                assert_eq!(d.items[1].value.as_deref().unwrap().len(), 7);
+                assert!(d.items[2].value.as_deref().unwrap().starts_with("20"));
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/src/fetcher/git/mod.rs
+++ b/src/fetcher/git/mod.rs
@@ -1,0 +1,86 @@
+//! Git / VCS fetchers backed by `gix`. All read-only (Safety::Safe) against the repo rooted at
+//! the process CWD (walk-up via `gix::discover`). Each fetcher is multi-shape: they all accept
+//! `Lines` as a universal fallback plus one or two structural shapes that carry the real data.
+//!
+//! Cache keys mix the discovered repo root so running splashboard in two different projects
+//! doesn't pollute each other's `git_status` cache entries.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+
+use crate::payload::{Body, LinesData, Payload};
+
+use super::{FetchContext, FetchError, Fetcher};
+
+mod blame_heatmap;
+mod commits_activity;
+mod contributors;
+mod latest_tag;
+mod recent_commits;
+mod stash_count;
+mod status;
+mod worktrees;
+
+#[cfg(test)]
+mod test_support;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        Arc::new(status::GitStatus),
+        Arc::new(stash_count::GitStashCount),
+        Arc::new(recent_commits::GitRecentCommits),
+        Arc::new(contributors::GitContributors),
+        Arc::new(commits_activity::GitCommitsActivity),
+        Arc::new(latest_tag::GitLatestTag),
+        Arc::new(worktrees::GitWorktrees),
+        Arc::new(blame_heatmap::GitBlameHeatmap),
+    ]
+}
+
+pub(crate) fn open_repo() -> Result<gix::Repository, FetchError> {
+    let cwd = std::env::current_dir().map_err(fail)?;
+    gix::discover(&cwd).map_err(fail)
+}
+
+pub(crate) fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+pub(crate) fn lines_body(values: Vec<String>) -> Body {
+    Body::Lines(LinesData { lines: values })
+}
+
+pub(crate) fn fail<E: std::fmt::Display>(e: E) -> FetchError {
+    FetchError::Failed(e.to_string())
+}
+
+/// Cache key that mixes the discovered repo root in. Falls back to `cwd` when discovery fails so
+/// two repos don't collide. Shape is included so `git_status` as Entries vs Badge gets separate
+/// cache slots.
+pub(crate) fn repo_cache_key(name: &str, ctx: &FetchContext) -> String {
+    let root = discover_root().unwrap_or_else(|| PathBuf::from(""));
+    let shape = ctx.shape.map(|s| s.as_str()).unwrap_or("default");
+    let raw = format!(
+        "{}|{}|{}|{}",
+        name,
+        root.display(),
+        shape,
+        ctx.format.as_deref().unwrap_or("")
+    );
+    let digest = Sha256::digest(raw.as_bytes());
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{name}-{hex}")
+}
+
+fn discover_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let repo = gix::discover(&cwd).ok()?;
+    repo.git_dir().parent().map(PathBuf::from)
+}

--- a/src/fetcher/git/recent_commits.rs
+++ b/src/fetcher/git/recent_commits.rs
@@ -37,7 +37,10 @@ impl Fetcher for GitRecentCommits {
         let repo = open_repo()?;
         let limit = parse_limit(ctx.format.as_deref());
         let commits = recent_commits(&repo, limit)?;
-        Ok(payload(render_body(commits, ctx.shape.unwrap_or(Shape::Timeline))))
+        Ok(payload(render_body(
+            commits,
+            ctx.shape.unwrap_or(Shape::Timeline),
+        )))
     }
 }
 
@@ -51,10 +54,7 @@ fn recent_commits(repo: &gix::Repository, limit: usize) -> Result<Vec<CommitInfo
     let Ok(head_id) = repo.head_id() else {
         return Ok(Vec::new());
     };
-    let walker = repo
-        .rev_walk([head_id.detach()])
-        .all()
-        .map_err(fail)?;
+    let walker = repo.rev_walk([head_id.detach()]).all().map_err(fail)?;
     let mut out = Vec::with_capacity(limit);
     for info in walker.take(limit) {
         let Ok(info) = info else { continue };

--- a/src/fetcher/git/recent_commits.rs
+++ b/src/fetcher/git/recent_commits.rs
@@ -1,0 +1,189 @@
+use async_trait::async_trait;
+use gix::prelude::ObjectIdExt;
+
+use crate::payload::{Body, Payload, TimelineData, TimelineEvent};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Timeline, Shape::Lines];
+const DEFAULT_LIMIT: usize = 10;
+
+/// Newest commits on HEAD, walked via gix rev-walk. The `format` field is parsed as a commit
+/// count (`"5"`, `"20"`) — absent or unparseable falls back to 10. `Lines` renders
+/// `<short> <summary>` one per line so users who want a flat list instead of the timeline
+/// renderer's relative-ago labels can still wire it up.
+pub struct GitRecentCommits;
+
+#[async_trait]
+impl Fetcher for GitRecentCommits {
+    fn name(&self) -> &str {
+        "git_recent_commits"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Timeline
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let limit = parse_limit(ctx.format.as_deref());
+        let commits = recent_commits(&repo, limit)?;
+        Ok(payload(render_body(commits, ctx.shape.unwrap_or(Shape::Timeline))))
+    }
+}
+
+struct CommitInfo {
+    short_hash: String,
+    summary: String,
+    timestamp: i64,
+}
+
+fn recent_commits(repo: &gix::Repository, limit: usize) -> Result<Vec<CommitInfo>, FetchError> {
+    let Ok(head_id) = repo.head_id() else {
+        return Ok(Vec::new());
+    };
+    let walker = repo
+        .rev_walk([head_id.detach()])
+        .all()
+        .map_err(fail)?;
+    let mut out = Vec::with_capacity(limit);
+    for info in walker.take(limit) {
+        let Ok(info) = info else { continue };
+        let Ok(commit) = repo.find_commit(info.id) else {
+            continue;
+        };
+        let summary = commit
+            .message()
+            .ok()
+            .map(|m| m.summary().to_string())
+            .unwrap_or_default();
+        let timestamp = commit.time().map(|t| t.seconds).unwrap_or(0);
+        let short_hash = info
+            .id
+            .attach(repo)
+            .shorten()
+            .map(|p| p.to_string())
+            .unwrap_or_default();
+        out.push(CommitInfo {
+            short_hash,
+            summary,
+            timestamp,
+        });
+    }
+    Ok(out)
+}
+
+fn parse_limit(format: Option<&str>) -> usize {
+    format
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_LIMIT)
+}
+
+fn render_body(commits: Vec<CommitInfo>, shape: Shape) -> Body {
+    match shape {
+        Shape::Lines => lines_body(
+            commits
+                .into_iter()
+                .map(|c| format!("{} {}", c.short_hash, c.summary))
+                .collect(),
+        ),
+        _ => Body::Timeline(TimelineData {
+            events: commits
+                .into_iter()
+                .map(|c| TimelineEvent {
+                    timestamp: c.timestamp,
+                    title: c.summary,
+                    detail: Some(c.short_hash),
+                    status: None,
+                })
+                .collect(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit, make_repo};
+    use super::*;
+
+    #[test]
+    fn empty_repo_returns_empty_timeline() {
+        let (_tmp, repo) = make_repo();
+        let commits = recent_commits(&repo, 10).unwrap();
+        assert!(commits.is_empty());
+    }
+
+    #[test]
+    fn recent_commits_are_newest_first() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "one");
+        commit(&repo, "two");
+        commit(&repo, "three");
+        let commits = recent_commits(&repo, 10).unwrap();
+        let titles: Vec<_> = commits.iter().map(|c| c.summary.clone()).collect();
+        assert_eq!(titles, vec!["three", "two", "one"]);
+    }
+
+    #[test]
+    fn limit_truncates() {
+        let (_tmp, repo) = make_repo();
+        for i in 0..5 {
+            commit(&repo, &format!("c{i}"));
+        }
+        let commits = recent_commits(&repo, 2).unwrap();
+        assert_eq!(commits.len(), 2);
+    }
+
+    #[test]
+    fn timeline_shape_emits_events_with_short_hash_detail() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "x");
+        let body = render_body(recent_commits(&repo, 10).unwrap(), Shape::Timeline);
+        match body {
+            Body::Timeline(d) => {
+                assert_eq!(d.events.len(), 1);
+                assert_eq!(d.events[0].title, "x");
+                assert!(d.events[0].detail.as_deref().unwrap().len() >= 7);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn lines_shape_prefixes_short_hash() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "hello");
+        let body = render_body(recent_commits(&repo, 10).unwrap(), Shape::Lines);
+        match body {
+            Body::Lines(d) => {
+                assert_eq!(d.lines.len(), 1);
+                assert!(d.lines[0].ends_with(" hello"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_limit_default() {
+        assert_eq!(parse_limit(None), DEFAULT_LIMIT);
+        assert_eq!(parse_limit(Some("")), DEFAULT_LIMIT);
+        assert_eq!(parse_limit(Some("abc")), DEFAULT_LIMIT);
+        assert_eq!(parse_limit(Some("0")), DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn parse_limit_parses_number() {
+        assert_eq!(parse_limit(Some("3")), 3);
+        assert_eq!(parse_limit(Some(" 7 ")), 7);
+    }
+}

--- a/src/fetcher/git/stash_count.rs
+++ b/src/fetcher/git/stash_count.rs
@@ -1,0 +1,113 @@
+use async_trait::async_trait;
+
+use crate::payload::{Body, EntriesData, Entry, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+
+/// Number of entries in the stash reflog. A missing `refs/stash` ref or an absent reflog returns
+/// zero — both are common (no stashes yet) and shouldn't surface as an error.
+pub struct GitStashCount;
+
+#[async_trait]
+impl Fetcher for GitStashCount {
+    fn name(&self) -> &str {
+        "git_stash_count"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let count = stash_count(&repo)?;
+        Ok(payload(render_body(count, ctx.shape.unwrap_or(Shape::Lines))))
+    }
+}
+
+fn stash_count(repo: &gix::Repository) -> Result<usize, FetchError> {
+    let Some(stash_ref) = repo.try_find_reference("refs/stash").map_err(fail)? else {
+        return Ok(0);
+    };
+    let mut platform = stash_ref.log_iter();
+    match platform.all().map_err(fail)? {
+        Some(iter) => Ok(iter.filter_map(Result::ok).count()),
+        None => Ok(0),
+    }
+}
+
+fn render_body(count: usize, shape: Shape) -> Body {
+    match shape {
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![Entry {
+                key: "stashes".into(),
+                value: Some(count.to_string()),
+                status: None,
+            }],
+        }),
+        _ => {
+            if count == 0 {
+                lines_body(Vec::new())
+            } else {
+                lines_body(vec![format!(
+                    "{count} stash{}",
+                    if count == 1 { "" } else { "es" }
+                )])
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit, make_repo, stash};
+    use super::*;
+
+    #[test]
+    fn zero_when_no_stash() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        assert_eq!(stash_count(&repo).unwrap(), 0);
+    }
+
+    #[test]
+    fn counts_single_stash() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        stash(&repo);
+        assert_eq!(stash_count(&repo).unwrap(), 1);
+    }
+
+    #[test]
+    fn lines_shape_is_empty_when_none() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        let body = render_body(stash_count(&repo).unwrap(), Shape::Lines);
+        match body {
+            Body::Lines(d) => assert!(d.lines.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn entries_shape_always_shows_count() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        let body = render_body(stash_count(&repo).unwrap(), Shape::Entries);
+        match body {
+            Body::Entries(d) => {
+                assert_eq!(d.items[0].key, "stashes");
+                assert_eq!(d.items[0].value.as_deref(), Some("0"));
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/src/fetcher/git/stash_count.rs
+++ b/src/fetcher/git/stash_count.rs
@@ -29,7 +29,10 @@ impl Fetcher for GitStashCount {
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let repo = open_repo()?;
         let count = stash_count(&repo)?;
-        Ok(payload(render_body(count, ctx.shape.unwrap_or(Shape::Lines))))
+        Ok(payload(render_body(
+            count,
+            ctx.shape.unwrap_or(Shape::Lines),
+        )))
     }
 }
 

--- a/src/fetcher/git/status.rs
+++ b/src/fetcher/git/status.rs
@@ -1,0 +1,252 @@
+use async_trait::async_trait;
+
+use crate::payload::{BadgeData, Body, EntriesData, Entry, Payload, Status as PayloadStatus};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Entries, Shape::Lines, Shape::Badge];
+
+/// Working tree snapshot: branch, dirty flag, ahead/behind vs upstream. Multi-shape so a user can
+/// pick a key/value panel (`Entries`, default), a one-liner (`Lines`), or a clean/dirty traffic
+/// light (`Badge`). Detached HEAD shows the short commit hash in place of the branch.
+pub struct GitStatus;
+
+#[async_trait]
+impl Fetcher for GitStatus {
+    fn name(&self) -> &str {
+        "git_status"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Entries
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let info = read_status(&repo)?;
+        Ok(payload(render_body(&info, ctx.shape.unwrap_or(Shape::Entries))))
+    }
+}
+
+struct StatusInfo {
+    branch: String,
+    detached: bool,
+    head_short: String,
+    dirty: bool,
+    ahead: Option<usize>,
+    behind: Option<usize>,
+}
+
+fn read_status(repo: &gix::Repository) -> Result<StatusInfo, FetchError> {
+    let head_ref = repo.head_ref().map_err(fail)?;
+    let detached = head_ref.is_none();
+    let branch = head_ref
+        .as_ref()
+        .map(|r| r.name().shorten().to_string())
+        .unwrap_or_else(|| "HEAD".into());
+    let head_short = repo
+        .head_id()
+        .ok()
+        .and_then(|id| id.shorten().ok().map(|p| p.to_string()))
+        .unwrap_or_default();
+    let dirty = repo.is_dirty().unwrap_or(false);
+    let (ahead, behind) = match ahead_behind(repo, head_ref.as_ref()) {
+        Some((a, b)) => (Some(a), Some(b)),
+        None => (None, None),
+    };
+    Ok(StatusInfo {
+        branch,
+        detached,
+        head_short,
+        dirty,
+        ahead,
+        behind,
+    })
+}
+
+fn ahead_behind(
+    repo: &gix::Repository,
+    head_ref: Option<&gix::Reference<'_>>,
+) -> Option<(usize, usize)> {
+    let head_ref = head_ref?;
+    let upstream_name = repo
+        .branch_remote_tracking_ref_name(head_ref.name(), gix::remote::Direction::Fetch)?
+        .ok()?;
+    let upstream_id = repo
+        .find_reference(upstream_name.as_ref())
+        .ok()?
+        .into_fully_peeled_id()
+        .ok()?
+        .detach();
+    let head_id = repo.head_id().ok()?.detach();
+    let ahead = repo
+        .rev_walk([head_id])
+        .with_hidden([upstream_id])
+        .all()
+        .ok()?
+        .filter_map(Result::ok)
+        .count();
+    let behind = repo
+        .rev_walk([upstream_id])
+        .with_hidden([head_id])
+        .all()
+        .ok()?
+        .filter_map(Result::ok)
+        .count();
+    Some((ahead, behind))
+}
+
+fn render_body(info: &StatusInfo, shape: Shape) -> Body {
+    match shape {
+        Shape::Badge => Body::Badge(BadgeData {
+            status: if info.dirty {
+                PayloadStatus::Warn
+            } else {
+                PayloadStatus::Ok
+            },
+            label: if info.dirty {
+                format!("{} · dirty", short_branch(info))
+            } else {
+                format!("{} · clean", short_branch(info))
+            },
+        }),
+        Shape::Lines => lines_body(vec![format_line(info)]),
+        _ => Body::Entries(EntriesData {
+            items: build_entries(info),
+        }),
+    }
+}
+
+fn build_entries(info: &StatusInfo) -> Vec<Entry> {
+    let mut items = vec![
+        entry(
+            "branch",
+            if info.detached { &info.head_short } else { &info.branch },
+            None,
+        ),
+        entry(
+            "state",
+            if info.dirty { "dirty" } else { "clean" },
+            Some(if info.dirty {
+                PayloadStatus::Warn
+            } else {
+                PayloadStatus::Ok
+            }),
+        ),
+    ];
+    if !info.head_short.is_empty() && !info.detached {
+        items.push(entry("head", &info.head_short, None));
+    }
+    if let (Some(a), Some(b)) = (info.ahead, info.behind) {
+        items.push(entry("ahead", &a.to_string(), None));
+        items.push(entry("behind", &b.to_string(), None));
+    }
+    items
+}
+
+fn format_line(info: &StatusInfo) -> String {
+    let mut out = short_branch(info);
+    if let (Some(a), Some(b)) = (info.ahead, info.behind)
+        && (a > 0 || b > 0)
+    {
+        out.push_str(&format!(" ↑{a} ↓{b}"));
+    }
+    out.push_str(if info.dirty { " · dirty" } else { " · clean" });
+    out
+}
+
+fn short_branch(info: &StatusInfo) -> String {
+    if info.detached {
+        format!("detached@{}", info.head_short)
+    } else {
+        info.branch.clone()
+    }
+}
+
+fn entry(key: &str, value: &str, status: Option<PayloadStatus>) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.into()),
+        status,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit, dirty_write, make_repo};
+    use super::*;
+
+    fn call(repo: &gix::Repository, shape: Shape) -> Body {
+        let info = read_status(repo).unwrap();
+        render_body(&info, shape)
+    }
+
+    #[test]
+    fn clean_repo_entries() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        let body = call(&repo, Shape::Entries);
+        let items = match body {
+            Body::Entries(d) => d.items,
+            _ => panic!(),
+        };
+        let map: std::collections::HashMap<_, _> =
+            items.iter().map(|e| (e.key.as_str(), e.value.as_deref().unwrap())).collect();
+        assert_eq!(map.get("branch"), Some(&"main"));
+        assert_eq!(map.get("state"), Some(&"clean"));
+    }
+
+    #[test]
+    fn dirty_repo_shows_warn_status() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        dirty_write(&repo, "README.md", "dirty\n");
+        let body = call(&repo, Shape::Entries);
+        let items = match body {
+            Body::Entries(d) => d.items,
+            _ => panic!(),
+        };
+        let state = items.iter().find(|e| e.key == "state").unwrap();
+        assert_eq!(state.value.as_deref(), Some("dirty"));
+        assert_eq!(state.status, Some(PayloadStatus::Warn));
+    }
+
+    #[test]
+    fn badge_shape_reflects_dirty() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        dirty_write(&repo, "README.md", "dirty\n");
+        let body = call(&repo, Shape::Badge);
+        match body {
+            Body::Badge(b) => {
+                assert_eq!(b.status, PayloadStatus::Warn);
+                assert!(b.label.contains("dirty"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn lines_shape_summarises_branch_and_state() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "initial");
+        let body = call(&repo, Shape::Lines);
+        match body {
+            Body::Lines(d) => {
+                assert_eq!(d.lines.len(), 1);
+                assert!(d.lines[0].contains("main"));
+                assert!(d.lines[0].contains("clean"));
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/src/fetcher/git/status.rs
+++ b/src/fetcher/git/status.rs
@@ -33,7 +33,10 @@ impl Fetcher for GitStatus {
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let repo = open_repo()?;
         let info = read_status(&repo)?;
-        Ok(payload(render_body(&info, ctx.shape.unwrap_or(Shape::Entries))))
+        Ok(payload(render_body(
+            &info,
+            ctx.shape.unwrap_or(Shape::Entries),
+        )))
     }
 }
 
@@ -130,7 +133,11 @@ fn build_entries(info: &StatusInfo) -> Vec<Entry> {
     let mut items = vec![
         entry(
             "branch",
-            if info.detached { &info.head_short } else { &info.branch },
+            if info.detached {
+                &info.head_short
+            } else {
+                &info.branch
+            },
             None,
         ),
         entry(
@@ -199,8 +206,10 @@ mod tests {
             Body::Entries(d) => d.items,
             _ => panic!(),
         };
-        let map: std::collections::HashMap<_, _> =
-            items.iter().map(|e| (e.key.as_str(), e.value.as_deref().unwrap())).collect();
+        let map: std::collections::HashMap<_, _> = items
+            .iter()
+            .map(|e| (e.key.as_str(), e.value.as_deref().unwrap()))
+            .collect();
         assert_eq!(map.get("branch"), Some(&"main"));
         assert_eq!(map.get("state"), Some(&"clean"));
     }

--- a/src/fetcher/git/test_support.rs
+++ b/src/fetcher/git/test_support.rs
@@ -70,10 +70,7 @@ pub fn stash(repo: &gix::Repository) {
     let file = path.join("README.md");
     let prev = std::fs::read_to_string(&file).unwrap_or_default();
     std::fs::write(&file, format!("{prev}wip\n")).unwrap();
-    run(
-        path,
-        &["stash", "push", "--include-untracked", "-m", "wip"],
-    );
+    run(path, &["stash", "push", "--include-untracked", "-m", "wip"]);
 }
 
 pub fn dirty_write(repo: &gix::Repository, file_rel: &str, contents: &str) {

--- a/src/fetcher/git/test_support.rs
+++ b/src/fetcher/git/test_support.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+//! Test-only repo builder shared by every git fetcher's tests. Uses the `git` CLI via
+//! `std::process::Command` rather than gix write APIs so we don't need extra gix features just
+//! for fixtures. CI runs with git installed (everywhere we care about).
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+pub fn make_repo() -> (TempDir, gix::Repository) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    run(tmp.path(), &["init", "-q", "-b", "main"]);
+    run(tmp.path(), &["config", "user.email", "test@example.com"]);
+    run(tmp.path(), &["config", "user.name", "Test"]);
+    run(tmp.path(), &["config", "commit.gpgsign", "false"]);
+    run(tmp.path(), &["config", "tag.gpgsign", "false"]);
+    let repo = gix::discover(tmp.path()).expect("discover");
+    (tmp, repo)
+}
+
+pub fn commit(repo: &gix::Repository, msg: &str) {
+    let path = repo.workdir().expect("workdir");
+    let file = path.join("README.md");
+    let prev = std::fs::read_to_string(&file).unwrap_or_default();
+    std::fs::write(&file, format!("{prev}{msg}\n")).unwrap();
+    run(path, &["add", "."]);
+    run(path, &["commit", "-q", "-m", msg]);
+}
+
+pub fn commit_as(repo: &gix::Repository, msg: &str, author: &str, email: &str) {
+    let path = repo.workdir().expect("workdir");
+    let file = path.join("README.md");
+    let prev = std::fs::read_to_string(&file).unwrap_or_default();
+    std::fs::write(&file, format!("{prev}{msg}\n")).unwrap();
+    run(path, &["add", "."]);
+    run(
+        path,
+        &[
+            "-c",
+            &format!("user.name={author}"),
+            "-c",
+            &format!("user.email={email}"),
+            "commit",
+            "-q",
+            "-m",
+            msg,
+        ],
+    );
+}
+
+pub fn commit_touching(repo: &gix::Repository, file_rel: &str, msg: &str) {
+    let path = repo.workdir().expect("workdir");
+    let file = path.join(file_rel);
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let prev = std::fs::read_to_string(&file).unwrap_or_default();
+    std::fs::write(&file, format!("{prev}{msg}\n")).unwrap();
+    run(path, &["add", "."]);
+    run(path, &["commit", "-q", "-m", msg]);
+}
+
+pub fn tag(repo: &gix::Repository, name: &str) {
+    run(repo.workdir().unwrap(), &["tag", name]);
+}
+
+pub fn stash(repo: &gix::Repository) {
+    let path = repo.workdir().unwrap();
+    let file = path.join("README.md");
+    let prev = std::fs::read_to_string(&file).unwrap_or_default();
+    std::fs::write(&file, format!("{prev}wip\n")).unwrap();
+    run(
+        path,
+        &["stash", "push", "--include-untracked", "-m", "wip"],
+    );
+}
+
+pub fn dirty_write(repo: &gix::Repository, file_rel: &str, contents: &str) {
+    let path = repo.workdir().unwrap();
+    std::fs::write(path.join(file_rel), contents).unwrap();
+}
+
+fn run(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git should be on PATH for tests");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/src/fetcher/git/worktrees.rs
+++ b/src/fetcher/git/worktrees.rs
@@ -1,0 +1,148 @@
+use async_trait::async_trait;
+
+use crate::payload::{Body, EntriesData, Entry, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+
+const SHAPES: &[Shape] = &[Shape::Entries, Shape::Lines];
+
+/// Linked worktrees plus the main worktree. `Entries` maps worktree id → `"<branch> @ <path>"`.
+/// `Lines` flattens to one worktree per line.
+pub struct GitWorktrees;
+
+#[async_trait]
+impl Fetcher for GitWorktrees {
+    fn name(&self) -> &str {
+        "git_worktrees"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let repo = open_repo()?;
+        let list = worktrees(&repo)?;
+        Ok(payload(render_body(list, ctx.shape.unwrap_or(Shape::Entries))))
+    }
+}
+
+struct WorktreeInfo {
+    id: String,
+    branch: Option<String>,
+    path: String,
+}
+
+fn worktrees(repo: &gix::Repository) -> Result<Vec<WorktreeInfo>, FetchError> {
+    let mut out = Vec::new();
+    if let Some(path) = repo.workdir() {
+        out.push(WorktreeInfo {
+            id: "(main)".into(),
+            branch: head_branch(repo),
+            path: path.display().to_string(),
+        });
+    }
+    for proxy in repo.worktrees().map_err(fail)? {
+        let id = proxy.id().to_string();
+        let path = proxy
+            .base()
+            .ok()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let branch = proxy
+            .into_repo_with_possibly_inaccessible_worktree()
+            .ok()
+            .as_ref()
+            .and_then(head_branch);
+        out.push(WorktreeInfo { id, branch, path });
+    }
+    Ok(out)
+}
+
+fn head_branch(repo: &gix::Repository) -> Option<String> {
+    repo.head_ref()
+        .ok()
+        .flatten()
+        .map(|r| r.name().shorten().to_string())
+}
+
+fn render_body(list: Vec<WorktreeInfo>, shape: Shape) -> Body {
+    match shape {
+        Shape::Lines => lines_body(list.into_iter().map(format_line).collect()),
+        _ => Body::Entries(EntriesData {
+            items: list
+                .into_iter()
+                .map(|wt| Entry {
+                    key: wt.id,
+                    value: Some(format_value(&wt.branch, &wt.path)),
+                    status: None,
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn format_line(wt: WorktreeInfo) -> String {
+    match wt.branch {
+        Some(b) => format!("{} ({}) @ {}", wt.id, b, wt.path),
+        None => format!("{} @ {}", wt.id, wt.path),
+    }
+}
+
+fn format_value(branch: &Option<String>, path: &str) -> String {
+    match branch {
+        Some(b) => format!("{b} @ {path}"),
+        None => path.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{commit, make_repo};
+    use super::*;
+
+    #[test]
+    fn returns_main_worktree_only_for_plain_repo() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "init");
+        let list = worktrees(&repo).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "(main)");
+        assert_eq!(list[0].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn entries_shape_key_is_id() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "init");
+        let body = render_body(worktrees(&repo).unwrap(), Shape::Entries);
+        match body {
+            Body::Entries(d) => {
+                assert_eq!(d.items[0].key, "(main)");
+                let value = d.items[0].value.as_deref().unwrap();
+                assert!(value.starts_with("main @ "));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn lines_shape_formats_each_entry() {
+        let (_tmp, repo) = make_repo();
+        commit(&repo, "init");
+        let body = render_body(worktrees(&repo).unwrap(), Shape::Lines);
+        match body {
+            Body::Lines(d) => {
+                assert_eq!(d.lines.len(), 1);
+                assert!(d.lines[0].starts_with("(main) (main) @ "));
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/src/fetcher/git/worktrees.rs
+++ b/src/fetcher/git/worktrees.rs
@@ -29,7 +29,10 @@ impl Fetcher for GitWorktrees {
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let repo = open_repo()?;
         let list = worktrees(&repo)?;
-        Ok(payload(render_body(list, ctx.shape.unwrap_or(Shape::Entries))))
+        Ok(payload(render_body(
+            list,
+            ctx.shape.unwrap_or(Shape::Entries),
+        )))
     }
 }
 

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -11,6 +11,7 @@ use crate::payload::{Body, LinesData, Payload};
 use crate::render::Shape;
 
 pub mod clock;
+pub mod git;
 pub mod read_store;
 pub mod static_text;
 pub mod stub;
@@ -187,6 +188,9 @@ impl Registry {
             r.register_realtime(f);
         }
         for f in system::cached_fetchers() {
+            r.register(f);
+        }
+        for f in git::fetchers() {
             r.register(f);
         }
         for f in stub::stubs() {

--- a/src/fetcher/stub.rs
+++ b/src/fetcher/stub.rs
@@ -1,14 +1,13 @@
 //! Placeholder fetchers that still return canned data. Each of these is blocked on a dedicated
-//! issue (#8 git, #11 github) and will be replaced one-by-one. Keeping them in a single module
-//! makes it obvious at a glance which parts of the default dashboard aren't real yet.
+//! issue (#11 github) and will be replaced one-by-one. Keeping them in a single module makes it
+//! obvious at a glance which parts of the default dashboard aren't real yet.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::payload::{
-    BadgeData, Bar, BarsData, Body, HeatmapData, NumberSeriesData, Payload, PointSeries,
-    PointSeriesData, Status, TimelineData, TimelineEvent,
+    BadgeData, Bar, BarsData, Body, HeatmapData, Payload, PointSeries, PointSeriesData, Status,
 };
 use crate::render::Shape;
 
@@ -16,35 +15,13 @@ use super::{FetchContext, FetchError, Fetcher, Safety};
 
 pub fn stubs() -> Vec<Arc<dyn Fetcher>> {
     vec![
-        Arc::new(GitCommitsStub),
         Arc::new(GithubPrsStub),
         Arc::new(TrendStub),
         Arc::new(ContributionsStub),
         Arc::new(CiStatusStub),
         Arc::new(DeployStatusStub),
         Arc::new(OncallStatusStub),
-        Arc::new(GitRecentCommitsStub),
     ]
-}
-
-pub struct GitCommitsStub;
-
-#[async_trait]
-impl Fetcher for GitCommitsStub {
-    fn name(&self) -> &str {
-        "git_commits"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Exec
-    }
-    fn shapes(&self) -> &[Shape] {
-        &[Shape::NumberSeries]
-    }
-    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
-        Ok(payload(Body::NumberSeries(NumberSeriesData {
-            values: vec![2, 5, 0, 3, 7, 4, 1, 6, 9, 2, 3, 5, 8, 4],
-        })))
-    }
 }
 
 pub struct GithubPrsStub;
@@ -265,64 +242,6 @@ fn badge(status: Status, label: &str) -> Payload {
     }))
 }
 
-/// Demo-quality recent-commit timeline. Offsets from `now` so the relative labels stay fresh
-/// (`Nm` / `Nh` / `Nd` / `Nw`) without the renderer caching stale "ago" strings. Stands in for
-/// the future `git_recent_commits` fetcher.
-pub struct GitRecentCommitsStub;
-
-#[async_trait]
-impl Fetcher for GitRecentCommitsStub {
-    fn name(&self) -> &str {
-        "git_recent_commits"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Safe
-    }
-    fn shapes(&self) -> &[Shape] {
-        &[Shape::Timeline]
-    }
-    async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
-        let now = chrono::Utc::now().timestamp();
-        let events = vec![
-            event(
-                now - 7 * 60,
-                "feat(render): timeline renderer",
-                None,
-                Some(Status::Ok),
-            ),
-            event(
-                now - 2 * 3600,
-                "feat(render): badge renderer",
-                None,
-                Some(Status::Ok),
-            ),
-            event(now - 26 * 3600, "docs: AGENTS.md", None, None),
-            event(now - 4 * 86_400, "feat: readstore home layout", None, None),
-            event(
-                now - 9 * 86_400,
-                "chore: bump deps",
-                None,
-                Some(Status::Warn),
-            ),
-        ];
-        Ok(payload(Body::Timeline(TimelineData { events })))
-    }
-}
-
-fn event(
-    timestamp: i64,
-    title: &str,
-    detail: Option<&str>,
-    status: Option<Status>,
-) -> TimelineEvent {
-    TimelineEvent {
-        timestamp,
-        title: title.into(),
-        detail: detail.map(|s| s.into()),
-        status,
-    }
-}
-
 fn payload(body: Body) -> Payload {
     Payload {
         icon: None,
@@ -338,7 +257,6 @@ mod tests {
 
     #[test]
     fn safety_classification_matches_feature_surface() {
-        assert_eq!(GitCommitsStub.safety(), Safety::Exec);
         assert_eq!(GithubPrsStub.safety(), Safety::Network);
     }
 
@@ -347,14 +265,12 @@ mod tests {
         let fetchers = stubs();
         let names: Vec<&str> = fetchers.iter().map(|f| f.name()).collect();
         for expected in [
-            "git_commits",
             "github_prs",
             "trend",
             "contributions",
             "ci_status",
             "deploy_status",
             "oncall_status",
-            "git_recent_commits",
         ] {
             assert!(names.contains(&expected), "missing stub: {expected}");
         }


### PR DESCRIPTION
## Summary

Ships the Git / VCS row of #41 as native `Fetcher` impls backed by `gix`. Each fetcher accepts `Lines` as a universal fallback plus its natural structural shape(s) — so every git widget can degrade into a one-liner without a config change.

| fetcher | shapes | default |
| --- | --- | --- |
| `git_status` | Lines / Entries / Badge | Entries |
| `git_stash_count` | Lines / Entries | Lines |
| `git_recent_commits` | Lines / Timeline | Timeline |
| `git_contributors` | Lines / Entries / Bars | Bars |
| `git_commits_activity` | Lines / NumberSeries / Heatmap | Heatmap |
| `git_latest_tag` | Lines / Entries | Lines |
| `git_worktrees` | Lines / Entries | Entries |
| `git_blame_heatmap` | Lines / Heatmap | Heatmap |

- All `Safety::Safe` (local reads only).
- `cache_key` mixes discovered repo root + shape so two projects don't share cache slots.
- `git_status` uses `rev_walk().with_hidden([upstream])` to get ahead/behind when an upstream is configured.
- `git_commits_activity` mirrors the GitHub graph: 7x52, Sunday-first, today's week on the right, month labels on top.
- `git_blame_heatmap` does tree-diff-based per-file churn; capped at 500 commits so a hot repo doesn't stall the splash.
- `git_commits` and `git_recent_commits` stubs are removed; dogfood + default configs switch to `git_commits_activity`.

Ticks #41 boxes: git_status, git_stash_count, git_recent_commits, git_contributors, git_commits_activity, git_latest_tag, git_worktrees, git_blame_heatmap.

## Test plan

- [x] ``cargo test`` (255 pass, incl. 34 new across the git module)
- [x] ``cargo clippy --all-targets -- -D warnings`` clean
- [x] ``cargo build --release`` succeeds
- [ ] Smoke: ``splashboard`` rendered in a real shell against this repo shows the status / commit / activity widgets without the "requires trust" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)