### PR TITLE
refactor(fetcher): rename sysinfo fetchers to prefix_suffix convention

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -63,12 +63,12 @@ render = { type = "badge", align = "left" }
 
 [[widget]]
 id = "disk_gauge"
-fetcher = "disk"
+fetcher = "disk_usage"
 render = "gauge"
 
 [[widget]]
 id = "disk_line"
-fetcher = "disk"
+fetcher = "disk_usage"
 render = "line_gauge"
 
 # ── NumberSeries ────────────────────────────────────────────────────
@@ -187,27 +187,27 @@ render = { type = "simple", align = "center" }
 
 [[widget]]
 id = "cpu"
-fetcher = "cpu_load"
+fetcher = "system_cpu"
 render = "gauge"
 
 [[widget]]
 id = "memory"
-fetcher = "memory"
+fetcher = "system_memory"
 render = "line_gauge"
 
 [[widget]]
 id = "uptime"
-fetcher = "uptime"
+fetcher = "system_uptime"
 render = { type = "simple", align = "center" }
 
 [[widget]]
 id = "load_avg"
-fetcher = "load_average"
+fetcher = "system_load"
 render = { type = "simple", align = "center" }
 
 [[widget]]
 id = "processes"
-fetcher = "process_top"
+fetcher = "system_processes"
 render = "table"
 
 # ── Layout ──────────────────────────────────────────────────────────
@@ -344,12 +344,12 @@ height = { length = 3 }
 
   [[row.child]]
   widget = "cpu"
-  title = "cpu_load"
+  title = "system_cpu"
   border = "rounded"
 
   [[row.child]]
   widget = "memory"
-  title = "memory"
+  title = "system_memory"
   border = "rounded"
 
 [[row]]
@@ -357,12 +357,12 @@ height = { length = 3 }
 
   [[row.child]]
   widget = "uptime"
-  title = "uptime"
+  title = "system_uptime"
   border = "rounded"
 
   [[row.child]]
   widget = "load_avg"
-  title = "load_average"
+  title = "system_load"
   border = "rounded"
 
 [[row]]
@@ -370,7 +370,7 @@ height = { length = 7 }
 
   [[row.child]]
   widget = "processes"
-  title = "process_top"
+  title = "system_processes"
   border = "rounded"
 
 # ── Clock options showcase rows ──────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Shapes are the **only** coupling between fetchers and renderers. If you find you
 Produces a `Payload`. Two flavors:
 
 - **`Fetcher` (cached, async)** — disk cache with TTL, daemon refreshes in background, renderer reads from cache. Right for anything that does I/O: git2, HTTP, filesystem scans.
-- **`RealtimeFetcher` (sync, per-frame)** — recomputed on every draw tick, no cache at all. Right for "right now" values: clock, cpu_load, uptime, countdowns, pomodoro. Contract: < 1ms, infallible, no I/O. If you want to put `reqwest` in a `RealtimeFetcher`, it's not realtime — it's cached.
+- **`RealtimeFetcher` (sync, per-frame)** — recomputed on every draw tick, no cache at all. Right for "right now" values: `clock`, `system_cpu`, `system_uptime`, `clock_countdown`, `pomodoro`. Contract: < 1ms, infallible, no I/O. If you want to put `reqwest` in a `RealtimeFetcher`, it's not realtime — it's cached.
 
 Key invariants:
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -14,7 +14,7 @@ render = "ascii_art"
 
 [[widget]]
 id = "disk"
-fetcher = "disk"
+fetcher = "disk_usage"
 render = "gauge"
 
 [[widget]]

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -122,7 +122,7 @@ pub trait RealtimeFetcher: Send + Sync {
 }
 
 /// Fetcher can't emit the shape the renderer expects. Surfaced as a placeholder so the splash
-/// keeps rendering even when the config pairs, say, `fetcher = "disk"` with `render = "calendar"`.
+/// keeps rendering even when the config pairs, say, `fetcher = "disk_usage"` with `render = "calendar"`.
 #[derive(Debug, Clone)]
 pub struct ShapeMismatch {
     pub fetcher: String,

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -134,7 +134,7 @@ impl Default for CpuLoadFetcher {
 
 impl RealtimeFetcher for CpuLoadFetcher {
     fn name(&self) -> &str {
-        "cpu_load"
+        "system_cpu"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -188,7 +188,7 @@ impl Default for MemoryFetcher {
 
 impl RealtimeFetcher for MemoryFetcher {
     fn name(&self) -> &str {
-        "memory"
+        "system_memory"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -237,7 +237,7 @@ pub struct UptimeFetcher;
 
 impl RealtimeFetcher for UptimeFetcher {
     fn name(&self) -> &str {
-        "uptime"
+        "system_uptime"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -264,7 +264,7 @@ pub struct LoadAverageFetcher;
 
 impl RealtimeFetcher for LoadAverageFetcher {
     fn name(&self) -> &str {
-        "load_average"
+        "system_load"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -324,7 +324,7 @@ impl Default for ProcessTopFetcher {
 
 impl RealtimeFetcher for ProcessTopFetcher {
     fn name(&self) -> &str {
-        "process_top"
+        "system_processes"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -374,7 +374,7 @@ pub struct DiskFetcher;
 #[async_trait]
 impl Fetcher for DiskFetcher {
     fn name(&self) -> &str {
-        "disk"
+        "disk_usage"
     }
     fn safety(&self) -> Safety {
         Safety::Safe

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -354,7 +354,7 @@ struct WidgetBuckets<'a> {
 
 /// Merges fresh daemon-written cache entries into the payload map between frames. Realtime
 /// payloads stay exactly as they were computed once before the loop — the animation window is
-/// short (2s) and recomputing per frame would make expensive fetchers like `process_top`
+/// short (2s) and recomputing per frame would make expensive fetchers like `system_processes`
 /// scale badly. Trust-gate and shape-mismatch placeholders are re-applied defensively so a
 /// daemon-written entry can't leak into a gated slot.
 fn refresh_payloads(
@@ -916,7 +916,7 @@ mod tests {
     #[test]
     fn partition_by_shape_support_keeps_widget_with_compatible_renderer() {
         let registry = Registry::with_builtins();
-        let widgets = vec![widget_with_render("d", "disk", Some("gauge"))];
+        let widgets = vec![widget_with_render("d", "disk_usage", Some("gauge"))];
         let shapes = single_shape("d", Shape::Ratio);
         let (valid, invalid) = partition_by_shape_support(&widgets, &shapes, &registry);
         assert_eq!(valid.len(), 1);
@@ -926,7 +926,7 @@ mod tests {
     #[test]
     fn partition_by_shape_support_rejects_incompatible_renderer() {
         let registry = Registry::with_builtins();
-        let widgets = vec![widget_with_render("d", "disk", Some("calendar"))];
+        let widgets = vec![widget_with_render("d", "disk_usage", Some("calendar"))];
         let shapes = single_shape("d", Shape::Calendar);
         let (valid, invalid) = partition_by_shape_support(&widgets, &shapes, &registry);
         assert!(valid.is_empty());


### PR DESCRIPTION
## Summary

Rename the sysinfo-backed fetchers to the `prefix_suffix` registry convention so their names match the module layout (same pattern as `clock_*` / `git_*`).

| old | new |
| --- | --- |
| `cpu_load` | `system_cpu` |
| `memory` | `system_memory` |
| `uptime` | `system_uptime` |
| `load_average` | `system_load` |
| `process_top` | `system_processes` |
| `disk` | `disk_usage` |

- Only the registry names change; Rust struct names (`CpuLoadFetcher`, `DiskFetcher`, …) stay put — internal symbols, separate rename if we want full symmetry.
- **Breaking for user configs** that reference the old names. No alias layer (clean break matches the project's no-shim preference). Same-PR migration of the bundled `src/default_config.toml` and the repo's dogfood `.splashboard/config.toml`.
- Doc pages under `docs-site/src/content/docs/reference/` are generated by `cargo xtask` and gitignored, so only source changes land here; CI regenerates the catalog.

Ticks the `system_*` / `disk_usage` rows under *Rename tracking* in #41.

## Test plan

- [x] `cargo test` (297 + 12 passed)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo xtask` regenerates `reference/` with new names present and old names gone
- [ ] Manual smoke: `splashboard` with the dogfood config renders the System showcase rows (cpu / memory / uptime / load / processes / disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)