### PR TITLE
refactor(core): split Lines shape into Text + TextBlock (#59)

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -8,7 +8,7 @@
 wait_for_fresh = false
 # `height` omitted — runtime auto-sizes the inline viewport to fit every configured row.
 
-# ── Hero band (Lines shape, 4 renderers) ──────────────────────────────
+# ── Hero band (Text / TextBlock shapes, 4 renderers) ─────────────────
 
 [[widget]]
 id = "greeting_simple"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ Splitting those axes is the whole design. Treat them as separate concerns; resis
 
 The **data-shape contract** between fetchers and renderers. Each `Body` variant corresponds to one `Shape`:
 
-- `Lines` — zero or more text lines
+- `Text` — exactly one string (clock time, branch name, greeting)
+- `TextBlock` — zero or more lines of text (recent commits, welcome notes, todo items)
 - `Entries` — key/value rows with optional status
 - `Ratio` — a single `0..=1` value + optional label
 - `NumberSeries` — `Vec<u64>`, histograms / sparklines
@@ -81,7 +82,7 @@ Consumes a `Payload` + `RenderOptions` and draws into a ratatui `Frame`. Each re
 
 Key invariants:
 
-- **One shape can feed multiple renderers**. `Lines` → `simple`, `ascii_art`, `animated_typewriter`. That flexibility is the point; resist "one shape, one renderer".
+- **One shape can feed multiple renderers**. `Text` → `simple`, `ascii_art`, `animated_typewriter`. That flexibility is the point; resist "one shape, one renderer".
 
 - **Empty-state handling is centralized**. `render::render_payload` short-circuits any body that `is_empty_body()` considers empty to the shared "nothing here yet" placeholder. Don't bake empty handling into individual renderers.
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -180,16 +180,14 @@ fn io_err<E: std::fmt::Display>(e: E) -> std::io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{Body, LinesData};
+    use crate::payload::{Body, TextData};
 
     fn sample() -> Payload {
         Payload {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData {
-                lines: vec!["hi".into()],
-            }),
+            body: Body::Text(TextData { value: "hi".into() }),
         }
     }
 

--- a/src/fetcher/clock/common.rs
+++ b/src/fetcher/clock/common.rs
@@ -7,7 +7,7 @@ use std::fmt::Write;
 
 use chrono::{DateTime, FixedOffset, Local, NaiveDate, Utc};
 
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextBlockData};
 
 pub const DEFAULT_FORMAT: &str = "%H:%M";
 
@@ -47,7 +47,7 @@ pub fn placeholder(msg: &str) -> Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::Lines(LinesData {
+        body: Body::TextBlock(TextBlockData {
             lines: vec![
                 format!("⚠ {msg}"),
                 "check [widget.options] in config".into(),

--- a/src/fetcher/clock/countdown.rs
+++ b/src/fetcher/clock/countdown.rs
@@ -1,19 +1,19 @@
-//! `clock_countdown` — remaining time to `target` (single, Lines) or `targets = [...]` (multi,
-//! Lines / Entries). Past targets render as `"passed"` so the widget keeps rendering through the
-//! event boundary.
+//! `clock_countdown` — remaining time to `target` (single, Text) or `targets = [...]` (multi,
+//! TextBlock / Entries). Past targets render as `"passed"` so the widget keeps rendering through
+//! the event boundary.
 
 use chrono::{DateTime, FixedOffset, NaiveDate, TimeZone, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, LinesData, Payload};
+use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TextData};
 use crate::render::Shape;
 use crate::samples;
 
 use super::common;
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::TextBlock, Shape::Entries];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -42,7 +42,7 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
         type_hint: "array of `{ label, target }`",
         required: false,
         default: None,
-        description: "Multiple labelled countdowns. Rendered as `Lines` by default or `Entries` when the renderer expects a key/value shape.",
+        description: "Multiple labelled countdowns. Rendered as `TextBlock` by default or `Entries` when the renderer expects a key/value shape.",
     },
 ];
 
@@ -83,7 +83,8 @@ impl RealtimeFetcher for ClockCountdownFetcher {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["Ship v2: 42d 3h"]),
+            Shape::Text => samples::text("Ship v2: 42d 3h"),
+            Shape::TextBlock => samples::text_block(&["Ship v2: 42d 3h", "Release: 7d"]),
             Shape::Entries => samples::entries(&[("Ship v2", "42d 3h"), ("Release", "7d")]),
             _ => return None,
         })
@@ -94,7 +95,7 @@ impl RealtimeFetcher for ClockCountdownFetcher {
             Err(msg) => return common::placeholder(&msg),
         };
         let now = common::now_in(opts.timezone.as_deref());
-        let shape = ctx.shape.unwrap_or(Shape::Lines);
+        let shape = ctx.shape.unwrap_or(Shape::Text);
         let body = match (&opts.targets, &opts.target, shape) {
             (Some(list), _, Shape::Entries) => Body::Entries(EntriesData {
                 items: list
@@ -106,17 +107,17 @@ impl RealtimeFetcher for ClockCountdownFetcher {
                     })
                     .collect(),
             }),
-            (Some(list), _, _) => Body::Lines(LinesData {
+            (Some(list), _, _) => Body::TextBlock(TextBlockData {
                 lines: list
                     .iter()
                     .map(|t| format!("{}: {}", t.label, format_remaining(&now, &t.target)))
                     .collect(),
             }),
-            (None, Some(target), _) => Body::Lines(LinesData {
-                lines: vec![format_single(&now, target, opts.target_label.as_deref())],
+            (None, Some(target), _) => Body::Text(TextData {
+                value: format_single(&now, target, opts.target_label.as_deref()),
             }),
-            (None, None, _) => Body::Lines(LinesData {
-                lines: vec!["no target configured".into()],
+            (None, None, _) => Body::Text(TextData {
+                value: "no target configured".into(),
             }),
         };
         Payload {
@@ -189,11 +190,11 @@ mod tests {
     }
 
     #[test]
-    fn single_target_emits_one_line() {
-        let p = ClockCountdownFetcher.compute(&ctx(Some(Shape::Lines), "target = \"2099-12-31\""));
+    fn single_target_emits_text() {
+        let p = ClockCountdownFetcher.compute(&ctx(Some(Shape::Text), "target = \"2099-12-31\""));
         match p.body {
-            Body::Lines(d) => assert_eq!(d.lines.len(), 1),
-            _ => panic!("expected lines"),
+            Body::Text(d) => assert!(!d.value.is_empty()),
+            _ => panic!("expected text"),
         }
     }
 
@@ -211,10 +212,10 @@ mod tests {
 
     #[test]
     fn past_target_renders_passed() {
-        let p = ClockCountdownFetcher.compute(&ctx(Some(Shape::Lines), "target = \"2000-01-01\""));
+        let p = ClockCountdownFetcher.compute(&ctx(Some(Shape::Text), "target = \"2000-01-01\""));
         match p.body {
-            Body::Lines(d) => assert!(d.lines[0].contains("passed")),
-            _ => panic!("expected lines"),
+            Body::Text(d) => assert!(d.value.contains("passed")),
+            _ => panic!("expected text"),
         }
     }
 

--- a/src/fetcher/clock/derived.rs
+++ b/src/fetcher/clock/derived.rs
@@ -5,13 +5,13 @@ use chrono::{DateTime, Datelike, FixedOffset, Timelike};
 use serde::Deserialize;
 
 use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextData};
 use crate::render::Shape;
 use crate::samples;
 
 use super::common;
 
-const SHAPES: &[Shape] = &[Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Text];
 
 pub struct ClockDerivedFetcher;
 
@@ -53,7 +53,7 @@ impl RealtimeFetcher for ClockDerivedFetcher {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         match shape {
-            Shape::Lines => Some(samples::lines(&["day 113 of 2026"])),
+            Shape::Text => Some(samples::text("day 113 of 2026")),
             _ => None,
         }
     }
@@ -80,7 +80,7 @@ impl RealtimeFetcher for ClockDerivedFetcher {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData { lines: vec![line] }),
+            body: Body::Text(TextData { value: line }),
         }
     }
 }
@@ -240,7 +240,7 @@ mod tests {
         FetchContext {
             widget_id: "d".into(),
             timeout: Duration::from_secs(1),
-            shape: Some(Shape::Lines),
+            shape: Some(Shape::Text),
             options: Some(toml::from_str(options).unwrap()),
             ..Default::default()
         }
@@ -287,15 +287,15 @@ mod tests {
     #[test]
     fn default_kind_is_time_of_day() {
         let p = ClockDerivedFetcher.compute(&ctx(""));
-        assert!(matches!(p.body, Body::Lines(_)));
+        assert!(matches!(p.body, Body::Text(_)));
     }
 
     #[test]
-    fn moon_phase_kind_emits_nonempty_line() {
+    fn moon_phase_kind_emits_nonempty_text() {
         let p = ClockDerivedFetcher.compute(&ctx("kind = \"moon_phase\""));
         match p.body {
-            Body::Lines(d) => assert!(!d.lines[0].is_empty()),
-            _ => panic!("expected lines"),
+            Body::Text(d) => assert!(!d.value.is_empty()),
+            _ => panic!("expected text"),
         }
     }
 }

--- a/src/fetcher/clock/mod.rs
+++ b/src/fetcher/clock/mod.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Datelike, FixedOffset, Timelike};
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, CalendarData, EntriesData, Entry, LinesData, Payload};
+use crate::payload::{Body, CalendarData, EntriesData, Entry, Payload, TextData};
 use crate::render::Shape;
 use crate::samples;
 
@@ -53,7 +53,7 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
     ]
 }
 
-const BASE_SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Calendar];
+const BASE_SHAPES: &[Shape] = &[Shape::Text, Shape::Entries, Shape::Calendar];
 
 /// Base clock — renders "now" as a formatted string, key/value breakdown, or month calendar.
 /// Options: `timezone` (IANA name) and `events` (days-of-month highlighted in Calendar shape).
@@ -83,7 +83,7 @@ impl RealtimeFetcher for ClockFetcher {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["14:35"]),
+            Shape::Text => samples::text("14:35"),
             Shape::Entries => samples::entries(&[
                 ("year", "2026"),
                 ("month", "04"),
@@ -102,7 +102,7 @@ impl RealtimeFetcher for ClockFetcher {
             Err(msg) => return common::placeholder(&msg),
         };
         let now = common::now_in(opts.timezone.as_deref());
-        let shape = ctx.shape.unwrap_or(Shape::Lines);
+        let shape = ctx.shape.unwrap_or(Shape::Text);
         let body = match shape {
             Shape::Entries => Body::Entries(EntriesData {
                 items: entries(&now),
@@ -113,11 +113,11 @@ impl RealtimeFetcher for ClockFetcher {
                 day: Some(now.day() as u8),
                 events: opts.events.unwrap_or_default(),
             }),
-            _ => Body::Lines(LinesData {
-                lines: vec![common::safe_format(
+            _ => Body::Text(TextData {
+                value: common::safe_format(
                     &now,
                     ctx.format.as_deref().unwrap_or(common::DEFAULT_FORMAT),
-                )],
+                ),
             }),
         };
         Payload {
@@ -165,14 +165,11 @@ mod tests {
     }
 
     #[test]
-    fn default_shape_is_lines_with_colon() {
+    fn default_shape_is_text_with_colon() {
         let p = ClockFetcher.compute(&ctx(None, None));
         match p.body {
-            Body::Lines(d) => {
-                assert_eq!(d.lines.len(), 1);
-                assert!(d.lines[0].contains(':'));
-            }
-            _ => panic!("expected lines"),
+            Body::Text(d) => assert!(d.value.contains(':')),
+            _ => panic!("expected text"),
         }
     }
 
@@ -196,10 +193,10 @@ mod tests {
 
     #[test]
     fn unknown_option_is_rejected_to_placeholder() {
-        let p = ClockFetcher.compute(&ctx(Some(Shape::Lines), Some("bogus = 1")));
+        let p = ClockFetcher.compute(&ctx(Some(Shape::Text), Some("bogus = 1")));
         match p.body {
-            Body::Lines(d) => assert!(d.lines[0].starts_with("⚠")),
-            _ => panic!("expected placeholder lines"),
+            Body::TextBlock(d) => assert!(d.lines[0].starts_with("⚠")),
+            _ => panic!("expected placeholder block"),
         }
     }
 

--- a/src/fetcher/clock/sunrise.rs
+++ b/src/fetcher/clock/sunrise.rs
@@ -1,18 +1,18 @@
 //! `clock_sunrise` — sunrise & sunset for a lat/lon, via a NOAA-style approximation (±1 min).
-//! Emits `Lines` (`"↑ 05:23  ↓ 18:47"`) or `Entries` (split rows).
+//! Emits `Text` (`"↑ 05:23  ↓ 18:47"`) or `Entries` (split rows).
 
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, TimeZone, Timelike, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, LinesData, Payload};
+use crate::payload::{Body, EntriesData, Entry, Payload, TextData};
 use crate::render::Shape;
 use crate::samples;
 
 use super::common;
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -66,7 +66,7 @@ impl RealtimeFetcher for ClockSunriseFetcher {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["↑ 05:23  ↓ 18:47"]),
+            Shape::Text => samples::text("↑ 05:23  ↓ 18:47"),
             Shape::Entries => samples::entries(&[("sunrise", "05:23"), ("sunset", "18:47")]),
             _ => return None,
         })
@@ -76,7 +76,7 @@ impl RealtimeFetcher for ClockSunriseFetcher {
             Ok(o) => o,
             Err(msg) => return common::placeholder(&msg),
         };
-        let shape = ctx.shape.unwrap_or(Shape::Lines);
+        let shape = ctx.shape.unwrap_or(Shape::Text);
         let body = match compute_events(&opts) {
             Ok((up, down)) => match shape {
                 Shape::Entries => Body::Entries(EntriesData {
@@ -85,15 +85,11 @@ impl RealtimeFetcher for ClockSunriseFetcher {
                         entry("sunset", &format_clock(&down)),
                     ],
                 }),
-                _ => Body::Lines(LinesData {
-                    lines: vec![format!(
-                        "↑ {}  ↓ {}",
-                        format_clock(&up),
-                        format_clock(&down)
-                    )],
+                _ => Body::Text(TextData {
+                    value: format!("↑ {}  ↓ {}", format_clock(&up), format_clock(&down)),
                 }),
             },
-            Err(msg) => Body::Lines(LinesData { lines: vec![msg] }),
+            Err(msg) => Body::Text(TextData { value: msg }),
         };
         Payload {
             icon: None,
@@ -202,28 +198,28 @@ mod tests {
     }
 
     #[test]
-    fn missing_latlon_renders_error_line() {
-        let p = ClockSunriseFetcher.compute(&ctx(Some(Shape::Lines), ""));
+    fn missing_latlon_renders_error_text() {
+        let p = ClockSunriseFetcher.compute(&ctx(Some(Shape::Text), ""));
         match p.body {
-            Body::Lines(d) => assert!(d.lines[0].contains("required")),
-            _ => panic!("expected lines"),
+            Body::Text(d) => assert!(d.value.contains("required")),
+            _ => panic!("expected text"),
         }
     }
 
     #[test]
     fn tokyo_returns_plausible_times() {
         let p = ClockSunriseFetcher.compute(&ctx(
-            Some(Shape::Lines),
+            Some(Shape::Text),
             r#"lat = 35.6762
 lon = 139.6503
 timezone = "Asia/Tokyo""#,
         ));
         match p.body {
-            Body::Lines(d) => {
-                assert!(d.lines[0].contains("↑"));
-                assert!(d.lines[0].contains("↓"));
+            Body::Text(d) => {
+                assert!(d.value.contains("↑"));
+                assert!(d.value.contains("↓"));
             }
-            _ => panic!("expected lines"),
+            _ => panic!("expected text"),
         }
     }
 

--- a/src/fetcher/clock/timezones.rs
+++ b/src/fetcher/clock/timezones.rs
@@ -5,13 +5,13 @@ use chrono::{DateTime, FixedOffset, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
-use crate::payload::{Body, EntriesData, Entry, LinesData, Payload};
+use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData};
 use crate::render::Shape;
 use crate::samples;
 
 use super::common;
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries];
 
 pub struct ClockTimezonesFetcher;
 
@@ -34,7 +34,7 @@ impl RealtimeFetcher for ClockTimezonesFetcher {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "UTC         14:35",
                 "Tokyo       23:35",
                 "New York    10:35",
@@ -51,7 +51,7 @@ impl RealtimeFetcher for ClockTimezonesFetcher {
             Err(msg) => return common::placeholder(&msg),
         };
         let fmt = ctx.format.as_deref().unwrap_or(common::DEFAULT_FORMAT);
-        let shape = ctx.shape.unwrap_or(Shape::Lines);
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
         let rows: Vec<(String, String)> = opts
             .timezones
             .iter()
@@ -68,7 +68,7 @@ impl RealtimeFetcher for ClockTimezonesFetcher {
                     })
                     .collect(),
             }),
-            _ => Body::Lines(LinesData {
+            _ => Body::TextBlock(TextBlockData {
                 lines: rows.into_iter().map(|(n, t)| format!("{n} {t}")).collect(),
             }),
         };
@@ -109,14 +109,14 @@ mod tests {
     }
 
     #[test]
-    fn lines_emits_one_row_per_zone() {
+    fn text_block_emits_one_row_per_zone() {
         let p = ClockTimezonesFetcher.compute(&ctx(
-            Some(Shape::Lines),
+            Some(Shape::TextBlock),
             "timezones = [\"Asia/Tokyo\", \"UTC\"]",
         ));
         match p.body {
-            Body::Lines(d) => assert_eq!(d.lines.len(), 2),
-            _ => panic!("expected lines"),
+            Body::TextBlock(d) => assert_eq!(d.lines.len(), 2),
+            _ => panic!("expected text_block"),
         }
     }
 
@@ -134,11 +134,13 @@ mod tests {
 
     #[test]
     fn invalid_zone_renders_placeholder_time() {
-        let p =
-            ClockTimezonesFetcher.compute(&ctx(Some(Shape::Lines), "timezones = [\"Not/AZone\"]"));
+        let p = ClockTimezonesFetcher.compute(&ctx(
+            Some(Shape::TextBlock),
+            "timezones = [\"Not/AZone\"]",
+        ));
         match p.body {
-            Body::Lines(d) => assert!(d.lines[0].ends_with("??")),
-            _ => panic!("expected lines"),
+            Body::TextBlock(d) => assert!(d.lines[0].ends_with("??")),
+            _ => panic!("expected text_block"),
         }
     }
 }

--- a/src/fetcher/clock/timezones.rs
+++ b/src/fetcher/clock/timezones.rs
@@ -134,10 +134,8 @@ mod tests {
 
     #[test]
     fn invalid_zone_renders_placeholder_time() {
-        let p = ClockTimezonesFetcher.compute(&ctx(
-            Some(Shape::TextBlock),
-            "timezones = [\"Not/AZone\"]",
-        ));
+        let p = ClockTimezonesFetcher
+            .compute(&ctx(Some(Shape::TextBlock), "timezones = [\"Not/AZone\"]"));
         match p.body {
             Body::TextBlock(d) => assert!(d.lines[0].ends_with("??")),
             _ => panic!("expected text_block"),

--- a/src/fetcher/git/blame_heatmap.rs
+++ b/src/fetcher/git/blame_heatmap.rs
@@ -45,7 +45,9 @@ impl Fetcher for GitBlameHeatmap {
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Heatmap => samples::heatmap_grid(5, 10),
-            Shape::Text => samples::text("src/main.rs (18), src/render/mod.rs (12), src/fetcher/mod.rs (9)"),
+            Shape::Text => {
+                samples::text("src/main.rs (18), src/render/mod.rs (12), src/fetcher/mod.rs (9)")
+            }
             _ => return None,
         })
     }

--- a/src/fetcher/git/blame_heatmap.rs
+++ b/src/fetcher/git/blame_heatmap.rs
@@ -13,16 +13,16 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::Text];
 const WEEKS: usize = 52;
 const TOP_FILES: usize = 7;
 const MAX_COMMITS: usize = 500;
 
 /// Per-file churn over the last 52 weeks. Rows are the top 7 most-touched files (truncated path),
 /// columns are weeks (rightmost = this week), cell = commits in that week touching that file.
-/// `Lines` emits a top-N summary `"src/main.rs (42), src/lib.rs (31), …"`.
+/// `Text` emits a top-N summary `"src/main.rs (42), src/lib.rs (31), …"`.
 pub struct GitBlameHeatmap;
 
 #[async_trait]
@@ -45,11 +45,7 @@ impl Fetcher for GitBlameHeatmap {
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Heatmap => samples::heatmap_grid(5, 10),
-            Shape::Lines => samples::lines(&[
-                "src/main.rs        18",
-                "src/render/mod.rs  12",
-                "src/fetcher/mod.rs  9",
-            ]),
+            Shape::Text => samples::text("src/main.rs (18), src/render/mod.rs (12), src/fetcher/mod.rs (9)"),
             _ => return None,
         })
     }
@@ -195,9 +191,9 @@ fn week_col(date: NaiveDate, start: NaiveDate) -> Option<usize> {
 
 fn render_body(churn: Churn, shape: Shape) -> Body {
     match shape {
-        Shape::Lines => {
+        Shape::Text => {
             if churn.files.is_empty() {
-                lines_body(Vec::new())
+                text_body("")
             } else {
                 let line = churn
                     .files
@@ -206,7 +202,7 @@ fn render_body(churn: Churn, shape: Shape) -> Body {
                     .map(|(f, c)| format!("{} ({c})", short_path(f)))
                     .collect::<Vec<_>>()
                     .join(", ");
-                lines_body(vec![line])
+                text_body(line)
             }
         }
         _ => Body::Heatmap(HeatmapData {
@@ -258,20 +254,19 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_summarises_with_counts() {
+    fn text_shape_summarises_with_counts() {
         let (_tmp, repo) = make_repo();
         commit_touching(&repo, "dir/deep/name.rs", "x");
         let body = render_body(
             churn(&repo, Local::now().date_naive()).unwrap(),
-            Shape::Lines,
+            Shape::Text,
         );
         match body {
-            Body::Lines(d) => {
-                assert_eq!(d.lines.len(), 1);
+            Body::Text(d) => {
                 assert!(
-                    d.lines[0].starts_with("name.rs ("),
-                    "unexpected line: {:?}",
-                    d.lines[0]
+                    d.value.starts_with("name.rs ("),
+                    "unexpected text: {:?}",
+                    d.value
                 );
             }
             _ => panic!(),

--- a/src/fetcher/git/commits_activity.rs
+++ b/src/fetcher/git/commits_activity.rs
@@ -8,16 +8,16 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::NumberSeries, Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::NumberSeries, Shape::Text];
 const WEEKS: usize = 52;
 const DAYS_PER_WEEK: usize = 7;
 
 /// Commit count per day over the last 52 weeks, anchored like GitHub: rightmost column contains
 /// today's week, rows are weekdays (0 = Sunday .. 6 = Saturday). `Heatmap` is the default; the
 /// `NumberSeries` alt flattens the grid into a 364-point array for sparkline rendering;
-/// `Lines` emits a one-line summary.
+/// `Text` emits a one-line summary.
 pub struct GitCommitsActivity;
 
 #[async_trait]
@@ -43,7 +43,7 @@ impl Fetcher for GitCommitsActivity {
             Shape::NumberSeries => samples::number_series(&[
                 2, 5, 3, 8, 4, 9, 6, 11, 7, 3, 4, 6, 2, 5, 8, 10, 7, 4, 9, 6,
             ]),
-            Shape::Lines => samples::lines(&["42 commits this month"]),
+            Shape::Text => samples::text("42 commits this month"),
             _ => return None,
         })
     }
@@ -142,12 +142,12 @@ fn render_body(grid: Vec<Vec<u32>>, today: NaiveDate, shape: Shape) -> Body {
         Shape::NumberSeries => Body::NumberSeries(NumberSeriesData {
             values: flatten_by_day(&grid),
         }),
-        Shape::Lines => {
+        Shape::Text => {
             let total: u64 = grid.iter().flatten().map(|v| *v as u64).sum();
             if total == 0 {
-                lines_body(Vec::new())
+                text_body("")
             } else {
-                lines_body(vec![format!("{total} commits in the last {WEEKS} weeks")])
+                text_body(format!("{total} commits in the last {WEEKS} weeks"))
             }
         }
         _ => Body::Heatmap(HeatmapData {
@@ -232,15 +232,12 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_summary() {
+    fn text_shape_summary() {
         let mut grid = vec![vec![0u32; WEEKS]; DAYS_PER_WEEK];
         grid[0][0] = 5;
-        let body = render_body(grid, any_weekday(), Shape::Lines);
+        let body = render_body(grid, any_weekday(), Shape::Text);
         match body {
-            Body::Lines(d) => {
-                assert_eq!(d.lines.len(), 1);
-                assert!(d.lines[0].contains("5 commits"));
-            }
+            Body::Text(d) => assert!(d.value.contains("5 commits")),
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -9,15 +9,15 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries, Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries, Shape::Text];
 const DEFAULT_DAYS: u64 = 30;
 const MAX_ENTRIES: usize = 10;
 
 /// Commit authors over the last N days (default 30, configurable via `format = "N"`). Ranked
 /// by commit count, truncated to the top 10 so a busy repo doesn't blow up the widget. `Bars`
-/// is the default (visual ranking); `Entries` emits `name: count` rows; `Lines` collapses to
+/// is the default (visual ranking); `Entries` emits `name: count` rows; `Text` collapses to
 /// `"alice (23), bob (11)"` style.
 pub struct GitContributors;
 
@@ -49,12 +49,7 @@ impl Fetcher for GitContributors {
                 ("charlie", "17"),
                 ("dave", "9"),
             ]),
-            Shape::Lines => samples::lines(&[
-                "alice     42",
-                "bob       28",
-                "charlie   17",
-                "dave       9",
-            ]),
+            Shape::Text => samples::text("alice (42), bob (28), charlie (17), dave (9)"),
             _ => return None,
         })
     }
@@ -119,16 +114,16 @@ fn render_body(ranked: Vec<(String, u64)>, shape: Shape) -> Body {
                 })
                 .collect(),
         }),
-        Shape::Lines => {
+        Shape::Text => {
             if ranked.is_empty() {
-                lines_body(Vec::new())
+                text_body("")
             } else {
                 let line = ranked
                     .into_iter()
                     .map(|(name, count)| format!("{name} ({count})"))
                     .collect::<Vec<_>>()
                     .join(", ");
-                lines_body(vec![line])
+                text_body(line)
             }
         }
         _ => Body::Bars(BarsData {
@@ -179,19 +174,19 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_empty_when_empty() {
-        let body = render_body(Vec::new(), Shape::Lines);
+    fn text_shape_empty_when_empty() {
+        let body = render_body(Vec::new(), Shape::Text);
         match body {
-            Body::Lines(d) => assert!(d.lines.is_empty()),
+            Body::Text(d) => assert!(d.value.is_empty()),
             _ => panic!(),
         }
     }
 
     #[test]
-    fn lines_shape_joins_with_counts() {
-        let body = render_body(vec![("alice".into(), 3), ("bob".into(), 1)], Shape::Lines);
+    fn text_shape_joins_with_counts() {
+        let body = render_body(vec![("alice".into(), 3), ("bob".into(), 1)], Shape::Text);
         match body {
-            Body::Lines(d) => assert_eq!(d.lines, vec!["alice (3), bob (1)".to_string()]),
+            Body::Text(d) => assert_eq!(d.value, "alice (3), bob (1)"),
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/latest_tag.rs
+++ b/src/fetcher/git/latest_tag.rs
@@ -5,11 +5,11 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
 
-/// Most recent annotated-or-lightweight tag by committer time of the peeled commit. `Lines` emits
+/// Most recent annotated-or-lightweight tag by committer time of the peeled commit. `Text` emits
 /// just the tag name; `Entries` adds the target short hash and the commit time as ISO date so a
 /// two-line "latest release" widget has somewhere to put the date.
 pub struct GitLatestTag;
@@ -26,14 +26,14 @@ impl Fetcher for GitLatestTag {
         SHAPES
     }
     fn default_shape(&self) -> Shape {
-        Shape::Lines
+        Shape::Text
     }
     fn cache_key(&self, ctx: &FetchContext) -> String {
         repo_cache_key(self.name(), ctx)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["v1.2.3"]),
+            Shape::Text => samples::text("v1.2.3"),
             Shape::Entries => samples::entries(&[
                 ("tag", "v1.2.3"),
                 ("short", "a1b2c3d"),
@@ -44,13 +44,13 @@ impl Fetcher for GitLatestTag {
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let repo = open_repo()?;
-        build(&repo, ctx.shape.unwrap_or(Shape::Lines))
+        build(&repo, ctx.shape.unwrap_or(Shape::Text))
     }
 }
 
 fn build(repo: &gix::Repository, shape: Shape) -> Result<Payload, FetchError> {
     let Some(tag) = latest_tag(repo)? else {
-        return Ok(payload(lines_body(Vec::new())));
+        return Ok(payload(text_body("")));
     };
     let body = match shape {
         Shape::Entries => Body::Entries(EntriesData {
@@ -60,7 +60,7 @@ fn build(repo: &gix::Repository, shape: Shape) -> Result<Payload, FetchError> {
                 entry("date", &tag.iso_date),
             ],
         }),
-        _ => lines_body(vec![tag.name]),
+        _ => text_body(tag.name),
     };
     Ok(payload(body))
 }
@@ -118,23 +118,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn returns_none_when_no_tags() {
+    fn returns_empty_text_when_no_tags() {
         let (_tmp, repo) = make_repo();
-        let p = build(&repo, Shape::Lines).unwrap();
+        let p = build(&repo, Shape::Text).unwrap();
         match p.body {
-            Body::Lines(d) => assert!(d.lines.is_empty()),
+            Body::Text(d) => assert!(d.value.is_empty()),
             _ => panic!(),
         }
     }
 
     #[test]
-    fn lines_shape_emits_tag_name() {
+    fn text_shape_emits_tag_name() {
         let (_tmp, repo) = make_repo();
         super::super::test_support::commit(&repo, "initial");
         super::super::test_support::tag(&repo, "v0.1.0");
-        let p = build(&repo, Shape::Lines).unwrap();
+        let p = build(&repo, Shape::Text).unwrap();
         match p.body {
-            Body::Lines(d) => assert_eq!(d.lines, vec!["v0.1.0".to_string()]),
+            Body::Text(d) => assert_eq!(d.value, "v0.1.0"),
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/mod.rs
+++ b/src/fetcher/git/mod.rs
@@ -1,6 +1,7 @@
 //! Git / VCS fetchers backed by `gix`. All read-only (Safety::Safe) against the repo rooted at
-//! the process CWD (walk-up via `gix::discover`). Each fetcher is multi-shape: they all accept
-//! `Lines` as a universal fallback plus one or two structural shapes that carry the real data.
+//! the process CWD (walk-up via `gix::discover`). Each fetcher is multi-shape: they accept one
+//! text variant (`Text` for single-string summaries, `TextBlock` for multi-row output) plus one
+//! or two structural shapes that carry the real data.
 //!
 //! Cache keys mix the discovered repo root so running splashboard in two different projects
 //! doesn't pollute each other's `git_status` cache entries.
@@ -10,7 +11,7 @@ use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextBlockData, TextData};
 
 use super::{FetchContext, FetchError, Fetcher};
 
@@ -53,8 +54,14 @@ pub(crate) fn payload(body: Body) -> Payload {
     }
 }
 
-pub(crate) fn lines_body(values: Vec<String>) -> Body {
-    Body::Lines(LinesData { lines: values })
+pub(crate) fn text_body(value: impl Into<String>) -> Body {
+    Body::Text(TextData {
+        value: value.into(),
+    })
+}
+
+pub(crate) fn text_block_body(values: Vec<String>) -> Body {
+    Body::TextBlock(TextBlockData { lines: values })
 }
 
 pub(crate) fn fail<E: std::fmt::Display>(e: E) -> FetchError {

--- a/src/fetcher/git/recent_commits.rs
+++ b/src/fetcher/git/recent_commits.rs
@@ -6,13 +6,13 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_block_body};
 
-const SHAPES: &[Shape] = &[Shape::Timeline, Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Timeline, Shape::TextBlock];
 const DEFAULT_LIMIT: usize = 10;
 
 /// Newest commits on HEAD, walked via gix rev-walk. The `format` field is parsed as a commit
-/// count (`"5"`, `"20"`) — absent or unparseable falls back to 10. `Lines` renders
+/// count (`"5"`, `"20"`) — absent or unparseable falls back to 10. `TextBlock` renders
 /// `<short> <summary>` one per line so users who want a flat list instead of the timeline
 /// renderer's relative-ago labels can still wire it up.
 pub struct GitRecentCommits;
@@ -41,7 +41,7 @@ impl Fetcher for GitRecentCommits {
                 (1_699_990_000, "fix(fetcher): tz fallback", Some("d4e5f6a")),
                 (1_699_900_000, "chore: bump ratatui", Some("e7f8a9b")),
             ]),
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "a1b2c3d feat(render): add heatmap",
                 "d4e5f6a fix(fetcher): tz fallback",
                 "e7f8a9b chore: bump ratatui",
@@ -107,7 +107,7 @@ fn parse_limit(format: Option<&str>) -> usize {
 
 fn render_body(commits: Vec<CommitInfo>, shape: Shape) -> Body {
     match shape {
-        Shape::Lines => lines_body(
+        Shape::TextBlock => text_block_body(
             commits
                 .into_iter()
                 .map(|c| format!("{} {}", c.short_hash, c.summary))
@@ -176,12 +176,12 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_prefixes_short_hash() {
+    fn text_block_shape_prefixes_short_hash() {
         let (_tmp, repo) = make_repo();
         commit(&repo, "hello");
-        let body = render_body(recent_commits(&repo, 10).unwrap(), Shape::Lines);
+        let body = render_body(recent_commits(&repo, 10).unwrap(), Shape::TextBlock);
         match body {
-            Body::Lines(d) => {
+            Body::TextBlock(d) => {
                 assert_eq!(d.lines.len(), 1);
                 assert!(d.lines[0].ends_with(" hello"));
             }

--- a/src/fetcher/git/stash_count.rs
+++ b/src/fetcher/git/stash_count.rs
@@ -5,9 +5,9 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
 
 /// Number of entries in the stash reflog. A missing `refs/stash` ref or an absent reflog returns
 /// zero — both are common (no stashes yet) and shouldn't surface as an error.
@@ -29,7 +29,7 @@ impl Fetcher for GitStashCount {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["3 stashes"]),
+            Shape::Text => samples::text("3 stashes"),
             Shape::Entries => samples::entries(&[("stashes", "3")]),
             _ => return None,
         })
@@ -39,7 +39,7 @@ impl Fetcher for GitStashCount {
         let count = stash_count(&repo)?;
         Ok(payload(render_body(
             count,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::Text),
         )))
     }
 }
@@ -66,12 +66,12 @@ fn render_body(count: usize, shape: Shape) -> Body {
         }),
         _ => {
             if count == 0 {
-                lines_body(Vec::new())
+                text_body("")
             } else {
-                lines_body(vec![format!(
+                text_body(format!(
                     "{count} stash{}",
                     if count == 1 { "" } else { "es" }
-                )])
+                ))
             }
         }
     }
@@ -98,12 +98,12 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_is_empty_when_none() {
+    fn text_shape_is_empty_when_none() {
         let (_tmp, repo) = make_repo();
         commit(&repo, "initial");
-        let body = render_body(stash_count(&repo).unwrap(), Shape::Lines);
+        let body = render_body(stash_count(&repo).unwrap(), Shape::Text);
         match body {
-            Body::Lines(d) => assert!(d.lines.is_empty()),
+            Body::Text(d) => assert!(d.value.is_empty()),
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/status.rs
+++ b/src/fetcher/git/status.rs
@@ -5,12 +5,12 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Entries, Shape::Lines, Shape::Badge];
+const SHAPES: &[Shape] = &[Shape::Entries, Shape::Text, Shape::Badge];
 
 /// Working tree snapshot: branch, dirty flag, ahead/behind vs upstream. Multi-shape so a user can
-/// pick a key/value panel (`Entries`, default), a one-liner (`Lines`), or a clean/dirty traffic
+/// pick a key/value panel (`Entries`, default), a one-liner (`Text`), or a clean/dirty traffic
 /// light (`Badge`). Detached HEAD shows the short commit hash in place of the branch.
 pub struct GitStatus;
 
@@ -39,7 +39,7 @@ impl Fetcher for GitStatus {
                 ("modified", "3"),
                 ("untracked", "1"),
             ]),
-            Shape::Lines => samples::lines(&["main  +2 −0  ◆3 ?1"]),
+            Shape::Text => samples::text("main  +2 −0  ◆3 ?1"),
             Shape::Badge => samples::badge(PayloadStatus::Ok, "clean"),
             _ => return None,
         })
@@ -136,7 +136,7 @@ fn render_body(info: &StatusInfo, shape: Shape) -> Body {
                 format!("{} · clean", short_branch(info))
             },
         }),
-        Shape::Lines => lines_body(vec![format_line(info)]),
+        Shape::Text => text_body(format_line(info)),
         _ => Body::Entries(EntriesData {
             items: build_entries(info),
         }),
@@ -259,15 +259,14 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_summarises_branch_and_state() {
+    fn text_shape_summarises_branch_and_state() {
         let (_tmp, repo) = make_repo();
         commit(&repo, "initial");
-        let body = call(&repo, Shape::Lines);
+        let body = call(&repo, Shape::Text);
         match body {
-            Body::Lines(d) => {
-                assert_eq!(d.lines.len(), 1);
-                assert!(d.lines[0].contains("main"));
-                assert!(d.lines[0].contains("clean"));
+            Body::Text(d) => {
+                assert!(d.value.contains("main"));
+                assert!(d.value.contains("clean"));
             }
             _ => panic!(),
         }

--- a/src/fetcher/git/worktrees.rs
+++ b/src/fetcher/git/worktrees.rs
@@ -5,12 +5,12 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::{fail, lines_body, open_repo, payload, repo_cache_key};
+use super::{fail, open_repo, payload, repo_cache_key, text_block_body};
 
-const SHAPES: &[Shape] = &[Shape::Entries, Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Entries, Shape::TextBlock];
 
 /// Linked worktrees plus the main worktree. `Entries` maps worktree id → `"<branch> @ <path>"`.
-/// `Lines` flattens to one worktree per line.
+/// `TextBlock` flattens to one worktree per line.
 pub struct GitWorktrees;
 
 #[async_trait]
@@ -34,7 +34,7 @@ impl Fetcher for GitWorktrees {
                 ("feat/foo", "/repo-feat"),
                 ("hotfix", "/repo-hotfix"),
             ]),
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "main           /repo",
                 "feat/foo       /repo-feat",
                 "hotfix         /repo-hotfix",
@@ -93,7 +93,7 @@ fn head_branch(repo: &gix::Repository) -> Option<String> {
 
 fn render_body(list: Vec<WorktreeInfo>, shape: Shape) -> Body {
     match shape {
-        Shape::Lines => lines_body(list.into_iter().map(format_line).collect()),
+        Shape::TextBlock => text_block_body(list.into_iter().map(format_line).collect()),
         _ => Body::Entries(EntriesData {
             items: list
                 .into_iter()
@@ -152,12 +152,12 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_formats_each_entry() {
+    fn text_block_shape_formats_each_entry() {
         let (_tmp, repo) = make_repo();
         commit(&repo, "init");
-        let body = render_body(worktrees(&repo).unwrap(), Shape::Lines);
+        let body = render_body(worktrees(&repo).unwrap(), Shape::TextBlock);
         match body {
-            Body::Lines(d) => {
+            Body::TextBlock(d) => {
                 assert_eq!(d.lines.len(), 1);
                 assert!(d.lines[0].starts_with("(main) (main) @ "));
             }

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -1,11 +1,11 @@
 //! `github_action_status` — current CI state for a repo, as a single badge plus optional
-//! `Lines` summary. Uses the latest workflow run across every workflow.
+//! `Text` summary. Uses the latest workflow run across every workflow.
 
 use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{BadgeData, Body, LinesData, Payload, Status};
+use crate::payload::{BadgeData, Body, Payload, Status, TextData};
 use crate::render::Shape;
 use crate::samples;
 
@@ -13,7 +13,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Badge, Shape::Lines];
+const SHAPES: &[Shape] = &[Shape::Badge, Shape::Text];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -67,7 +67,7 @@ impl Fetcher for GithubActionStatus {
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Badge => samples::badge(Status::Ok, "ci passing"),
-            Shape::Lines => samples::lines(&["main · passing"]),
+            Shape::Text => samples::text("main · passing"),
             _ => return None,
         })
     }
@@ -120,11 +120,11 @@ struct WorkflowRun {
 fn render_body(run: &WorkflowRun, shape: Shape) -> Body {
     let (status, label_word) = classify(run);
     match shape {
-        Shape::Lines => Body::Lines(LinesData {
-            lines: vec![format!(
+        Shape::Text => Body::Text(TextData {
+            value: format!(
                 "{} · {label_word}",
                 run.head_branch.as_deref().unwrap_or("?")
-            )],
+            ),
         }),
         _ => Body::Badge(BadgeData {
             status,

--- a/src/fetcher/github/assigned_issues.rs
+++ b/src/fetcher/github/assigned_issues.rs
@@ -14,7 +14,7 @@ use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload, placeholder};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -53,7 +53,7 @@ impl Fetcher for GithubAssignedIssues {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "unhappychoice/splashboard#41 meta: widget catalog & roadmap",
                 "unhappychoice/splashboard#17 theme system",
             ]),
@@ -84,7 +84,7 @@ impl Fetcher for GithubAssignedIssues {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
             true,
         )))
     }

--- a/src/fetcher/github/common.rs
+++ b/src/fetcher/github/common.rs
@@ -7,7 +7,7 @@ use chrono::DateTime;
 use sha2::{Digest, Sha256};
 
 use crate::fetcher::{FetchContext, FetchError};
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextBlockData};
 
 pub fn payload(body: Body) -> Payload {
     Payload {
@@ -18,14 +18,14 @@ pub fn payload(body: Body) -> Payload {
     }
 }
 
-pub fn lines_body(values: Vec<String>) -> Body {
-    Body::Lines(LinesData { lines: values })
+pub fn text_block_body(values: Vec<String>) -> Body {
+    Body::TextBlock(TextBlockData { lines: values })
 }
 
 /// Two-line warning body — mirrors `clock::common::placeholder` so misconfigured widgets look
 /// consistent across fetcher families.
 pub fn placeholder(msg: &str) -> Payload {
-    payload(Body::Lines(LinesData {
+    payload(Body::TextBlock(TextBlockData {
         lines: vec![
             format!("⚠ {msg}"),
             "check [widget.options] or set GH_TOKEN".into(),

--- a/src/fetcher/github/good_first_issues.rs
+++ b/src/fetcher/github/good_first_issues.rs
@@ -14,7 +14,7 @@ use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -74,7 +74,7 @@ impl Fetcher for GithubGoodFirstIssues {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "ratatui/ratatui#999 improve docs for Paragraph",
                 "tokio-rs/console#123 add quickstart section",
             ]),
@@ -119,7 +119,7 @@ impl Fetcher for GithubGoodFirstIssues {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
             include_repo,
         )))
     }

--- a/src/fetcher/github/items.rs
+++ b/src/fetcher/github/items.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-use crate::payload::{Body, EntriesData, Entry, LinesData, TimelineData, TimelineEvent};
+use crate::payload::{Body, EntriesData, Entry, TextBlockData, TimelineData, TimelineEvent};
 use crate::render::Shape;
 
 use super::common::{RepoSlug, parse_timestamp};
@@ -37,10 +37,10 @@ pub fn repo_from_url(url: &str) -> Option<RepoSlug> {
     RepoSlug::parse(rest)
 }
 
-/// Renders issue / PR items to one of `Lines` / `Entries` / `Timeline`. When `include_repo` is
-/// true, each line/event is prefixed with `owner/name` — used by user-scope fetchers that
-/// return items across many repos. Per-repo fetchers pass `false` so the repo name isn't
-/// repeated on every row.
+/// Renders issue / PR items to one of `TextBlock` / `Entries` / `Timeline`. When
+/// `include_repo` is true, each line/event is prefixed with `owner/name` — used by user-scope
+/// fetchers that return items across many repos. Per-repo fetchers pass `false` so the repo
+/// name isn't repeated on every row.
 pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Body {
     match shape {
         Shape::Entries => Body::Entries(EntriesData {
@@ -64,7 +64,7 @@ pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Bo
                 })
                 .collect(),
         }),
-        _ => Body::Lines(LinesData {
+        _ => Body::TextBlock(TextBlockData {
             lines: items
                 .iter()
                 .map(|i| format!("{} {}", short_label(i, include_repo), i.title))

--- a/src/fetcher/github/my_prs.rs
+++ b/src/fetcher/github/my_prs.rs
@@ -15,7 +15,7 @@ use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload, placeholder};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -54,7 +54,7 @@ impl Fetcher for GithubMyPrs {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "unhappychoice/splashboard#54 feat(docs): generate widget catalogue",
                 "unhappychoice/splashboard#51 feat(fetcher): split clock options",
             ]),
@@ -89,7 +89,7 @@ impl Fetcher for GithubMyPrs {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
             true,
         )))
     }

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, LinesData, Payload, TimelineData, TimelineEvent};
+use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent};
 use crate::render::Shape;
 use crate::samples;
 
@@ -13,7 +13,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{cache_key, parse_options, parse_timestamp, payload, placeholder};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -63,7 +63,7 @@ impl Fetcher for GithubNotifications {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "splashboard review_requested: feat: heatmap",
                 "ratatui mention: rfc: themes",
             ]),
@@ -93,7 +93,7 @@ impl Fetcher for GithubNotifications {
         let items: Vec<Notification> = rest_get(&path).await?;
         Ok(payload(render_body(
             &items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
         )))
     }
 }
@@ -139,7 +139,7 @@ fn render_body(items: &[Notification], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
-        _ => Body::Lines(LinesData {
+        _ => Body::TextBlock(TextBlockData {
             lines: items
                 .iter()
                 .map(|n| {
@@ -183,10 +183,10 @@ mod tests {
     }
 
     #[test]
-    fn lines_body_composes_repo_reason_title() {
-        let body = render_body(&[sample()], Shape::Lines);
-        let Body::Lines(l) = body else {
-            panic!("expected lines");
+    fn text_block_body_composes_repo_reason_title() {
+        let body = render_body(&[sample()], Shape::TextBlock);
+        let Body::TextBlock(l) = body else {
+            panic!("expected text_block");
         };
         assert!(l.lines[0].contains("unhappychoice/splashboard"));
         assert!(l.lines[0].contains("review_requested"));

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -5,7 +5,9 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent};
+use crate::payload::{
+    Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent,
+};
 use crate::render::Shape;
 use crate::samples;
 

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent};
+use crate::payload::{
+    Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent,
+};
 use crate::render::Shape;
 use crate::samples;
 

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, LinesData, Payload, TimelineData, TimelineEvent};
+use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent};
 use crate::render::Shape;
 use crate::samples;
 
@@ -14,7 +14,7 @@ use super::common::{
     RepoSlug, cache_key, parse_options, parse_timestamp, payload, placeholder, resolve_repo,
 };
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 5;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -65,7 +65,7 @@ impl Fetcher for GithubRecentReleases {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["v0.3.0  2026-04-10", "v0.2.1  2026-03-05"]),
+            Shape::TextBlock => samples::text_block(&["v0.3.0  2026-04-10", "v0.2.1  2026-03-05"]),
             Shape::Entries => {
                 samples::entries(&[("v0.3.0", "2026-04-10"), ("v0.2.1", "2026-03-05")])
             }
@@ -93,7 +93,7 @@ impl Fetcher for GithubRecentReleases {
         let items: Vec<Release> = rest_get(&path).await?;
         Ok(payload(render_body(
             &items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
         )))
     }
 }
@@ -138,7 +138,7 @@ fn render_body(items: &[Release], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
-        _ => Body::Lines(LinesData {
+        _ => Body::TextBlock(TextBlockData {
             lines: items
                 .iter()
                 .map(|r| {

--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -14,7 +14,7 @@ use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
 use super::items::{IssueItem, render_items};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -65,8 +65,8 @@ impl Fetcher for GithubRepoIssues {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => {
-                samples::lines(&["#41 meta: widget catalog & roadmap", "#17 theme system"])
+            Shape::TextBlock => {
+                samples::text_block(&["#41 meta: widget catalog & roadmap", "#17 theme system"])
             }
             Shape::Entries => {
                 samples::entries(&[("#41", "meta: widget catalog"), ("#17", "theme system")])
@@ -105,7 +105,7 @@ impl Fetcher for GithubRepoIssues {
             .collect();
         Ok(payload(render_items(
             &issues,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
             false,
         )))
     }

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -14,7 +14,7 @@ use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
 use super::items::{IssueItem, render_items};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -65,7 +65,7 @@ impl Fetcher for GithubRepoPrs {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "#54 feat(docs): generate widget catalogue",
                 "#51 feat(fetcher): split clock options",
             ]),
@@ -101,7 +101,7 @@ impl Fetcher for GithubRepoPrs {
         let items: Vec<IssueItem> = rest_get(&path).await?;
         Ok(payload(render_items(
             &items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
             false,
         )))
     }

--- a/src/fetcher/github/repo_stars.rs
+++ b/src/fetcher/github/repo_stars.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, LinesData, Payload};
+use crate::payload::{Body, EntriesData, Entry, Payload, TextData};
 use crate::render::Shape;
 use crate::samples;
 
@@ -13,7 +13,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     name: "repo",
@@ -52,7 +52,7 @@ impl Fetcher for GithubRepoStars {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["★ 142"]),
+            Shape::Text => samples::text("★ 142"),
             Shape::Entries => samples::entries(&[
                 ("stars", "142"),
                 ("forks", "9"),
@@ -73,7 +73,7 @@ impl Fetcher for GithubRepoStars {
         };
         let path = format!("/repos/{}/{}", slug.owner, slug.name);
         let repo: RepoInfo = rest_get(&path).await?;
-        let body = match ctx.shape.unwrap_or(Shape::Lines) {
+        let body = match ctx.shape.unwrap_or(Shape::Text) {
             Shape::Entries => Body::Entries(EntriesData {
                 items: vec![
                     entry("stars", &repo.stargazers_count.to_string()),
@@ -82,8 +82,8 @@ impl Fetcher for GithubRepoStars {
                     entry("open_issues", &repo.open_issues_count.to_string()),
                 ],
             }),
-            _ => Body::Lines(LinesData {
-                lines: vec![format!("★ {}", repo.stargazers_count)],
+            _ => Body::Text(TextData {
+                value: format!("★ {}", repo.stargazers_count),
             }),
         };
         Ok(payload(body))

--- a/src/fetcher/github/review_requests.rs
+++ b/src/fetcher/github/review_requests.rs
@@ -14,7 +14,7 @@ use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload, placeholder};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::Lines, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -53,7 +53,7 @@ impl Fetcher for GithubReviewRequests {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "ratatui/ratatui#1234 feat: add pie chart",
                 "tokio-rs/tokio#5678 fix: race in spawn",
             ]),
@@ -88,7 +88,7 @@ impl Fetcher for GithubReviewRequests {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::Lines),
+            ctx.shape.unwrap_or(Shape::TextBlock),
             true,
         )))
     }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextBlockData};
 use crate::render::Shape;
 use crate::samples;
 
@@ -140,7 +140,7 @@ pub fn shape_mismatch_placeholder(err: &ShapeMismatch) -> Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::Lines(LinesData { lines }),
+        body: Body::TextBlock(TextBlockData { lines }),
     }
 }
 
@@ -277,7 +277,7 @@ impl Registry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{Body, LinesData};
+    use crate::payload::{Body, TextData};
 
     struct Dummy(&'static str, Safety);
 
@@ -290,14 +290,16 @@ mod tests {
             self.1
         }
         fn shapes(&self) -> &[Shape] {
-            &[Shape::Lines]
+            &[Shape::Text]
         }
         async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
             Ok(Payload {
                 icon: None,
                 status: None,
                 format: None,
-                body: Body::Lines(LinesData { lines: vec![] }),
+                body: Body::Text(TextData {
+                    value: String::new(),
+                }),
             })
         }
     }
@@ -312,14 +314,16 @@ mod tests {
             self.1
         }
         fn shapes(&self) -> &[Shape] {
-            &[Shape::Lines]
+            &[Shape::Text]
         }
         fn compute(&self, _: &FetchContext) -> Payload {
             Payload {
                 icon: None,
                 status: None,
                 format: None,
-                body: Body::Lines(LinesData { lines: vec![] }),
+                body: Body::Text(TextData {
+                    value: String::new(),
+                }),
             }
         }
     }
@@ -385,7 +389,7 @@ mod tests {
             ..Default::default()
         };
         let p = f.fetch(&ctx).await.unwrap();
-        assert!(matches!(p.body, Body::Lines(_)));
+        assert!(matches!(p.body, Body::Text(_)));
         assert_eq!(f.safety(), Safety::Network);
     }
 

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 
 use crate::payload::{
-    Bar, BarsData, Body, CalendarData, EntriesData, HeatmapData, ImageData, LinesData,
-    NumberSeriesData, Payload, PointSeriesData, RatioData,
+    Bar, BarsData, Body, CalendarData, EntriesData, HeatmapData, ImageData, NumberSeriesData,
+    Payload, PointSeriesData, RatioData, TextBlockData, TextData,
 };
 use crate::render::Shape;
 
@@ -14,7 +14,8 @@ use super::{FetchContext, FetchError, Fetcher, Safety};
 /// the escape hatch for user-defined widgets, so it supports the non-dynamic shapes exhaustively;
 /// config picks which variant a specific file maps to.
 const READ_STORE_SHAPES: &[Shape] = &[
-    Shape::Lines,
+    Shape::Text,
+    Shape::TextBlock,
     Shape::Entries,
     Shape::Ratio,
     Shape::NumberSeries,
@@ -63,9 +64,9 @@ impl Fetcher for ReadStoreFetcher {
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         // Runtime always derives a shape (renderer's single accepted shape, or our
-        // `default_shape`); `None` falls back defensively to Lines so direct callers still
+        // `default_shape`); `None` falls back defensively to TextBlock so direct callers still
         // behave.
-        let shape = ctx.shape.unwrap_or(Shape::Lines);
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
         let file_format = ctx
             .file_format
             .as_deref()
@@ -82,11 +83,11 @@ impl Fetcher for ReadStoreFetcher {
     }
 }
 
-/// `text` is the natural default for `lines`; everything else needs structure. Saves users
+/// `text` is the natural default for text shapes; everything else needs structure. Saves users
 /// from writing `file_format = "text"` for every simple notes widget.
 fn default_format_for_shape(shape: Shape) -> &'static str {
     match shape {
-        Shape::Lines => "text",
+        Shape::Text | Shape::TextBlock => "text",
         _ => "json",
     }
 }
@@ -132,7 +133,10 @@ fn load_body(path: &std::path::Path, file_format: &str, shape: Shape) -> Result<
 
 fn parse_body(text: &str, file_format: &str, shape: Shape) -> Result<Body, FetchError> {
     match (file_format, shape) {
-        ("text", Shape::Lines) => Ok(Body::Lines(LinesData {
+        ("text", Shape::Text) => Ok(Body::Text(TextData {
+            value: text.to_string(),
+        })),
+        ("text", Shape::TextBlock) => Ok(Body::TextBlock(TextBlockData {
             lines: text.lines().map(str::to_string).collect(),
         })),
         ("text", _) => Err(FetchError::Failed(format!(
@@ -159,7 +163,8 @@ fn from_json(text: &str, shape: Shape) -> Result<Body, FetchError> {
         };
     }
     match shape {
-        Shape::Lines => parse_as!(LinesData, Lines),
+        Shape::Text => parse_as!(TextData, Text),
+        Shape::TextBlock => parse_as!(TextBlockData, TextBlock),
         Shape::Entries => parse_as!(EntriesData, Entries),
         Shape::Ratio => parse_as!(RatioData, Ratio),
         Shape::NumberSeries => parse_as!(NumberSeriesData, NumberSeries),
@@ -184,7 +189,8 @@ fn from_toml(text: &str, shape: Shape) -> Result<Body, FetchError> {
         };
     }
     match shape {
-        Shape::Lines => parse_as!(LinesData, Lines),
+        Shape::Text => parse_as!(TextData, Text),
+        Shape::TextBlock => parse_as!(TextBlockData, TextBlock),
         Shape::Entries => parse_as!(EntriesData, Entries),
         Shape::Ratio => parse_as!(RatioData, Ratio),
         Shape::NumberSeries => parse_as!(NumberSeriesData, NumberSeries),
@@ -204,6 +210,9 @@ fn from_toml(text: &str, shape: Shape) -> Result<Body, FetchError> {
 /// stays quiet rather than breaking — matches the "optional" flavor of ReadStore widgets.
 fn empty_body(shape: Shape) -> Body {
     match shape {
+        Shape::Text => Body::Text(TextData {
+            value: String::new(),
+        }),
         Shape::Entries => Body::Entries(EntriesData { items: Vec::new() }),
         Shape::Ratio => Body::Ratio(RatioData {
             value: 0.0,
@@ -229,7 +238,7 @@ fn empty_body(shape: Shape) -> Body {
             row_labels: None,
             col_labels: None,
         }),
-        _ => Body::Lines(LinesData { lines: Vec::new() }),
+        _ => Body::TextBlock(TextBlockData { lines: Vec::new() }),
     }
 }
 
@@ -298,19 +307,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn text_shape_lines_splits_on_newline() {
+    async fn text_block_splits_on_newline() {
         let tmp = tempfile::tempdir().unwrap();
         let store = tmp.path().join("store");
         std::fs::create_dir_all(&store).unwrap();
         std::fs::write(store.join("notes.txt"), "one\ntwo\nthree").unwrap();
         let _guard = ScopedHome::new(tmp.path());
         let p = ReadStoreFetcher
-            .fetch(&ctx("notes", Shape::Lines, "text"))
+            .fetch(&ctx("notes", Shape::TextBlock, "text"))
             .await
             .unwrap();
         match p.body {
-            Body::Lines(d) => assert_eq!(d.lines, vec!["one", "two", "three"]),
-            other => panic!("expected lines body, got {other:?}"),
+            Body::TextBlock(d) => assert_eq!(d.lines, vec!["one", "two", "three"]),
+            other => panic!("expected text_block body, got {other:?}"),
         }
     }
 
@@ -329,9 +338,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_shape_falls_back_to_lines() {
-        // Runtime always supplies a shape now, but defensively treat `None` as Lines so a stray
-        // caller doesn't get an error and the cache_key stays stable.
+    async fn missing_shape_falls_back_to_text_block() {
+        // Runtime always supplies a shape now, but defensively treat `None` as TextBlock so a
+        // stray caller doesn't get an error and the cache_key stays stable.
         let tmp = tempfile::tempdir().unwrap();
         let store = tmp.path().join("store");
         std::fs::create_dir_all(&store).unwrap();
@@ -345,8 +354,8 @@ mod tests {
         };
         let p = ReadStoreFetcher.fetch(&c).await.unwrap();
         match p.body {
-            Body::Lines(d) => assert_eq!(d.lines, vec!["hello"]),
-            other => panic!("expected lines body, got {other:?}"),
+            Body::TextBlock(d) => assert_eq!(d.lines, vec!["hello"]),
+            other => panic!("expected text_block body, got {other:?}"),
         }
     }
 
@@ -368,7 +377,7 @@ mod tests {
     #[test]
     fn cache_key_differs_across_shapes() {
         let a = ReadStoreFetcher.cache_key(&ctx("habit", Shape::Heatmap, "json"));
-        let b = ReadStoreFetcher.cache_key(&ctx("habit", Shape::Lines, "json"));
+        let b = ReadStoreFetcher.cache_key(&ctx("habit", Shape::TextBlock, "json"));
         assert_ne!(a, b);
     }
 }

--- a/src/fetcher/static_text.rs
+++ b/src/fetcher/static_text.rs
@@ -1,15 +1,15 @@
 use async_trait::async_trait;
 
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextBlockData, TextData};
 use crate::render::Shape;
 use crate::samples;
 
 use super::{FetchContext, FetchError, Fetcher, Safety};
 
-/// Emits `format` verbatim, splitting on `\n` so users can ship multi-line fixed text blocks
-/// ("welcome to this project", setup notes, etc.) without needing a dedicated fetcher. Empty
-/// or missing format produces an empty line list — the widget renders nothing rather than a
-/// spurious blank line.
+/// Emits `format` verbatim. Declares both text shapes: `Text` returns the entire format as one
+/// string, `TextBlock` splits on `\n` so users can ship multi-line fixed text blocks ("welcome
+/// to this project", setup notes, etc.) without needing a dedicated fetcher. Empty or missing
+/// format produces empty output — the widget renders nothing rather than a spurious blank line.
 pub struct StaticText;
 
 #[async_trait]
@@ -21,26 +21,38 @@ impl Fetcher for StaticText {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Lines]
+        &[Shape::Text, Shape::TextBlock]
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::TextBlock
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         match shape {
-            Shape::Lines => Some(samples::lines(&["Hello, splashboard!"])),
+            Shape::Text => Some(samples::text("Hello, splashboard!")),
+            Shape::TextBlock => Some(samples::text_block(&["Hello, splashboard!"])),
             _ => None,
         }
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let source = ctx.format.as_deref().unwrap_or("");
-        let lines = if source.is_empty() {
-            Vec::new()
-        } else {
-            source.split('\n').map(String::from).collect()
+        let body = match ctx.shape.unwrap_or(Shape::TextBlock) {
+            Shape::Text => Body::Text(TextData {
+                value: source.to_string(),
+            }),
+            _ => {
+                let lines = if source.is_empty() {
+                    Vec::new()
+                } else {
+                    source.split('\n').map(String::from).collect()
+                };
+                Body::TextBlock(TextBlockData { lines })
+            }
         };
         Ok(Payload {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData { lines }),
+            body,
         })
     }
 }
@@ -60,17 +72,17 @@ mod tests {
         }
     }
 
-    fn text_lines(p: Payload) -> Vec<String> {
+    fn block_lines(p: Payload) -> Vec<String> {
         match p.body {
-            Body::Lines(t) => t.lines,
-            _ => panic!("expected text body"),
+            Body::TextBlock(t) => t.lines,
+            _ => panic!("expected text_block body"),
         }
     }
 
     #[tokio::test]
     async fn single_line_format() {
         let p = StaticText.fetch(&ctx(Some("Hello!"))).await.unwrap();
-        assert_eq!(text_lines(p), vec!["Hello!".to_string()]);
+        assert_eq!(block_lines(p), vec!["Hello!".to_string()]);
     }
 
     #[tokio::test]
@@ -80,7 +92,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            text_lines(p),
+            block_lines(p),
             vec![
                 "line one".to_string(),
                 "line two".to_string(),
@@ -92,20 +104,29 @@ mod tests {
     #[tokio::test]
     async fn missing_format_yields_empty_list() {
         let p = StaticText.fetch(&ctx(None)).await.unwrap();
-        assert!(text_lines(p).is_empty());
+        assert!(block_lines(p).is_empty());
     }
 
     #[tokio::test]
     async fn empty_format_yields_empty_list() {
         let p = StaticText.fetch(&ctx(Some(""))).await.unwrap();
-        assert!(text_lines(p).is_empty());
+        assert!(block_lines(p).is_empty());
     }
 
     #[tokio::test]
     async fn trailing_newline_preserves_blank_line() {
-        // Users who don't want the trailing blank shouldn't trail a \n; we preserve split
-        // semantics so the rendered output matches the format string byte-for-byte.
         let p = StaticText.fetch(&ctx(Some("a\n"))).await.unwrap();
-        assert_eq!(text_lines(p), vec!["a".to_string(), "".to_string()]);
+        assert_eq!(block_lines(p), vec!["a".to_string(), "".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn text_shape_emits_whole_string() {
+        let mut c = ctx(Some("line one\nline two"));
+        c.shape = Some(Shape::Text);
+        let p = StaticText.fetch(&c).await.unwrap();
+        match p.body {
+            Body::Text(t) => assert_eq!(t.value, "line one\nline two"),
+            _ => panic!("expected text body"),
+        }
     }
 }

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -9,7 +9,9 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use sysinfo::{Disks, ProcessesToUpdate, System};
 
-use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, LinesData, Payload, RatioData};
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, Payload, RatioData, TextBlockData, TextData,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -30,8 +32,8 @@ pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![Arc::new(DiskFetcher)]
 }
 
-/// `os / host / uptime / load / cpu / memory` rollup. Entries by default; `Lines` collapses each
-/// row to `"key: value"` so the same fetcher can feed the `text` / `ascii_art` renderers.
+/// `os / host / uptime / load / cpu / memory` rollup. `Entries` by default; `TextBlock`
+/// collapses each row to `"key: value"` so the same fetcher can feed the plain text renderer.
 pub struct SystemFetcher {
     state: Mutex<System>,
     os: String,
@@ -65,7 +67,7 @@ impl RealtimeFetcher for SystemFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Entries, Shape::Lines]
+        &[Shape::Entries, Shape::TextBlock]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
@@ -77,7 +79,7 @@ impl RealtimeFetcher for SystemFetcher {
                 ("cpu", "18%"),
                 ("memory", "67%"),
             ]),
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "os: linux",
                 "host: dev",
                 "uptime: 3d 4h",
@@ -101,7 +103,7 @@ impl RealtimeFetcher for SystemFetcher {
             ("memory", format!("{:.0}%", memory_ratio(&sys) * 100.0)),
         ];
         match ctx.shape.unwrap_or(Shape::Entries) {
-            Shape::Lines => payload(Body::Lines(LinesData {
+            Shape::TextBlock => payload(Body::TextBlock(TextBlockData {
                 lines: rows.iter().map(|(k, v)| format!("{k}: {v}")).collect(),
             })),
             _ => payload(Body::Entries(EntriesData {
@@ -111,7 +113,7 @@ impl RealtimeFetcher for SystemFetcher {
     }
 }
 
-/// Aggregated CPU usage across all cores. `Ratio` (0..=1) for gauges, `Lines` for plain text.
+/// Aggregated CPU usage across all cores. `Ratio` (0..=1) for gauges, `Text` for plain text.
 pub struct CpuLoadFetcher {
     state: Mutex<System>,
 }
@@ -140,12 +142,12 @@ impl RealtimeFetcher for CpuLoadFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio, Shape::Lines]
+        &[Shape::Ratio, Shape::Text]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Ratio => samples::ratio(0.42, "cpu"),
-            Shape::Lines => samples::lines(&["42%"]),
+            Shape::Text => samples::text("42%"),
             _ => return None,
         })
     }
@@ -156,7 +158,7 @@ impl RealtimeFetcher for CpuLoadFetcher {
         let ratio = (f64::from(pct) / 100.0).clamp(0.0, 1.0);
         let label = format!("{pct:.0}%");
         match ctx.shape.unwrap_or(Shape::Ratio) {
-            Shape::Lines => payload(Body::Lines(LinesData { lines: vec![label] })),
+            Shape::Text => payload(Body::Text(TextData { value: label })),
             _ => payload(Body::Ratio(RatioData {
                 value: ratio,
                 label: Some(label),
@@ -165,7 +167,7 @@ impl RealtimeFetcher for CpuLoadFetcher {
     }
 }
 
-/// RAM usage. `Ratio` by default, `Lines` as `"3.2 GB / 16 GB"`, `Entries` as used/total/free rows.
+/// RAM usage. `Ratio` by default, `Text` as `"3.2 GB / 16 GB"`, `Entries` as used/total/free rows.
 pub struct MemoryFetcher {
     state: Mutex<System>,
 }
@@ -194,12 +196,12 @@ impl RealtimeFetcher for MemoryFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio, Shape::Lines, Shape::Entries]
+        &[Shape::Ratio, Shape::Text, Shape::Entries]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Ratio => samples::ratio(0.67, "memory"),
-            Shape::Lines => samples::lines(&["6.4 GiB / 16 GiB"]),
+            Shape::Text => samples::text("6.4 GiB / 16 GiB"),
             Shape::Entries => samples::entries(&[
                 ("used", "6.4 GiB"),
                 ("total", "16 GiB"),
@@ -216,7 +218,7 @@ impl RealtimeFetcher for MemoryFetcher {
         let ratio = ratio_of(used, total);
         let label = format!("{} / {}", format_bytes(used), format_bytes(total));
         match ctx.shape.unwrap_or(Shape::Ratio) {
-            Shape::Lines => payload(Body::Lines(LinesData { lines: vec![label] })),
+            Shape::Text => payload(Body::Text(TextData { value: label })),
             Shape::Entries => payload(Body::Entries(EntriesData {
                 items: vec![
                     entry("used", &format_bytes(used)),
@@ -243,22 +245,22 @@ impl RealtimeFetcher for UptimeFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Lines]
+        &[Shape::Text]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         match shape {
-            Shape::Lines => Some(samples::lines(&["3d 4h 12m"])),
+            Shape::Text => Some(samples::text("3d 4h 12m")),
             _ => None,
         }
     }
     fn compute(&self, _: &FetchContext) -> Payload {
-        payload(Body::Lines(LinesData {
-            lines: vec![format_uptime(System::uptime())],
+        payload(Body::Text(TextData {
+            value: format_uptime(System::uptime()),
         }))
     }
 }
 
-/// 1 / 5 / 15-minute load average. `Lines` default; `Entries` splits the three windows.
+/// 1 / 5 / 15-minute load average. `Text` default; `Entries` splits the three windows.
 /// Windows doesn't expose load average — shown as `"n/a (windows)"` there.
 pub struct LoadAverageFetcher;
 
@@ -270,11 +272,11 @@ impl RealtimeFetcher for LoadAverageFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Lines, Shape::Entries]
+        &[Shape::Text, Shape::Entries]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
-            Shape::Lines => samples::lines(&["0.42  0.38  0.31"]),
+            Shape::Text => samples::text("0.42  0.38  0.31"),
             Shape::Entries => {
                 samples::entries(&[("1min", "0.42"), ("5min", "0.38"), ("15min", "0.31")])
             }
@@ -283,7 +285,7 @@ impl RealtimeFetcher for LoadAverageFetcher {
     }
     fn compute(&self, ctx: &FetchContext) -> Payload {
         let la = System::load_average();
-        match ctx.shape.unwrap_or(Shape::Lines) {
+        match ctx.shape.unwrap_or(Shape::Text) {
             Shape::Entries => payload(Body::Entries(EntriesData {
                 items: vec![
                     entry("1min", &format_load(la.one)),
@@ -291,15 +293,15 @@ impl RealtimeFetcher for LoadAverageFetcher {
                     entry("15min", &format_load(la.fifteen)),
                 ],
             })),
-            _ => payload(Body::Lines(LinesData {
-                lines: vec![load_line(la.one, la.five, la.fifteen)],
+            _ => payload(Body::Text(TextData {
+                value: load_line(la.one, la.five, la.fifteen),
             })),
         }
     }
 }
 
-/// Top N processes by CPU usage. `Entries` default (`"python": "42.1%"`), `Lines` collapses to
-/// one process per row.
+/// Top N processes by CPU usage. `Entries` default (`"python": "42.1%"`), `TextBlock` collapses
+/// to one process per row.
 pub struct ProcessTopFetcher {
     state: Mutex<System>,
 }
@@ -330,7 +332,7 @@ impl RealtimeFetcher for ProcessTopFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Entries, Shape::Lines]
+        &[Shape::Entries, Shape::TextBlock]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
@@ -340,7 +342,7 @@ impl RealtimeFetcher for ProcessTopFetcher {
                 ("firefox", "6.3%"),
                 ("zsh", "2.1%"),
             ]),
-            Shape::Lines => samples::lines(&[
+            Shape::TextBlock => samples::text_block(&[
                 "node       12.4%",
                 "cargo       8.1%",
                 "firefox     6.3%",
@@ -354,7 +356,7 @@ impl RealtimeFetcher for ProcessTopFetcher {
         sys.refresh_processes(ProcessesToUpdate::All, true);
         let rows = top_processes(&sys, PROCESS_TOP_COUNT);
         match ctx.shape.unwrap_or(Shape::Entries) {
-            Shape::Lines => payload(Body::Lines(LinesData {
+            Shape::TextBlock => payload(Body::TextBlock(TextBlockData {
                 lines: rows.iter().map(|(n, c)| format!("{n}  {c:.1}%")).collect(),
             })),
             _ => payload(Body::Entries(EntriesData {
@@ -368,7 +370,7 @@ impl RealtimeFetcher for ProcessTopFetcher {
 }
 
 /// Disk usage. Cached (mount scan on each refresh is a syscall, not <1ms). Defaults to the
-/// largest disk as `Ratio`; `Lines` renders `"45% of 500 GB"`; `Bars` lists every mount.
+/// largest disk as `Ratio`; `Text` renders `"45% of 500 GB"`; `Bars` lists every mount.
 pub struct DiskFetcher;
 
 #[async_trait]
@@ -380,12 +382,12 @@ impl Fetcher for DiskFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio, Shape::Lines, Shape::Bars]
+        &[Shape::Ratio, Shape::Text, Shape::Bars]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Ratio => samples::ratio(0.58, "disk"),
-            Shape::Lines => samples::lines(&["58% of 400 GB"]),
+            Shape::Text => samples::text("58% of 400 GB"),
             Shape::Bars => samples::bars(&[("/", 42), ("/home", 110), ("/data", 200)]),
             _ => return None,
         })
@@ -396,12 +398,10 @@ impl Fetcher for DiskFetcher {
             Shape::Bars => payload(Body::Bars(BarsData {
                 bars: disk_bars(&disks),
             })),
-            Shape::Lines => payload(Body::Lines(LinesData {
-                lines: vec![
-                    primary_disk(&disks)
-                        .map(|(t, a)| disk_label(t, a))
-                        .unwrap_or_else(|| "no disks detected".into()),
-                ],
+            Shape::Text => payload(Body::Text(TextData {
+                value: primary_disk(&disks)
+                    .map(|(t, a)| disk_label(t, a))
+                    .unwrap_or_else(|| "no disks detected".into()),
             })),
             _ => primary_disk(&disks)
                 .map(|(total, available)| {
@@ -412,8 +412,8 @@ impl Fetcher for DiskFetcher {
                     }))
                 })
                 .unwrap_or_else(|| {
-                    payload(Body::Lines(LinesData {
-                        lines: vec!["no disks detected".into()],
+                    payload(Body::Text(TextData {
+                        value: "no disks detected".into(),
                     }))
                 }),
         })
@@ -588,9 +588,9 @@ mod tests {
     }
 
     #[test]
-    fn cpu_load_emits_lines_when_requested() {
-        let p = CpuLoadFetcher::new().compute(&ctx_with_shape(Some(Shape::Lines)));
-        assert!(matches!(p.body, Body::Lines(_)));
+    fn cpu_load_emits_text_when_requested() {
+        let p = CpuLoadFetcher::new().compute(&ctx_with_shape(Some(Shape::Text)));
+        assert!(matches!(p.body, Body::Text(_)));
     }
 
     #[test]
@@ -613,18 +613,18 @@ mod tests {
     }
 
     #[test]
-    fn uptime_emits_single_line() {
+    fn uptime_emits_text() {
         let p = UptimeFetcher.compute(&ctx_with_shape(None));
-        let Body::Lines(l) = p.body else {
-            panic!("expected lines");
+        let Body::Text(t) = p.body else {
+            panic!("expected text");
         };
-        assert_eq!(l.lines.len(), 1);
+        assert!(!t.value.is_empty());
     }
 
     #[test]
-    fn load_average_defaults_to_lines() {
+    fn load_average_defaults_to_text() {
         let p = LoadAverageFetcher.compute(&ctx_with_shape(None));
-        assert!(matches!(p.body, Body::Lines(_)));
+        assert!(matches!(p.body, Body::Text(_)));
     }
 
     #[test]
@@ -647,10 +647,10 @@ mod tests {
     }
 
     #[test]
-    fn system_lines_shape_returns_key_value_strings() {
-        let p = SystemFetcher::new().compute(&ctx_with_shape(Some(Shape::Lines)));
-        let Body::Lines(l) = p.body else {
-            panic!("expected lines");
+    fn system_text_block_shape_returns_key_value_strings() {
+        let p = SystemFetcher::new().compute(&ctx_with_shape(Some(Shape::TextBlock)));
+        let Body::TextBlock(l) = p.body else {
+            panic!("expected text_block");
         };
         assert_eq!(l.lines.len(), 6);
         assert!(l.lines.iter().all(|s| s.contains(": ")));
@@ -666,10 +666,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn disk_defaults_to_ratio_or_lines_fallback() {
+    async fn disk_defaults_to_ratio_or_text_fallback() {
         let ctx = ctx_with_shape(None);
         let p = DiskFetcher.fetch(&ctx).await.unwrap();
-        assert!(matches!(p.body, Body::Ratio(_) | Body::Lines(_)));
+        assert!(matches!(p.body, Body::Ratio(_) | Body::Text(_)));
     }
 
     #[tokio::test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -332,7 +332,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::payload::{Body, LinesData, Payload};
+    use crate::payload::{Body, Payload, TextBlockData};
     use crate::render::test_utils::{line_text, render_to_buffer_with};
 
     fn text_widget(lines: &[&str]) -> Payload {
@@ -340,7 +340,7 @@ mod tests {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData {
+            body: Body::TextBlock(TextBlockData {
                 lines: lines.iter().map(|s| s.to_string()).collect(),
             }),
         }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -15,15 +15,18 @@ pub struct Payload {
 }
 
 /// Data-shape of a fetched payload. Variants describe the **shape of the data**, not how it's
-/// rendered — the same shape can feed multiple renderers (e.g. `Lines` feeds both the plain
+/// rendered — the same shape can feed multiple renderers (e.g. `Text` feeds both the plain
 /// `simple` renderer and the big-text `ascii_art` renderer). Config's `render = "…"` picks the
 /// renderer, compat-checked against the shape at dispatch time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "shape", content = "data", rename_all = "snake_case")]
 pub enum Body {
-    /// Zero or more lines of text. Used by anything that emits short strings (clock, greeting,
-    /// branch name) or multi-line blocks (welcome notes, todo items).
-    Lines(LinesData),
+    /// A single string. Used by anything that emits one logical row: clock time, greeting,
+    /// branch name, countdown label.
+    Text(TextData),
+    /// Zero or more lines of text. Used by anything intrinsically multi-line: recent commits,
+    /// worktrees, welcome notes, todo items.
+    TextBlock(TextBlockData),
     /// Key/value rows. Used by system info, env dumps, anything label:value shaped.
     Entries(EntriesData),
     /// A single 0..=1 value with an optional display label. Gauges, progress bars, donuts.
@@ -61,7 +64,12 @@ pub enum Status {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LinesData {
+pub struct TextData {
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TextBlockData {
     pub lines: Vec<String>,
 }
 
@@ -190,33 +198,51 @@ mod tests {
     }
 
     #[test]
-    fn lines_round_trips() {
+    fn text_round_trips() {
         let p = Payload {
             icon: None,
             status: None,
             format: Some("{branch}".into()),
-            body: Body::Lines(LinesData {
-                lines: vec!["main".into()],
+            body: Body::Text(TextData {
+                value: "main".into(),
             }),
         };
         assert_eq!(p, round_trip(&p));
     }
 
     #[test]
-    fn lines_parses_from_spec_example() {
-        let json = r#"{"shape":"lines","data":{"lines":["main"]}}"#;
+    fn text_parses_from_spec_example() {
+        let json = r#"{"shape":"text","data":{"value":"main"}}"#;
         let p: Payload = serde_json::from_str(json).unwrap();
-        assert!(matches!(p.body, Body::Lines(_)));
+        assert!(matches!(p.body, Body::Text(_)));
     }
 
     #[test]
-    fn lines_serializes_with_expected_shape_tag() {
-        let p = bare(Body::Lines(LinesData {
-            lines: vec!["main".into()],
+    fn text_serializes_with_expected_shape_tag() {
+        let p = bare(Body::Text(TextData {
+            value: "main".into(),
         }));
         let v: serde_json::Value = serde_json::to_value(&p).unwrap();
-        assert_eq!(v["shape"], "lines");
-        assert_eq!(v["data"]["lines"][0], "main");
+        assert_eq!(v["shape"], "text");
+        assert_eq!(v["data"]["value"], "main");
+    }
+
+    #[test]
+    fn text_block_round_trips() {
+        let p = bare(Body::TextBlock(TextBlockData {
+            lines: vec!["feat: a".into(), "fix: b".into()],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn text_block_serializes_with_expected_shape_tag() {
+        let p = bare(Body::TextBlock(TextBlockData {
+            lines: vec!["a".into()],
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["shape"], "text_block");
+        assert_eq!(v["data"]["lines"][0], "a");
     }
 
     #[test]
@@ -284,12 +310,9 @@ mod tests {
     }
 
     #[test]
-    fn single_line_via_lines_variant() {
-        // Replaces the old Bignum round-trip: short strings are now just a Lines body with one
-        // element, shared with multi-line content. Which renderer consumes it (big-text vs plain)
-        // is a config decision, not a Body shape decision.
-        let p = bare(Body::Lines(LinesData {
-            lines: vec!["12:34".into()],
+    fn single_line_via_text_variant() {
+        let p = bare(Body::Text(TextData {
+            value: "12:34".into(),
         }));
         assert_eq!(p, round_trip(&p));
     }
@@ -364,7 +387,7 @@ mod tests {
 
     #[test]
     fn optional_fields_absent_in_serialization() {
-        let p = bare(Body::Lines(LinesData { lines: vec![] }));
+        let p = bare(Body::TextBlock(TextBlockData { lines: vec![] }));
         let json = serde_json::to_string(&p).unwrap();
         assert!(!json.contains("icon"));
         assert!(!json.contains("status"));

--- a/src/render/animated_typewriter.rs
+++ b/src/render/animated_typewriter.rs
@@ -7,16 +7,20 @@ use ratatui::{
     widgets::Paragraph,
 };
 
-use crate::payload::{Body, LinesData};
+use crate::payload::{Body, TextData};
 
 use super::{RenderOptions, Renderer, Shape};
 
 const DEFAULT_CHARS_PER_SECOND: f64 = 40.0;
 
-/// Typewriter-style progressive reveal over the `Lines` shape. Each frame shows
+/// Typewriter-style progressive reveal over the `Text` shape. Each frame shows
 /// `elapsed * chars_per_second` characters of the payload, truncating to whatever has "typed"
 /// by now. Only animates inside a render loop — on cached fast-path draws it appears fully
 /// typed, which is intentional (we don't slow repeat invocations for effect).
+///
+/// Accepts `Text` only. A typewriter reveal over a multi-line block (release notes, commit
+/// list) is rarely what the user wants, and the fetcher choosing `Text` vs `TextBlock` signals
+/// intent clearly — single-sentence greetings are the canonical use.
 pub struct AnimatedTypewriterRenderer;
 
 impl Renderer for AnimatedTypewriterRenderer {
@@ -24,22 +28,22 @@ impl Renderer for AnimatedTypewriterRenderer {
         "animated_typewriter"
     }
     fn accepts(&self) -> &[Shape] {
-        &[Shape::Lines]
+        &[Shape::Text]
     }
     fn animates(&self) -> bool {
         true
     }
     fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
-        if let Body::Lines(d) = body {
+        if let Body::Text(d) = body {
             render_typewriter(frame, area, d, opts);
         }
     }
 }
 
-fn render_typewriter(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
-    let total: usize = data.lines.iter().map(|l| l.chars().count() + 1).sum();
+fn render_typewriter(frame: &mut Frame, area: Rect, data: &TextData, opts: &RenderOptions) {
+    let total = data.value.chars().count();
     let budget = chars_revealed(total);
-    let revealed = reveal(&data.lines, budget);
+    let revealed: String = data.value.chars().take(budget).collect();
     let p = Paragraph::new(revealed).alignment(parse_align(opts.align.as_deref()));
     frame.render_widget(p, area);
 }
@@ -59,27 +63,6 @@ fn chars_revealed(total: usize) -> usize {
     budget.min(total)
 }
 
-fn reveal(lines: &[String], budget: usize) -> String {
-    let mut remaining = budget;
-    let mut out = String::new();
-    for (i, line) in lines.iter().enumerate() {
-        if i > 0 {
-            if remaining == 0 {
-                break;
-            }
-            out.push('\n');
-            remaining -= 1;
-        }
-        let take = remaining.min(line.chars().count());
-        out.extend(line.chars().take(take));
-        remaining -= take;
-        if remaining == 0 {
-            break;
-        }
-    }
-    out
-}
-
 /// First-caller-wins timestamp. Shared across renderer invocations so a multi-frame loop sees
 /// monotonically increasing elapsed time.
 fn process_start() -> Instant {
@@ -89,21 +72,19 @@ fn process_start() -> Instant {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    fn reveal(text: &str, budget: usize) -> String {
+        text.chars().take(budget).collect()
+    }
 
     #[test]
     fn reveal_truncates_at_budget() {
-        let lines = vec!["hello".to_string(), "world".to_string()];
-        assert_eq!(reveal(&lines, 3), "hel");
-        assert_eq!(reveal(&lines, 5), "hello");
-        assert_eq!(reveal(&lines, 6), "hello\n");
-        assert_eq!(reveal(&lines, 11), "hello\nworld");
-        assert_eq!(reveal(&lines, 99), "hello\nworld");
+        assert_eq!(reveal("hello", 3), "hel");
+        assert_eq!(reveal("hello", 5), "hello");
+        assert_eq!(reveal("hello", 99), "hello");
     }
 
     #[test]
     fn empty_budget_yields_empty_string() {
-        let lines = vec!["x".to_string()];
-        assert_eq!(reveal(&lines, 0), "");
+        assert_eq!(reveal("x", 0), "");
     }
 }

--- a/src/render/ascii_art.rs
+++ b/src/render/ascii_art.rs
@@ -164,9 +164,7 @@ mod tests {
             icon: None,
             status: None,
             format: None,
-            body: Body::Text(TextData {
-                value: text.into(),
-            }),
+            body: Body::Text(TextData { value: text.into() }),
         }
     }
 

--- a/src/render/ascii_art.rs
+++ b/src/render/ascii_art.rs
@@ -2,7 +2,7 @@ use ratatui::{Frame, layout::Rect, widgets::Paragraph};
 use tui_big_text::{BigText, PixelSize};
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, LinesData};
+use crate::payload::{Body, TextData};
 
 use super::{RenderOptions, Renderer, Shape};
 
@@ -30,8 +30,12 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
 ];
 
-/// ASCII-art text rendering over the `Lines` shape. The `style` option selects the visual
+/// ASCII-art text rendering over the `Text` shape. The `style` option selects the visual
 /// treatment; additional sub-options refine the chosen style.
+///
+/// Accepts `Text` only — big glyphs span multiple terminal rows, so multi-line input would
+/// blow past any reasonable widget height. Fetchers that want big-text output must emit a
+/// single-string `Text` payload; multi-line fetchers should render via `simple` / `list`.
 ///
 /// - `style = "blocks"` (default): half-block glyphs via `tui-big-text`. Sub-option
 ///   `pixel_size` = "full" | "quadrant" | "sextant"; unset picks by area height.
@@ -44,13 +48,13 @@ impl Renderer for AsciiArtRenderer {
         "ascii_art"
     }
     fn accepts(&self) -> &[Shape] {
-        &[Shape::Lines]
+        &[Shape::Text]
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
     }
     fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
-        if let Body::Lines(d) = body {
+        if let Body::Text(d) = body {
             match opts.style.as_deref() {
                 Some("figlet") => render_figlet(frame, area, d, opts),
                 _ => render_blocks(frame, area, d, opts),
@@ -59,46 +63,40 @@ impl Renderer for AsciiArtRenderer {
     }
 }
 
-fn render_blocks(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
+fn render_blocks(frame: &mut Frame, area: Rect, data: &TextData, opts: &RenderOptions) {
     let pixel_size = opts
         .pixel_size
         .as_deref()
         .and_then(parse_pixel_size)
         .unwrap_or_else(|| pick_pixel_size(area));
-    let natural_width = blocks_width(&data.lines, pixel_size);
+    let natural_width = blocks_width(&data.value, pixel_size);
     let target = align_rect(area, natural_width, opts.align.as_deref());
-    let lines: Vec<_> = data.lines.iter().map(|s| s.clone().into()).collect();
     let big = BigText::builder()
         .pixel_size(pixel_size)
-        .lines(lines)
+        .lines(vec![data.value.clone().into()])
         .build();
     frame.render_widget(big, target);
 }
 
-fn render_figlet(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
-    let rendered = data
-        .lines
-        .iter()
-        .map(|l| figletify(l))
-        .collect::<Vec<_>>()
-        .join("\n");
+fn render_figlet(frame: &mut Frame, area: Rect, data: &TextData, opts: &RenderOptions) {
+    let rendered = figletify(&data.value);
     let p = Paragraph::new(rendered).alignment(parse_alignment(opts.align.as_deref()));
     frame.render_widget(p, area);
 }
 
-/// Maximum natural width (in terminal cells) of a tui-big-text block string at the given
-/// pixel size. Based on the 8x8 base font; `pixels_per_cell` compresses each axis. Only the
-/// three variants we recognise in `parse_pixel_size` are listed — anything else falls back to
-/// a conservative default.
-fn blocks_width(lines: &[String], pixel_size: PixelSize) -> u16 {
-    let max_chars = lines.iter().map(|l| l.chars().count()).max().unwrap_or(0) as u16;
+/// Natural width (in terminal cells) of a tui-big-text block string at the given pixel size.
+/// Based on the 8x8 base font; `pixels_per_cell` compresses each axis. Only the three variants
+/// we recognise in `parse_pixel_size` are listed — anything else falls back to a conservative
+/// default.
+fn blocks_width(text: &str, pixel_size: PixelSize) -> u16 {
+    let chars = text.chars().count() as u16;
     let glyph_cols = match pixel_size {
         PixelSize::Full => 8,
         PixelSize::Quadrant => 4,
         PixelSize::Sextant => 4,
         _ => 4,
     };
-    max_chars.saturating_mul(glyph_cols)
+    chars.saturating_mul(glyph_cols)
 }
 
 fn align_rect(area: Rect, content_width: u16, align: Option<&str>) -> Rect {
@@ -157,7 +155,7 @@ fn pick_pixel_size(area: Rect) -> PixelSize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{LinesData, Payload};
+    use crate::payload::{Payload, TextData};
     use crate::render::test_utils::render_to_buffer_with_spec;
     use crate::render::{Registry, RenderSpec};
 
@@ -166,8 +164,8 @@ mod tests {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData {
-                lines: vec![text.into()],
+            body: Body::Text(TextData {
+                value: text.into(),
             }),
         }
     }

--- a/src/render/list.rs
+++ b/src/render/list.rs
@@ -4,7 +4,7 @@ use ratatui::{
     widgets::{List, ListItem},
 };
 
-use crate::payload::{Body, LinesData};
+use crate::payload::{Body, TextBlockData};
 
 use super::{RenderOptions, Renderer, Shape};
 
@@ -25,10 +25,10 @@ fn align_rect(area: Rect, content_width: u16, align: Option<&str>) -> Rect {
     }
 }
 
-/// Renders lines through ratatui's `List` widget. Behaviourally close to `simple` today; the
-/// distinction matters once we add list-specific options (bullet marker, highlight selected
-/// item, scrollbar). Alternate renderer for the `Lines` shape so tests of the 1→N dispatch
-/// stay honest.
+/// Renders a multi-line block through ratatui's `List` widget. Behaviourally close to `simple`
+/// today; the distinction matters once we add list-specific options (bullet marker, highlight
+/// selected item, scrollbar). Alternate renderer for the `TextBlock` shape so tests of the 1→N
+/// dispatch stay honest.
 pub struct ListRenderer;
 
 impl Renderer for ListRenderer {
@@ -36,16 +36,16 @@ impl Renderer for ListRenderer {
         "list"
     }
     fn accepts(&self) -> &[Shape] {
-        &[Shape::Lines]
+        &[Shape::TextBlock]
     }
     fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
-        if let Body::Lines(d) = body {
+        if let Body::TextBlock(d) = body {
             render_list(frame, area, d, opts);
         }
     }
 }
 
-fn render_list(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
+fn render_list(frame: &mut Frame, area: Rect, data: &TextBlockData, opts: &RenderOptions) {
     let max = data
         .lines
         .iter()
@@ -64,7 +64,7 @@ fn render_list(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOpt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{LinesData, Payload};
+    use crate::payload::{Payload, TextBlockData};
     use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
     use crate::render::{Registry, RenderSpec};
 
@@ -73,7 +73,7 @@ mod tests {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData {
+            body: Body::TextBlock(TextBlockData {
                 lines: lines.iter().map(|s| s.to_string()).collect(),
             }),
         }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -34,12 +34,13 @@ mod timeline;
 #[cfg(test)]
 pub mod test_utils;
 
-/// Data shape a fetcher produces. A shape is consumed by one or more renderers — a `Lines`
+/// Data shape a fetcher produces. A shape is consumed by one or more renderers — a `Text`
 /// shape can be rendered by `simple` (plain text), `ascii_art` (big-text via tui-big-text),
 /// and future alternatives (figlet, animated typewriter) without the fetcher needing to know.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Shape {
-    Lines,
+    Text,
+    TextBlock,
     Entries,
     Ratio,
     NumberSeries,
@@ -54,7 +55,8 @@ pub enum Shape {
 
 pub fn shape_of(body: &Body) -> Shape {
     match body {
-        Body::Lines(_) => Shape::Lines,
+        Body::Text(_) => Shape::Text,
+        Body::TextBlock(_) => Shape::TextBlock,
         Body::Entries(_) => Shape::Entries,
         Body::Ratio(_) => Shape::Ratio,
         Body::NumberSeries(_) => Shape::NumberSeries,
@@ -73,7 +75,8 @@ impl Shape {
     /// lengths stay reasonable.
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Lines => "lines",
+            Self::Text => "text",
+            Self::TextBlock => "text_block",
             Self::Entries => "entries",
             Self::Ratio => "ratio",
             Self::NumberSeries => "number_series",
@@ -205,7 +208,8 @@ impl Registry {
 
 pub fn default_renderer_for(shape: Shape) -> &'static str {
     match shape {
-        Shape::Lines => "simple",
+        Shape::Text => "simple",
+        Shape::TextBlock => "simple",
         Shape::Entries => "table",
         Shape::Ratio => "gauge",
         Shape::NumberSeries => "sparkline",
@@ -271,7 +275,8 @@ pub fn render_payload(
 /// - Everything else checks its natural collection.
 pub fn is_empty_body(body: &Body) -> bool {
     match body {
-        Body::Lines(d) => d.lines.is_empty() || d.lines.iter().all(|l| l.is_empty()),
+        Body::Text(d) => d.value.is_empty(),
+        Body::TextBlock(d) => d.lines.is_empty() || d.lines.iter().all(|l| l.is_empty()),
         Body::Entries(d) => d.items.is_empty(),
         Body::NumberSeries(d) => d.values.is_empty(),
         Body::PointSeries(d) => d.series.iter().all(|s| s.points.is_empty()),
@@ -383,7 +388,8 @@ mod tests {
     #[test]
     fn default_renderer_covers_every_shape() {
         for s in [
-            Shape::Lines,
+            Shape::Text,
+            Shape::TextBlock,
             Shape::Entries,
             Shape::Ratio,
             Shape::NumberSeries,
@@ -408,12 +414,17 @@ mod tests {
     #[test]
     fn is_empty_body_matches_expectations() {
         use crate::payload::{
-            BarsData, EntriesData, HeatmapData, ImageData, LinesData, NumberSeriesData,
-            PointSeriesData, RatioData,
+            BarsData, EntriesData, HeatmapData, ImageData, NumberSeriesData, PointSeriesData,
+            RatioData, TextBlockData, TextData,
         };
         // Empty cases.
-        assert!(is_empty_body(&Body::Lines(LinesData { lines: vec![] })));
-        assert!(is_empty_body(&Body::Lines(LinesData {
+        assert!(is_empty_body(&Body::Text(TextData {
+            value: String::new(),
+        })));
+        assert!(is_empty_body(&Body::TextBlock(TextBlockData {
+            lines: vec![],
+        })));
+        assert!(is_empty_body(&Body::TextBlock(TextBlockData {
             lines: vec![String::new()],
         })));
         assert!(is_empty_body(&Body::Entries(EntriesData { items: vec![] })));
@@ -434,7 +445,10 @@ mod tests {
             col_labels: None,
         })));
         // Non-empty and "structurally always present" cases.
-        assert!(!is_empty_body(&Body::Lines(LinesData {
+        assert!(!is_empty_body(&Body::Text(TextData {
+            value: "x".into(),
+        })));
+        assert!(!is_empty_body(&Body::TextBlock(TextBlockData {
             lines: vec!["x".into()],
         })));
         assert!(!is_empty_body(&Body::Ratio(RatioData {
@@ -469,16 +483,16 @@ mod tests {
     }
 
     #[test]
-    fn lines_shape_has_multiple_renderers() {
-        // The point of the whole registry: one shape, many renderers. Lines is consumed by both
+    fn text_shape_has_multiple_renderers() {
+        // The point of the whole registry: one shape, many renderers. `Text` is consumed by both
         // the plain `simple` renderer and the `ascii_art` renderer — users pick via config.
         let r = Registry::with_builtins();
-        assert!(r.get("simple").unwrap().accepts().contains(&Shape::Lines));
+        assert!(r.get("simple").unwrap().accepts().contains(&Shape::Text));
         assert!(
             r.get("ascii_art")
                 .unwrap()
                 .accepts()
-                .contains(&Shape::Lines)
+                .contains(&Shape::Text)
         );
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -445,9 +445,7 @@ mod tests {
             col_labels: None,
         })));
         // Non-empty and "structurally always present" cases.
-        assert!(!is_empty_body(&Body::Text(TextData {
-            value: "x".into(),
-        })));
+        assert!(!is_empty_body(&Body::Text(TextData { value: "x".into() })));
         assert!(!is_empty_body(&Body::TextBlock(TextBlockData {
             lines: vec!["x".into()],
         })));
@@ -488,11 +486,6 @@ mod tests {
         // the plain `simple` renderer and the `ascii_art` renderer — users pick via config.
         let r = Registry::with_builtins();
         assert!(r.get("simple").unwrap().accepts().contains(&Shape::Text));
-        assert!(
-            r.get("ascii_art")
-                .unwrap()
-                .accepts()
-                .contains(&Shape::Text)
-        );
+        assert!(r.get("ascii_art").unwrap().accepts().contains(&Shape::Text));
     }
 }

--- a/src/render/test_utils.rs
+++ b/src/render/test_utils.rs
@@ -12,7 +12,7 @@ pub fn render_to_buffer(payload: &Payload, width: u16, height: u16) -> Buffer {
 }
 
 /// Render a single payload through a specific renderer spec — used when a test needs to
-/// exercise a non-default renderer (e.g. `ascii_art` for a `Lines` payload).
+/// exercise a non-default renderer (e.g. `ascii_art` for a `Text` payload).
 pub fn render_to_buffer_with_spec(
     payload: &Payload,
     spec: Option<&RenderSpec>,

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -5,7 +5,7 @@ use ratatui::{
 };
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, LinesData};
+use crate::payload::Body;
 
 use super::{RenderOptions, Renderer, Shape};
 
@@ -17,9 +17,9 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     description: "Horizontal alignment of the rendered text within its cell.",
 }];
 
-/// Plain-text renderer: stacks `LinesData.lines` into a ratatui `Paragraph`. The default
-/// renderer for the `Lines` shape, used for greetings, project notes, static blocks. Honours
-/// the `align` option (left / center / right).
+/// Plain-text renderer. Accepts both `Text` (single string) and `TextBlock` (multi-line) and
+/// draws them as a ratatui `Paragraph`. The default renderer for both shapes. Honours the
+/// `align` option (left / center / right).
 pub struct SimpleRenderer;
 
 impl Renderer for SimpleRenderer {
@@ -27,21 +27,20 @@ impl Renderer for SimpleRenderer {
         "simple"
     }
     fn accepts(&self) -> &[Shape] {
-        &[Shape::Lines]
+        &[Shape::Text, Shape::TextBlock]
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
     }
     fn render(&self, frame: &mut Frame, area: Rect, body: &Body, opts: &RenderOptions) {
-        if let Body::Lines(d) = body {
-            render_lines(frame, area, d, opts);
-        }
+        let content = match body {
+            Body::Text(d) => d.value.clone(),
+            Body::TextBlock(d) => d.lines.join("\n"),
+            _ => return,
+        };
+        let p = Paragraph::new(content).alignment(parse_align(opts.align.as_deref()));
+        frame.render_widget(p, area);
     }
-}
-
-fn render_lines(frame: &mut Frame, area: Rect, data: &LinesData, opts: &RenderOptions) {
-    let p = Paragraph::new(data.lines.join("\n")).alignment(parse_align(opts.align.as_deref()));
-    frame.render_widget(p, area);
 }
 
 fn parse_align(s: Option<&str>) -> Alignment {
@@ -55,23 +54,41 @@ fn parse_align(s: Option<&str>) -> Alignment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{LinesData, Payload};
+    use crate::payload::{Payload, TextBlockData, TextData};
     use crate::render::test_utils::{line_text, render_to_buffer};
 
-    fn payload(lines: &[&str]) -> Payload {
+    fn text_payload(value: &str) -> Payload {
         Payload {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData {
+            body: Body::Text(TextData {
+                value: value.to_string(),
+            }),
+        }
+    }
+
+    fn block_payload(lines: &[&str]) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::TextBlock(TextBlockData {
                 lines: lines.iter().map(|s| s.to_string()).collect(),
             }),
         }
     }
 
     #[test]
-    fn renders_lines_at_top() {
-        let buf = render_to_buffer(&payload(&["hello world"]), 30, 5);
+    fn renders_text_at_top() {
+        let buf = render_to_buffer(&text_payload("hello world"), 30, 5);
         assert!(line_text(&buf, 0).contains("hello world"));
+    }
+
+    #[test]
+    fn renders_text_block_stacked() {
+        let buf = render_to_buffer(&block_payload(&["first", "second"]), 30, 5);
+        assert!(line_text(&buf, 0).contains("first"));
+        assert!(line_text(&buf, 1).contains("second"));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -587,7 +587,7 @@ fn render_specs(widgets: &[WidgetConfig]) -> HashMap<WidgetId, RenderSpec> {
 mod tests {
     use super::*;
     use crate::layout::Layout as LayoutTree;
-    use crate::payload::{Body, LinesData};
+    use crate::payload::{Body, TextData};
     use ratatui::{Terminal, backend::TestBackend};
 
     fn text_payload(line: &str) -> Payload {
@@ -595,9 +595,7 @@ mod tests {
             icon: None,
             status: None,
             format: None,
-            body: Body::Lines(LinesData {
-                lines: vec![line.into()],
-            }),
+            body: Body::Text(TextData { value: line.into() }),
         }
     }
 
@@ -735,8 +733,8 @@ mod tests {
             .cache_key(&fetch_context(&widgets[0], None, Duration::from_secs(0)));
         let loaded = cache.load(&key).unwrap();
         match loaded.payload.body {
-            Body::Lines(t) => assert_eq!(t.lines, vec!["Hi!".to_string()]),
-            _ => panic!("expected text body"),
+            Body::TextBlock(t) => assert_eq!(t.lines, vec!["Hi!".to_string()]),
+            _ => panic!("expected text_block body"),
         }
     }
 
@@ -898,7 +896,7 @@ mod tests {
         let w = widget_with_render("t", "clock", None);
         assert_eq!(
             derive_shape(&w, &registry, &render_registry),
-            Some(Shape::Lines)
+            Some(Shape::Text)
         );
     }
 
@@ -909,7 +907,7 @@ mod tests {
         let w = widget_with_render("t", "clock", Some("definitely_not_a_renderer"));
         assert_eq!(
             derive_shape(&w, &registry, &render_registry),
-            Some(Shape::Lines)
+            Some(Shape::Text)
         );
     }
 
@@ -954,7 +952,7 @@ mod tests {
             widget_with_render("c", "clock", Some("calendar")),
         ];
         let mut shapes = HashMap::new();
-        shapes.insert("a".into(), Shape::Lines);
+        shapes.insert("a".into(), Shape::Text);
         shapes.insert("b".into(), Shape::Entries);
         shapes.insert("c".into(), Shape::Calendar);
         let (valid, invalid) = partition_by_shape_support(&widgets, &shapes, &registry);

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -4,15 +4,16 @@
 //! (or the realtime equivalent). Those declarations stay next to the fetcher code so they can't
 //! drift out of sync. This module supplies:
 //!
-//! - small constructors (`lines`, `entries`, `ratio`, …) so the declarations stay one-liners;
+//! - small constructors (`text`, `text_block`, `entries`, `ratio`, …) so the declarations stay one-liners;
 //! - [`canonical_sample`], the shape-level fallback used when a fetcher doesn't override.
 //!
 //! The samples are consumed at docs-generation time by `xtask`, and are reachable at runtime by
 //! any future CLI that wants to preview what a fetcher emits without hitting I/O.
 
 use crate::payload::{
-    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData, LinesData,
-    NumberSeriesData, PointSeries, PointSeriesData, RatioData, Status, TimelineData, TimelineEvent,
+    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData,
+    NumberSeriesData, PointSeries, PointSeriesData, RatioData, Status, TextBlockData, TextData,
+    TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 
@@ -21,7 +22,8 @@ use crate::render::Shape;
 /// portably.
 pub fn canonical_sample(shape: Shape) -> Option<Body> {
     Some(match shape {
-        Shape::Lines => lines(&["splashboard", "greetings on cd"]),
+        Shape::Text => text("splashboard"),
+        Shape::TextBlock => text_block(&["splashboard", "greetings on cd"]),
         Shape::Entries => entries(&[("key", "value"), ("foo", "bar"), ("baz", "qux")]),
         Shape::Ratio => ratio(0.67, "used"),
         Shape::NumberSeries => {
@@ -41,8 +43,14 @@ pub fn canonical_sample(shape: Shape) -> Option<Body> {
     })
 }
 
-pub fn lines(ss: &[&str]) -> Body {
-    Body::Lines(LinesData {
+pub fn text(s: &str) -> Body {
+    Body::Text(TextData {
+        value: s.to_string(),
+    })
+}
+
+pub fn text_block(ss: &[&str]) -> Body {
+    Body::TextBlock(TextBlockData {
         lines: ss.iter().map(|s| (*s).to_string()).collect(),
     })
 }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use crate::cache::tmp_path_for;
 use crate::config::{Config, WidgetConfig, default_global_path};
 use crate::fetcher::{Registry, Safety};
-use crate::payload::{Body, LinesData, Payload};
+use crate::payload::{Body, Payload, TextBlockData};
 
 const TRUST_ALL_ENV: &str = "SPLASHBOARD_TRUST_ALL";
 
@@ -168,7 +168,7 @@ pub fn requires_trust_placeholder() -> Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::Lines(LinesData {
+        body: Body::TextBlock(TextBlockData {
             lines: vec!["🔒 requires trust".into(), "run `splashboard trust`".into()],
         }),
     }
@@ -211,7 +211,7 @@ mod tests {
             self.safety
         }
         fn shapes(&self) -> &[Shape] {
-            &[Shape::Lines]
+            &[Shape::Text]
         }
         async fn fetch(&self, _: &FetchContext) -> Result<Payload, FetchError> {
             unimplemented!("fake fetcher not invoked in tests")
@@ -231,7 +231,7 @@ mod tests {
             self.safety
         }
         fn shapes(&self) -> &[Shape] {
-            &[Shape::Lines]
+            &[Shape::Text]
         }
         fn compute(&self, _: &FetchContext) -> Payload {
             unimplemented!("fake realtime not invoked in tests")
@@ -447,11 +447,11 @@ mod tests {
     fn placeholder_has_lock_icon_in_first_line() {
         let p = requires_trust_placeholder();
         match p.body {
-            Body::Lines(t) => {
+            Body::TextBlock(t) => {
                 assert!(t.lines[0].contains("🔒"));
                 assert!(t.lines[1].contains("splashboard trust"));
             }
-            _ => panic!("expected lines body"),
+            _ => panic!("expected text_block body"),
         }
     }
 }

--- a/xtask/src/gen_matrix.rs
+++ b/xtask/src/gen_matrix.rs
@@ -22,7 +22,8 @@ use splashboard::render::{Registry as RenderRegistry, Renderer, Shape};
 use crate::snapshots;
 
 const ALL_SHAPES: &[Shape] = &[
-    Shape::Lines,
+    Shape::Text,
+    Shape::TextBlock,
     Shape::Entries,
     Shape::Ratio,
     Shape::NumberSeries,


### PR DESCRIPTION
## Summary

Closes #59 — splits the ambiguous `Shape::Lines` into two explicit variants so arity is encoded in the type system:

- `Shape::Text` / `Body::Text(TextData { value: String })` — one logical row (clock, greeting, branch name, countdown label).
- `Shape::TextBlock` / `Body::TextBlock(TextBlockData { lines: Vec<String> })` — intrinsically multi-line (recent commits, worktrees, release notes).

Renderer fit-checks are now enforced at dispatch:

| renderer | accepts |
| --- | --- |
| `simple` | `Text`, `TextBlock` |
| `ascii_art` | `Text` |
| `animated_typewriter` | `Text` |
| `list` | `TextBlock` |

`ascii_art` / `animated_typewriter` no longer silently blow up with 24-row big-text towers; a mismatch renders the in-band shape error instead.

Fetcher migrations (each branches on `ctx.shape` when multi-shape):

- `Text` only: `clock`, `clock_derived`, `clock_sunrise`, `system_cpu`, `system_uptime`, `system_load`, `disk_usage`, `git_status`, `git_latest_tag`, `git_stash_count`, `git_contributors`, `git_commits_activity`, `git_blame_heatmap`, `github_action_status`, `github_repo_stars`.
- `TextBlock` only: `clock_timezones`, `system` (rollup), `system_processes`, `git_recent_commits`, `git_worktrees`, every GitHub list fetcher (`github_notifications`, `github_my_prs`, `github_assigned_issues`, `github_review_requests`, `github_good_first_issues`, `github_repo_prs`, `github_repo_issues`, `github_recent_releases`).
- Both: `static_text`, `read_store`, `clock_countdown`.

## Wire-breaking change (pre-v1)

- Serde shape tags shift `"lines"` → `"text"` / `"text_block"`.
- Cache keys include the shape label, so every text-based fetcher misses cache once on upgrade — benign one-time refetch.
- No deprecation shim — `Lines` / `LinesData` removed entirely.
- `render = \"...\"` spellings in configs don't change. If you had `render = \"ascii_art\"` paired with a multi-line fetcher, you now see an in-band mismatch error instead of broken big-text — that's the whole point.

Also updates AGENTS.md and the dogfood `.splashboard/config.toml` to reference the new shape names, and regenerates `xtask::gen_matrix` to include both variants in the reference matrix.

## Test plan

- [x] `cargo test` green (319 passed).
- [x] `cargo clippy --all-targets -- -D warnings` clean (both workspace and `xtask`).
- [x] `cargo xtask` regenerates docs-site reference with `text` / `text_block` rows.
- [ ] Spot-check the dogfood splash locally (`cargo run`) to confirm hero band + GitHub/system/git widgets all render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)