### PR TITLE
feat(render): add animated_postfx renderer

### DIFF
--- a/.splashboard/config.toml
+++ b/.splashboard/config.toml
@@ -43,6 +43,42 @@ fetcher = "static"
 render = { type = "list_plain", align = "center" }
 format = "ratatui::List widget\nalternative to text_plain\nselectable items, later"
 
+[[widget]]
+id = "postfx_demo"
+fetcher = "static"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "dissolve", duration_ms = 1200, pixel_size = "quadrant", align = "center" }
+format = "splashboard"
+
+[[widget]]
+id = "postfx_fade"
+fetcher = "static"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "fade_in", duration_ms = 1200, pixel_size = "quadrant", align = "center" }
+format = "fade"
+
+[[widget]]
+id = "postfx_coalesce"
+fetcher = "static"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce", duration_ms = 1200, pixel_size = "quadrant", align = "center" }
+format = "coalesce"
+
+[[widget]]
+id = "postfx_sweep"
+fetcher = "static"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "sweep_in_down", duration_ms = 1200, pixel_size = "quadrant", align = "center" }
+format = "sweep"
+
+[[widget]]
+id = "postfx_slide"
+fetcher = "static"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "slide_in_down", duration_ms = 1200, pixel_size = "quadrant", align = "center" }
+format = "slide"
+
+[[widget]]
+id = "postfx_hsl"
+fetcher = "static"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "hsl_shift", duration_ms = 1500, pixel_size = "quadrant", align = "center" }
+format = "hsl"
+
 # ── GitHub activity ──────────────────────────────────────────────────
 # Every repo-scope fetcher (repo_prs / repo_issues / repo_stars / action_*) auto-detects the
 # owner/name slug from the cwd's git remote. User-scope (my_prs / review_requests /
@@ -257,6 +293,42 @@ flex = "center"
   [[row.child]]
   widget = "notes"
   width = { length = 44 }
+
+[[row]]
+height = { length = 4 }
+flex = "center"
+
+  [[row.child]]
+  widget = "postfx_demo"
+  width = { length = 64 }
+
+[[row]]
+height = { length = 4 }
+flex = "center"
+
+  [[row.child]]
+  widget = "postfx_fade"
+  width = { length = 20 }
+
+  [[row.child]]
+  widget = "postfx_coalesce"
+  width = { length = 28 }
+
+  [[row.child]]
+  widget = "postfx_sweep"
+  width = { length = 22 }
+
+[[row]]
+height = { length = 4 }
+flex = "center"
+
+  [[row.child]]
+  widget = "postfx_slide"
+  width = { length = 22 }
+
+  [[row.child]]
+  widget = "postfx_hsl"
+  width = { length = 18 }
 
 # ── GitHub band ──────────────────────────────────────────────────────
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Prioritization rubric (see #41 for the full version):
 
 ### Testing
 
-- `cargo test` must be green before a PR is opened. `cargo clippy --all-targets -- -D warnings` too.
+- `cargo test` must be green before a PR is opened. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` too — CI runs all three.
 - Tests that mutate process env (`SPLASHBOARD_HOME` is the notable one) must take `paths::TEST_ENV_LOCK` to serialize with other tests.
 - Rendering tests use `src/render/test_utils.rs` — `render_to_buffer*()` helpers return a `Buffer` you can scan for expected cells/symbols.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +472,20 @@ dependencies = [
  "rustversion",
  "ryu",
  "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
  "static_assertions",
 ]
 
@@ -2538,6 +2577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,7 +3091,7 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",
- "compact_str",
+ "compact_str 0.8.1",
  "crossterm",
  "indoc",
  "instability",
@@ -3525,6 +3580,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo",
+ "tachyonfx",
  "tempfile",
  "time",
  "tokio",
@@ -3623,6 +3679,20 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "tachyonfx"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de9d53c5afe979f7de9d5ba856c9829b118d6aca6335750201f1ada46bc198e2"
+dependencies = [
+ "bon",
+ "compact_str 0.9.0",
+ "micromath",
+ "ratatui",
+ "thiserror 2.0.18",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ dirs = "5"
 clap = { version = "4", features = ["derive"] }
 tui-big-text = "0.7"
 tui-piechart = "=0.2.8"
+tachyonfx = { version = "0.21", default-features = false, features = ["std"] }
 ratatui-image = "4"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process"] }

--- a/src/render/animated_postfx.rs
+++ b/src/render/animated_postfx.rs
@@ -1,0 +1,284 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ratatui::{Frame, layout::Rect, style::Color, widgets::Paragraph};
+use tachyonfx::{
+    Duration as FxDuration, Effect, EffectRenderer, EffectTimer, Interpolation, fx,
+    pattern::SweepPattern,
+};
+
+use crate::payload::Body;
+use crate::theme::Theme;
+
+use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
+
+/// Shader-like post-process layered on top of another renderer. Draws the inner renderer
+/// normally, then applies a tachyonfx `Effect` over the occupied area for the duration of the
+/// runtime's ANIMATION_WINDOW. After the effect completes, the inner render is left untouched
+/// so the final frozen frame matches what a static widget would produce.
+///
+/// Accepts every shape — the actual compatibility check is delegated to the resolved inner
+/// renderer, which is picked via `inner = "..."` (falls back to the shape's default).
+pub struct AnimatedPostfxRenderer;
+
+const ALL_SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::PointSeries,
+    Shape::Bars,
+    Shape::Image,
+    Shape::Calendar,
+    Shape::Heatmap,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const DEFAULT_DURATION_MS: u64 = 800;
+const DEFAULT_EFFECT: &str = "fade_in";
+
+impl Renderer for AnimatedPostfxRenderer {
+    fn name(&self) -> &str {
+        "animated_postfx"
+    }
+    fn accepts(&self) -> &[Shape] {
+        ALL_SHAPES
+    }
+    fn animates(&self) -> bool {
+        true
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        registry: &Registry,
+    ) {
+        render_postfx(frame, area, body, opts, theme, registry);
+    }
+}
+
+fn render_postfx(
+    frame: &mut Frame,
+    area: Rect,
+    body: &Body,
+    opts: &RenderOptions,
+    theme: &Theme,
+    registry: &Registry,
+) {
+    let shape = shape_of(body);
+    let inner_name = opts
+        .inner
+        .as_deref()
+        .unwrap_or_else(|| default_renderer_for(shape));
+    let Some(inner) = registry.get(inner_name) else {
+        render_inline_error(
+            frame,
+            area,
+            &format!("unknown inner renderer: {inner_name}"),
+        );
+        return;
+    };
+    if !inner.accepts().contains(&shape) {
+        render_inline_error(
+            frame,
+            area,
+            &format!("inner {inner_name} cannot display {shape:?}"),
+        );
+        return;
+    }
+    inner.render(frame, area, body, &inner_options(opts), theme, registry);
+
+    let duration_ms = opts.duration_ms.unwrap_or(DEFAULT_DURATION_MS) as u32;
+    let elapsed_ms = elapsed_since_start_ms();
+    // Once the effect window closes, leave the inner render as-is so the frozen splash looks
+    // the same as it would without the effect.
+    if elapsed_ms >= duration_ms {
+        return;
+    }
+    let effect_name = opts.effect.as_deref().unwrap_or(DEFAULT_EFFECT);
+    let mut effect = build_effect(effect_name, duration_ms);
+    frame.render_effect(&mut effect, area, FxDuration::from_millis(elapsed_ms));
+}
+
+/// Strip the postfx-specific options before handing off to the inner renderer so it only
+/// sees the fields it understands (style / pixel_size / align).
+fn inner_options(opts: &RenderOptions) -> RenderOptions {
+    RenderOptions {
+        style: opts.style.clone(),
+        pixel_size: opts.pixel_size.clone(),
+        align: opts.align.clone(),
+        inner: None,
+        effect: None,
+        duration_ms: None,
+    }
+}
+
+/// Map an effect name to a tachyonfx `Effect`. Unknown names fall back to `fade_in` so a typo
+/// degrades gracefully instead of crashing the widget — the fetcher's data still reaches the
+/// inner renderer either way.
+///
+/// All variants only modify foreground colours (or the cell character itself for
+/// dissolve/coalesce). We intentionally avoid tachyonfx's `fade_from` / `sweep_in` / `slide_in`
+/// because those paint the `faded_color` onto the cell background, which overlays the
+/// terminal's default background with a solid black rectangle on any non-default-black
+/// theme. `fade_from_fg` + `SweepPattern` produces the same directional reveal without that
+/// artefact.
+fn build_effect(name: &str, duration_ms: u32) -> Effect {
+    let timer: EffectTimer = EffectTimer::from_ms(duration_ms, Interpolation::QuadOut);
+    match name {
+        "fade_in" => fx::fade_from_fg(Color::Black, timer),
+        "fade_out" => fx::fade_to_fg(Color::Black, timer),
+        "dissolve" => fx::dissolve(timer),
+        "coalesce" => fx::coalesce(timer),
+        "sweep_in" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::left_to_right(10))
+        }
+        "sweep_in_right" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::right_to_left(10))
+        }
+        "sweep_in_down" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::up_to_down(10))
+        }
+        "sweep_in_up" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::down_to_up(10))
+        }
+        "slide_in" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::left_to_right(3))
+        }
+        "slide_in_right" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::right_to_left(3))
+        }
+        "slide_in_down" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::up_to_down(3))
+        }
+        "slide_in_up" => {
+            fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::down_to_up(3))
+        }
+        "hsl_shift" => fx::hsl_shift(Some([180.0, 0.0, 0.0]), None, timer),
+        _ => fx::fade_from_fg(Color::Black, timer),
+    }
+}
+
+fn render_inline_error(frame: &mut Frame, area: Rect, msg: &str) {
+    frame.render_widget(Paragraph::new(msg), area);
+}
+
+fn elapsed_since_start_ms() -> u32 {
+    let elapsed = process_start().elapsed().as_millis();
+    elapsed.min(u32::MAX as u128) as u32
+}
+
+fn process_start() -> Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    *START.get_or_init(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, TextData};
+    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+
+    #[test]
+    fn known_effects_build_without_panic() {
+        for name in [
+            "fade_in",
+            "fade_out",
+            "dissolve",
+            "coalesce",
+            "sweep_in",
+            "sweep_in_right",
+            "sweep_in_down",
+            "sweep_in_up",
+            "slide_in",
+            "slide_in_right",
+            "slide_in_down",
+            "slide_in_up",
+            "hsl_shift",
+        ] {
+            let _ = build_effect(name, 800);
+        }
+    }
+
+    #[test]
+    fn unknown_effect_falls_back_silently() {
+        // Typos shouldn't crash — we return a fade_in effect instead so the widget stays visible.
+        let _ = build_effect("totally-not-a-real-effect", 800);
+    }
+
+    #[test]
+    fn renders_text_without_panic() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "hello".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_postfx".into(),
+            options: RenderOptions {
+                inner: Some("text_ascii".into()),
+                effect: Some("dissolve".into()),
+                duration_ms: Some(400),
+                ..Default::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        // Draws through the inner renderer + applies the effect. The assertion is just "doesn't
+        // panic" — the visual output depends on wall-clock elapsed time so a cell-level compare
+        // would be flaky.
+        let _buf = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 20, 4);
+    }
+
+    #[test]
+    fn unknown_inner_renders_inline_error() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData { value: "hi".into() }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_postfx".into(),
+            options: RenderOptions {
+                inner: Some("does_not_exist".into()),
+                ..Default::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        let buf = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 40, 2);
+        let joined: String = (0..2)
+            .map(|y| crate::render::test_utils::line_text(&buf, y))
+            .collect();
+        assert!(
+            joined.contains("unknown inner"),
+            "expected inline error, got {joined:?}"
+        );
+    }
+
+    #[test]
+    fn inner_options_drops_postfx_fields() {
+        let opts = RenderOptions {
+            style: Some("figlet".into()),
+            pixel_size: Some("quadrant".into()),
+            align: Some("center".into()),
+            inner: Some("text_ascii".into()),
+            effect: Some("dissolve".into()),
+            duration_ms: Some(1200),
+        };
+        let inner = inner_options(&opts);
+        assert_eq!(inner.style.as_deref(), Some("figlet"));
+        assert_eq!(inner.pixel_size.as_deref(), Some("quadrant"));
+        assert_eq!(inner.align.as_deref(), Some("center"));
+        assert!(inner.inner.is_none());
+        assert!(inner.effect.is_none());
+        assert!(inner.duration_ms.is_none());
+    }
+}

--- a/src/render/animated_typewriter.rs
+++ b/src/render/animated_typewriter.rs
@@ -11,7 +11,7 @@ use ratatui::{
 use crate::payload::{Body, TextData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -47,6 +47,7 @@ impl Renderer for AnimatedTypewriterRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Text(d) = body {
             render_typewriter(frame, area, d, opts, theme);

--- a/src/render/chart_bar.rs
+++ b/src/render/chart_bar.rs
@@ -3,7 +3,7 @@ use ratatui::{Frame, layout::Rect, style::Style, widgets::BarChart};
 use crate::payload::{BarsData, Body};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -26,6 +26,7 @@ impl Renderer for ChartBarRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Bars(d) = body {
             render_bars(frame, area, d, theme);

--- a/src/render/chart_line.rs
+++ b/src/render/chart_line.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use crate::payload::{Body, PointSeries, PointSeriesData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES];
 
@@ -32,6 +32,7 @@ impl Renderer for ChartLineRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::PointSeries(d) = body {
             render_line_chart(frame, area, d, theme);

--- a/src/render/chart_pie.rs
+++ b/src/render/chart_pie.rs
@@ -4,7 +4,7 @@ use tui_piechart::{PieChart, PieSlice};
 use crate::payload::{BarsData, Body};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES];
 
@@ -31,6 +31,7 @@ impl Renderer for ChartPieRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Bars(d) = body {
             render_pie(frame, area, d, theme);

--- a/src/render/chart_scatter.rs
+++ b/src/render/chart_scatter.rs
@@ -7,7 +7,7 @@ use ratatui::{
 use crate::payload::{Body, PointSeries, PointSeriesData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES];
 
@@ -33,6 +33,7 @@ impl Renderer for ChartScatterRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::PointSeries(d) = body {
             render_scatter(frame, area, d, theme);

--- a/src/render/chart_sparkline.rs
+++ b/src/render/chart_sparkline.rs
@@ -3,7 +3,7 @@ use ratatui::{Frame, layout::Rect, widgets::Sparkline};
 use crate::payload::{Body, NumberSeriesData};
 use crate::theme::Theme;
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 pub struct ChartSparklineRenderer;
 
@@ -21,6 +21,7 @@ impl Renderer for ChartSparklineRenderer {
         body: &Body,
         _opts: &RenderOptions,
         _theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::NumberSeries(d) = body {
             render_sparkline(frame, area, d);

--- a/src/render/gauge_circle.rs
+++ b/src/render/gauge_circle.rs
@@ -3,7 +3,7 @@ use ratatui::{Frame, layout::Rect, style::Style, text::Span, widgets::Gauge};
 use crate::payload::{Body, RatioData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -26,6 +26,7 @@ impl Renderer for GaugeCircleRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Ratio(d) = body {
             render_gauge(frame, area, d, theme);

--- a/src/render/gauge_line.rs
+++ b/src/render/gauge_line.rs
@@ -3,7 +3,7 @@ use ratatui::{Frame, layout::Rect, style::Style, text::Span, widgets::LineGauge}
 use crate::payload::{Body, RatioData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -28,6 +28,7 @@ impl Renderer for GaugeLineRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Ratio(d) = body {
             render_line_gauge(frame, area, d, theme);

--- a/src/render/grid_calendar.rs
+++ b/src/render/grid_calendar.rs
@@ -9,7 +9,7 @@ use time::{Date, Month};
 use crate::payload::{Body, CalendarData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::ACCENT_TODAY, theme::ACCENT_EVENT, theme::TEXT];
 
@@ -35,6 +35,7 @@ impl Renderer for GridCalendarRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Calendar(d) = body {
             render_calendar(frame, area, d, theme);

--- a/src/render/grid_heatmap.rs
+++ b/src/render/grid_heatmap.rs
@@ -3,7 +3,7 @@ use ratatui::{Frame, buffer::Buffer, layout::Rect};
 use crate::payload::{Body, HeatmapData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_HEATMAP, theme::TEXT];
 
@@ -39,6 +39,7 @@ impl Renderer for GridHeatmapRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Heatmap(d) = body {
             render_heatmap(frame, area, d, opts, theme);

--- a/src/render/grid_table.rs
+++ b/src/render/grid_table.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use crate::payload::{Body, EntriesData, Entry};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[
     theme::STATUS_OK,
@@ -39,6 +39,7 @@ impl Renderer for GridTableRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Entries(d) = body {
             render_entries(frame, area, d, theme);

--- a/src/render/list_plain.rs
+++ b/src/render/list_plain.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use crate::payload::{Body, TextBlockData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -52,6 +52,7 @@ impl Renderer for ListPlainRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::TextBlock(d) = body {
             render_list(frame, area, d, opts, theme);

--- a/src/render/list_timeline.rs
+++ b/src/render/list_timeline.rs
@@ -10,7 +10,7 @@ use ratatui::{
 use crate::payload::{Body, Status, TimelineData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[
     theme::STATUS_OK,
@@ -45,6 +45,7 @@ impl Renderer for ListTimelineRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Timeline(d) = body {
             render_timeline_at(frame, area, d, opts, Utc::now().timestamp(), theme);

--- a/src/render/media_image.rs
+++ b/src/render/media_image.rs
@@ -8,7 +8,7 @@ use ratatui_image::{StatefulImage, picker::Picker};
 use crate::payload::{Body, ImageData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -31,6 +31,7 @@ impl Renderer for MediaImageRenderer {
         body: &Body,
         _opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Image(d) = body {
             render_image_payload(frame, area, d, theme);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -14,6 +14,7 @@ use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::theme::{ColorKey, Theme};
 
+mod animated_postfx;
 mod animated_typewriter;
 mod chart_bar;
 mod chart_line;
@@ -114,6 +115,20 @@ pub struct RenderOptions {
     /// structural renderers (grid_table, gauge_*, chart_*) ignore it.
     #[serde(default)]
     pub align: Option<String>,
+    /// animated_postfx: name of the inner renderer whose output the effect is applied over.
+    /// None falls back to the shape's default renderer.
+    #[serde(default)]
+    pub inner: Option<String>,
+    /// animated_postfx: effect to apply. Names map to tachyonfx effects (`fade_in`, `fade_out`,
+    /// `dissolve`, `coalesce`, `sweep_in`, `slide_in`, `hsl_shift`, `glitch`). None defaults to
+    /// `fade_in`. Unknown names fall back to `fade_in` rather than failing the widget.
+    #[serde(default)]
+    pub effect: Option<String>,
+    /// animated_postfx: effect duration in milliseconds. None defaults to 800 — short enough
+    /// that the effect completes well within the 2s ANIMATION_WINDOW, leaving the final frame
+    /// static for the remainder.
+    #[serde(default)]
+    pub duration_ms: Option<u64>,
 }
 
 /// What the TOML accepts for `render`. Short form `render = "text_plain"` uses defaults; long
@@ -178,6 +193,7 @@ pub trait Renderer: Send + Sync {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        registry: &Registry,
     );
 }
 
@@ -192,6 +208,7 @@ impl Registry {
         r.register(Arc::new(text_plain::TextPlainRenderer));
         r.register(Arc::new(text_ascii::TextAsciiRenderer));
         r.register(Arc::new(animated_typewriter::AnimatedTypewriterRenderer));
+        r.register(Arc::new(animated_postfx::AnimatedPostfxRenderer));
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
@@ -283,7 +300,7 @@ pub fn render_payload(
         );
         return;
     }
-    renderer.render(frame, area, &payload.body, &options, theme);
+    renderer.render(frame, area, &payload.body, &options, theme, registry);
 }
 
 /// `true` when the body has no meaningful data to render. Callers (most usefully
@@ -386,12 +403,26 @@ mod tests {
     }
 
     #[test]
+    fn full_form_carries_postfx_options() {
+        let w: Wrapper = toml::from_str(
+            r#"render = { type = "animated_postfx", inner = "text_ascii", effect = "dissolve", duration_ms = 1200 }"#,
+        )
+        .unwrap();
+        let opts = w.render.options();
+        assert_eq!(w.render.renderer_name(), "animated_postfx");
+        assert_eq!(opts.inner.as_deref(), Some("text_ascii"));
+        assert_eq!(opts.effect.as_deref(), Some("dissolve"));
+        assert_eq!(opts.duration_ms, Some(1200));
+    }
+
+    #[test]
     fn registry_resolves_all_builtins() {
         let r = Registry::with_builtins();
         for name in [
             "text_plain",
             "text_ascii",
             "animated_typewriter",
+            "animated_postfx",
             "status_badge",
             "list_plain",
             "list_timeline",

--- a/src/render/status_badge.rs
+++ b/src/render/status_badge.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use crate::payload::{BadgeData, Body, Status};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[
     theme::STATUS_OK,
@@ -43,6 +43,7 @@ impl Renderer for StatusBadgeRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Badge(d) = body {
             render_badge(frame, area, d, opts, theme);

--- a/src/render/text_ascii.rs
+++ b/src/render/text_ascii.rs
@@ -5,7 +5,7 @@ use crate::options::OptionSchema;
 use crate::payload::{Body, TextData};
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -66,6 +66,7 @@ impl Renderer for TextAsciiRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         if let Body::Text(d) = body {
             match opts.style.as_deref() {

--- a/src/render/text_plain.rs
+++ b/src/render/text_plain.rs
@@ -9,7 +9,7 @@ use crate::options::OptionSchema;
 use crate::payload::Body;
 use crate::theme::{self, ColorKey, Theme};
 
-use super::{RenderOptions, Renderer, Shape};
+use super::{Registry, RenderOptions, Renderer, Shape};
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
 
@@ -46,6 +46,7 @@ impl Renderer for TextPlainRenderer {
         body: &Body,
         opts: &RenderOptions,
         theme: &Theme,
+        _registry: &Registry,
     ) {
         let content = match body {
             Body::Text(d) => d.value.clone(),


### PR DESCRIPTION
## Summary
- New `animated_postfx` meta-renderer that layers tachyonfx shader-like effects (fade / dissolve / coalesce / sweep / slide / hsl_shift) on top of any existing renderer. Inner renderer is picked via `inner = "..."` (falls back to the shape's default).
- `Renderer::render` grows a `registry: &Registry` parameter so animated_postfx can resolve its inner by name; all other renderers accept it as `_registry` and behave identically.
- All shipped effects touch only the foreground (or the cell character for dissolve/coalesce) so the terminal's default background shows through — tachyonfx's built-in `fade_from` / `sweep_in` / `slide_in` paint `faded_color` onto the bg which produces a solid black rectangle on any non-default-black theme; sweep/slide are reimplemented as `fade_from_fg` + `SweepPattern` to avoid that artefact.
- Dogfood config gains a showcase row (hero `splashboard` dissolve) plus two rows covering fade_in, coalesce, sweep_in_down, slide_in_down, and hsl_shift.

Ticks the `animated_postfx` box in #61.

Config example:
```toml
render = { type = "animated_postfx", inner = "text_ascii", effect = "dissolve", duration_ms = 1200, pixel_size = "quadrant", align = "center" }
```

## Test plan
- [x] `cargo test` (330 passing, 5 new in `animated_postfx`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo build --release`
- [x] Visual check in the dogfood splash — effects play inside the 2s ANIMATION_WINDOW, freeze to static inner render after `duration_ms`, terminal background stays intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)