### PR TITLE
docs(agents): note cargo fmt in the pre-PR checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ Prioritization rubric (see #41 for the full version):
 
 ### Testing
 
-- `cargo test` must be green before a PR is opened. `cargo clippy --all-targets -- -D warnings` too.
+- `cargo test` must be green before a PR is opened. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` too — CI runs all three.
 - Tests that mutate process env (`SPLASHBOARD_HOME` is the notable one) must take `paths::TEST_ENV_LOCK` to serialize with other tests.
 - Rendering tests use `src/render/test_utils.rs` — `render_to_buffer*()` helpers return a `Buffer` you can scan for expected cells/symbols.
 


### PR DESCRIPTION
## Summary
- Adds `cargo fmt --all -- --check` to the Testing section of `AGENTS.md` alongside `cargo test` and `cargo clippy`.
- CI already runs fmt; the omission here had agents pushing unformatted code (observed on #74).

## Test plan
- [x] Docs-only change; no code to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)