### PR TITLE
refactor(config): split settings.toml + dashboard.toml (#82)

### DIFF
--- a/.splashboard/dashboard.toml
+++ b/.splashboard/dashboard.toml
@@ -1,17 +1,15 @@
-# Dogfood config — rendered in project_github_activity style (#77). When someone cd's
+# Dogfood dashboard — rendered in project_github_activity style (#77). When someone cd's
 # into this repo, they see the polished preset we ship. Hero / subtitle / section
 # dividers / body. No panel borders: breathing rows + static dividers give structure.
+#
+# Dashboard files hold only widgets + rows. User preferences ([general], [theme]) live in
+# `$HOME/.splashboard/settings.toml` — padding, viewport height, theme preset, etc. belong
+# there so they apply to every dashboard the same user sees.
 #
 # Placeholders for #79 / #81 features not yet landed:
 #   - hero uses `static "splashboard"` (→ `project_name` fetcher post-#81)
 #   - subtitle is hand-written (→ `project` Entries fetcher post-#81)
 #   - hero uses `text_ascii` blocks quadrant (→ figlet banner font post-#79)
-
-[general]
-wait_for_fresh = false
-padding = { x = 2, y = 1 }
-
-# ── Hero ─────────────────────────────────────────────────────────────
 
 [[widget]]
 id = "hero"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,16 +8,38 @@ use crate::layout::{BgLevel, BorderStyle, Child, Flex, Layout};
 use crate::render::RenderSpec;
 use crate::theme::ThemeConfig;
 
-const DEFAULT_CONFIG: &str = include_str!("default_config.toml");
+const DEFAULT_SETTINGS: &str = include_str!("default_settings.toml");
+const DEFAULT_HOME_DASHBOARD: &str = include_str!("default_home_dashboard.toml");
+const DEFAULT_PROJECT_DASHBOARD: &str = include_str!("default_project_dashboard.toml");
 
-#[derive(Debug, Clone, Deserialize, Default)]
+/// Combined view the runtime consumes: user preferences composed with the active dashboard.
+#[derive(Debug, Clone, Default)]
 pub struct Config {
+    pub general: General,
+    pub theme: ThemeConfig,
+    pub widgets: Vec<WidgetConfig>,
+    pub rows: Vec<RowConfig>,
+}
+
+/// User preferences: `[general]` + `[theme]`. Loaded from `$HOME/.splashboard/settings.toml`.
+/// Shared across every dashboard the same user sees; per-dir overrides are 0.x out of scope.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SettingsConfig {
     #[serde(default)]
     pub general: General,
     /// Semantic colour overrides. Omitted keys use the built-in defaults; see
     /// [`crate::theme`] for the list of tokens.
     #[serde(default)]
     pub theme: ThemeConfig,
+}
+
+/// Widgets + rows. Loaded from one of:
+///
+/// - a per-dir `./.splashboard/dashboard.toml` or `./.splashboard.toml`
+/// - `$HOME/.splashboard/project.dashboard.toml` (CWD == git repo root, no per-dir override)
+/// - `$HOME/.splashboard/home.dashboard.toml` (everything else)
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DashboardConfig {
     #[serde(default, rename = "widget")]
     pub widgets: Vec<WidgetConfig>,
     #[serde(default, rename = "row")]
@@ -165,20 +187,13 @@ pub enum BorderSpec {
 }
 
 impl Config {
-    pub fn default_baked() -> Self {
-        toml::from_str(DEFAULT_CONFIG).expect("built-in default config must parse")
-    }
-
-    pub fn load_or_default(path: &Path) -> Result<Self, String> {
-        match std::fs::read_to_string(path) {
-            Ok(s) => Self::parse(&s).map_err(|e| format!("{}: {e}", path.display())),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default_baked()),
-            Err(e) => Err(format!("{}: {e}", path.display())),
+    pub fn from_parts(settings: SettingsConfig, dashboard: DashboardConfig) -> Self {
+        Self {
+            general: settings.general,
+            theme: settings.theme,
+            widgets: dashboard.widgets,
+            rows: dashboard.rows,
         }
-    }
-
-    pub fn parse(toml_str: &str) -> Result<Self, String> {
-        toml::from_str(toml_str).map_err(|e| e.to_string())
     }
 
     pub fn to_layout(&self) -> Layout {
@@ -205,40 +220,126 @@ impl Config {
     }
 }
 
-fn row_height_estimate(size: Option<SizeSpec>) -> u16 {
-    match size {
-        Some(SizeSpec::Length(n)) | Some(SizeSpec::Min(n)) | Some(SizeSpec::Max(n)) => n,
-        Some(SizeSpec::Fill(_)) => 3,
-        Some(SizeSpec::Percentage(_)) => 0,
-        None => 3,
+impl SettingsConfig {
+    pub fn default_baked() -> Self {
+        toml::from_str(DEFAULT_SETTINGS).expect("built-in default settings must parse")
+    }
+
+    pub fn parse(toml_str: &str) -> Result<Self, String> {
+        toml::from_str(toml_str).map_err(|e| e.to_string())
+    }
+
+    /// Loads the user's settings file, or the baked default if it's missing. Errors bubble up
+    /// for parse failures so users see what's broken instead of silently getting defaults.
+    pub fn load_or_default(path: &Path) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Self::parse(&s).map_err(|e| format!("{}: {e}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default_baked()),
+            Err(e) => Err(format!("{}: {e}", path.display())),
+        }
     }
 }
 
-pub const LOCAL_CONFIG_CANDIDATES: &[&str] = &[".splashboard/config.toml", ".splashboard.toml"];
+impl DashboardConfig {
+    pub fn default_home() -> Self {
+        toml::from_str(DEFAULT_HOME_DASHBOARD).expect("built-in home dashboard must parse")
+    }
 
-pub fn resolve_config_path() -> Option<PathBuf> {
+    pub fn default_project() -> Self {
+        toml::from_str(DEFAULT_PROJECT_DASHBOARD).expect("built-in project dashboard must parse")
+    }
+
+    pub fn parse(toml_str: &str) -> Result<Self, String> {
+        toml::from_str(toml_str).map_err(|e| e.to_string())
+    }
+}
+
+/// Where the active dashboard came from. Drives trust gating (local files need explicit trust;
+/// the HOME-backed defaults are implicitly trusted) and which baked fallback applies when the
+/// file is missing.
+#[derive(Debug, Clone)]
+pub enum DashboardSource {
+    /// Per-dir dashboard discovered in the CWD (`./.splashboard/dashboard.toml` or
+    /// `./.splashboard.toml`). Trust-gated.
+    Local(PathBuf),
+    /// `$HOME/.splashboard/project.dashboard.toml` — used when CWD is a git repo root and no
+    /// per-dir dashboard overrides. Baked-in default applies when the file is absent.
+    Project,
+    /// `$HOME/.splashboard/home.dashboard.toml` — the ambient fallback. Baked-in default
+    /// applies when the file is absent.
+    Home,
+}
+
+pub const LOCAL_DASHBOARD_CANDIDATES: &[&str] =
+    &[".splashboard/dashboard.toml", ".splashboard.toml"];
+
+/// Dashboard resolution for a shell-startup render. Returns `Home` as a final fallback so the
+/// splash always has something to show.
+pub fn resolve_dashboard_source() -> DashboardSource {
+    let cwd = std::env::current_dir().ok();
+    match cwd.as_deref() {
+        Some(c) => resolve_from(c, /* on_cd = */ false).unwrap_or(DashboardSource::Home),
+        None => DashboardSource::Home,
+    }
+}
+
+/// Dashboard resolution for an `--on-cd` render. Returns `None` in the fallback case so the
+/// shell hook exits silently instead of repainting the home splash on every `cd`.
+pub fn resolve_on_cd_dashboard_source() -> Option<DashboardSource> {
     let cwd = std::env::current_dir().ok()?;
-    find_local(&cwd).or_else(default_global_path)
+    resolve_from(&cwd, /* on_cd = */ true)
 }
 
-pub fn resolve_cwd_only_path() -> Option<PathBuf> {
+/// Nearest project-local dashboard file, for the trust subcommands. Walks up ancestors so
+/// running `splashboard trust` from a subdirectory picks the same dashboard the startup
+/// resolver would use at the repo root.
+pub fn resolve_local_dashboard_path() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
-    find_local_at(&cwd)
+    find_local_walking_up(&cwd)
 }
 
-/// Walks up from the current directory looking for a project-local config. Used by the trust
-/// commands so `splashboard trust` / `revoke` target the nearest `.splashboard.toml` the same
-/// way `splashboard` itself would pick one up.
-pub fn resolve_local_config_path() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    find_local(&cwd)
+fn resolve_from(cwd: &Path, on_cd: bool) -> Option<DashboardSource> {
+    if is_home_dir(cwd) {
+        // Dotfiles-in-git case: CWD == $HOME still means "home context", not "project".
+        return if on_cd {
+            None
+        } else {
+            Some(DashboardSource::Home)
+        };
+    }
+    if let Some(path) = find_local_at(cwd) {
+        return Some(DashboardSource::Local(path));
+    }
+    if is_git_repo_root(cwd) {
+        return Some(DashboardSource::Project);
+    }
+    if on_cd {
+        None
+    } else {
+        Some(DashboardSource::Home)
+    }
 }
 
-pub fn default_global_path() -> Option<PathBuf> {
-    crate::paths::config_path()
+fn is_home_dir(path: &Path) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    canonicalize_or(path) == canonicalize_or(&home)
 }
 
-fn find_local(start: &Path) -> Option<PathBuf> {
+fn canonicalize_or(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn is_git_repo_root(cwd: &Path) -> bool {
+    // "CWD == repo root" using direct `.git` presence. `gix::discover` walks upward, so using
+    // it here would misclassify subdirectories as project roots and re-render the project
+    // dashboard on every sub-cd. Checking for `.git` right here keeps the rule crisp.
+    let dot_git = cwd.join(".git");
+    dot_git.is_dir() || dot_git.is_file()
+}
+
+fn find_local_walking_up(start: &Path) -> Option<PathBuf> {
     let mut current = Some(start);
     while let Some(dir) = current {
         if let Some(path) = find_local_at(dir) {
@@ -250,10 +351,19 @@ fn find_local(start: &Path) -> Option<PathBuf> {
 }
 
 fn find_local_at(dir: &Path) -> Option<PathBuf> {
-    LOCAL_CONFIG_CANDIDATES
+    LOCAL_DASHBOARD_CANDIDATES
         .iter()
         .map(|name| dir.join(name))
         .find(|p| p.is_file())
+}
+
+fn row_height_estimate(size: Option<SizeSpec>) -> u16 {
+    match size {
+        Some(SizeSpec::Length(n)) | Some(SizeSpec::Min(n)) | Some(SizeSpec::Max(n)) => n,
+        Some(SizeSpec::Fill(_)) => 3,
+        Some(SizeSpec::Percentage(_)) => 0,
+        None => 3,
+    }
 }
 
 fn to_row_child(row: &RowConfig) -> Child {
@@ -333,22 +443,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_baked_config_parses() {
-        let _ = Config::default_baked();
+    fn default_baked_settings_parses() {
+        let _ = SettingsConfig::default_baked();
     }
 
     #[test]
-    fn default_baked_is_empty() {
-        // Baked-in default ships no widgets — a fresh install renders nothing until the user
-        // drops a real config in place. Previous demo-content defaults pulled in stub fetchers
-        // that have since been removed.
-        let c = Config::default_baked();
-        assert!(c.widgets.is_empty());
-        assert!(c.rows.is_empty());
+    fn default_home_dashboard_parses() {
+        let _ = DashboardConfig::default_home();
     }
 
     #[test]
-    fn minimal_config_parses() {
+    fn default_project_dashboard_parses() {
+        let _ = DashboardConfig::default_project();
+    }
+
+    #[test]
+    fn minimal_dashboard_parses() {
         let toml = r#"
 [[widget]]
 id = "x"
@@ -360,10 +470,10 @@ height = { length = 3 }
 [[row.child]]
 widget = "x"
 "#;
-        let c = Config::parse(toml).unwrap();
-        assert_eq!(c.widgets.len(), 1);
-        assert_eq!(c.rows.len(), 1);
-        assert_eq!(c.rows[0].children.len(), 1);
+        let d = DashboardConfig::parse(toml).unwrap();
+        assert_eq!(d.widgets.len(), 1);
+        assert_eq!(d.rows.len(), 1);
+        assert_eq!(d.rows[0].children.len(), 1);
     }
 
     #[test]
@@ -386,15 +496,15 @@ height = { min = 6 }
 widget = "x"
 width = { max = 30 }
 "#;
-        let c = Config::parse(toml).unwrap();
-        assert!(matches!(c.rows[0].height, Some(SizeSpec::Fill(2))));
+        let d = DashboardConfig::parse(toml).unwrap();
+        assert!(matches!(d.rows[0].height, Some(SizeSpec::Fill(2))));
         assert!(matches!(
-            c.rows[0].children[0].width,
+            d.rows[0].children[0].width,
             Some(SizeSpec::Percentage(50))
         ));
-        assert!(matches!(c.rows[1].height, Some(SizeSpec::Min(6))));
+        assert!(matches!(d.rows[1].height, Some(SizeSpec::Min(6))));
         assert!(matches!(
-            c.rows[1].children[0].width,
+            d.rows[1].children[0].width,
             Some(SizeSpec::Max(30))
         ));
     }
@@ -415,7 +525,7 @@ border = "{name}"
 widget = "x"
 "#
             );
-            Config::parse(&toml).unwrap();
+            DashboardConfig::parse(&toml).unwrap();
         }
     }
 
@@ -434,24 +544,62 @@ height = { length = 2 }
 widget = "x"
 bg = "default"
 "#;
-        let c = Config::parse(toml).unwrap();
-        assert_eq!(c.rows[0].bg, Some(BgSpec::Subtle));
-        assert_eq!(c.rows[0].children[0].bg, Some(BgSpec::Default));
+        let d = DashboardConfig::parse(toml).unwrap();
+        assert_eq!(d.rows[0].bg, Some(BgSpec::Subtle));
+        assert_eq!(d.rows[0].children[0].bg, Some(BgSpec::Default));
     }
 
     #[test]
-    fn invalid_toml_returns_error() {
-        let r = Config::parse("this is not [valid toml");
+    fn invalid_dashboard_toml_returns_error() {
+        let r = DashboardConfig::parse("this is not [valid toml");
         assert!(r.is_err());
     }
 
     #[test]
-    fn missing_file_falls_back_to_default() {
+    fn missing_settings_file_falls_back_to_default() {
         let path = Path::new("/does/not/exist.toml");
-        let c = Config::load_or_default(path).unwrap();
-        // Baked-in default is empty; what matters is that the call resolves `Ok` rather than
-        // bubbling the missing-file error.
-        assert!(c.widgets.is_empty());
+        let s = SettingsConfig::load_or_default(path).unwrap();
+        assert!(s.general.height.is_none());
+    }
+
+    #[test]
+    fn settings_parses_general_and_theme() {
+        let toml = r#"
+[general]
+wait_for_fresh = true
+height = 24
+
+[theme]
+preset = "nord"
+"#;
+        let s = SettingsConfig::parse(toml).unwrap();
+        assert!(s.general.wait_for_fresh);
+        assert_eq!(s.general.height, Some(24));
+        assert_eq!(s.theme.preset.as_deref(), Some("nord"));
+    }
+
+    #[test]
+    fn dashboard_ignores_stray_settings_sections() {
+        // Dashboard files may end up with leftover `[general]` / `[theme]` blocks after a
+        // manual migration. Silently ignore them so the dashboard still parses.
+        let toml = r#"
+[general]
+wait_for_fresh = true
+
+[theme]
+preset = "nord"
+
+[[widget]]
+id = "x"
+fetcher = "static"
+
+[[row]]
+[[row.child]]
+widget = "x"
+"#;
+        let d = DashboardConfig::parse(toml).unwrap();
+        assert_eq!(d.widgets.len(), 1);
+        assert_eq!(d.rows.len(), 1);
     }
 
     #[test]
@@ -459,7 +607,7 @@ bg = "default"
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join(".splashboard.toml");
         std::fs::write(&file, "").unwrap();
-        assert_eq!(find_local(dir.path()).unwrap(), file);
+        assert_eq!(find_local_at(dir.path()).unwrap(), file);
     }
 
     #[test]
@@ -467,19 +615,19 @@ bg = "default"
         let dir = tempfile::tempdir().unwrap();
         let subdir = dir.path().join(".splashboard");
         std::fs::create_dir(&subdir).unwrap();
-        let file = subdir.join("config.toml");
+        let file = subdir.join("dashboard.toml");
         std::fs::write(&file, "").unwrap();
-        assert_eq!(find_local(dir.path()).unwrap(), file);
+        assert_eq!(find_local_at(dir.path()).unwrap(), file);
     }
 
     #[test]
     fn find_local_prefers_directory_form_when_both_exist() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir(dir.path().join(".splashboard")).unwrap();
-        let dir_file = dir.path().join(".splashboard/config.toml");
+        let dir_file = dir.path().join(".splashboard/dashboard.toml");
         std::fs::write(&dir_file, "").unwrap();
         std::fs::write(dir.path().join(".splashboard.toml"), "").unwrap();
-        assert_eq!(find_local(dir.path()).unwrap(), dir_file);
+        assert_eq!(find_local_at(dir.path()).unwrap(), dir_file);
     }
 
     #[test]
@@ -489,13 +637,13 @@ bg = "default"
         std::fs::write(&file, "").unwrap();
         let nested = root.path().join("a").join("b").join("c");
         std::fs::create_dir_all(&nested).unwrap();
-        assert_eq!(find_local(&nested).unwrap(), file);
+        assert_eq!(find_local_walking_up(&nested).unwrap(), file);
     }
 
     #[test]
-    fn find_local_returns_none_when_absent() {
+    fn find_local_walking_up_returns_none_when_absent() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(find_local(dir.path()).is_none());
+        assert!(find_local_walking_up(dir.path()).is_none());
     }
 
     #[test]
@@ -505,7 +653,56 @@ bg = "default"
         let nested = root.path().join("sub");
         std::fs::create_dir(&nested).unwrap();
         assert!(find_local_at(&nested).is_none());
-        assert!(find_local(&nested).is_some());
+        assert!(find_local_walking_up(&nested).is_some());
+    }
+
+    #[test]
+    fn resolve_prefers_local_over_project() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        std::fs::write(dir.path().join(".splashboard.toml"), "").unwrap();
+        let src = resolve_from(dir.path(), false).unwrap();
+        assert!(matches!(src, DashboardSource::Local(_)));
+    }
+
+    #[test]
+    fn resolve_picks_project_when_cwd_is_repo_root() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        let src = resolve_from(dir.path(), false).unwrap();
+        assert!(matches!(src, DashboardSource::Project));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_home_outside_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = resolve_from(dir.path(), false).unwrap();
+        assert!(matches!(src, DashboardSource::Home));
+    }
+
+    #[test]
+    fn on_cd_silent_in_plain_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve_from(dir.path(), true).is_none());
+    }
+
+    #[test]
+    fn on_cd_fires_at_repo_root() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        let src = resolve_from(dir.path(), true).unwrap();
+        assert!(matches!(src, DashboardSource::Project));
+    }
+
+    #[test]
+    fn on_cd_silent_in_repo_subdir() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        let sub = root.path().join("src");
+        std::fs::create_dir(&sub).unwrap();
+        // Sub-directory: even though an ancestor is a git root, `resolve_from` must not walk
+        // up — that's what keeps cd into src/ from re-triggering the project splash.
+        assert!(resolve_from(&sub, true).is_none());
     }
 
     #[test]
@@ -528,8 +725,9 @@ widget = "a"
 [[row.child]]
 widget = "b"
 "#;
-        let c = Config::parse(toml).unwrap();
-        let layout = c.to_layout();
+        let d = DashboardConfig::parse(toml).unwrap();
+        let config = Config::from_parts(SettingsConfig::default(), d);
+        let layout = config.to_layout();
         match layout {
             Layout::Stack { children, .. } => {
                 assert!(!children.is_empty());

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,36 +1,65 @@
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use clap::ValueEnum;
 use tokio::process::{Child, Command};
 
-use crate::config::Config;
+use crate::config::{Config, DashboardConfig, DashboardSource, SettingsConfig};
+use crate::paths;
 use crate::runtime;
 
-/// Entry point for the `fetch-only` subcommand. Run by the detached child process: resolves the
-/// config, drives the fetchers, writes the cache, and exits. The parent splashboard invocation
-/// either detaches from this child and exits, or (in `--wait` mode) blocks on it with a deadline.
-pub async fn run_fetch_only(config_path: Option<&Path>) -> io::Result<()> {
-    // Read config bytes once; compute hash + parse from that buffer so the trust check can't be
-    // TOCTOU'd between parse and hash.
-    let (config, ident) = match config_path {
-        Some(p) => {
-            let (c, h) = crate::trust::load_config_and_hash(p)?;
-            (c, Some((p, h)))
+/// Which dashboard the parent resolved. Passed to the daemon subprocess so it loads the same
+/// source without having to re-resolve from scratch (avoids drift if CWD changed between
+/// parent spawn and daemon start).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum DashboardKind {
+    Local,
+    Home,
+    Project,
+}
+
+impl DashboardSource {
+    pub fn kind(&self) -> DashboardKind {
+        match self {
+            Self::Local(_) => DashboardKind::Local,
+            Self::Home => DashboardKind::Home,
+            Self::Project => DashboardKind::Project,
         }
-        None => (Config::default_baked(), None),
-    };
-    let ident_ref = ident.as_ref().map(|(p, h)| (*p, h.as_str()));
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Local(p) => Some(p),
+            _ => None,
+        }
+    }
+}
+
+/// Entry point for the `fetch-only` subcommand. Run by the detached child process: resolves the
+/// dashboard, drives the fetchers, writes the cache, and exits. The parent splashboard invocation
+/// either detaches from this child and exits, or (in `--wait` mode) blocks on it with a deadline.
+pub async fn run_fetch_only(kind: DashboardKind, path: Option<&Path>) -> io::Result<()> {
+    let (dashboard, ident) = load_dashboard(kind, path)?;
+    let settings = load_settings_or_default();
+    let config = Config::from_parts(settings, dashboard);
+    let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
     runtime::fetch_and_persist(&config, ident_ref).await;
     Ok(())
 }
 
-pub fn spawn_fetch_daemon(config_path: Option<&Path>) -> io::Result<Child> {
+pub fn spawn_fetch_daemon(source: &DashboardSource) -> io::Result<Child> {
     let exe = std::env::current_exe()?;
     let mut cmd = Command::new(exe);
-    cmd.arg("fetch-only");
-    if let Some(p) = config_path {
-        cmd.arg("--config").arg(p);
+    cmd.arg("fetch-only")
+        .arg("--kind")
+        .arg(match source.kind() {
+            DashboardKind::Local => "local",
+            DashboardKind::Home => "home",
+            DashboardKind::Project => "project",
+        });
+    if let Some(p) = source.path() {
+        cmd.arg("--path").arg(p);
     }
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -38,6 +67,43 @@ pub fn spawn_fetch_daemon(config_path: Option<&Path>) -> io::Result<Child> {
         .kill_on_drop(false);
     detach(cmd.as_std_mut());
     cmd.spawn()
+}
+
+fn load_dashboard(
+    kind: DashboardKind,
+    path: Option<&Path>,
+) -> io::Result<(DashboardConfig, Option<(PathBuf, String)>)> {
+    match kind {
+        DashboardKind::Local => {
+            let p =
+                path.ok_or_else(|| io::Error::other("fetch-only --kind local requires --path"))?;
+            let (d, h) = crate::trust::load_dashboard_and_hash(p)?;
+            Ok((d, Some((p.to_path_buf(), h))))
+        }
+        DashboardKind::Home => Ok((load_home_dashboard_or_baked(), None)),
+        DashboardKind::Project => Ok((load_project_dashboard_or_baked(), None)),
+    }
+}
+
+fn load_home_dashboard_or_baked() -> DashboardConfig {
+    paths::home_dashboard_path()
+        .and_then(|p| std::fs::read_to_string(&p).ok())
+        .and_then(|s| DashboardConfig::parse(&s).ok())
+        .unwrap_or_else(DashboardConfig::default_home)
+}
+
+fn load_project_dashboard_or_baked() -> DashboardConfig {
+    paths::project_dashboard_path()
+        .and_then(|p| std::fs::read_to_string(&p).ok())
+        .and_then(|s| DashboardConfig::parse(&s).ok())
+        .unwrap_or_else(DashboardConfig::default_project)
+}
+
+fn load_settings_or_default() -> SettingsConfig {
+    paths::settings_path()
+        .and_then(|p| std::fs::read_to_string(&p).ok())
+        .and_then(|s| SettingsConfig::parse(&s).ok())
+        .unwrap_or_else(SettingsConfig::default_baked)
 }
 
 #[cfg(unix)]
@@ -63,17 +129,31 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn run_fetch_only_with_missing_path_uses_baked_default() {
-        // Passing None must fall back to the built-in config rather than erroring.
-        run_fetch_only(None).await.unwrap();
+    async fn run_fetch_only_home_uses_baked_default() {
+        // No file under SPLASHBOARD_HOME: falls back to the empty baked home dashboard. Runs
+        // to completion rather than erroring — the daemon has no stdio to report over. The
+        // temp-dir rebase doesn't mutate `SPLASHBOARD_HOME` (that would need the env lock and
+        // would drag us into holding-mutex-across-await warnings); we rely on the empty-HOME
+        // branch producing the baked default either way.
+        run_fetch_only(DashboardKind::Home, None).await.unwrap();
     }
 
     #[tokio::test]
-    async fn run_fetch_only_bubbles_parse_errors() {
+    async fn run_fetch_only_local_bubbles_parse_errors() {
         let dir = tempfile::tempdir().unwrap();
         let bad = dir.path().join("bad.toml");
         std::fs::write(&bad, "this is [not valid toml").unwrap();
-        let err = run_fetch_only(Some(&bad)).await.unwrap_err();
+        let err = run_fetch_only(DashboardKind::Local, Some(&bad))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+    }
+
+    #[tokio::test]
+    async fn run_fetch_only_local_without_path_errors() {
+        let err = run_fetch_only(DashboardKind::Local, None)
+            .await
+            .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Other);
     }
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -1,3 +1,0 @@
-# Baked-in fallback. Used only when no `$HOME/.splashboard/config.toml` and no walk-up
-# `./.splashboard/config.toml` exists. Intentionally empty — a fresh install renders nothing
-# until the user drops a real config in place.

--- a/src/default_home_dashboard.toml
+++ b/src/default_home_dashboard.toml
@@ -1,0 +1,3 @@
+# Baked-in home dashboard fallback. Rendered when the CWD isn't a git repo root and no per-dir
+# dashboard is in scope, and `$HOME/.splashboard/home.dashboard.toml` is absent. Intentionally
+# empty — a fresh install renders nothing until the user drops real widgets in.

--- a/src/default_project_dashboard.toml
+++ b/src/default_project_dashboard.toml
@@ -1,0 +1,4 @@
+# Baked-in project dashboard fallback. Rendered when the CWD is a git repo root with no per-dir
+# dashboard and no `$HOME/.splashboard/project.dashboard.toml`. Intentionally empty — keeps
+# splashboard silent on repos the user hasn't configured. Users drop widgets here (or via
+# `splashboard install --template`) to make "cd into a project" show a project-flavoured splash.

--- a/src/default_settings.toml
+++ b/src/default_settings.toml
@@ -1,0 +1,3 @@
+# Baked-in settings fallback. Loaded when `$HOME/.splashboard/settings.toml` is absent.
+# Intentionally empty — a fresh install picks up the built-in theme defaults and default
+# viewport sizing. Users drop their own `[general]` / `[theme]` in to override.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,16 @@ use std::path::{Path, PathBuf};
 use clap::{Parser, Subcommand};
 
 use splashboard::catalog;
-use splashboard::config::{self, Config, WidgetConfig};
+use splashboard::config::{
+    self, Config, DashboardConfig, DashboardSource, SettingsConfig, WidgetConfig,
+};
+use splashboard::daemon::{self, DashboardKind};
 use splashboard::fetcher::{Registry, Safety};
+use splashboard::paths;
 use splashboard::render::Registry as RenderRegistry;
+use splashboard::runtime;
 use splashboard::shell::{self, Shell};
-use splashboard::trust::{TrustStore, load_config_and_hash};
-use splashboard::{daemon, runtime};
+use splashboard::trust::{TrustStore, load_dashboard_and_hash};
 
 const OPT_OUT_ENV_VARS: &[&str] = &["CI", "SPLASHBOARD_SILENT", "NO_SPLASHBOARD"];
 const MIN_WIDTH: u16 = 40;
@@ -18,9 +22,9 @@ const MIN_HEIGHT: u16 = 16;
 #[derive(Parser)]
 #[command(version, about = "A customizable terminal splash screen")]
 struct Cli {
-    /// Render only if the current directory directly holds a config file; otherwise exit
-    /// silently. Intended for cd-hook invocations so the splash shows exactly once per project
-    /// entry instead of on every subdirectory navigation.
+    /// Render only if the current directory directly resolves to a dashboard (per-dir file or
+    /// git repo root); otherwise exit silently. Intended for cd-hook invocations so the splash
+    /// shows exactly once per project entry instead of on every subdirectory navigation.
     #[arg(long)]
     on_cd: bool,
 
@@ -40,20 +44,20 @@ enum Command {
         #[arg(value_enum)]
         shell: Shell,
     },
-    /// Grant this project-local config permission to run Network and Exec widgets. Safe widgets
+    /// Grant this project-local dashboard permission to run Network widgets. Safe widgets
     /// always run regardless; this is the consent step for anything that talks to the outside
     /// world. Defaults to the nearest `.splashboard.toml` walking up from the current directory.
     Trust {
         #[arg(value_name = "PATH")]
         path: Option<PathBuf>,
     },
-    /// Remove trust for a project-local config. Network and Exec widgets in it will render the
+    /// Remove trust for a project-local dashboard. Network widgets in it will render the
     /// "🔒 requires trust" placeholder until re-trusted.
     Revoke {
         #[arg(value_name = "PATH")]
         path: Option<PathBuf>,
     },
-    /// Print the currently trusted local configs.
+    /// Print the currently trusted local dashboards.
     ListTrusted,
     /// Browse the built-in fetcher and renderer catalog — the same info the docs site exposes,
     /// rendered for the terminal. Run without a target for an overview; use
@@ -66,8 +70,10 @@ enum Command {
     /// splashboard invocation; not intended to be run directly.
     #[command(hide = true)]
     FetchOnly {
+        #[arg(long, value_enum)]
+        kind: DashboardKind,
         #[arg(long)]
-        config: Option<PathBuf>,
+        path: Option<PathBuf>,
     },
 }
 
@@ -89,7 +95,9 @@ async fn main() -> io::Result<()> {
             print!("{}", shell::init_snippet(shell));
             Ok(())
         }
-        Some(Command::FetchOnly { config }) => daemon::run_fetch_only(config.as_deref()).await,
+        Some(Command::FetchOnly { kind, path }) => {
+            daemon::run_fetch_only(kind, path.as_deref()).await
+        }
         Some(Command::Trust { path }) => run_trust(path),
         Some(Command::Revoke { path }) => run_revoke(path),
         Some(Command::ListTrusted) => run_list_trusted(),
@@ -111,20 +119,22 @@ async fn render_splash(wait: bool) -> io::Result<()> {
     if !should_render() {
         return Ok(());
     }
-    let (config, ident) = load_full_config()?;
+    let source = config::resolve_dashboard_source();
+    let (config, ident) = load_full_config(&source)?;
     let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
-    runtime::run(&config, ident_ref, wait).await
+    runtime::run(&config, &source, ident_ref, wait).await
 }
 
 async fn render_for_cd(wait: bool) -> io::Result<()> {
     if !should_render() {
         return Ok(());
     }
-    let Some(path) = config::resolve_cwd_only_path() else {
+    let Some(source) = config::resolve_on_cd_dashboard_source() else {
         return Ok(());
     };
-    let (config, hash) = load_config_and_hash(&path).map_err(io::Error::other)?;
-    runtime::run(&config, Some((&path, &hash)), wait).await
+    let (config, ident) = load_full_config(&source)?;
+    let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
+    runtime::run(&config, &source, ident_ref, wait).await
 }
 
 fn should_render() -> bool {
@@ -151,33 +161,68 @@ fn is_large_enough(width: u16, height: u16) -> bool {
     width >= MIN_WIDTH && height >= MIN_HEIGHT
 }
 
-/// Returns the resolved config plus an optional `(path, hash)` pair. Missing file / baked
-/// default produces `None` — trust gating treats that as implicitly trusted. When a file is
-/// present, reading and hashing happen in a single [`load_config_and_hash`] call so the trust
-/// check can't be TOCTOU'd between parse and hash.
-fn load_full_config() -> io::Result<(Config, Option<(PathBuf, String)>)> {
-    match config::resolve_config_path() {
-        Some(p) => {
-            let (config, hash) = load_config_and_hash(&p).map_err(io::Error::other)?;
-            Ok((config, Some((p, hash))))
+/// Loads settings + the resolved dashboard and composes them into a `Config`. The optional
+/// `(path, hash)` identifies a local dashboard for trust gating; HOME-backed sources return
+/// `None` so they're treated as implicitly trusted.
+fn load_full_config(source: &DashboardSource) -> io::Result<(Config, Option<(PathBuf, String)>)> {
+    let settings = load_settings()?;
+    let (dashboard, ident) = match source {
+        DashboardSource::Local(p) => {
+            let (d, h) = load_dashboard_and_hash(p).map_err(io::Error::other)?;
+            (d, Some((p.clone(), h)))
         }
-        None => Ok((Config::default_baked(), None)),
+        DashboardSource::Home => (load_home_dashboard_or_baked()?, None),
+        DashboardSource::Project => (load_project_dashboard_or_baked()?, None),
+    };
+    Ok((Config::from_parts(settings, dashboard), ident))
+}
+
+fn load_settings() -> io::Result<SettingsConfig> {
+    match paths::settings_path() {
+        Some(p) => SettingsConfig::load_or_default(&p).map_err(io::Error::other),
+        None => Ok(SettingsConfig::default_baked()),
+    }
+}
+
+fn load_home_dashboard_or_baked() -> io::Result<DashboardConfig> {
+    load_dashboard_file_or(paths::home_dashboard_path(), DashboardConfig::default_home)
+}
+
+fn load_project_dashboard_or_baked() -> io::Result<DashboardConfig> {
+    load_dashboard_file_or(
+        paths::project_dashboard_path(),
+        DashboardConfig::default_project,
+    )
+}
+
+fn load_dashboard_file_or(
+    path: Option<PathBuf>,
+    baked: impl FnOnce() -> DashboardConfig,
+) -> io::Result<DashboardConfig> {
+    let Some(path) = path else {
+        return Ok(baked());
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(s) => DashboardConfig::parse(&s)
+            .map_err(|e| io::Error::other(format!("{}: {e}", path.display()))),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(baked()),
+        Err(e) => Err(e),
     }
 }
 
 fn run_trust(path: Option<PathBuf>) -> io::Result<()> {
     let Some(target) = resolve_trust_target(path) else {
         eprintln!(
-            "no project-local config found (run from inside a directory with .splashboard.toml)"
+            "no project-local dashboard found (run from inside a directory with .splashboard.toml)"
         );
         return Ok(());
     };
     // Read the bytes once so the hash we show the user matches the hash we store — and so an
     // attacker can't swap the file between "here's what it asks for" and "ok I trust it".
-    let (config, hash) = load_config_and_hash(&target).map_err(io::Error::other)?;
+    let (dashboard, hash) = load_dashboard_and_hash(&target).map_err(io::Error::other)?;
     let registry = Registry::with_builtins();
-    print_trust_summary(&target, &hash, &config.widgets, &registry)?;
-    if !prompt_yes_no("Trust this config?")? {
+    print_trust_summary(&target, &hash, &dashboard.widgets, &registry)?;
+    if !prompt_yes_no("Trust this dashboard?")? {
         println!("not trusted");
         return Ok(());
     }
@@ -189,7 +234,7 @@ fn run_trust(path: Option<PathBuf>) -> io::Result<()> {
 
 fn run_revoke(path: Option<PathBuf>) -> io::Result<()> {
     let Some(target) = resolve_trust_target(path) else {
-        eprintln!("no project-local config found");
+        eprintln!("no project-local dashboard found");
         return Ok(());
     };
     let mut store = TrustStore::load();
@@ -241,7 +286,7 @@ fn run_catalog(target: Option<CatalogTarget>) -> io::Result<()> {
 }
 
 fn resolve_trust_target(override_path: Option<PathBuf>) -> Option<PathBuf> {
-    override_path.or_else(config::resolve_local_config_path)
+    override_path.or_else(config::resolve_local_dashboard_path)
 }
 
 fn print_trust_summary(
@@ -253,7 +298,7 @@ fn print_trust_summary(
     // Paths and widget ids/fetchers flow into the terminal unmodified; sanitize control chars so
     // a malicious config can't spoof the prompt with ANSI escape sequences.
     println!(
-        "Config: {}",
+        "Dashboard: {}",
         sanitize_for_display(&path.display().to_string())
     );
     println!("sha256: {hash}");
@@ -270,7 +315,7 @@ fn print_trust_summary(
             Safety::Exec => "exec",
         };
         if declared == 0 {
-            println!("This config requests:");
+            println!("This dashboard requests:");
         }
         println!(
             "  - {label:<7}: {} ({})",

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -3,8 +3,8 @@
 use std::path::PathBuf;
 
 /// All splashboard state lives under a single dotted directory in the user's home:
-/// `$HOME/.splashboard/`. Keeps config, trust store, cache, and ReadStore data in one
-/// place — same pattern as per-directory `.splashboard/` configs. Overridable via the
+/// `$HOME/.splashboard/`. Keeps settings, dashboards, trust store, cache, and ReadStore data
+/// in one place — same pattern as per-directory `.splashboard/` configs. Overridable via the
 /// `SPLASHBOARD_HOME` env var for tests, CI, or power users who want to relocate.
 ///
 /// Rationale over the platform-specific `dirs` crate: for a CLI tool, `~/Library/...` on
@@ -18,8 +18,20 @@ pub fn splashboard_home() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".splashboard"))
 }
 
-pub fn config_path() -> Option<PathBuf> {
-    splashboard_home().map(|d| d.join("config.toml"))
+/// User preferences (`[general]` + `[theme]`). Always lives in HOME — per-dir overrides are
+/// out of scope for 0.x.
+pub fn settings_path() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("settings.toml"))
+}
+
+/// Default dashboard when no per-dir dashboard applies and the CWD isn't a project root.
+pub fn home_dashboard_path() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("home.dashboard.toml"))
+}
+
+/// Default project dashboard used when the CWD is a git repo root without a per-dir dashboard.
+pub fn project_dashboard_path() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("project.dashboard.toml"))
 }
 
 pub fn trust_store_path() -> Option<PathBuf> {
@@ -61,7 +73,15 @@ mod tests {
             std::env::set_var("SPLASHBOARD_HOME", &path);
         }
         assert_eq!(splashboard_home(), Some(path.clone()));
-        assert_eq!(config_path(), Some(path.join("config.toml")));
+        assert_eq!(settings_path(), Some(path.join("settings.toml")));
+        assert_eq!(
+            home_dashboard_path(),
+            Some(path.join("home.dashboard.toml"))
+        );
+        assert_eq!(
+            project_dashboard_path(),
+            Some(path.join("project.dashboard.toml"))
+        );
         assert_eq!(trust_store_path(), Some(path.join("trust.toml")));
         assert_eq!(cache_dir(), Some(path.join("cache")));
         assert_eq!(read_store_dir(), Some(path.join("store")));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -133,6 +133,7 @@ const DEFAULT_VIEWPORT_LINES: u16 = 16;
 
 pub async fn run(
     config: &Config,
+    source: &crate::config::DashboardSource,
     config_ident: Option<(&Path, &str)>,
     wait: bool,
 ) -> io::Result<()> {
@@ -234,13 +235,13 @@ pub async fn run(
             requested_height,
             viewport_lines,
         )?;
-        let _ = daemon::spawn_fetch_daemon(config_ident.map(|(p, _)| p));
+        let _ = daemon::spawn_fetch_daemon(source);
         finalize_splash(&mut terminal);
         return Ok(());
     }
 
     let window = loop_window.unwrap();
-    match daemon::spawn_fetch_daemon(config_ident.map(|(p, _)| p)) {
+    match daemon::spawn_fetch_daemon(source) {
         Ok(mut child) => {
             // Multi-frame loop: ticks the frame every FRAME_TICK so animated renderers can
             // animate; picks up daemon-written cache entries as they land; stops when the

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::cache::tmp_path_for;
-use crate::config::{Config, WidgetConfig, default_global_path};
+use crate::config::{DashboardConfig, WidgetConfig};
 use crate::fetcher::{Registry, Safety};
 use crate::payload::{Body, Payload, TextBlockData};
 
@@ -62,30 +62,19 @@ impl TrustStore {
         Ok(())
     }
 
-    /// Caller is expected to have already read the config bytes and hashed them (via
-    /// [`load_config_and_hash`]). Re-hashing here would open a TOCTOU window: a trusted file
+    /// Caller is expected to have already read the dashboard bytes and hashed them (via
+    /// [`load_dashboard_and_hash`]). Re-hashing here would open a TOCTOU window: a trusted file
     /// could be swapped for an attacker-crafted one between the caller's load and our hash.
+    ///
+    /// `ident = None` signals a HOME-backed source (settings, `home.dashboard.toml`, or
+    /// `project.dashboard.toml`) — always implicitly trusted because the user owns HOME.
     pub fn decide(&self, ident: Option<(&Path, &str)>) -> TrustDecision {
-        self.decide_with_global(ident, default_global_path().as_deref())
-    }
-
-    fn decide_with_global(
-        &self,
-        ident: Option<(&Path, &str)>,
-        global: Option<&Path>,
-    ) -> TrustDecision {
         if trust_all_override() {
             return TrustDecision::ImplicitlyTrusted;
         }
         let Some((path, hash)) = ident else {
             return TrustDecision::ImplicitlyTrusted;
         };
-        // Literal equality only. A symlink that resolves to the global config is NOT the global
-        // config — the attacker controls the cwd it runs in, which subverts the whole point of
-        // trusting global configs.
-        if global == Some(path) {
-            return TrustDecision::ImplicitlyTrusted;
-        }
         let canon = canonicalize_or(path);
         for entry in &self.entries {
             if canonicalize_or(&entry.path) == canon && entry.sha256 == hash {
@@ -121,15 +110,16 @@ impl TrustStore {
     }
 }
 
-/// Reads the config bytes once and returns both the parsed `Config` and its sha256. All
-/// trust-sensitive callers MUST use this instead of `Config::load_or_default` + `hash_file` —
-/// two separate reads would let an attacker swap the file between the load and the hash.
-pub fn load_config_and_hash(path: &Path) -> io::Result<(Config, String)> {
+/// Reads the dashboard bytes once and returns both the parsed `DashboardConfig` and its
+/// sha256. All trust-sensitive callers MUST use this instead of `DashboardConfig::parse` +
+/// `hash_file` — two separate reads would let an attacker swap the file between the load and
+/// the hash.
+pub fn load_dashboard_and_hash(path: &Path) -> io::Result<(DashboardConfig, String)> {
     let bytes = std::fs::read(path)?;
     let hash = hash_bytes(&bytes);
     let text = std::str::from_utf8(&bytes).map_err(io::Error::other)?;
-    let config = Config::parse(text).map_err(io::Error::other)?;
-    Ok((config, hash))
+    let dashboard = DashboardConfig::parse(text).map_err(io::Error::other)?;
+    Ok((dashboard, hash))
 }
 
 pub fn hash_file(path: &Path) -> io::Result<String> {
@@ -280,11 +270,11 @@ mod tests {
     }
 
     #[test]
-    fn load_config_and_hash_returns_matching_hash() {
+    fn load_dashboard_and_hash_returns_matching_hash() {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join(".splashboard.toml");
         std::fs::write(&p, "").unwrap();
-        let (_cfg, hash) = load_config_and_hash(&p).unwrap();
+        let (_cfg, hash) = load_dashboard_and_hash(&p).unwrap();
         assert_eq!(hash, hash_file(&p).unwrap());
     }
 
@@ -340,33 +330,13 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    fn symlink_to_global_is_not_implicitly_trusted() {
-        use std::os::unix::fs::symlink;
-        let dir = tempfile::tempdir().unwrap();
-        let fake_global = dir.path().join("global.toml");
-        std::fs::write(&fake_global, "content").unwrap();
-        let local = dir.path().join(".splashboard.toml");
-        symlink(&fake_global, &local).unwrap();
-        // Sanity: the symlink canonicalizes to the global path.
-        assert_eq!(canonicalize_or(&local), canonicalize_or(&fake_global));
-        // But decide must NOT treat the symlink as the global config.
+    fn home_backed_source_is_implicitly_trusted_via_none_ident() {
+        // HOME-backed sources (settings.toml, home.dashboard.toml, project.dashboard.toml) are
+        // implicitly trusted by the caller passing `ident = None`. A local dashboard with the
+        // same on-disk bytes is NOT auto-trusted — the gate is caller-driven, not path-driven.
         let store = TrustStore::default();
-        let hash = hash_file(&local).unwrap();
-        let decision = store.decide_with_global(Some((&local, &hash)), Some(&fake_global));
-        assert_eq!(decision, TrustDecision::Untrusted);
-    }
-
-    #[test]
-    fn literal_global_path_is_implicitly_trusted() {
-        let dir = tempfile::tempdir().unwrap();
-        let global = dir.path().join("global.toml");
-        std::fs::write(&global, "x").unwrap();
-        let hash = hash_file(&global).unwrap();
-        let store = TrustStore::default();
-        let decision = store.decide_with_global(Some((&global, &hash)), Some(&global));
-        assert_eq!(decision, TrustDecision::ImplicitlyTrusted);
+        assert_eq!(store.decide(None), TrustDecision::ImplicitlyTrusted);
     }
 
     #[test]


### PR DESCRIPTION
Closes #82.

## Summary

- Retires `$HOME/.splashboard/config.toml`. `[general]` + `[theme]` now live in `settings.toml`; widgets + rows in sibling `home.dashboard.toml` / `project.dashboard.toml`. Per-dir configs move to `./.splashboard/dashboard.toml` (or `./.splashboard.toml`).
- Adds CWD-aware dashboard resolution: `direct-local → CWD == git repo root → $HOME fallback`, with `CWD == $HOME` short-circuiting the git check so dotfile repos don't trigger project mode.
- Simplifies the trust model: HOME-backed sources are implicitly trusted (callers pass `ident = None`), so the `decide_with_global` carve-out and symlink-canonicalize guard go away. Only `Local` dashboards in a user-owned CWD need `splashboard trust`.
- Updates the fetch-only daemon to take `--kind home|project|local [--path X]` so the child loads the same resolved source instead of rediscovering via CWD.

## On-cd semantics

`--on-cd` uses the same resolver but drops the home-fallback so subdirectories exit silently. The result:

| CWD | startup | --on-cd |
|---|---|---|
| has `.splashboard.toml` / `.splashboard/dashboard.toml` | local | local |
| == git repo root, no per-dir | project | project |
| == $HOME | home | silent |
| subdir of a repo / random dir | home | silent |

## Breaking change

Per-issue guidance (`マイグレーションとかは不要。破壊的にやっておk`): no compatibility layer, old `config.toml` is simply no longer read. Users need to split their existing config by hand — trivial cut/paste (`[general]`/`[theme]` → `~/.splashboard/settings.toml`; `[[widget]]`/`[[row]]` → `~/.splashboard/home.dashboard.toml`) — and rename per-dir `.splashboard/config.toml` → `.splashboard/dashboard.toml`.

## Scope kept to the issue

- Out of scope: docs (#78) updates, `splashboard install --template` rewrite, `splashboard theme <name>`.
- Skipped DoD item: old `config.toml` migration + deprecation warning (breaking, per user).
- Baked default dashboards intentionally ship empty for now; they're the split, not a content PR.

## Test plan

- [x] `cargo test` — 354 lib tests + 12 bin tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `splashboard fetch-only --kind home` runs to completion with baked default
- [x] `splashboard fetch-only --kind local` without `--path` returns a clear error
- [ ] manual: `splashboard` at repo root (project source), in subdir (home source), in $HOME (home source); `splashboard --on-cd` silent in subdir, fires at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now organized into separate user settings and dashboard files for clarity.
  * Local per-directory dashboards now supported with built-in trust verification.
  * Dedicated home and project dashboard configurations with smart fallback resolution.

* **Refactor**
  * Dashboard loading and resolution reworked for improved flexibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->