### PR TITLE
chore(ci): measure coverage with cargo-llvm-cov and upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,28 +39,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: cargo test --all-targets
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
         with:
-          components: llvm-tools-preview
+          components: ${{ matrix.os == 'ubuntu-latest' && 'llvm-tools-preview' || '' }}
       - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate coverage
+      - if: matrix.os == 'ubuntu-latest'
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run tests
+        if: matrix.os != 'ubuntu-latest'
+        run: cargo test --all-targets
+      - name: Run tests with coverage
+        if: matrix.os == 'ubuntu-latest'
         run: cargo llvm-cov --package splashboard --lcov --output-path lcov.info
       - name: Upload to Codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4
         with:
           files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --all-targets
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage
+        run: cargo llvm-cov --package splashboard --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # splashboard
 
+[![CI](https://github.com/unhappychoice/splashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/unhappychoice/splashboard/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/unhappychoice/splashboard/branch/main/graph/badge.svg)](https://codecov.io/gh/unhappychoice/splashboard)
+
 A customizable terminal splash rendered on shell startup and on `cd`.
 
 > `splashboard` = `splash` + `dashboard` — a splash screen for your shell, rendered as a dashboard.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "xtask/**"
+  - "src/render/test_utils.rs"
+  - "docs-site/**"
+  - "**/tests/**"


### PR DESCRIPTION
## Summary
- Add a `coverage` job to CI that runs `cargo llvm-cov --package splashboard --lcov` on ubuntu-latest and uploads `lcov.info` via `codecov/codecov-action@v4`.
- Add `codecov.yml` with `informational: true` for both project & patch (no failing thresholds), and ignore `xtask/`, `src/render/test_utils.rs`, `docs-site/`, and `**/tests/**`.
- Add CI + Codecov badges to the README.

Local run: 356 + 12 tests pass, total ~76% line / 75% function / 78% region.

Codecov side (after merge):
- Enable repo at https://app.codecov.io/gh/unhappychoice/splashboard.
- Optionally add `CODECOV_TOKEN` to repo Secrets — public repo so tokenless upload works, but the token is more reliable.

## Test plan
- [ ] CI `coverage` job is green and uploads `lcov.info`.
- [ ] Codecov dashboard shows the report and the badge in the README resolves.
- [ ] Existing `format` / `clippy` / `test` jobs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)