### PR TITLE
feat(fetcher): add fetchers + shape extensions for 0.x presets

### DIFF
--- a/src/fetcher/clock/mod.rs
+++ b/src/fetcher/clock/mod.rs
@@ -164,11 +164,41 @@ mod tests {
         }
     }
 
+    fn ctx_with_format(format: &str) -> FetchContext {
+        FetchContext {
+            widget_id: "clock".into(),
+            format: Some(format.into()),
+            timeout: Duration::from_secs(1),
+            shape: Some(Shape::Text),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn default_shape_is_text_with_colon() {
         let p = ClockFetcher.compute(&ctx(None, None));
         match p.body {
             Body::Text(d) => assert!(d.value.contains(':')),
+            _ => panic!("expected text"),
+        }
+    }
+
+    #[test]
+    fn custom_format_renders_date_template() {
+        let p = ClockFetcher.compute(&ctx_with_format("%Y · %A"));
+        match p.body {
+            Body::Text(d) => {
+                assert!(
+                    d.value.contains(" · "),
+                    "expected middot separator from template, got {:?}",
+                    d.value
+                );
+                assert!(
+                    d.value.chars().next().is_some_and(|c| c.is_ascii_digit()),
+                    "expected year digits at start, got {:?}",
+                    d.value
+                );
+            }
             _ => panic!("expected text"),
         }
     }

--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -118,9 +118,23 @@ async fn download_avatar(user: &str, size: u32) -> Result<PathBuf, FetchError> {
         .bytes()
         .await
         .map_err(|e| FetchError::Failed(format!("avatar body: {e}")))?;
-    let path = out_dir.join(format!("{user}-{size}.png"));
+    // GitHub serves whichever image format the user uploaded, even when the URL ends in `.png`.
+    // The image crate decodes by extension hint, so we need to write the file with the right
+    // suffix or decoding fails.
+    let ext = image_extension(&bytes);
+    let path = out_dir.join(format!("{user}-{size}.{ext}"));
     std::fs::write(&path, &bytes).map_err(|e| FetchError::Failed(format!("write avatar: {e}")))?;
     Ok(path)
+}
+
+fn image_extension(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        "png"
+    } else if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        "jpg"
+    } else {
+        "png"
+    }
 }
 
 fn avatar_dir() -> Option<PathBuf> {
@@ -245,5 +259,48 @@ mod tests {
     fn options_reject_unknown_keys() {
         let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
         assert!(parse_options::<Options>(Some(&raw)).is_err());
+    }
+
+    #[test]
+    fn image_extension_detects_png() {
+        assert_eq!(image_extension(b"\x89PNG\r\n\x1a\nrest"), "png");
+    }
+
+    #[test]
+    fn image_extension_detects_jpeg() {
+        assert_eq!(image_extension(&[0xff, 0xd8, 0xff, 0xdb, 0x00]), "jpg");
+    }
+
+    #[test]
+    fn image_extension_unknown_falls_back_to_png() {
+        assert_eq!(image_extension(&[0, 0, 0, 0]), "png");
+    }
+
+    /// Live smoke test — downloads the splashboard author's avatar and verifies the file looks
+    /// like a real PNG or JPEG. `#[ignore]` keeps CI offline-safe; run with
+    /// `cargo test -- --ignored fetcher::github::avatar::tests::live --nocapture`.
+    #[tokio::test]
+    #[ignore]
+    async fn live_downloads_image_under_cache_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = EnvGuard::set(&[("SPLASHBOARD_HOME", Some(tmp.path().to_str().unwrap()))]);
+        let path = download_avatar("unhappychoice", 64).await.unwrap();
+        eprintln!("wrote {}", path.display());
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            bytes.len() > 256,
+            "avatar suspiciously small: {} bytes",
+            bytes.len()
+        );
+        let ext = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default();
+        assert!(matches!(ext, "png" | "jpg"), "unexpected extension {ext:?}");
+        match ext {
+            "png" => assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n"),
+            "jpg" => assert_eq!(&bytes[..3], &[0xff, 0xd8, 0xff]),
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -1,0 +1,249 @@
+//! `github_avatar` — download a github.com avatar PNG and expose it as `Body::Image`.
+//!
+//! Safety::Safe: the host is hardcoded (`github.com/<user>.png`), so config can't redirect
+//! traffic to a different origin. No auth is needed — the endpoint is public — so we do not
+//! attach `GH_TOKEN`, avoiding accidental token exposure along the redirect chain.
+//!
+//! Caching: the PNG is written to `$SPLASHBOARD_HOME/cache/avatars/<user>-<size>.png`. The
+//! fetcher framework already gates re-downloads via `refresh_interval`; we default to one week
+//! since avatars rarely change.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::paths;
+use crate::payload::{Body, ImageData, Payload, TextData};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::http;
+use super::common::cache_key;
+
+const AVATAR_BASE: &str = "https://github.com";
+const DEFAULT_SIZE: u32 = 200;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string (github login)",
+        required: false,
+        default: Some("$GITHUB_USER env var"),
+        description: "GitHub login to fetch the avatar for. Falls back to the `GITHUB_USER` env var.",
+    },
+    OptionSchema {
+        name: "size",
+        type_hint: "integer (px)",
+        required: false,
+        default: Some("200"),
+        description: "Requested avatar edge size in pixels. GitHub serves a square image of this size.",
+    },
+];
+
+/// Downloads the user's avatar PNG to the cache and emits an `Image` body pointing at it.
+pub struct GithubAvatar;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub size: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for GithubAvatar {
+    fn name(&self) -> &str {
+        "github_avatar"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Image]
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, _shape: Shape) -> Option<Body> {
+        None
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return Ok(placeholder(&msg)),
+        };
+        let user = match resolve_user(opts.user.as_deref()) {
+            Ok(u) => u,
+            Err(msg) => return Ok(placeholder(&msg)),
+        };
+        let size = opts.size.unwrap_or(DEFAULT_SIZE);
+        let path = match download_avatar(&user, size).await {
+            Ok(p) => p,
+            Err(e) => return Ok(placeholder(&e.to_string())),
+        };
+        Ok(payload(Body::Image(ImageData {
+            path: path.to_string_lossy().into_owned(),
+        })))
+    }
+}
+
+async fn download_avatar(user: &str, size: u32) -> Result<PathBuf, FetchError> {
+    let out_dir = avatar_dir()
+        .ok_or_else(|| FetchError::Failed("$HOME not available for avatar cache".into()))?;
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|e| FetchError::Failed(format!("create avatar cache dir: {e}")))?;
+    let url = format!("{AVATAR_BASE}/{user}.png?size={size}");
+    let res = http()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("avatar request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("avatar {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("avatar body: {e}")))?;
+    let path = out_dir.join(format!("{user}-{size}.png"));
+    std::fs::write(&path, &bytes).map_err(|e| FetchError::Failed(format!("write avatar: {e}")))?;
+    Ok(path)
+}
+
+fn avatar_dir() -> Option<PathBuf> {
+    paths::cache_dir().map(|d| d.join("avatars"))
+}
+
+fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
+    if let Some(u) = explicit.filter(|s| !s.is_empty()) {
+        return Ok(u.into());
+    }
+    if let Ok(u) = std::env::var("GITHUB_USER")
+        && !u.is_empty()
+    {
+        return Ok(u);
+    }
+    Err("set `user = \"<login>\"` or the GITHUB_USER env var".into())
+}
+
+fn parse_options<T: serde::de::DeserializeOwned + Default>(
+    raw: Option<&toml::Value>,
+) -> Result<T, String> {
+    match raw {
+        None => Ok(T::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+fn placeholder(msg: &str) -> Payload {
+    payload(Body::Text(TextData {
+        value: format!("⚠ {msg}"),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        restore: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let lock = crate::paths::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let restore = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let prev = std::env::var(k).ok();
+                    match v {
+                        Some(value) => unsafe { std::env::set_var(k, value) },
+                        None => unsafe { std::env::remove_var(k) },
+                    }
+                    (*k, prev)
+                })
+                .collect();
+            Self {
+                _lock: lock,
+                restore,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.restore {
+                match v {
+                    Some(value) => unsafe { std::env::set_var(k, value) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_user_prefers_explicit_option() {
+        let _g = EnvGuard::set(&[("GITHUB_USER", Some("from-env"))]);
+        assert_eq!(resolve_user(Some("from-opt")).unwrap(), "from-opt");
+    }
+
+    #[test]
+    fn resolve_user_falls_back_to_env() {
+        let _g = EnvGuard::set(&[("GITHUB_USER", Some("env-user"))]);
+        assert_eq!(resolve_user(None).unwrap(), "env-user");
+    }
+
+    #[test]
+    fn resolve_user_empty_option_falls_through_to_env() {
+        let _g = EnvGuard::set(&[("GITHUB_USER", Some("env-user"))]);
+        assert_eq!(resolve_user(Some("")).unwrap(), "env-user");
+    }
+
+    #[test]
+    fn resolve_user_fails_when_neither_supplied() {
+        let _g = EnvGuard::set(&[("GITHUB_USER", None)]);
+        let err = resolve_user(None).unwrap_err();
+        assert!(err.contains("GITHUB_USER"));
+    }
+
+    #[test]
+    fn options_default_when_absent() {
+        let opts: Options = parse_options(None).unwrap();
+        assert!(opts.user.is_none());
+        assert!(opts.size.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(parse_options::<Options>(Some(&raw)).is_err());
+    }
+}

--- a/src/fetcher/github/mod.rs
+++ b/src/fetcher/github/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 mod action_history;
 mod action_status;
 mod assigned_issues;
+mod avatar;
 pub(crate) mod client;
 pub(crate) mod common;
 mod contributions;
@@ -45,5 +46,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(contributors_monthly::GithubContributorsMonthly),
         Arc::new(contributions::GithubContributions),
         Arc::new(languages::GithubLanguages),
+        Arc::new(avatar::GithubAvatar),
     ]
 }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -19,6 +19,7 @@ pub mod project;
 pub mod read_store;
 pub mod static_text;
 pub mod system;
+pub mod weather;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Safety {
@@ -225,6 +226,7 @@ impl Registry {
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(project::ProjectName));
         r.register(Arc::new(project::Project));
+        r.register(Arc::new(weather::WeatherFetcher));
         for f in clock::realtime_fetchers() {
             r.register_realtime(f);
         }

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -7,8 +7,10 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use serde::Deserialize;
 use sysinfo::{Disks, ProcessesToUpdate, System};
 
+use crate::options::OptionSchema;
 use crate::payload::{
     Bar, BarsData, Body, EntriesData, Entry, Payload, RatioData, TextBlockData, TextData,
 };
@@ -32,8 +34,36 @@ pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![Arc::new(DiskFetcher)]
 }
 
+const SYSTEM_OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "kind",
+    type_hint: "\"terminal\" | \"os\" | \"os_version\" | \"hostname\" | \"shell\" | \"arch\"",
+    required: false,
+    default: Some("\"terminal\""),
+    description: "Selects the single value emitted by the `Text` shape. Ignored by `Entries` / `TextBlock` shapes, which always return the full rollup.",
+}];
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SystemOptions {
+    #[serde(default)]
+    pub kind: Option<SystemKind>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemKind {
+    #[default]
+    Terminal,
+    Os,
+    OsVersion,
+    Hostname,
+    Shell,
+    Arch,
+}
+
 /// `os / host / uptime / load / cpu / memory` rollup. `Entries` by default; `TextBlock`
-/// collapses each row to `"key: value"` so the same fetcher can feed the plain text renderer.
+/// collapses each row to `"key: value"`; `Text` emits a single identity field selected by the
+/// `kind` option (terminal name, OS label, hostname, shell, arch) for hero / attribution lines.
 pub struct SystemFetcher {
     state: Mutex<System>,
     os: String,
@@ -67,7 +97,10 @@ impl RealtimeFetcher for SystemFetcher {
         Safety::Safe
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Entries, Shape::TextBlock]
+        &[Shape::Entries, Shape::TextBlock, Shape::Text]
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        SYSTEM_OPTION_SCHEMAS
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
@@ -87,10 +120,14 @@ impl RealtimeFetcher for SystemFetcher {
                 "cpu: 18%",
                 "memory: 67%",
             ]),
+            Shape::Text => samples::text("iTerm2"),
             _ => return None,
         })
     }
     fn compute(&self, ctx: &FetchContext) -> Payload {
+        if matches!(ctx.shape, Some(Shape::Text)) {
+            return self.compute_text(ctx);
+        }
         let mut sys = self.state.lock().expect("system state mutex poisoned");
         sys.refresh_cpu_usage();
         sys.refresh_memory();
@@ -111,6 +148,88 @@ impl RealtimeFetcher for SystemFetcher {
             })),
         }
     }
+}
+
+impl SystemFetcher {
+    fn compute_text(&self, ctx: &FetchContext) -> Payload {
+        let opts: SystemOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return options_placeholder(&msg),
+        };
+        let value = resolve_system_kind(opts.kind.unwrap_or_default());
+        payload(Body::Text(TextData { value }))
+    }
+}
+
+fn resolve_system_kind(kind: SystemKind) -> String {
+    match kind {
+        SystemKind::Terminal => detect_terminal(),
+        SystemKind::Os => System::name().unwrap_or_else(|| "unknown".into()),
+        SystemKind::OsVersion => os_label(),
+        SystemKind::Hostname => System::host_name().unwrap_or_else(|| "unknown".into()),
+        SystemKind::Shell => detect_shell(),
+        SystemKind::Arch => std::env::consts::ARCH.into(),
+    }
+}
+
+/// Detect the terminal emulator via well-known env vars. Env vars are the only signal available
+/// without spawning a subprocess, so this is a best-effort match with a generic fallback.
+fn detect_terminal() -> String {
+    let env = |k: &str| std::env::var(k).ok();
+    if env("WT_SESSION").is_some() {
+        return "Windows Terminal".into();
+    }
+    if env("GHOSTTY_RESOURCES_DIR").is_some() {
+        return "Ghostty".into();
+    }
+    if env("KITTY_WINDOW_ID").is_some() || env("TERM").as_deref() == Some("xterm-kitty") {
+        return "Kitty".into();
+    }
+    if env("ALACRITTY_WINDOW_ID").is_some() || env("ALACRITTY_LOG").is_some() {
+        return "Alacritty".into();
+    }
+    if env("WEZTERM_PANE").is_some() {
+        return "WezTerm".into();
+    }
+    match env("TERM_PROGRAM").as_deref() {
+        Some("iTerm.app") => "iTerm2".into(),
+        Some("Apple_Terminal") => "Terminal".into(),
+        Some("ghostty") => "Ghostty".into(),
+        Some("WezTerm") => "WezTerm".into(),
+        Some("Hyper") => "Hyper".into(),
+        Some("vscode") => "VS Code".into(),
+        Some(other) if !other.is_empty() => other.into(),
+        _ => "terminal".into(),
+    }
+}
+
+fn detect_shell() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .and_then(|s| {
+            std::path::Path::new(&s)
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "shell".into())
+}
+
+fn parse_options<T: serde::de::DeserializeOwned + Default>(
+    raw: Option<&toml::Value>,
+) -> Result<T, String> {
+    match raw {
+        None => Ok(T::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+fn options_placeholder(msg: &str) -> Payload {
+    payload(Body::Text(TextData {
+        value: format!("⚠ {msg}"),
+    }))
 }
 
 /// Aggregated CPU usage across all cores. `Ratio` (0..=1) for gauges, `Text` for plain text.
@@ -559,6 +678,17 @@ mod tests {
         }
     }
 
+    fn ctx_text(options: Option<&str>) -> FetchContext {
+        let options = options.map(|s| toml::from_str::<toml::Value>(s).unwrap());
+        FetchContext {
+            widget_id: "w".into(),
+            timeout: Duration::from_secs(1),
+            shape: Some(Shape::Text),
+            options,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn format_uptime_covers_minute_hour_day_ranges() {
         assert_eq!(format_uptime(0), "0m");
@@ -647,6 +777,38 @@ mod tests {
             panic!("expected entries");
         };
         assert_eq!(e.items.len(), 6);
+    }
+
+    #[test]
+    fn system_text_shape_defaults_to_terminal_kind() {
+        let p = SystemFetcher::new().compute(&ctx_text(None));
+        let Body::Text(t) = p.body else {
+            panic!("expected text");
+        };
+        assert!(!t.value.is_empty());
+    }
+
+    #[test]
+    fn system_text_shape_emits_arch_when_requested() {
+        let p = SystemFetcher::new().compute(&ctx_text(Some("kind = \"arch\"")));
+        let Body::Text(t) = p.body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, std::env::consts::ARCH);
+    }
+
+    #[test]
+    fn system_text_shape_rejects_unknown_kind_to_placeholder() {
+        let p = SystemFetcher::new().compute(&ctx_text(Some("kind = \"bogus\"")));
+        let Body::Text(t) = p.body else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("⚠"));
+    }
+
+    #[test]
+    fn detect_terminal_returns_non_empty_label() {
+        assert!(!detect_terminal().is_empty());
     }
 
     #[test]

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -811,6 +811,30 @@ mod tests {
         assert!(!detect_terminal().is_empty());
     }
 
+    /// Prints one Text-shape line per `kind` on the host running the tests. Kept `#[ignore]` so
+    /// the regular run stays side-effect free, but a dev can verify real output with
+    /// `cargo test -- --ignored fetcher::system::tests::live_system_text_all_kinds --nocapture`.
+    #[test]
+    #[ignore]
+    fn live_system_text_all_kinds() {
+        let cases = [
+            ("terminal", "kind = \"terminal\""),
+            ("os", "kind = \"os\""),
+            ("os_version", "kind = \"os_version\""),
+            ("hostname", "kind = \"hostname\""),
+            ("shell", "kind = \"shell\""),
+            ("arch", "kind = \"arch\""),
+        ];
+        for (label, opts) in cases {
+            let p = SystemFetcher::new().compute(&ctx_text(Some(opts)));
+            let Body::Text(t) = p.body else {
+                panic!("expected text for {label}");
+            };
+            eprintln!("{label:<12} → {}", t.value);
+            assert!(!t.value.is_empty());
+        }
+    }
+
     #[test]
     fn system_text_block_shape_returns_key_value_strings() {
         let p = SystemFetcher::new().compute(&ctx_with_shape(Some(Shape::TextBlock)));

--- a/src/fetcher/weather.rs
+++ b/src/fetcher/weather.rs
@@ -139,13 +139,13 @@ async fn fetch_report(lat: f64, lon: f64, units: Units) -> Result<Sample, FetchE
 }
 
 fn build_url(lat: f64, lon: f64, units: Units) -> String {
-    let mut url = format!(
+    let base = format!(
         "{API_BASE}?latitude={lat}&longitude={lon}&current=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m"
     );
-    if matches!(units, Units::Imperial) {
-        url.push_str("&temperature_unit=fahrenheit&wind_speed_unit=mph");
+    match units {
+        Units::Metric => format!("{base}&wind_speed_unit=ms"),
+        Units::Imperial => format!("{base}&temperature_unit=fahrenheit&wind_speed_unit=mph"),
     }
-    url
 }
 
 #[derive(Debug, Deserialize)]
@@ -292,10 +292,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_url_metric_omits_imperial_units() {
+    fn build_url_metric_requests_ms_wind() {
         let url = build_url(35.68, 139.76, Units::Metric);
         assert!(url.contains("latitude=35.68"));
         assert!(url.contains("longitude=139.76"));
+        assert!(url.contains("wind_speed_unit=ms"));
         assert!(!url.contains("fahrenheit"));
         assert!(!url.contains("mph"));
     }
@@ -365,5 +366,21 @@ mod tests {
         let raw: toml::Value =
             toml::from_str("latitude = 1.0\nlongitude = 2.0\nbogus = true").unwrap();
         assert!(parse_options::<WeatherOptions>(Some(&raw)).is_err());
+    }
+
+    /// Live smoke test — hits Open-Meteo. `#[ignore]` keeps CI offline-safe; run with
+    /// `cargo test -- --ignored fetcher::weather::tests::live` to verify real API shape.
+    #[tokio::test]
+    #[ignore]
+    async fn live_tokyo_forecast_populates_entries() {
+        let report = fetch_report(35.68, 139.76, Units::Metric).await.unwrap();
+        let body = entries(&report);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 3);
+        for row in &e.items {
+            eprintln!("{} → {}", row.key, row.value.as_deref().unwrap_or(""));
+        }
     }
 }

--- a/src/fetcher/weather.rs
+++ b/src/fetcher/weather.rs
@@ -1,0 +1,369 @@
+//! `weather` fetcher — Open-Meteo forecast for a fixed (latitude, longitude).
+//!
+//! Safety::Safe because the host is hardcoded: the user supplies coordinates, not a URL, so
+//! config can't redirect traffic to an attacker-controlled origin. No API key is required and
+//! no token leaves the machine.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{Body, EntriesData, Entry, Payload, TextData};
+use crate::render::Shape;
+
+use super::github::common::cache_key;
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+const API_BASE: &str = "https://api.open-meteo.com/v1/forecast";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "latitude",
+        type_hint: "float (degrees)",
+        required: true,
+        default: None,
+        description: "Latitude of the location to query (e.g., `35.68` for Tokyo).",
+    },
+    OptionSchema {
+        name: "longitude",
+        type_hint: "float (degrees)",
+        required: true,
+        default: None,
+        description: "Longitude of the location to query (e.g., `139.76` for Tokyo).",
+    },
+    OptionSchema {
+        name: "units",
+        type_hint: "\"metric\" | \"imperial\"",
+        required: false,
+        default: Some("\"metric\""),
+        description: "Temperature and wind unit system. Metric renders °C / m/s; imperial renders °F / mph.",
+    },
+];
+
+/// Open-Meteo forecast widget. Entries shape (primary): condition / temp / wind / humidity.
+pub struct WeatherFetcher;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WeatherOptions {
+    pub latitude: f64,
+    pub longitude: f64,
+    #[serde(default)]
+    pub units: Option<Units>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Units {
+    #[default]
+    Metric,
+    Imperial,
+}
+
+#[async_trait]
+impl Fetcher for WeatherFetcher {
+    fn name(&self) -> &str {
+        "weather"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Entries, Shape::Text]
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Entries => entries(&Sample::default()),
+            Shape::Text => Body::Text(TextData {
+                value: Sample::default().as_text(),
+            }),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: WeatherOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return Ok(placeholder(&msg)),
+        };
+        let units = opts.units.unwrap_or_default();
+        let report = fetch_report(opts.latitude, opts.longitude, units).await?;
+        let body = match ctx.shape.unwrap_or(Shape::Entries) {
+            Shape::Text => Body::Text(TextData {
+                value: report.as_text(),
+            }),
+            _ => entries(&report),
+        };
+        Ok(payload(body))
+    }
+}
+
+async fn fetch_report(lat: f64, lon: f64, units: Units) -> Result<Sample, FetchError> {
+    let url = build_url(lat, lon, units);
+    let res = http()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("weather request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("weather {status}")));
+    }
+    let raw: ApiResponse = res
+        .json()
+        .await
+        .map_err(|e| FetchError::Failed(format!("weather json parse: {e}")))?;
+    Ok(Sample {
+        code: raw.current.weather_code,
+        temperature: raw.current.temperature_2m,
+        wind_speed: raw.current.wind_speed_10m,
+        humidity: raw.current.relative_humidity_2m,
+        units,
+    })
+}
+
+fn build_url(lat: f64, lon: f64, units: Units) -> String {
+    let mut url = format!(
+        "{API_BASE}?latitude={lat}&longitude={lon}&current=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m"
+    );
+    if matches!(units, Units::Imperial) {
+        url.push_str("&temperature_unit=fahrenheit&wind_speed_unit=mph");
+    }
+    url
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    current: Current,
+}
+
+#[derive(Debug, Deserialize)]
+struct Current {
+    temperature_2m: f64,
+    weather_code: u16,
+    wind_speed_10m: f64,
+    relative_humidity_2m: u8,
+}
+
+struct Sample {
+    code: u16,
+    temperature: f64,
+    wind_speed: f64,
+    humidity: u8,
+    units: Units,
+}
+
+impl Default for Sample {
+    fn default() -> Self {
+        Self {
+            code: 3,
+            temperature: 18.0,
+            wind_speed: 4.0,
+            humidity: 67,
+            units: Units::Metric,
+        }
+    }
+}
+
+impl Sample {
+    fn temperature_label(&self) -> String {
+        let unit = match self.units {
+            Units::Metric => "°C",
+            Units::Imperial => "°F",
+        };
+        format!("{:.0}{unit}", self.temperature)
+    }
+    fn wind_label(&self) -> String {
+        let unit = match self.units {
+            Units::Metric => "m/s",
+            Units::Imperial => "mph",
+        };
+        format!("{:.0} {unit}", self.wind_speed)
+    }
+    fn humidity_label(&self) -> String {
+        format!("{}%", self.humidity)
+    }
+    fn as_text(&self) -> String {
+        let (emoji, condition) = weather_description(self.code);
+        format!(
+            "{emoji} {condition} · {} · 💨 {} · 💧 {}",
+            self.temperature_label(),
+            self.wind_label(),
+            self.humidity_label(),
+        )
+    }
+}
+
+fn entries(s: &Sample) -> Body {
+    let (emoji, condition) = weather_description(s.code);
+    let rows = [
+        (format!("{emoji} {condition}"), s.temperature_label()),
+        ("💨 wind".into(), s.wind_label()),
+        ("💧 humidity".into(), s.humidity_label()),
+    ];
+    Body::Entries(EntriesData {
+        items: rows
+            .into_iter()
+            .map(|(k, v)| Entry {
+                key: k,
+                value: Some(v),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+/// WMO weather interpretation codes (Open-Meteo uses the standard table).
+fn weather_description(code: u16) -> (&'static str, &'static str) {
+    match code {
+        0 => ("🌞", "clear"),
+        1 => ("🌤", "mostly clear"),
+        2 => ("⛅", "partly cloudy"),
+        3 => ("☁", "overcast"),
+        45 | 48 => ("🌫", "fog"),
+        51 | 53 | 55 => ("🌦", "drizzle"),
+        56 | 57 => ("🌧", "freezing drizzle"),
+        61 | 63 | 65 => ("🌧", "rain"),
+        66 | 67 => ("🌧", "freezing rain"),
+        71 | 73 | 75 | 77 => ("🌨", "snow"),
+        80..=82 => ("🌦", "rain showers"),
+        85 | 86 => ("🌨", "snow showers"),
+        95 => ("⛈", "thunderstorm"),
+        96 | 99 => ("⛈", "thunderstorm w/ hail"),
+        _ => ("🌡", "unknown"),
+    }
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+fn parse_options<T: serde::de::DeserializeOwned>(raw: Option<&toml::Value>) -> Result<T, String> {
+    match raw {
+        None => Err("weather requires `latitude` and `longitude` options".into()),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+fn placeholder(msg: &str) -> Payload {
+    payload(Body::Text(TextData {
+        value: format!("⚠ {msg}"),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_url_metric_omits_imperial_units() {
+        let url = build_url(35.68, 139.76, Units::Metric);
+        assert!(url.contains("latitude=35.68"));
+        assert!(url.contains("longitude=139.76"));
+        assert!(!url.contains("fahrenheit"));
+        assert!(!url.contains("mph"));
+    }
+
+    #[test]
+    fn build_url_imperial_sets_fahrenheit_and_mph() {
+        let url = build_url(40.71, -74.0, Units::Imperial);
+        assert!(url.contains("temperature_unit=fahrenheit"));
+        assert!(url.contains("wind_speed_unit=mph"));
+    }
+
+    #[test]
+    fn weather_description_covers_canonical_codes() {
+        assert_eq!(weather_description(0).1, "clear");
+        assert_eq!(weather_description(3).1, "overcast");
+        assert_eq!(weather_description(63).1, "rain");
+        assert_eq!(weather_description(95).1, "thunderstorm");
+        assert_eq!(weather_description(1234).1, "unknown");
+    }
+
+    #[test]
+    fn sample_entries_expose_three_rows() {
+        let body = entries(&Sample::default());
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 3);
+        assert!(e.items[0].value.as_deref().unwrap().ends_with("°C"));
+        assert!(e.items[1].value.as_deref().unwrap().ends_with("m/s"));
+        assert!(e.items[2].value.as_deref().unwrap().ends_with('%'));
+    }
+
+    #[test]
+    fn imperial_units_render_fahrenheit_and_mph() {
+        let s = Sample {
+            units: Units::Imperial,
+            ..Sample::default()
+        };
+        assert!(s.temperature_label().ends_with("°F"));
+        assert!(s.wind_label().ends_with("mph"));
+    }
+
+    #[test]
+    fn api_response_deserializes_open_meteo_current() {
+        let raw = r#"{"current":{"time":"2026-04-23T12:00","temperature_2m":18.2,"weather_code":3,"wind_speed_10m":4.1,"relative_humidity_2m":67}}"#;
+        let parsed: ApiResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.current.weather_code, 3);
+        assert_eq!(parsed.current.relative_humidity_2m, 67);
+    }
+
+    #[test]
+    fn parse_options_requires_latitude_and_longitude() {
+        let err: String = parse_options::<WeatherOptions>(None).unwrap_err();
+        assert!(err.contains("latitude"));
+    }
+
+    #[test]
+    fn parse_options_accepts_floats() {
+        let raw: toml::Value = toml::from_str("latitude = 35.68\nlongitude = 139.76").unwrap();
+        let opts: WeatherOptions = parse_options(Some(&raw)).unwrap();
+        assert_eq!(opts.latitude, 35.68);
+        assert_eq!(opts.longitude, 139.76);
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_keys() {
+        let raw: toml::Value =
+            toml::from_str("latitude = 1.0\nlongitude = 2.0\nbogus = true").unwrap();
+        assert!(parse_options::<WeatherOptions>(Some(&raw)).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Fills in the fetcher gaps needed by the 0.x dashboard presets (#77).

- **`clock`** — confirm the existing strftime path (top-level `format` field) with a test. No new code; covers `"%e %B %Y · %A"` style templates that `home_daily` needs.
- **`system`** — extend with `Text` shape + `kind` option (`terminal` / `os` / `os_version` / `hostname` / `shell` / `arch`). Terminal detection via well-known env vars (`WT_SESSION`, `TERM_PROGRAM`, `KITTY_WINDOW_ID`, `ALACRITTY_WINDOW_ID`, `WEZTERM_PANE`, `GHOSTTY_RESOURCES_DIR`, …) with a generic fallback.
- **`weather`** (new) — Open-Meteo forecast at a fixed host (`api.open-meteo.com`). `Safety::Safe` because the user supplies coordinates, not a URL. Options: `latitude` / `longitude` / `units` (`"metric" | "imperial"`). Emits `Entries` (primary) or `Text`.
- **`github_avatar`** (new) — downloads `github.com/<user>.png?size=N` into `\$SPLASHBOARD_HOME/cache/avatars/<user>-<size>.png` and emits `Body::Image`. Fixed host, no auth (public endpoint), so no `GH_TOKEN` leaks along the redirect chain. `user` falls back to `\$GITHUB_USER`.

Closes checklist items on #81.

## Test plan

- [x] `cargo test` — 415 passed (+22 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask` regenerates the reference matrix (weather + github_avatar pages appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub avatar fetcher for downloading and caching user profile avatars.
  * Added weather fetcher for current conditions via Open-Meteo, supporting metric/imperial units.
  * Extended system fetcher to display individual system details (OS, hostname, architecture, shell, terminal).

* **Tests**
  * Added comprehensive tests for new fetchers and extended system information functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->