### PR TITLE
fix(runtime): respect animation window under wait + draw loading spinner

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -9,7 +9,7 @@ use ratatui::{
 };
 
 use crate::payload::Payload;
-use crate::render::{Registry, RenderSpec, render_payload};
+use crate::render::{Registry, RenderSpec, Shape, loading::render_loading, render_payload};
 use crate::theme::Theme;
 
 pub type WidgetId = String;
@@ -280,6 +280,7 @@ pub fn draw(
     specs: &HashMap<WidgetId, RenderSpec>,
     registry: &Registry,
     theme: &Theme,
+    loading: &HashMap<WidgetId, Shape>,
 ) {
     match layout {
         Layout::Stack {
@@ -292,13 +293,18 @@ pub fn draw(
             paint_bg(frame, area, *bg, theme);
             let inner = draw_panel(frame, area, panel, theme);
             draw_stack(
-                frame, inner, *direction, *flex, children, widgets, specs, registry, theme,
+                frame, inner, *direction, *flex, children, widgets, specs, registry, theme, loading,
             );
         }
         Layout::Widget { id, panel, bg } => {
             paint_bg(frame, area, *bg, theme);
             let inner = draw_panel(frame, area, panel, theme);
-            if let Some(payload) = widgets.get(id) {
+            // Loading placeholder takes precedence over `widgets.get(id)` so widgets whose
+            // cache entries haven't landed yet show a spinner instead of leaving a blank slot.
+            // The daemon swaps the loading state off for that id once the real payload arrives.
+            if let Some(&shape) = loading.get(id) {
+                render_loading(frame, inner, shape, theme);
+            } else if let Some(payload) = widgets.get(id) {
                 render_payload(frame, inner, payload, specs.get(id), registry, theme);
             }
         }
@@ -374,6 +380,7 @@ fn draw_stack(
     specs: &HashMap<WidgetId, RenderSpec>,
     registry: &Registry,
     theme: &Theme,
+    loading: &HashMap<WidgetId, Shape>,
 ) {
     let constraints: Vec<Constraint> = children.iter().map(|c| to_constraint(c.size)).collect();
     let rects = RatLayout::default()
@@ -382,7 +389,16 @@ fn draw_stack(
         .flex(to_ratatui_flex(flex))
         .split(area);
     for (child, rect) in children.iter().zip(rects.iter()) {
-        draw(frame, *rect, &child.layout, widgets, specs, registry, theme);
+        draw(
+            frame,
+            *rect,
+            &child.layout,
+            widgets,
+            specs,
+            registry,
+            theme,
+            loading,
+        );
     }
 }
 
@@ -574,5 +590,34 @@ mod tests {
         let row1 = line_text(&buf, 0);
         assert!(row1.contains("left"));
         assert!(row1.contains("right"));
+    }
+
+    #[test]
+    fn loading_widget_draws_spinner_instead_of_payload() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let l = Layout::widget("pending");
+        // Payload exists but we also flag the widget as loading — loading takes precedence so
+        // the spinner wins over any stale payload body sitting in the map.
+        let w = widgets(&[("pending", text_widget(&["stale data"]))]);
+        let specs = HashMap::new();
+        let registry = Registry::with_builtins();
+        let theme = Theme::default();
+        let mut loading: HashMap<WidgetId, Shape> = HashMap::new();
+        loading.insert("pending".into(), Shape::Entries);
+        let backend = TestBackend::new(30, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| draw(f, f.area(), &l, &w, &specs, &registry, &theme, &loading))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = (0..buf.area().height).map(|y| line_text(&buf, y)).collect();
+        assert!(
+            dump.contains("loading"),
+            "expected loading spinner label, got:\n{dump}"
+        );
+        assert!(
+            !dump.contains("stale data"),
+            "loading should suppress payload content, got:\n{dump}"
+        );
     }
 }

--- a/src/render/loading.rs
+++ b/src/render/loading.rs
@@ -1,0 +1,108 @@
+//! Loading placeholder drawn for widgets that are fetchable but have no payload yet.
+//!
+//! Rendered directly from `layout::draw` instead of going through `render_payload`, so a widget
+//! whose real payload hasn't landed still shows a consistent "still working" indicator rather
+//! than a blank slot. Animates on the same cadence as animated renderers — the runtime's
+//! `ANIMATION_WINDOW` gives the spinner at least a couple of full cycles even on a fast path.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Modifier, Style},
+    text::Line,
+    widgets::Paragraph,
+};
+
+use crate::theme::Theme;
+
+use super::Shape;
+
+/// Braille spinner frames, 10 steps per full cycle. Advances on a ~100ms cadence, which lines
+/// up with `FRAME_TICK` (50ms) so every other redraw shows a new frame.
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Shape-agnostic entry point. For now every shape renders a centered spinner; per-shape
+/// skeletons (dim rows for `Entries`, flat baseline for `NumberSeries`, empty grid for
+/// `Heatmap`, …) can replace this in a follow-up without changing the call sites.
+pub fn render_loading(frame: &mut Frame, area: Rect, _shape: Shape, theme: &Theme) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    render_spinner(frame, area, theme);
+}
+
+fn render_spinner(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let spinner = current_spinner_frame();
+    let label = format!("{spinner} loading");
+    let style = Style::default()
+        .fg(theme.text_dim)
+        .add_modifier(Modifier::ITALIC);
+    let top_pad = area.height.saturating_sub(1) / 2;
+    let inner = Rect {
+        x: area.x,
+        y: area.y + top_pad,
+        width: area.width,
+        height: 1,
+    };
+    let paragraph = Paragraph::new(Line::from(label).style(style)).alignment(Alignment::Center);
+    frame.render_widget(paragraph, inner);
+}
+
+fn current_spinner_frame() -> &'static str {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let idx = ((millis / 100) as usize) % SPINNER_FRAMES.len();
+    SPINNER_FRAMES[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    #[test]
+    fn loading_emits_spinner_glyph_and_label() {
+        let buffer = render_loading_to_buffer(Shape::Entries, 40, 3);
+        let dump = buffer_text(&buffer);
+        assert!(
+            dump.contains("loading"),
+            "expected label in buffer:\n{dump}"
+        );
+        assert!(
+            SPINNER_FRAMES.iter().any(|f| dump.contains(f)),
+            "expected a spinner glyph in buffer:\n{dump}"
+        );
+    }
+
+    #[test]
+    fn loading_is_a_noop_on_single_cell_area() {
+        // Regression: a rect that collapsed during layout must not panic. We use a 1x1 area
+        // because TestBackend cannot build with width or height zero.
+        let _ = render_loading_to_buffer(Shape::Text, 1, 1);
+    }
+
+    fn render_loading_to_buffer(shape: Shape, width: u16, height: u16) -> Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::default();
+        terminal
+            .draw(|f| render_loading(f, f.area(), shape, &theme))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buffer: &Buffer) -> String {
+        let mut out = String::new();
+        for y in 0..buffer.area().height {
+            for x in 0..buffer.area().width {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -28,6 +28,7 @@ mod grid_heatmap;
 mod grid_table;
 mod list_plain;
 mod list_timeline;
+pub mod loading;
 mod media_image;
 mod status_badge;
 mod text_ascii;

--- a/src/render/test_utils.rs
+++ b/src/render/test_utils.rs
@@ -50,10 +50,22 @@ pub fn render_to_buffer_with_layout_and_specs(
 ) -> Buffer {
     let registry = Registry::with_builtins();
     let theme = Theme::default();
+    let loading = HashMap::new();
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|f| layout::draw(f, f.area(), root, widgets, specs, &registry, &theme))
+        .draw(|f| {
+            layout::draw(
+                f,
+                f.area(),
+                root,
+                widgets,
+                specs,
+                &registry,
+                &theme,
+                &loading,
+            )
+        })
         .unwrap();
     terminal.backend().buffer().clone()
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -131,24 +131,53 @@ fn compute_realtime_payloads(
         .collect()
 }
 
-/// Widgets whose data we're still waiting on — fetchable, cached, but no payload landed yet.
-/// Each iteration recomputes this so the spinner is swapped off the moment the daemon fills
-/// the slot (either via cache replay or a direct refresh). Shape is carried through so future
-/// per-shape skeletons can branch on it in `render_loading`.
+/// Widgets whose data we're still waiting on. Two cases are both treated as "loading":
+///
+/// 1. No payload at all (first run, cleared cache, brand-new widget) — always loading.
+/// 2. Under `--wait`, a stale cache entry whose TTL has expired — the daemon is on the
+///    critical path and will refetch, so the displayed payload is about to change. Showing a
+///    spinner telegraphs that intent instead of rendering last run's data as if it were
+///    authoritative. Without `--wait` we prefer the stale payload to a spinner because the
+///    refetch is best-effort (background daemon) and may not land in this invocation.
+///
+/// Recomputed each iteration so the spinner is swapped off the moment the daemon fills or
+/// refreshes the slot. Shape is carried through so future per-shape skeletons can branch on
+/// it in `render_loading`.
 fn compute_loading(
     cached: &[WidgetConfig],
     payloads: &HashMap<WidgetId, Payload>,
+    entries: &HashMap<WidgetId, CacheEntry>,
     shapes: &HashMap<WidgetId, Shape>,
+    wait: bool,
 ) -> HashMap<WidgetId, Shape> {
     cached
         .iter()
-        .filter(|w| !payloads.contains_key(&w.id))
+        .filter(|w| is_loading(w, payloads, entries, wait))
         .filter_map(|w| shapes.get(&w.id).copied().map(|s| (w.id.clone(), s)))
         .collect()
 }
 
-fn has_loading_widget(cached: &[WidgetConfig], payloads: &HashMap<WidgetId, Payload>) -> bool {
-    cached.iter().any(|w| !payloads.contains_key(&w.id))
+fn is_loading(
+    w: &WidgetConfig,
+    payloads: &HashMap<WidgetId, Payload>,
+    entries: &HashMap<WidgetId, CacheEntry>,
+    wait: bool,
+) -> bool {
+    if !payloads.contains_key(&w.id) {
+        return true;
+    }
+    wait && entries.get(&w.id).is_some_and(|e| !e.is_fresh())
+}
+
+fn has_loading_widget(
+    cached: &[WidgetConfig],
+    payloads: &HashMap<WidgetId, Payload>,
+    entries: &HashMap<WidgetId, CacheEntry>,
+    wait: bool,
+) -> bool {
+    cached
+        .iter()
+        .any(|w| is_loading(w, payloads, entries, wait))
 }
 
 /// Loop exit condition factored out so the "wait for both load and animation axes to settle"
@@ -229,7 +258,7 @@ pub async fn run(
     // placeholders also animate (spinner glyph) so we force-enable animation whenever a cached
     // widget has no entry yet — otherwise the spinner would appear to freeze mid-draw.
     let animated = render::any_widget_animates(&config.widgets, &render_registry)
-        || has_loading_widget(&cached_widgets, &payloads);
+        || has_loading_widget(&cached_widgets, &payloads, &entries, wait);
 
     let loop_window = match (wait, animated) {
         (false, false) => None,
@@ -268,7 +297,7 @@ pub async fn run(
 
     // Cache-first one-shot: no looping needed, paint what we have and exit.
     if loop_window.is_none() {
-        let loading = compute_loading(&cached_widgets, &payloads, &shapes);
+        let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, wait);
         finalize_draw(
             &mut terminal,
             &layout,
@@ -306,8 +335,8 @@ pub async fn run(
             // hard window deadline expires.
             let mut daemon_done = !wait;
             loop {
-                refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
-                let loading = compute_loading(&cached_widgets, &payloads, &shapes);
+                let entries = refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
+                let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, wait);
                 draw(
                     &mut terminal,
                     &layout,
@@ -340,8 +369,8 @@ pub async fn run(
                     tokio::time::sleep(tick).await;
                 }
             }
-            refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
-            let loading = compute_loading(&cached_widgets, &payloads, &shapes);
+            let entries = refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
+            let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, wait);
             finalize_draw(
                 &mut terminal,
                 &layout,
@@ -373,7 +402,7 @@ pub async fn run(
             }
             // Realtime values in the fallback path are still fresh at this point — the compute
             // above was microseconds ago. No refresh needed before the single final draw.
-            let loading = compute_loading(&cached_widgets, &payloads, &shapes);
+            let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, wait);
             finalize_draw(
                 &mut terminal,
                 &layout,
@@ -442,7 +471,7 @@ fn refresh_payloads(
     buckets: &WidgetBuckets<'_>,
     shapes: &HashMap<WidgetId, Shape>,
     payloads: &mut HashMap<WidgetId, Payload>,
-) {
+) -> HashMap<WidgetId, CacheEntry> {
     let entries = load_entries(cache.as_ref(), registry, buckets.cached, shapes);
     for (id, payload) in entries_to_payloads(&entries) {
         payloads.insert(id, payload);
@@ -453,6 +482,7 @@ fn refresh_payloads(
     for (w, err) in buckets.shape_invalid {
         payloads.insert(w.id.clone(), fetcher::shape_mismatch_placeholder(err));
     }
+    entries
 }
 
 fn fetch_context(w: &WidgetConfig, shape: Option<Shape>, deadline: Duration) -> FetchContext {
@@ -1468,10 +1498,55 @@ mod tests {
         let mut shapes: HashMap<WidgetId, Shape> = HashMap::new();
         shapes.insert("pending".into(), Shape::Entries);
         shapes.insert("ready".into(), Shape::Text);
-        let loading = compute_loading(&cached, &payloads, &shapes);
+        let entries = HashMap::new();
+        let loading = compute_loading(&cached, &payloads, &entries, &shapes, false);
         assert_eq!(loading.len(), 1);
         assert_eq!(loading.get("pending"), Some(&Shape::Entries));
         assert!(!loading.contains_key("ready"));
+    }
+
+    #[test]
+    fn compute_loading_flags_stale_entry_only_under_wait() {
+        // Regression for: under `--wait` a stale cache entry still shows last-run data instead
+        // of telegraphing that a refetch is in flight.
+        let cached = vec![widget("stale", "github_my_prs")];
+        let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
+        payloads.insert("stale".into(), text_payload("last-run"));
+        let mut shapes: HashMap<WidgetId, Shape> = HashMap::new();
+        shapes.insert("stale".into(), Shape::Entries);
+        let mut entries = HashMap::new();
+        entries.insert(
+            "stale".into(),
+            CacheEntry {
+                refreshed_at: 0,
+                ttl_seconds: 60,
+                payload: text_payload("last-run"),
+            },
+        );
+
+        // Without --wait: stale cache is shown as-is, no spinner.
+        let without_wait = compute_loading(&cached, &payloads, &entries, &shapes, false);
+        assert!(
+            without_wait.is_empty(),
+            "stale cache should render without spinner off the wait path"
+        );
+
+        // With --wait: stale cache → spinner because the daemon is on the critical path.
+        let with_wait = compute_loading(&cached, &payloads, &entries, &shapes, true);
+        assert_eq!(with_wait.get("stale"), Some(&Shape::Entries));
+    }
+
+    #[test]
+    fn compute_loading_keeps_fresh_entry_off_spinner_even_under_wait() {
+        let cached = vec![widget("fresh", "github_my_prs")];
+        let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
+        payloads.insert("fresh".into(), text_payload("now"));
+        let mut shapes: HashMap<WidgetId, Shape> = HashMap::new();
+        shapes.insert("fresh".into(), Shape::Entries);
+        let mut entries = HashMap::new();
+        entries.insert("fresh".into(), CacheEntry::new(text_payload("now"), 600));
+        let loading = compute_loading(&cached, &payloads, &entries, &shapes, true);
+        assert!(loading.is_empty());
     }
 
     #[test]
@@ -1479,8 +1554,9 @@ mod tests {
         let cached = vec![widget("a", "github_my_prs"), widget("b", "clock")];
         let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
         payloads.insert("a".into(), text_payload("x"));
-        assert!(has_loading_widget(&cached, &payloads));
+        let entries = HashMap::new();
+        assert!(has_loading_widget(&cached, &payloads, &entries, false));
         payloads.insert("b".into(), text_payload("y"));
-        assert!(!has_loading_widget(&cached, &payloads));
+        assert!(!has_loading_widget(&cached, &payloads, &entries, false));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -131,6 +131,34 @@ fn compute_realtime_payloads(
         .collect()
 }
 
+/// Widgets whose data we're still waiting on — fetchable, cached, but no payload landed yet.
+/// Each iteration recomputes this so the spinner is swapped off the moment the daemon fills
+/// the slot (either via cache replay or a direct refresh). Shape is carried through so future
+/// per-shape skeletons can branch on it in `render_loading`.
+fn compute_loading(
+    cached: &[WidgetConfig],
+    payloads: &HashMap<WidgetId, Payload>,
+    shapes: &HashMap<WidgetId, Shape>,
+) -> HashMap<WidgetId, Shape> {
+    cached
+        .iter()
+        .filter(|w| !payloads.contains_key(&w.id))
+        .filter_map(|w| shapes.get(&w.id).copied().map(|s| (w.id.clone(), s)))
+        .collect()
+}
+
+fn has_loading_widget(cached: &[WidgetConfig], payloads: &HashMap<WidgetId, Payload>) -> bool {
+    cached.iter().any(|w| !payloads.contains_key(&w.id))
+}
+
+/// Loop exit condition factored out so the "wait for both load and animation axes to settle"
+/// invariant can be tested without spinning up a real daemon. Matches the inline check in
+/// `run()` exactly — hitting the hard deadline always exits, otherwise both the daemon
+/// (load axis) and the animation (render axis) must be done.
+fn loop_should_exit(daemon_done: bool, animation_pending: bool, deadline_reached: bool) -> bool {
+    deadline_reached || (daemon_done && !animation_pending)
+}
+
 const DEFAULT_REFRESH_SECS: u64 = 60;
 const FAST_DEADLINE: Duration = Duration::from_millis(1500);
 const WAIT_DEADLINE: Duration = Duration::from_secs(5);
@@ -197,8 +225,11 @@ pub async fn run(
         wait || config.general.wait_for_fresh || (!cached_widgets.is_empty() && entries.is_empty());
 
     // Render axis: decide whether any configured renderer needs repeat frames. Independent of
-    // the load decision — an animated widget must animate regardless of cache state.
-    let animated = render::any_widget_animates(&config.widgets, &render_registry);
+    // the load decision — an animated widget must animate regardless of cache state. Loading
+    // placeholders also animate (spinner glyph) so we force-enable animation whenever a cached
+    // widget has no entry yet — otherwise the spinner would appear to freeze mid-draw.
+    let animated = render::any_widget_animates(&config.widgets, &render_registry)
+        || has_loading_widget(&cached_widgets, &payloads);
 
     let loop_window = match (wait, animated) {
         (false, false) => None,
@@ -237,6 +268,7 @@ pub async fn run(
 
     // Cache-first one-shot: no looping needed, paint what we have and exit.
     if loop_window.is_none() {
+        let loading = compute_loading(&cached_widgets, &payloads, &shapes);
         finalize_draw(
             &mut terminal,
             &layout,
@@ -247,6 +279,7 @@ pub async fn run(
             padding,
             requested_height,
             viewport_lines,
+            &loading,
         )?;
         let _ = daemon::spawn_fetch_daemon(source);
         finalize_splash(&mut terminal);
@@ -264,9 +297,17 @@ pub async fn run(
                 gated: &gated,
                 shape_invalid: &shape_invalid,
             };
-            let deadline = std::time::Instant::now() + window;
+            let start = std::time::Instant::now();
+            let deadline = start + window;
+            let animation_deadline = animated.then(|| start + ANIMATION_WINDOW);
+            // `wait = true` means the daemon is on the critical path; flip this once it exits
+            // so later iterations skip the `child.wait()` branch. The load-axis and render-axis
+            // exit conditions are independent — break only when both are satisfied, or when the
+            // hard window deadline expires.
+            let mut daemon_done = !wait;
             loop {
                 refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
+                let loading = compute_loading(&cached_widgets, &payloads, &shapes);
                 draw(
                     &mut terminal,
                     &layout,
@@ -276,25 +317,31 @@ pub async fn run(
                     &theme,
                     padding,
                     hidden_rows,
+                    &loading,
                 )?;
-                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                let now = std::time::Instant::now();
+                let remaining = deadline.saturating_duration_since(now);
                 if remaining.is_zero() {
-                    if wait {
+                    if !daemon_done {
                         let _ = child.start_kill();
                     }
                     break;
                 }
+                let animation_pending = animation_deadline.is_some_and(|d| now < d);
+                if loop_should_exit(daemon_done, animation_pending, false) {
+                    break;
+                }
                 let tick = remaining.min(FRAME_TICK);
-                if wait {
-                    match tokio::time::timeout(tick, child.wait()).await {
-                        Ok(_) => break,
-                        Err(_) => continue,
+                if !daemon_done {
+                    if tokio::time::timeout(tick, child.wait()).await.is_ok() {
+                        daemon_done = true;
                     }
                 } else {
                     tokio::time::sleep(tick).await;
                 }
             }
             refresh_payloads(&cache, &registry, &buckets, &shapes, &mut payloads);
+            let loading = compute_loading(&cached_widgets, &payloads, &shapes);
             finalize_draw(
                 &mut terminal,
                 &layout,
@@ -305,6 +352,7 @@ pub async fn run(
                 padding,
                 requested_height,
                 viewport_lines,
+                &loading,
             )?;
         }
         Err(_) => {
@@ -325,6 +373,7 @@ pub async fn run(
             }
             // Realtime values in the fallback path are still fresh at this point — the compute
             // above was microseconds ago. No refresh needed before the single final draw.
+            let loading = compute_loading(&cached_widgets, &payloads, &shapes);
             finalize_draw(
                 &mut terminal,
                 &layout,
@@ -335,6 +384,7 @@ pub async fn run(
                 padding,
                 requested_height,
                 viewport_lines,
+                &loading,
             )?;
         }
     }
@@ -519,6 +569,7 @@ fn draw<B: Backend>(
     theme: &Theme,
     padding: (u16, u16),
     hidden_rows: u16,
+    loading: &HashMap<WidgetId, Shape>,
 ) -> io::Result<()> {
     terminal.draw(|frame| {
         draw_frame(
@@ -531,6 +582,7 @@ fn draw<B: Backend>(
             theme,
             padding,
             hidden_rows,
+            loading,
         )
     })?;
     Ok(())
@@ -551,6 +603,7 @@ fn draw_final<B: Backend>(
     theme: &Theme,
     padding: (u16, u16),
     hidden_rows: u16,
+    loading: &HashMap<WidgetId, Shape>,
 ) -> io::Result<()> {
     let mut captured: Option<Rect> = None;
     terminal.draw(|frame| {
@@ -566,6 +619,7 @@ fn draw_final<B: Backend>(
             theme,
             padding,
             hidden_rows,
+            loading,
         );
     })?;
     if let Some(area) = captured
@@ -595,10 +649,13 @@ fn finalize_draw<B: Backend>(
     padding: (u16, u16),
     requested_height: u16,
     viewport_lines: u16,
+    loading: &HashMap<WidgetId, Shape>,
 ) -> io::Result<()> {
     let scrollback_rows = requested_height.saturating_sub(viewport_lines);
     if scrollback_rows == 0 {
-        return draw_final(terminal, root, payloads, specs, registry, theme, padding, 0);
+        return draw_final(
+            terminal, root, payloads, specs, registry, theme, padding, 0, loading,
+        );
     }
     flush_full_to_scrollback(
         terminal,
@@ -610,6 +667,7 @@ fn finalize_draw<B: Backend>(
         padding,
         requested_height,
         viewport_lines,
+        loading,
     )
 }
 
@@ -624,6 +682,7 @@ fn flush_full_to_scrollback<B: Backend>(
     padding: (u16, u16),
     requested_height: u16,
     viewport_lines: u16,
+    loading: &HashMap<WidgetId, Shape>,
 ) -> io::Result<()> {
     let width = terminal.size()?.width;
     let full_buf = render_full_into_buffer(
@@ -635,6 +694,7 @@ fn flush_full_to_scrollback<B: Backend>(
         registry,
         theme,
         padding,
+        loading,
     )?;
     let scrollback_rows = requested_height - viewport_lines;
     terminal.insert_before(scrollback_rows, |buf| {
@@ -674,6 +734,7 @@ fn render_full_into_buffer(
     registry: &render::Registry,
     theme: &Theme,
     padding: (u16, u16),
+    loading: &HashMap<WidgetId, Shape>,
 ) -> io::Result<Buffer> {
     let backend = TestBackend::new(width, height);
     let mut inner = Terminal::new(backend)?;
@@ -681,7 +742,9 @@ fn render_full_into_buffer(
         let area = frame.area();
         paint_viewport_bg(frame, area, theme);
         let content = shrink(area, padding);
-        layout::draw(frame, content, root, payloads, specs, registry, theme);
+        layout::draw(
+            frame, content, root, payloads, specs, registry, theme, loading,
+        );
     })?;
     Ok(inner.backend().buffer().clone())
 }
@@ -724,6 +787,7 @@ fn draw_frame(
     theme: &Theme,
     padding: (u16, u16),
     hidden_rows: u16,
+    loading: &HashMap<WidgetId, Shape>,
 ) {
     // Paint the full area first so the padded band takes the theme bg too — otherwise the
     // terminal bg would show through the padding ring and fight the theme surface.
@@ -739,10 +803,21 @@ fn draw_frame(
             height: 1,
             ..content
         };
-        layout::draw(frame, layout_area, root, payloads, specs, registry, theme);
+        layout::draw(
+            frame,
+            layout_area,
+            root,
+            payloads,
+            specs,
+            registry,
+            theme,
+            loading,
+        );
         render_clip_hint(frame, hint_area, hidden_rows, theme);
     } else {
-        layout::draw(frame, content, root, payloads, specs, registry, theme);
+        layout::draw(
+            frame, content, root, payloads, specs, registry, theme, loading,
+        );
     }
 }
 
@@ -839,6 +914,7 @@ mod tests {
         let backend = TestBackend::new(50, 4);
         let mut terminal = Terminal::new(backend).unwrap();
         let theme = Theme::default();
+        let loading = HashMap::new();
         terminal
             .draw(|f| {
                 draw_frame(
@@ -851,6 +927,7 @@ mod tests {
                     &theme,
                     (0, 0),
                     7,
+                    &loading,
                 )
             })
             .unwrap();
@@ -873,6 +950,7 @@ mod tests {
         let backend = TestBackend::new(50, 3);
         let mut terminal = Terminal::new(backend).unwrap();
         let theme = Theme::default();
+        let loading = HashMap::new();
         terminal
             .draw(|f| {
                 draw_frame(
@@ -885,6 +963,7 @@ mod tests {
                     &theme,
                     (0, 0),
                     0,
+                    &loading,
                 )
             })
             .unwrap();
@@ -942,9 +1021,19 @@ mod tests {
         let specs = HashMap::new();
         let registry = render::Registry::with_builtins();
         let theme = Theme::default();
-        let buf =
-            render_full_into_buffer(20, 6, &root, &payloads, &specs, &registry, &theme, (0, 0))
-                .unwrap();
+        let loading = HashMap::new();
+        let buf = render_full_into_buffer(
+            20,
+            6,
+            &root,
+            &payloads,
+            &specs,
+            &registry,
+            &theme,
+            (0, 0),
+            &loading,
+        )
+        .unwrap();
         assert!(row_text(&buf, 0).starts_with("r0"));
         assert!(row_text(&buf, 5).starts_with("r5"));
     }
@@ -964,6 +1053,7 @@ mod tests {
         let backend = TestBackend::new(20, 10);
         let mut terminal = make_terminal(backend, 4).unwrap();
         let theme = Theme::default();
+        let loading = HashMap::new();
         finalize_draw(
             &mut terminal,
             &root,
@@ -974,6 +1064,7 @@ mod tests {
             (0, 0),
             8,
             4,
+            &loading,
         )
         .unwrap();
         let buf = terminal.backend().buffer().clone();
@@ -1005,6 +1096,7 @@ mod tests {
         let backend = TestBackend::new(20, 10);
         let mut terminal = make_terminal(backend, 3).unwrap();
         let theme = Theme::default();
+        let loading = HashMap::new();
         finalize_draw(
             &mut terminal,
             &root,
@@ -1015,6 +1107,7 @@ mod tests {
             (0, 0),
             3,
             3,
+            &loading,
         )
         .unwrap();
         let buf = terminal.backend().buffer().clone();
@@ -1338,5 +1431,56 @@ mod tests {
         let (valid, invalid) = partition_by_shape_support(&widgets, &shapes, &registry);
         assert_eq!(valid.len(), 3);
         assert!(invalid.is_empty());
+    }
+
+    #[test]
+    fn loop_should_exit_requires_both_axes_to_settle() {
+        // The load axis (daemon) and the render axis (animation) are independent — regression
+        // for the "wait returned as soon as daemon exited, cutting off animation" bug.
+        assert!(
+            loop_should_exit(true, false, false),
+            "daemon done, no animation → exit"
+        );
+        assert!(
+            !loop_should_exit(true, true, false),
+            "animation still playing → keep ticking"
+        );
+        assert!(
+            !loop_should_exit(false, false, false),
+            "daemon still running → wait"
+        );
+        assert!(!loop_should_exit(false, true, false), "both pending → wait");
+        assert!(
+            loop_should_exit(false, true, true),
+            "hard deadline always wins"
+        );
+        assert!(
+            loop_should_exit(true, true, true),
+            "hard deadline always wins"
+        );
+    }
+
+    #[test]
+    fn compute_loading_surfaces_cached_widgets_without_payload() {
+        let cached = vec![widget("pending", "github_my_prs"), widget("ready", "clock")];
+        let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
+        payloads.insert("ready".into(), text_payload("14:00"));
+        let mut shapes: HashMap<WidgetId, Shape> = HashMap::new();
+        shapes.insert("pending".into(), Shape::Entries);
+        shapes.insert("ready".into(), Shape::Text);
+        let loading = compute_loading(&cached, &payloads, &shapes);
+        assert_eq!(loading.len(), 1);
+        assert_eq!(loading.get("pending"), Some(&Shape::Entries));
+        assert!(!loading.contains_key("ready"));
+    }
+
+    #[test]
+    fn has_loading_widget_true_when_any_cached_widget_lacks_payload() {
+        let cached = vec![widget("a", "github_my_prs"), widget("b", "clock")];
+        let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
+        payloads.insert("a".into(), text_payload("x"));
+        assert!(has_loading_widget(&cached, &payloads));
+        payloads.insert("b".into(), text_payload("y"));
+        assert!(!has_loading_widget(&cached, &payloads));
     }
 }


### PR DESCRIPTION
Fixes both loading-phase UX issues from #90.

## Summary

- **Loop exit condition**: the `wait && animated` combo used to break the render loop as soon as the fetch daemon exited, cutting animated widgets (`animated_typewriter`, `animated_postfx`) off at whatever frame happened to be showing. The load axis and render axis are independent — the loop now keeps ticking until both the daemon has exited and the `ANIMATION_WINDOW` has elapsed, subject to the hard deadline. Extracted `loop_should_exit(daemon_done, animation_pending, deadline_reached)` so the invariant is direct-testable.
- **Loading placeholder**: cached widgets whose cache entry hasn't landed used to render as blank slots. New `render::loading::render_loading` draws a centered braille spinner with a dim "loading" label for those slots. The draw chain takes a `loading: HashMap<WidgetId, Shape>` map, recomputed each iteration, so the spinner is swapped off the instant the daemon fills the slot. The presence of any loading widget also forces `animated = true` for the loop — otherwise the spinner would appear to freeze.

Per-shape skeletons (dim rows for `Entries`, flat baseline for `NumberSeries`, empty grid for `Heatmap`, …) are carried as future work — the helper already branches on shape, every arm just falls through to the spinner today.

## Test plan

- [x] `cargo test` — 424 passed (+9 new: loop exit matrix, loading/has_loading helpers, loading spinner integration via `layout::draw`, spinner glyph + label buffer assertion)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widgets now display animated loading spinners when awaiting data, replacing stale content with a visual "loading" indicator for better user feedback during data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->