### PR TITLE
refactor(fetcher): rename project_name/project → git_repo_name/github_repo

### DIFF
--- a/.splashboard/dashboard.toml
+++ b/.splashboard/dashboard.toml
@@ -7,23 +7,23 @@
 # `$HOME/.splashboard/settings.toml` — padding, viewport height, theme preset, etc. belong
 # there so they apply to every dashboard the same user sees.
 #
-# Everything is fetched at draw time — hero + subtitle come from `project_name` +
-# `project` (git origin + GitHub API), stats/activity from git_* / github_* fetchers.
+# Everything is fetched at draw time — hero + subtitle come from `git_repo_name` +
+# `github_repo` (git origin + GitHub API), stats/activity from git_* / github_* fetchers.
 
 # ── Header ───────────────────────────────────────────────────────────
 
 [[widget]]
 id = "hero"
-fetcher = "project_name"
+fetcher = "git_repo_name"
 render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce", duration_ms = 1500, style = "figlet", font = "banner", color = "panel_title", align = "center" }
 
-# Subtitle: `project` emits TextBlock (slug / description / license on their own
-# rows). `text_plain` renders via ratatui's `Paragraph` which centers each line
-# individually, so short lines like "ISC" still sit under the hero centreline
-# instead of hugging the block's left edge.
+# Subtitle: `github_repo` emits TextBlock (slug / description / license on their
+# own rows). `text_plain` renders via ratatui's `Paragraph` which centers each
+# line individually, so short lines like "ISC" still sit under the hero
+# centreline instead of hugging the block's left edge.
 [[widget]]
 id = "subtitle"
-fetcher = "project"
+fetcher = "github_repo"
 render = { type = "text_plain", align = "center" }
 
 [[widget]]
@@ -86,8 +86,8 @@ bg = "subtle"
   [[row.child]]
   widget = "hero"
 
-# Subtitle: 3 stacked lines (slug / description / license) via project's TextBlock
-# shape. Centered on a 70-cell column inside the band.
+# Subtitle: 3 stacked lines (slug / description / license) via github_repo's
+# TextBlock shape. Centered on a 70-cell column inside the band.
 [[row]]
 height = { length = 3 }
 bg = "subtle"

--- a/docs-site/src/content/docs/guides/concepts.md
+++ b/docs-site/src/content/docs/guides/concepts.md
@@ -144,7 +144,7 @@ fetcher that emits that shape can drive it.
 
            clock ──────┐                 ┌────────── text_plain
            basic_static┤                 ├────────── text_ascii
-           project_name┤── Shape::Text ──┤
+           git_repo_name┤── Shape::Text ──┤
            ...         ┤                 ├──── animated_typewriter
                        └─────────────────┘
 

--- a/docs-site/src/content/docs/guides/configuration.md
+++ b/docs-site/src/content/docs/guides/configuration.md
@@ -208,12 +208,12 @@ definitive list.
 
 [[widget]]
 id = "hero"
-fetcher = "project_name"
+fetcher = "git_repo_name"
 render = { type = "text_ascii", style = "figlet", font = "banner", align = "center", color = "panel_title" }
 
 [[widget]]
 id = "subtitle"
-fetcher = "project"
+fetcher = "github_repo"
 render = { type = "text_plain", align = "center" }
 
 [[widget]]

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -157,12 +157,12 @@ Full TOML:
 
 [[widget]]
 id = "hero"
-fetcher = "project_name"
+fetcher = "git_repo_name"
 render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce", duration_ms = 1500, style = "figlet", font = "banner", color = "panel_title", align = "center" }
 
 [[widget]]
 id = "subtitle"
-fetcher = "project"
+fetcher = "github_repo"
 render = { type = "text_plain", align = "center" }
 
 [[widget]]

--- a/src/fetcher/git/mod.rs
+++ b/src/fetcher/git/mod.rs
@@ -20,6 +20,7 @@ mod commits_activity;
 mod contributors;
 mod latest_tag;
 mod recent_commits;
+mod repo_name;
 mod stash_count;
 mod status;
 mod worktrees;
@@ -37,6 +38,7 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(latest_tag::GitLatestTag),
         Arc::new(worktrees::GitWorktrees),
         Arc::new(blame_heatmap::GitBlameHeatmap),
+        Arc::new(repo_name::GitRepoName),
     ]
 }
 

--- a/src/fetcher/git/repo_name.rs
+++ b/src/fetcher/git/repo_name.rs
@@ -1,0 +1,71 @@
+//! `git_repo_name` — repo name as Text, suitable for hero rendering. Derived from the
+//! `origin` remote (or the first configured remote) parsed as `owner/name`; falls back to the
+//! cwd's directory name when no github remote exists so a local-only clone still has a header.
+
+use async_trait::async_trait;
+
+use crate::payload::{Body, Payload, TextData};
+use crate::render::Shape;
+
+use super::super::github::common::slug_from_url;
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{payload, repo_cache_key, text_body};
+
+pub struct GitRepoName;
+
+#[async_trait]
+impl Fetcher for GitRepoName {
+    fn name(&self) -> &str {
+        "git_repo_name"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Text]
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    fn sample_body(&self, _shape: Shape) -> Option<Body> {
+        Some(Body::Text(TextData {
+            value: "splashboard".into(),
+        }))
+    }
+    async fn fetch(&self, _ctx: &FetchContext) -> Result<Payload, FetchError> {
+        Ok(payload(text_body(
+            detect_name().unwrap_or_else(|| "project".into()),
+        )))
+    }
+}
+
+fn detect_name() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    remote_name(&cwd).or_else(|| cwd.file_name().map(|s| s.to_string_lossy().into_owned()))
+}
+
+fn remote_name(cwd: &std::path::Path) -> Option<String> {
+    let repo = gix::discover(cwd).ok()?;
+    let names: Vec<_> = repo.remote_names().into_iter().collect();
+    let preferred = names
+        .iter()
+        .find(|n| n.as_ref() == "origin")
+        .or_else(|| names.first())?;
+    let remote = repo.find_remote(preferred.as_ref()).ok()?;
+    let url = remote.url(gix::remote::Direction::Fetch)?;
+    slug_from_url(&url.to_bstring().to_string()).map(|s| s.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_is_non_empty() {
+        let sample = GitRepoName.sample_body(Shape::Text).unwrap();
+        match sample {
+            Body::Text(d) => assert!(!d.value.is_empty()),
+            _ => panic!("expected text sample"),
+        }
+    }
+}

--- a/src/fetcher/github/mod.rs
+++ b/src/fetcher/github/mod.rs
@@ -23,6 +23,7 @@ mod languages;
 mod my_prs;
 mod notifications;
 mod recent_releases;
+mod repo;
 mod repo_issues;
 mod repo_prs;
 mod repo_stars;
@@ -49,5 +50,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(languages::GithubLanguages),
         Arc::new(avatar::GithubAvatar),
         Arc::new(user::GithubUser),
+        Arc::new(repo::GithubRepo),
     ]
 }

--- a/src/fetcher/github/repo.rs
+++ b/src/fetcher/github/repo.rs
@@ -1,15 +1,8 @@
-//! `project_name` / `project` — identity of the repo you cd'd into.
-//!
-//! - `project_name` is purely local: parses the git remote's `owner/name` (or falls back to the
-//!   cwd's directory name when there's no github remote). Text shape only. No network.
-//! - `project` pulls the full identity triple (`slug`, `description`, `license`) from the GitHub
-//!   REST API `/repos/{o}/{n}`. Safe — the host is hardcoded, so the auth token can only leave
-//!   to a known origin. Entries or Text.
-//!
-//! Both are zero-config: drop them in, they find the repo via the `origin` remote. Useful for
-//! dashboards where the header wants the real project identity instead of a hand-written label.
+//! `github_repo` — identity triple `{ slug, description, license }` sourced from the GitHub
+//! REST API `/repos/{o}/{n}`. Entries shape feeds `grid_table` (inline or rows); Text joins
+//! the non-empty fields with `·` for a compact subtitle.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -18,50 +11,16 @@ use sha2::{Digest, Sha256};
 use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TextData};
 use crate::render::Shape;
 
-use super::github::client::rest_get;
-use super::github::common::{RepoSlug, resolve_repo, slug_from_url};
-use super::{FetchContext, FetchError, Fetcher, Safety};
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::rest_get;
+use super::common::resolve_repo;
 
-/// `project_name` — repo name as Text, suitable for hero rendering. Derived from
-/// `origin` (or the first configured remote) parsed as `owner/name`; falls back to the cwd's
-/// directory name when no remote exists so a fresh local-only clone still has a header.
-pub struct ProjectName;
+pub struct GithubRepo;
 
 #[async_trait]
-impl Fetcher for ProjectName {
+impl Fetcher for GithubRepo {
     fn name(&self) -> &str {
-        "project_name"
-    }
-    fn safety(&self) -> Safety {
-        Safety::Safe
-    }
-    fn shapes(&self) -> &[Shape] {
-        &[Shape::Text]
-    }
-    fn cache_key(&self, _ctx: &FetchContext) -> String {
-        cwd_scoped(self.name())
-    }
-    fn sample_body(&self, _shape: Shape) -> Option<Body> {
-        Some(Body::Text(TextData {
-            value: "splashboard".into(),
-        }))
-    }
-    async fn fetch(&self, _ctx: &FetchContext) -> Result<Payload, FetchError> {
-        Ok(payload(Body::Text(TextData {
-            value: detect_name().unwrap_or_else(|| "project".into()),
-        })))
-    }
-}
-
-/// `project` — identity triple `{ slug, description, license }` sourced from the GitHub REST
-/// API `/repos/{o}/{n}`. Entries shape feeds `grid_table` (inline or rows); Text joins the
-/// non-empty fields with `·` for a compact subtitle.
-pub struct Project;
-
-#[async_trait]
-impl Fetcher for Project {
-    fn name(&self) -> &str {
-        "project"
+        "github_repo"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -179,25 +138,6 @@ impl Metadata {
     }
 }
 
-fn detect_name() -> Option<String> {
-    let cwd = std::env::current_dir().ok()?;
-    slug_from_cwd(&cwd)
-        .map(|s| s.name)
-        .or_else(|| cwd.file_name().map(|s| s.to_string_lossy().into_owned()))
-}
-
-fn slug_from_cwd(cwd: &Path) -> Option<RepoSlug> {
-    let repo = gix::discover(cwd).ok()?;
-    let names: Vec<_> = repo.remote_names().into_iter().collect();
-    let preferred = names
-        .iter()
-        .find(|n| n.as_ref() == "origin")
-        .or_else(|| names.first())?;
-    let remote = repo.find_remote(preferred.as_ref()).ok()?;
-    let url = remote.url(gix::remote::Direction::Fetch)?;
-    slug_from_url(&url.to_bstring().to_string())
-}
-
 fn cwd_scoped(name: &str) -> String {
     let cwd: PathBuf = std::env::current_dir().unwrap_or_default();
     let digest = Sha256::digest(cwd.to_string_lossy().as_bytes());
@@ -271,17 +211,8 @@ mod tests {
     }
 
     #[test]
-    fn project_name_sample_is_non_empty() {
-        let sample = ProjectName.sample_body(Shape::Text).unwrap();
-        match sample {
-            Body::Text(d) => assert!(!d.value.is_empty()),
-            _ => panic!("expected text sample"),
-        }
-    }
-
-    #[test]
-    fn project_sample_entries_has_three_rows() {
-        let sample = Project.sample_body(Shape::Entries).unwrap();
+    fn sample_entries_has_three_rows() {
+        let sample = GithubRepo.sample_body(Shape::Entries).unwrap();
         match sample {
             Body::Entries(d) => assert_eq!(d.items.len(), 3),
             _ => panic!("expected entries sample"),

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -15,7 +15,6 @@ use crate::samples;
 pub mod clock;
 pub mod git;
 pub mod github;
-pub mod project;
 pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
@@ -225,8 +224,6 @@ impl Registry {
         let mut r = Self::default();
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
-        r.register(Arc::new(project::ProjectName));
-        r.register(Arc::new(project::Project));
         r.register(Arc::new(weather::WeatherFetcher));
         for f in clock::realtime_fetchers() {
             r.register_realtime(f);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1385,14 +1385,14 @@ mod tests {
 
     #[test]
     fn derive_shape_prefers_fetcher_primary_when_renderer_accepts_multiple() {
-        // `project` lists shapes as [Entries, TextBlock, Text]; `text_plain` accepts
+        // `github_repo` lists shapes as [Entries, TextBlock, Text]; `text_plain` accepts
         // [Text, TextBlock]. Under the old "renderer-first" rule this picked Text and
         // forced the subtitle back to a one-liner. The new intersection rule picks the
         // fetcher's first accepted shape (TextBlock here) so multi-line fetchers get
         // their natural shape without a per-widget override.
         let registry = Registry::with_builtins();
         let render_registry = render::Registry::with_builtins();
-        let w = widget_with_render("s", "project", Some("text_plain"));
+        let w = widget_with_render("s", "github_repo", Some("text_plain"));
         assert_eq!(
             derive_shape(&w, &registry, &render_registry),
             Some(Shape::TextBlock)

--- a/src/templates/project_github_activity.toml
+++ b/src/templates/project_github_activity.toml
@@ -1,5 +1,5 @@
 # project_github_activity — per-repo preset. Hero is the repo name as a figlet banner
-# (fetched dynamically via `project_name` → git remote origin), subtitle shows the repo
+# (fetched dynamically via `git_repo_name` → git remote origin), subtitle shows the repo
 # slug / description / license. Header band sits on `bg = "subtle"` so it reads as a
 # distinct panel; body pairs languages / releases, PRs / issues, commits / contributors
 # into 2-column rows so the dashboard reads as a tight grid rather than a tall stack.
@@ -12,16 +12,16 @@
 
 [[widget]]
 id = "hero"
-fetcher = "project_name"
+fetcher = "git_repo_name"
 render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce", duration_ms = 1500, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
 
-# Subtitle: `project` emits TextBlock (slug / description / license on their own rows).
+# Subtitle: `github_repo` emits TextBlock (slug / description / license on their own rows).
 # `text_plain` renders via ratatui's `Paragraph` which centers each line individually,
 # so short lines like "ISC" still sit under the hero centreline instead of hugging the
 # block's left edge.
 [[widget]]
 id = "subtitle"
-fetcher = "project"
+fetcher = "github_repo"
 render = { type = "text_plain", align = "center" }
 
 [[widget]]
@@ -81,7 +81,7 @@ bg = "subtle"
   [[row.child]]
   widget = "hero"
 
-# Subtitle: 3 stacked lines (slug / description / license) via project's TextBlock
+# Subtitle: 3 stacked lines (slug / description / license) via github_repo's TextBlock
 # shape. Centered on a 70-cell column inside the band.
 [[row]]
 height = { length = 3 }


### PR DESCRIPTION
## Summary

- `project_name` → `git_repo_name` (moved to `src/fetcher/git/repo_name.rs`, struct `GitRepoName`) — reads the git remote via `gix`, falls back to the cwd basename.
- `project` → `github_repo` (moved to `src/fetcher/github/repo.rs`, struct `GithubRepo`) — hits the GitHub REST API `/repos/{o}/{n}` for the `{ slug, description, license }` triple.
- The `project` prefix didn't reflect what these fetchers do; the names now match their namespace (git/ vs github/) and their underlying source.
- Template `project_github_activity.toml` and the `derive_shape` test in `runtime.rs` follow the new names.

Refs #81 (0.x release scope, DoD ticks for both fetchers).

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test` — rename-specific tests pass; the 2 pre-existing template failures (`"static"` vs `"basic_static"`) reproduce on `main` and are unrelated.
- [x] `cargo xtask` — docs regen produces `git_repo_name.md` / `github_repo.md`, stale `project*.md` removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git repository name detection that automatically identifies the repository name from git remotes or the current directory.
  * Added GitHub repository fetcher for enhanced GitHub project data retrieval.

* **Refactor**
  * Consolidated repository fetching logic and removed legacy project fetcher implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->