### PR TITLE
fix(config): respect $HOME in is_home_dir so Windows CI passes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -340,7 +340,14 @@ fn resolve_from(cwd: &Path, on_cd: bool) -> Option<DashboardSource> {
 }
 
 fn is_home_dir(path: &Path) -> bool {
-    let Some(home) = dirs::home_dir() else {
+    // Respect `HOME` first so the test suite can redirect the home dir on any platform.
+    // On Windows, `dirs::home_dir()` consults `SHGetKnownFolderPath(FOLDERID_Profile)` and
+    // ignores env vars; checking `HOME` keeps behavior aligned with shells that set it
+    // (git-bash, MSYS, WSL, configured PowerShell profiles).
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir);
+    let Some(home) = home else {
         return false;
     };
     canonicalize_or(path) == canonicalize_or(&home)


### PR DESCRIPTION
## Summary
- Windows CI on `main` is red: `config::tests::on_cd_fires_home_at_home_dir` panics at the `unwrap()` in `resolve_from(tmp.path(), true)` ([run 24869349791](https://github.com/unhappychoice/splashboard/actions/runs/24869349791)).
- Root cause: `is_home_dir` compared CWD against `dirs::home_dir()`, which on Windows calls `SHGetKnownFolderPath(FOLDERID_Profile)` and ignores the `HOME` env var — so the test's `set_var("HOME", ...)` had no effect and `is_home_dir` returned false, making `resolve_from` return `None` under `on_cd = true`.
- Fix: consult `HOME` first in `is_home_dir`, falling back to `dirs::home_dir()`. Also aligns with shells that do set `HOME` on Windows (git-bash, MSYS, WSL, PowerShell profiles that source one).

## Test plan
- [x] `cargo test --lib config::tests` (local, Linux)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI green on windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home directory detection to properly respect the `HOME` environment variable, ensuring consistent behavior across different shell environments and test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->