### PR TITLE
feat(render): signature opening animations for home_splash hero

### DIFF
--- a/.splashboard/dashboard.toml
+++ b/.splashboard/dashboard.toml
@@ -15,7 +15,7 @@
 [[widget]]
 id = "hero"
 fetcher = "git_repo_name"
-render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce", duration_ms = 1500, style = "figlet", font = "banner", color = "panel_title", align = "center" }
+render = { type = "text_ascii", style = "figlet", font = "banner", color = "panel_title", align = "center" }
 
 # Subtitle: `github_repo` emits TextBlock (slug / description / license on their
 # own rows). `text_plain` renders via ratatui's `Paragraph` which centers each

--- a/docs-site/src/content/docs/guides/concepts/renderer.md
+++ b/docs-site/src/content/docs/guides/concepts/renderer.md
@@ -32,7 +32,7 @@ follow a `family_variant` convention so siblings cluster: `text_plain`
 `grid_table` / `grid_calendar` / `grid_heatmap`, `list_plain` /
 `list_timeline`, `status_badge`, `media_image`,
 `animated_typewriter` / `animated_postfx` /
-`animated_figlet_morph` / `animated_boot`.
+`animated_figlet_morph` / `animated_boot` / `animated_scanlines`.
 
 The convention extends beyond renderers — theme token names, preset
 names, fetcher names all follow it. No standalone public tokens that
@@ -61,10 +61,13 @@ multi-frame loop so the animation actually plays.
 
 `animated_typewriter` (character-by-character reveal),
 `animated_postfx` (tachyonfx-powered sweep / fade / coalesce /
-`stagger_reveal` / `matrix_rain` / `particle_burst`),
-`animated_figlet_morph` (figlet-font sequence crossfade), and
-`animated_boot` (boot-log scroll then hero) return `true`. Everything
-else stays `false` — the splash paints once and exits.
+`stagger_reveal` / `matrix_rain` / `particle_burst` / `bounce_in` /
+`elastic_in` / `checkerboard_in` / `neon_flash`),
+`animated_figlet_morph` (figlet-font sequence crossfade),
+`animated_boot` (boot-log scroll then hero), and
+`animated_scanlines` (CRT-style horizontal scanline sweep) return
+`true`. Everything else stays `false` — the splash paints once and
+exits.
 
 ### `render(…)` — the draw
 
@@ -100,10 +103,10 @@ Most renderers draw single-line or fixed output and stick with the
 default `1`. A row with `height = "auto"` asks its child's renderer
 how tall it wants to be, given the row's width. `text_ascii` overrides
 to report the wrapped figlet block height so multi-word heroes get a
-row sized to fit; `animated_postfx` / `animated_boot` delegate to
-their inner renderer via the `registry`, and
-`animated_figlet_morph` asks `text_ascii` for the tallest height
-across its font sequence so earlier phases never clip.
+row sized to fit; `animated_postfx` / `animated_boot` /
+`animated_scanlines` delegate to their inner renderer via the
+`registry`, and `animated_figlet_morph` asks `text_ascii` for the
+tallest height across its font sequence so earlier phases never clip.
 
 ## `RenderOptions`
 
@@ -186,8 +189,13 @@ renderer would have drawn without the wrapper.
   render.
 - `particle_burst` — particles radiate in from the centre and resolve
   into the inner render. The default for `home_splash`'s hero.
+- `bounce_in` / `elastic_in` — bounce / spring timing curves for a
+  playful arrival.
+- `checkerboard_in` — tile-by-tile fade-in on a checker grid.
+- `neon_flash` — a bright hue / lightness pulse that settles back into
+  the theme colour; for a "neon sign warming up" vibe.
 
-Two sibling renderers bring their own timeline instead of a tachyonfx
+Three sibling renderers bring their own timeline instead of a tachyonfx
 pattern:
 
 - `animated_figlet_morph` — steps `text_ascii` through a sequence of
@@ -196,6 +204,9 @@ pattern:
 - `animated_boot` — scrolls a list of `[ OK ] …` boot-log lines during
   the first ~70% of the window, then hands off to the inner renderer
   for the resting frame. Best on tall hero cells (8+ rows).
+- `animated_scanlines` — CRT-style horizontal scanline sweeps down the
+  widget cell, revealing the inner render as it passes. Rows below the
+  scanline stay blank until the line reaches them.
 
 The inner renderer keeps its own option schema; options pass through
 untouched.

--- a/docs-site/src/content/docs/guides/concepts/renderer.md
+++ b/docs-site/src/content/docs/guides/concepts/renderer.md
@@ -32,7 +32,8 @@ follow a `family_variant` convention so siblings cluster: `text_plain`
 `grid_table` / `grid_calendar` / `grid_heatmap`, `list_plain` /
 `list_timeline`, `status_badge`, `media_image`,
 `animated_typewriter` / `animated_postfx` /
-`animated_figlet_morph` / `animated_boot` / `animated_scanlines`.
+`animated_figlet_morph` / `animated_boot` / `animated_scanlines` /
+`animated_splitflap` / `animated_wave`.
 
 The convention extends beyond renderers — theme token names, preset
 names, fetcher names all follow it. No standalone public tokens that
@@ -62,10 +63,12 @@ multi-frame loop so the animation actually plays.
 `animated_typewriter` (character-by-character reveal),
 `animated_postfx` (tachyonfx-powered sweep / fade / coalesce /
 `stagger_reveal` / `matrix_rain` / `particle_burst` / `bounce_in` /
-`elastic_in` / `checkerboard_in` / `neon_flash`),
+`elastic_in` / `checkerboard_in` / `neon_flash` / `glitch_in`),
 `animated_figlet_morph` (figlet-font sequence crossfade),
-`animated_boot` (boot-log scroll then hero), and
-`animated_scanlines` (CRT-style horizontal scanline sweep) return
+`animated_boot` (boot-log scroll then hero),
+`animated_scanlines` (CRT-style horizontal scanline sweep),
+`animated_splitflap` (departure-board per-cell letter cycling), and
+`animated_wave` (vertical crest travels left-to-right) return
 `true`. Everything else stays `false` — the splash paints once and
 exits.
 
@@ -104,9 +107,10 @@ default `1`. A row with `height = "auto"` asks its child's renderer
 how tall it wants to be, given the row's width. `text_ascii` overrides
 to report the wrapped figlet block height so multi-word heroes get a
 row sized to fit; `animated_postfx` / `animated_boot` /
-`animated_scanlines` delegate to their inner renderer via the
-`registry`, and `animated_figlet_morph` asks `text_ascii` for the
-tallest height across its font sequence so earlier phases never clip.
+`animated_scanlines` / `animated_splitflap` / `animated_wave`
+delegate to their inner renderer via the `registry`, and
+`animated_figlet_morph` asks `text_ascii` for the tallest height
+across its font sequence so earlier phases never clip.
 
 ## `RenderOptions`
 
@@ -194,8 +198,10 @@ renderer would have drawn without the wrapper.
 - `checkerboard_in` — tile-by-tile fade-in on a checker grid.
 - `neon_flash` — a bright hue / lightness pulse that settles back into
   the theme colour; for a "neon sign warming up" vibe.
+- `glitch_in` — scrambles a fraction of cells with broken-signal glyphs
+  during the window, then releases into the clean inner render.
 
-Three sibling renderers bring their own timeline instead of a tachyonfx
+Five sibling renderers bring their own timeline instead of a tachyonfx
 pattern:
 
 - `animated_figlet_morph` — steps `text_ascii` through a sequence of
@@ -207,6 +213,12 @@ pattern:
 - `animated_scanlines` — CRT-style horizontal scanline sweeps down the
   widget cell, revealing the inner render as it passes. Rows below the
   scanline stay blank until the line reaches them.
+- `animated_splitflap` — departures-board aesthetic; every non-blank
+  cell cycles through `A-Z / 0-9 / punctuation` and lands on its final
+  glyph at a position-dependent settle time. Left columns land first.
+- `animated_wave` — a bright vertical crest sweeps left-to-right across
+  the cell; columns ahead of the crest stay blank, columns behind are
+  revealed, and the crest column itself is highlighted with the accent.
 
 The inner renderer keeps its own option schema; options pass through
 untouched.

--- a/docs-site/src/content/docs/guides/concepts/renderer.md
+++ b/docs-site/src/content/docs/guides/concepts/renderer.md
@@ -31,7 +31,8 @@ follow a `family_variant` convention so siblings cluster: `text_plain`
 `chart_line` / `chart_pie` / `chart_scatter` / `chart_sparkline`,
 `grid_table` / `grid_calendar` / `grid_heatmap`, `list_plain` /
 `list_timeline`, `status_badge`, `media_image`,
-`animated_typewriter` / `animated_postfx`.
+`animated_typewriter` / `animated_postfx` /
+`animated_figlet_morph` / `animated_boot`.
 
 The convention extends beyond renderers — theme token names, preset
 names, fetcher names all follow it. No standalone public tokens that
@@ -58,10 +59,12 @@ within a single draw cycle. Consulted by the runtime: any `true`
 upgrades the draw phase from a one-shot paint to a 2-second
 multi-frame loop so the animation actually plays.
 
-`animated_typewriter` (character-by-character reveal) and
-`animated_postfx` (tachyonfx-powered sweep / fade / coalesce) return
-`true`. Everything else stays `false` — the splash paints once and
-exits.
+`animated_typewriter` (character-by-character reveal),
+`animated_postfx` (tachyonfx-powered sweep / fade / coalesce /
+`stagger_reveal` / `matrix_rain` / `particle_burst`),
+`animated_figlet_morph` (figlet-font sequence crossfade), and
+`animated_boot` (boot-log scroll then hero) return `true`. Everything
+else stays `false` — the splash paints once and exits.
 
 ### `render(…)` — the draw
 
@@ -97,8 +100,10 @@ Most renderers draw single-line or fixed output and stick with the
 default `1`. A row with `height = "auto"` asks its child's renderer
 how tall it wants to be, given the row's width. `text_ascii` overrides
 to report the wrapped figlet block height so multi-word heroes get a
-row sized to fit; `animated_postfx` delegates to its inner renderer
-via the `registry`.
+row sized to fit; `animated_postfx` / `animated_boot` delegate to
+their inner renderer via the `registry`, and
+`animated_figlet_morph` asks `text_ascii` for the tallest height
+across its font sequence so earlier phases never clip.
 
 ## `RenderOptions`
 
@@ -157,7 +162,7 @@ layout logic:
 [[widget]]
 id = "hero"
 fetcher = "system"
-render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce",
+render = { type = "animated_postfx", inner = "text_ascii", effect = "particle_burst",
            duration_ms = 1500, style = "figlet", font = "ansi_shadow", align = "center" }
 ```
 
@@ -167,6 +172,30 @@ The outer `animated_postfx` carries the effect parameters
 calls the inner renderer for the frozen frame, then applies the
 effect shader on top. The final rested frame is whatever the inner
 renderer would have drawn without the wrapper.
+
+`animated_postfx` ships with a menu of effect names (full list in the
+[renderer reference](/splashboard/reference/renderers/animated/animated_postfx/)):
+
+- `fade_in` / `fade_out` / `dissolve` / `coalesce` / `hsl_shift` — stock
+  tachyonfx reveals.
+- `sweep_in` / `sweep_in_right` / `sweep_in_down` / `sweep_in_up` /
+  `slide_in*` — directional wipes.
+- `stagger_reveal` / `stagger_reveal_radial` — per-cell diagonal /
+  radial fade-in, calm enough for daily-use presets.
+- `matrix_rain` — random glyphs rain and dissolve into the underlying
+  render.
+- `particle_burst` — particles radiate in from the centre and resolve
+  into the inner render. The default for `home_splash`'s hero.
+
+Two sibling renderers bring their own timeline instead of a tachyonfx
+pattern:
+
+- `animated_figlet_morph` — steps `text_ascii` through a sequence of
+  figlet fonts (`small` → `banner` → `ansi_shadow` by default) with a
+  short crossfade between phases. The final font is the resting frame.
+- `animated_boot` — scrolls a list of `[ OK ] …` boot-log lines during
+  the first ~70% of the window, then hands off to the inner renderer
+  for the resting frame. Best on tall hero cells (8+ rows).
 
 The inner renderer keeps its own option schema; options pass through
 untouched.

--- a/docs-site/src/content/docs/guides/concepts/shape.md
+++ b/docs-site/src/content/docs/guides/concepts/shape.md
@@ -33,7 +33,7 @@ every fetcher emitting it.
 
 | shape | default renderer | also accepted by | used for |
 |---|---|---|---|
-| [`Text`](#text) | `text_plain` | `text_ascii`, `animated_typewriter`, `animated_postfx` | single-string values |
+| [`Text`](#text) | `text_plain` | `text_ascii`, `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`, `animated_boot` | single-string values |
 | [`TextBlock`](#textblock) | `text_plain` | `list_plain` | zero or more lines |
 | [`Entries`](#entries) | `grid_table` | — | key / value rows |
 | [`Ratio`](#ratio) | `gauge_circle` | `gauge_line` | a `0..=1` progress |
@@ -63,7 +63,8 @@ Body::Text(TextData { value: String })
 ```
 
 Renderers: `text_plain` (default), `text_ascii` (figlet / block letters),
-`animated_typewriter`, `animated_postfx`.
+`animated_typewriter`, `animated_postfx`, `animated_figlet_morph`,
+`animated_boot`.
 
 Typical fetchers: `clock`, `clock_derived`, `git_repo_name`, `git_status`,
 `github_repo_stars`, `basic_static`.

--- a/docs-site/src/content/docs/guides/concepts/shape.md
+++ b/docs-site/src/content/docs/guides/concepts/shape.md
@@ -33,7 +33,7 @@ every fetcher emitting it.
 
 | shape | default renderer | also accepted by | used for |
 |---|---|---|---|
-| [`Text`](#text) | `text_plain` | `text_ascii`, `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`, `animated_boot` | single-string values |
+| [`Text`](#text) | `text_plain` | `text_ascii`, `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`, `animated_boot`, `animated_scanlines` | single-string values |
 | [`TextBlock`](#textblock) | `text_plain` | `list_plain` | zero or more lines |
 | [`Entries`](#entries) | `grid_table` | — | key / value rows |
 | [`Ratio`](#ratio) | `gauge_circle` | `gauge_line` | a `0..=1` progress |
@@ -64,7 +64,7 @@ Body::Text(TextData { value: String })
 
 Renderers: `text_plain` (default), `text_ascii` (figlet / block letters),
 `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`,
-`animated_boot`.
+`animated_boot`, `animated_scanlines`.
 
 Typical fetchers: `clock`, `clock_derived`, `git_repo_name`, `git_status`,
 `github_repo_stars`, `basic_static`.

--- a/docs-site/src/content/docs/guides/concepts/shape.md
+++ b/docs-site/src/content/docs/guides/concepts/shape.md
@@ -33,7 +33,7 @@ every fetcher emitting it.
 
 | shape | default renderer | also accepted by | used for |
 |---|---|---|---|
-| [`Text`](#text) | `text_plain` | `text_ascii`, `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`, `animated_boot`, `animated_scanlines` | single-string values |
+| [`Text`](#text) | `text_plain` | `text_ascii`, `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`, `animated_boot`, `animated_scanlines`, `animated_splitflap`, `animated_wave` | single-string values |
 | [`TextBlock`](#textblock) | `text_plain` | `list_plain` | zero or more lines |
 | [`Entries`](#entries) | `grid_table` | — | key / value rows |
 | [`Ratio`](#ratio) | `gauge_circle` | `gauge_line` | a `0..=1` progress |
@@ -64,7 +64,8 @@ Body::Text(TextData { value: String })
 
 Renderers: `text_plain` (default), `text_ascii` (figlet / block letters),
 `animated_typewriter`, `animated_postfx`, `animated_figlet_morph`,
-`animated_boot`, `animated_scanlines`.
+`animated_boot`, `animated_scanlines`, `animated_splitflap`,
+`animated_wave`.
 
 Typical fetchers: `clock`, `clock_derived`, `git_repo_name`, `git_status`,
 `github_repo_stars`, `basic_static`.

--- a/docs-site/src/content/docs/guides/concepts/widget.md
+++ b/docs-site/src/content/docs/guides/concepts/widget.md
@@ -127,7 +127,8 @@ the user's prompt.
 Most renderers produce the same output every frame, so splashboard
 paints once and exits. When a widget's renderer declares
 `animates() = true` (`animated_postfx`, `animated_typewriter`,
-`animated_figlet_morph`, `animated_boot`, `animated_scanlines`), the
+`animated_figlet_morph`, `animated_boot`, `animated_scanlines`,
+`animated_splitflap`, `animated_wave`), the
 runtime upgrades the draw phase into a multi-frame loop capped at
 `ANIMATION_WINDOW` (2 seconds). The final frame is left static, so
 the splash rests at the effect's end state rather than mid-motion.

--- a/docs-site/src/content/docs/guides/concepts/widget.md
+++ b/docs-site/src/content/docs/guides/concepts/widget.md
@@ -127,7 +127,7 @@ the user's prompt.
 Most renderers produce the same output every frame, so splashboard
 paints once and exits. When a widget's renderer declares
 `animates() = true` (`animated_postfx`, `animated_typewriter`,
-`animated_figlet_morph`, `animated_boot`), the
+`animated_figlet_morph`, `animated_boot`, `animated_scanlines`), the
 runtime upgrades the draw phase into a multi-frame loop capped at
 `ANIMATION_WINDOW` (2 seconds). The final frame is left static, so
 the splash rests at the effect's end state rather than mid-motion.

--- a/docs-site/src/content/docs/guides/concepts/widget.md
+++ b/docs-site/src/content/docs/guides/concepts/widget.md
@@ -126,7 +126,8 @@ the user's prompt.
 
 Most renderers produce the same output every frame, so splashboard
 paints once and exits. When a widget's renderer declares
-`animates() = true` (`animated_postfx`, `animated_typewriter`), the
+`animates() = true` (`animated_postfx`, `animated_typewriter`,
+`animated_figlet_morph`, `animated_boot`), the
 runtime upgrades the draw phase into a multi-frame loop capped at
 `ANIMATION_WINDOW` (2 seconds). The final frame is left static, so
 the splash rests at the effect's end state rather than mid-motion.

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -31,7 +31,7 @@ clock, and the date.
 
 | role | implementation |
 |---|---|
-| hero | `system` (kind = terminal) → `text_ascii` (figlet, ansi_shadow), wrapped in `animated_postfx` (sweep_in) |
+| hero | `system` (kind = terminal) → `text_ascii` (figlet, ansi_shadow), wrapped in `animated_postfx` (particle_burst) |
 | greeting | `basic_static "good "` + `clock_derived` (kind = time_of_day) → `text_plain` |
 | clock | `clock` (format `%H:%M`) → `text_ascii` (figlet, standard), wrapped in `animated_postfx` (fade_in) |
 | date | `clock` (format `%A · %e %B %Y`) → `text_plain` |
@@ -92,7 +92,7 @@ issues, languages breakdown, recent releases.
 
 | role | implementation |
 |---|---|
-| hero | `git_repo_name` → `text_ascii` (figlet, ansi_shadow), wrapped in `animated_postfx` (coalesce) |
+| hero | `git_repo_name` → `text_ascii` (figlet, ansi_shadow) |
 | subtitle | `github_repo` (slug / description / license) → `text_plain` |
 | repo stats | `github_repo_stars` → `grid_table` (inline) |
 | languages | `github_languages` → `chart_bar` (horizontal) |

--- a/src/install/preview.rs
+++ b/src/install/preview.rs
@@ -17,7 +17,9 @@ use crate::fetcher::{RegisteredFetcher, Registry as FetcherRegistry};
 use crate::layout as layout_engine;
 use crate::layout::WidgetId;
 use crate::payload::{Body, ImageData, Payload, TextBlockData, TextData};
-use crate::render::{Registry as RenderRegistry, RenderSpec, Shape, default_renderer_for};
+use crate::render::{
+    Registry as RenderRegistry, RenderOptions, RenderSpec, Shape, default_renderer_for,
+};
 use crate::samples;
 use crate::theme::Theme;
 
@@ -186,6 +188,47 @@ fn deanimate(spec: RenderSpec) -> RenderSpec {
             type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
             options: options.clone(),
         },
+        RenderSpec::Short(ref name) if name == "animated_boot" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_boot" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
+        // animated_figlet_morph's resting frame = text_ascii with the sequence's last font.
+        // No inner knob here — the renderer always delegates to text_ascii — so swap in a
+        // matching text_ascii spec for the preview.
+        RenderSpec::Short(ref name) if name == "animated_figlet_morph" => RenderSpec::Full {
+            type_name: "text_ascii".into(),
+            options: RenderOptions {
+                style: Some("figlet".into()),
+                font: Some("ansi_shadow".into()),
+                ..RenderOptions::default()
+            },
+        },
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_figlet_morph" => {
+            let resting_font = options
+                .font_sequence
+                .as_ref()
+                .and_then(|seq| seq.last().cloned())
+                .unwrap_or_else(|| "ansi_shadow".into());
+            RenderSpec::Full {
+                type_name: "text_ascii".into(),
+                options: RenderOptions {
+                    style: Some("figlet".into()),
+                    font: Some(resting_font),
+                    color: options.color.clone(),
+                    align: options.align.clone(),
+                    ..RenderOptions::default()
+                },
+            }
+        }
         other => other,
     }
 }

--- a/src/install/preview.rs
+++ b/src/install/preview.rs
@@ -208,6 +208,26 @@ fn deanimate(spec: RenderSpec) -> RenderSpec {
             type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
             options: options.clone(),
         },
+        RenderSpec::Short(ref name) if name == "animated_splitflap" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_splitflap" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
+        RenderSpec::Short(ref name) if name == "animated_wave" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_wave" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
         // animated_figlet_morph's resting frame = text_ascii with the sequence's last font.
         // No inner knob here — the renderer always delegates to text_ascii — so swap in a
         // matching text_ascii spec for the preview.

--- a/src/install/preview.rs
+++ b/src/install/preview.rs
@@ -198,6 +198,16 @@ fn deanimate(spec: RenderSpec) -> RenderSpec {
             type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
             options: options.clone(),
         },
+        RenderSpec::Short(ref name) if name == "animated_scanlines" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_scanlines" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
         // animated_figlet_morph's resting frame = text_ascii with the sequence's last font.
         // No inner knob here — the renderer always delegates to text_ascii — so swap in a
         // matching text_ascii spec for the preview.

--- a/src/render/animated_boot.rs
+++ b/src/render/animated_boot.rs
@@ -1,0 +1,290 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::options::OptionSchema;
+use crate::payload::Body;
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::TEXT, theme::TEXT_SECONDARY, theme::STATUS_OK];
+
+const DEFAULT_DURATION_MS: u64 = 1800;
+
+const BOOT_SHARE: f32 = 0.70;
+
+const DEFAULT_LINES: &[&str] = &[
+    "mounting /splash",
+    "loading theme",
+    "connecting terminal",
+    "starting splashboard",
+    "ready",
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "inner",
+        type_hint: "renderer name (e.g. \"text_ascii\")",
+        required: false,
+        default: Some("shape default renderer"),
+        description: "Renderer drawn once the boot sequence completes. Falls back to the shape's natural default.",
+    },
+    OptionSchema {
+        name: "boot_lines",
+        type_hint: "array of short strings",
+        required: false,
+        default: Some("a built-in `[ OK ] ...` list"),
+        description: "Boot-log lines scrolled in one by one. Each line is prefixed with a green `[ OK ]` automatically; keep each string short enough to fit the widget width.",
+    },
+    OptionSchema {
+        name: "duration_ms",
+        type_hint: "milliseconds (u64)",
+        required: false,
+        default: Some("1800"),
+        description: "Total duration. The boot log scrolls during the first ~70% and the inner render takes over for the remainder — stays inside the 2s ANIMATION_WINDOW.",
+    },
+];
+
+/// Retro boot-log reveal. Scrolls a series of `[ OK ] ...` lines into the widget, then clears
+/// and hands off to the inner renderer so the final frame looks like a static hero. Best used
+/// on a tall hero cell (8+ rows) — shorter cells truncate the log.
+///
+/// Accepts every shape: the actual compatibility check is delegated to the resolved inner
+/// renderer. The inner renderer is what shows once the boot log finishes.
+pub struct AnimatedBootRenderer;
+
+const ALL_SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::PointSeries,
+    Shape::Bars,
+    Shape::Image,
+    Shape::Calendar,
+    Shape::Heatmap,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+impl Renderer for AnimatedBootRenderer {
+    fn name(&self) -> &str {
+        "animated_boot"
+    }
+    fn accepts(&self) -> &[Shape] {
+        ALL_SHAPES
+    }
+    fn animates(&self) -> bool {
+        true
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        registry: &Registry,
+    ) {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            draw_inline_error(
+                frame,
+                area,
+                &format!("unknown inner renderer: {inner_name}"),
+            );
+            return;
+        };
+        if !inner.accepts().contains(&shape) {
+            draw_inline_error(
+                frame,
+                area,
+                &format!("inner {inner_name} cannot display {shape:?}"),
+            );
+            return;
+        }
+
+        let total = opts.duration_ms.unwrap_or(DEFAULT_DURATION_MS).max(1) as u32;
+        let elapsed = elapsed_since_start_ms();
+        let boot_ms = (total as f32 * BOOT_SHARE) as u32;
+        let lines = boot_lines(opts);
+        if elapsed >= boot_ms || lines.is_empty() {
+            inner.render(frame, area, body, &inner_options(opts), theme, registry);
+            return;
+        }
+        draw_boot_log(frame, area, &lines, elapsed, boot_ms, theme);
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        max_width: u16,
+        registry: &Registry,
+    ) -> u16 {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            return 1;
+        };
+        inner.natural_height(body, &inner_options(opts), max_width, registry)
+    }
+}
+
+fn draw_boot_log(
+    frame: &mut Frame,
+    area: Rect,
+    lines: &[String],
+    elapsed_ms: u32,
+    boot_ms: u32,
+    theme: &Theme,
+) {
+    let progress = (elapsed_ms as f32 / boot_ms.max(1) as f32).clamp(0.0, 1.0);
+    let visible_count = ((progress * lines.len() as f32).ceil() as usize).min(lines.len());
+    if visible_count == 0 {
+        return;
+    }
+    let ok_style = Style::default()
+        .fg(theme.status_ok)
+        .add_modifier(Modifier::BOLD);
+    let body_style = Style::default().fg(theme.text_secondary);
+    let rendered: Vec<Line> = lines
+        .iter()
+        .take(visible_count)
+        .map(|l| {
+            Line::from(vec![
+                Span::styled("[ OK ] ", ok_style),
+                Span::styled(l.clone(), body_style),
+            ])
+        })
+        .collect();
+
+    let content_height = rendered.len() as u16;
+    let chunks = Layout::vertical([
+        Constraint::Fill(1),
+        Constraint::Length(content_height.min(area.height)),
+        Constraint::Fill(1),
+    ])
+    .split(area);
+    let p = Paragraph::new(rendered).alignment(Alignment::Left);
+    frame.render_widget(p, chunks[1]);
+}
+
+fn boot_lines(opts: &RenderOptions) -> Vec<String> {
+    match opts.boot_lines.as_ref() {
+        Some(list) => list.clone(),
+        None => DEFAULT_LINES.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn inner_options(opts: &RenderOptions) -> RenderOptions {
+    RenderOptions {
+        inner: None,
+        effect: None,
+        duration_ms: None,
+        boot_lines: None,
+        font_sequence: None,
+        ..opts.clone()
+    }
+}
+
+fn draw_inline_error(frame: &mut Frame, area: Rect, msg: &str) {
+    frame.render_widget(Paragraph::new(msg), area);
+}
+
+fn elapsed_since_start_ms() -> u32 {
+    let elapsed = process_start().elapsed().as_millis();
+    elapsed.min(u32::MAX as u128) as u32
+}
+
+fn process_start() -> Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    *START.get_or_init(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, TextData};
+    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+
+    #[test]
+    fn boot_lines_falls_back_to_default_when_none() {
+        let opts = RenderOptions::default();
+        assert_eq!(boot_lines(&opts).len(), DEFAULT_LINES.len());
+    }
+
+    #[test]
+    fn boot_lines_respects_empty_override() {
+        let opts = RenderOptions {
+            boot_lines: Some(vec![]),
+            ..RenderOptions::default()
+        };
+        assert!(boot_lines(&opts).is_empty());
+    }
+
+    #[test]
+    fn inner_options_strips_boot_fields() {
+        let opts = RenderOptions {
+            inner: Some("text_ascii".into()),
+            effect: Some("fade_in".into()),
+            duration_ms: Some(1500),
+            boot_lines: Some(vec!["a".into()]),
+            font_sequence: Some(vec!["small".into()]),
+            style: Some("figlet".into()),
+            ..RenderOptions::default()
+        };
+        let inner = inner_options(&opts);
+        assert!(inner.inner.is_none());
+        assert!(inner.effect.is_none());
+        assert!(inner.duration_ms.is_none());
+        assert!(inner.boot_lines.is_none());
+        assert!(inner.font_sequence.is_none());
+        assert_eq!(inner.style.as_deref(), Some("figlet"));
+    }
+
+    #[test]
+    fn renders_without_panic() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "hello".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_boot".into(),
+            options: RenderOptions {
+                inner: Some("text_ascii".into()),
+                style: Some("figlet".into()),
+                font: Some("standard".into()),
+                duration_ms: Some(400),
+                ..RenderOptions::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        let _ = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 60, 12);
+    }
+}

--- a/src/render/animated_figlet_morph.rs
+++ b/src/render/animated_figlet_morph.rs
@@ -1,0 +1,245 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ratatui::{Frame, layout::Rect, style::Color};
+use tachyonfx::{Duration as FxDuration, Effect, EffectRenderer, EffectTimer, Interpolation, fx};
+
+use crate::options::OptionSchema;
+use crate::payload::Body;
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::TEXT, theme::PANEL_TITLE];
+
+const DEFAULT_DURATION_MS: u64 = 1800;
+
+const DEFAULT_SEQUENCE: &[&str] = &["small", "banner", "ansi_shadow"];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "font_sequence",
+        type_hint: "array of font names (e.g. [\"small\", \"banner\", \"ansi_shadow\"])",
+        required: false,
+        default: Some("[\"small\", \"banner\", \"ansi_shadow\"]"),
+        description: "Figlet fonts to step through. Each phase renders the text in the next font and quickly crossfades to the one after. The final entry is what the static resting frame shows — pick the font you'd normally use for the hero.",
+    },
+    OptionSchema {
+        name: "duration_ms",
+        type_hint: "milliseconds (u64)",
+        required: false,
+        default: Some("1800"),
+        description: "Total morph duration across every phase. Split evenly between phases; kept short so the motion lands inside the 2s ANIMATION_WINDOW.",
+    },
+    OptionSchema {
+        name: "color",
+        type_hint: "theme token name (e.g. \"panel_title\", \"text\")",
+        required: false,
+        default: Some("\"text\""),
+        description: "Foreground colour token forwarded to text_ascii. Any `[theme]` key name is accepted.",
+    },
+    OptionSchema {
+        name: "align",
+        type_hint: "\"left\" | \"center\" | \"right\"",
+        required: false,
+        default: Some("\"left\""),
+        description: "Horizontal alignment forwarded to text_ascii.",
+    },
+];
+
+/// Animated hero that steps the text through a sequence of figlet fonts, letting each phase
+/// crossfade into the next. The last font is the resting frame — once the window closes the
+/// output matches what a plain `text_ascii { style = "figlet", font = <last> }` would produce.
+///
+/// Delegates rendering to `text_ascii` with a per-phase `font` override, so the same figlet
+/// word-wrap + alignment logic is reused. Only `Text` is supported.
+pub struct AnimatedFigletMorphRenderer;
+
+impl Renderer for AnimatedFigletMorphRenderer {
+    fn name(&self) -> &str {
+        "animated_figlet_morph"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::Text]
+    }
+    fn animates(&self) -> bool {
+        true
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        registry: &Registry,
+    ) {
+        render_morph(frame, area, body, opts, theme, registry);
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        max_width: u16,
+        registry: &Registry,
+    ) -> u16 {
+        let Some(text_ascii) = registry.get("text_ascii") else {
+            return 1;
+        };
+        // Height is whatever the tallest font in the sequence would need — otherwise the
+        // widget's row would be sized for the resting font and the earlier phases would clip.
+        sequence(opts)
+            .iter()
+            .map(|font| {
+                let forwarded = text_ascii_opts(opts, font);
+                text_ascii.natural_height(body, &forwarded, max_width, registry)
+            })
+            .max()
+            .unwrap_or(1)
+    }
+}
+
+fn render_morph(
+    frame: &mut Frame,
+    area: Rect,
+    body: &Body,
+    opts: &RenderOptions,
+    theme: &Theme,
+    registry: &Registry,
+) {
+    let Some(text_ascii) = registry.get("text_ascii") else {
+        return;
+    };
+    let seq = sequence(opts);
+    let total = opts.duration_ms.unwrap_or(DEFAULT_DURATION_MS).max(1) as u32;
+    let elapsed = elapsed_since_start_ms();
+    let (phase, phase_elapsed, phase_len) = phase_for(elapsed, total, seq.len());
+    let font = seq[phase];
+    let forwarded = text_ascii_opts(opts, font);
+    text_ascii.render(frame, area, body, &forwarded, theme, registry);
+
+    if elapsed >= total {
+        return;
+    }
+    // Crossfade window inside each phase: fade_in at the start, fade_out at the end. The
+    // resting phase (last) skips the fade_out so the final frame is a clean static render.
+    let fade_ms = phase_len.min(260);
+    if phase_elapsed < fade_ms {
+        let mut effect = fx::fade_from_fg(
+            Color::Black,
+            EffectTimer::from_ms(fade_ms, Interpolation::QuadOut),
+        );
+        apply(frame, area, &mut effect, phase_elapsed);
+    } else if phase + 1 < seq.len() && phase_elapsed + fade_ms >= phase_len {
+        let mut effect = fx::fade_to_fg(
+            Color::Black,
+            EffectTimer::from_ms(fade_ms, Interpolation::QuadIn),
+        );
+        let into_fade = phase_elapsed + fade_ms - phase_len;
+        apply(frame, area, &mut effect, into_fade);
+    }
+}
+
+fn apply(frame: &mut Frame, area: Rect, effect: &mut Effect, elapsed_ms: u32) {
+    frame.render_effect(effect, area, FxDuration::from_millis(elapsed_ms));
+}
+
+fn sequence(opts: &RenderOptions) -> Vec<&str> {
+    match opts.font_sequence.as_ref() {
+        Some(list) if !list.is_empty() => list.iter().map(|s| s.as_str()).collect(),
+        _ => DEFAULT_SEQUENCE.to_vec(),
+    }
+}
+
+fn phase_for(elapsed: u32, total: u32, phase_count: usize) -> (usize, u32, u32) {
+    let count = phase_count.max(1) as u32;
+    let phase_len = total / count;
+    let last_idx = (count - 1) as usize;
+    if elapsed >= total || phase_len == 0 {
+        return (last_idx, 0, phase_len.max(1));
+    }
+    let idx = (elapsed / phase_len).min(count - 1) as usize;
+    let phase_elapsed = elapsed - (idx as u32) * phase_len;
+    (idx, phase_elapsed, phase_len)
+}
+
+fn text_ascii_opts(opts: &RenderOptions, font: &str) -> RenderOptions {
+    RenderOptions {
+        style: Some("figlet".into()),
+        font: Some(font.to_string()),
+        color: opts.color.clone(),
+        align: opts.align.clone(),
+        ..RenderOptions::default()
+    }
+}
+
+fn elapsed_since_start_ms() -> u32 {
+    let elapsed = process_start().elapsed().as_millis();
+    elapsed.min(u32::MAX as u128) as u32
+}
+
+fn process_start() -> Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    *START.get_or_init(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, TextData};
+    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+
+    #[test]
+    fn phase_for_picks_last_on_overflow() {
+        let (idx, _, _) = phase_for(5_000, 1_500, 3);
+        assert_eq!(idx, 2);
+    }
+
+    #[test]
+    fn phase_for_returns_start_of_first_phase() {
+        let (idx, elapsed, len) = phase_for(0, 900, 3);
+        assert_eq!(idx, 0);
+        assert_eq!(elapsed, 0);
+        assert_eq!(len, 300);
+    }
+
+    #[test]
+    fn phase_for_advances_on_boundary() {
+        let (idx, _, _) = phase_for(310, 900, 3);
+        assert_eq!(idx, 1);
+    }
+
+    #[test]
+    fn sequence_falls_back_to_default_when_empty() {
+        let opts = RenderOptions {
+            font_sequence: Some(vec![]),
+            ..RenderOptions::default()
+        };
+        assert_eq!(sequence(&opts), DEFAULT_SEQUENCE.to_vec());
+    }
+
+    #[test]
+    fn renders_without_panic() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData { value: "hi".into() }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_figlet_morph".into(),
+            options: RenderOptions {
+                duration_ms: Some(400),
+                ..RenderOptions::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        let _ = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 60, 14);
+    }
+}

--- a/src/render/animated_postfx.rs
+++ b/src/render/animated_postfx.rs
@@ -3,8 +3,8 @@ use std::time::Instant;
 
 use ratatui::{Frame, layout::Rect, style::Color, widgets::Paragraph};
 use tachyonfx::{
-    Duration as FxDuration, Effect, EffectRenderer, EffectTimer, Interpolation, fx,
-    fx::EvolveSymbolSet,
+    Duration as FxDuration, Effect, EffectRenderer, EffectTimer, Interpolation, IntoEffect, fx,
+    fx::{EvolveSymbolSet, Glitch},
     pattern::{CheckerboardPattern, DiagonalPattern, DissolvePattern, RadialPattern, SweepPattern},
 };
 
@@ -24,10 +24,10 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
     OptionSchema {
         name: "effect",
-        type_hint: "\"fade_in\" | \"fade_out\" | \"dissolve\" | \"coalesce\" | \"sweep_in\" | \"sweep_in_right\" | \"sweep_in_down\" | \"sweep_in_up\" | \"slide_in\" | \"slide_in_right\" | \"slide_in_down\" | \"slide_in_up\" | \"hsl_shift\" | \"stagger_reveal\" | \"stagger_reveal_radial\" | \"matrix_rain\" | \"particle_burst\" | \"bounce_in\" | \"elastic_in\" | \"checkerboard_in\" | \"neon_flash\"",
+        type_hint: "\"fade_in\" | \"fade_out\" | \"dissolve\" | \"coalesce\" | \"sweep_in\" | \"sweep_in_right\" | \"sweep_in_down\" | \"sweep_in_up\" | \"slide_in\" | \"slide_in_right\" | \"slide_in_down\" | \"slide_in_up\" | \"hsl_shift\" | \"stagger_reveal\" | \"stagger_reveal_radial\" | \"matrix_rain\" | \"particle_burst\" | \"bounce_in\" | \"elastic_in\" | \"checkerboard_in\" | \"neon_flash\" | \"glitch_in\"",
         required: false,
         default: Some("\"fade_in\""),
-        description: "tachyonfx effect applied to the inner render. `sweep_in*` / `slide_in*` use a directional reveal (default = left→right; `_right`/`_down`/`_up` suffixes invert the direction). `stagger_reveal` reveals cells along a diagonal (top-left → bottom-right); `stagger_reveal_radial` reveals outward from the centre. `matrix_rain` rains random glyphs that dissolve into the underlying render; `particle_burst` scatters radial particles that resolve into the figlet. `bounce_in` / `elastic_in` use bounce/spring timing curves for a playful arrival; `checkerboard_in` reveals tiles in a checker pattern; `neon_flash` pulses through a bright hue before settling. Unknown names fall back to `fade_in` rather than failing the widget.",
+        description: "tachyonfx effect applied to the inner render. `sweep_in*` / `slide_in*` use a directional reveal (default = left→right; `_right`/`_down`/`_up` suffixes invert the direction). `stagger_reveal` reveals cells along a diagonal (top-left → bottom-right); `stagger_reveal_radial` reveals outward from the centre. `matrix_rain` rains random glyphs that dissolve into the underlying render; `particle_burst` scatters radial particles that resolve into the figlet. `bounce_in` / `elastic_in` use bounce/spring timing curves for a playful arrival; `checkerboard_in` reveals tiles in a checker pattern; `neon_flash` pulses through a bright hue before settling. `glitch_in` scrambles a fraction of cells then settles into the clean render — a broken-signal / decode vibe. Unknown names fall back to `fade_in` rather than failing the widget.",
     },
     OptionSchema {
         name: "duration_ms",
@@ -236,6 +236,19 @@ fn build_effect(name: &str, duration_ms: u32) -> Effect {
             None,
             EffectTimer::from_ms(duration_ms, Interpolation::SineInOut),
         ),
+        "glitch_in" => {
+            // Glitch cells mutate a fraction of the area at random for short bursts. We cap
+            // the whole run with `with_duration` so the effect stops exactly at the boundary;
+            // afterwards `render_postfx` skips re-applying it and the clean inner render is
+            // what the user sees.
+            let glitch = Glitch::builder()
+                .cell_glitch_ratio(0.30)
+                .action_start_delay_ms(0..(duration_ms / 2).max(1))
+                .action_ms((duration_ms / 10).max(40)..(duration_ms / 3).max(120))
+                .build()
+                .into_effect();
+            fx::with_duration(FxDuration::from_millis(duration_ms), glitch)
+        }
         _ => fx::fade_from_fg(Color::Black, timer),
     }
 }
@@ -284,6 +297,7 @@ mod tests {
             "elastic_in",
             "checkerboard_in",
             "neon_flash",
+            "glitch_in",
         ] {
             let _ = build_effect(name, 800);
         }

--- a/src/render/animated_postfx.rs
+++ b/src/render/animated_postfx.rs
@@ -4,7 +4,8 @@ use std::time::Instant;
 use ratatui::{Frame, layout::Rect, style::Color, widgets::Paragraph};
 use tachyonfx::{
     Duration as FxDuration, Effect, EffectRenderer, EffectTimer, Interpolation, fx,
-    pattern::SweepPattern,
+    fx::EvolveSymbolSet,
+    pattern::{DiagonalPattern, DissolvePattern, RadialPattern, SweepPattern},
 };
 
 use crate::options::OptionSchema;
@@ -23,10 +24,10 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
     OptionSchema {
         name: "effect",
-        type_hint: "\"fade_in\" | \"fade_out\" | \"dissolve\" | \"coalesce\" | \"sweep_in\" | \"sweep_in_right\" | \"sweep_in_down\" | \"sweep_in_up\" | \"slide_in\" | \"slide_in_right\" | \"slide_in_down\" | \"slide_in_up\" | \"hsl_shift\"",
+        type_hint: "\"fade_in\" | \"fade_out\" | \"dissolve\" | \"coalesce\" | \"sweep_in\" | \"sweep_in_right\" | \"sweep_in_down\" | \"sweep_in_up\" | \"slide_in\" | \"slide_in_right\" | \"slide_in_down\" | \"slide_in_up\" | \"hsl_shift\" | \"stagger_reveal\" | \"stagger_reveal_radial\" | \"matrix_rain\" | \"particle_burst\"",
         required: false,
         default: Some("\"fade_in\""),
-        description: "tachyonfx effect applied to the inner render. `sweep_in*` / `slide_in*` use a directional reveal (default = left→right; `_right`/`_down`/`_up` suffixes invert the direction). Unknown names fall back to `fade_in` rather than failing the widget.",
+        description: "tachyonfx effect applied to the inner render. `sweep_in*` / `slide_in*` use a directional reveal (default = left→right; `_right`/`_down`/`_up` suffixes invert the direction). `stagger_reveal` reveals cells along a diagonal (top-left → bottom-right); `stagger_reveal_radial` reveals outward from the centre. `matrix_rain` rains random glyphs that dissolve into the underlying render; `particle_burst` scatters radial particles that resolve into the figlet. Unknown names fall back to `fade_in` rather than failing the widget.",
     },
     OptionSchema {
         name: "duration_ms",
@@ -207,6 +208,14 @@ fn build_effect(name: &str, duration_ms: u32) -> Effect {
             fx::fade_from_fg(Color::Black, timer).with_pattern(SweepPattern::down_to_up(3))
         }
         "hsl_shift" => fx::hsl_shift(Some([180.0, 0.0, 0.0]), None, timer),
+        "stagger_reveal" => fx::fade_from_fg(Color::Black, timer)
+            .with_pattern(DiagonalPattern::top_left_to_bottom_right()),
+        "stagger_reveal_radial" => fx::fade_from_fg(Color::Black, timer)
+            .with_pattern(RadialPattern::with_transition((0.5, 0.5), 6.0)),
+        "matrix_rain" => fx::evolve_into(EvolveSymbolSet::BlocksVertical, timer)
+            .with_pattern(DissolvePattern::new()),
+        "particle_burst" => fx::evolve_into(EvolveSymbolSet::Shaded, timer)
+            .with_pattern(RadialPattern::with_transition((0.5, 0.5), 8.0)),
         _ => fx::fade_from_fg(Color::Black, timer),
     }
 }
@@ -247,6 +256,10 @@ mod tests {
             "slide_in_down",
             "slide_in_up",
             "hsl_shift",
+            "stagger_reveal",
+            "stagger_reveal_radial",
+            "matrix_rain",
+            "particle_burst",
         ] {
             let _ = build_effect(name, 800);
         }

--- a/src/render/animated_postfx.rs
+++ b/src/render/animated_postfx.rs
@@ -5,7 +5,7 @@ use ratatui::{Frame, layout::Rect, style::Color, widgets::Paragraph};
 use tachyonfx::{
     Duration as FxDuration, Effect, EffectRenderer, EffectTimer, Interpolation, fx,
     fx::EvolveSymbolSet,
-    pattern::{DiagonalPattern, DissolvePattern, RadialPattern, SweepPattern},
+    pattern::{CheckerboardPattern, DiagonalPattern, DissolvePattern, RadialPattern, SweepPattern},
 };
 
 use crate::options::OptionSchema;
@@ -24,10 +24,10 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
     OptionSchema {
         name: "effect",
-        type_hint: "\"fade_in\" | \"fade_out\" | \"dissolve\" | \"coalesce\" | \"sweep_in\" | \"sweep_in_right\" | \"sweep_in_down\" | \"sweep_in_up\" | \"slide_in\" | \"slide_in_right\" | \"slide_in_down\" | \"slide_in_up\" | \"hsl_shift\" | \"stagger_reveal\" | \"stagger_reveal_radial\" | \"matrix_rain\" | \"particle_burst\"",
+        type_hint: "\"fade_in\" | \"fade_out\" | \"dissolve\" | \"coalesce\" | \"sweep_in\" | \"sweep_in_right\" | \"sweep_in_down\" | \"sweep_in_up\" | \"slide_in\" | \"slide_in_right\" | \"slide_in_down\" | \"slide_in_up\" | \"hsl_shift\" | \"stagger_reveal\" | \"stagger_reveal_radial\" | \"matrix_rain\" | \"particle_burst\" | \"bounce_in\" | \"elastic_in\" | \"checkerboard_in\" | \"neon_flash\"",
         required: false,
         default: Some("\"fade_in\""),
-        description: "tachyonfx effect applied to the inner render. `sweep_in*` / `slide_in*` use a directional reveal (default = left→right; `_right`/`_down`/`_up` suffixes invert the direction). `stagger_reveal` reveals cells along a diagonal (top-left → bottom-right); `stagger_reveal_radial` reveals outward from the centre. `matrix_rain` rains random glyphs that dissolve into the underlying render; `particle_burst` scatters radial particles that resolve into the figlet. Unknown names fall back to `fade_in` rather than failing the widget.",
+        description: "tachyonfx effect applied to the inner render. `sweep_in*` / `slide_in*` use a directional reveal (default = left→right; `_right`/`_down`/`_up` suffixes invert the direction). `stagger_reveal` reveals cells along a diagonal (top-left → bottom-right); `stagger_reveal_radial` reveals outward from the centre. `matrix_rain` rains random glyphs that dissolve into the underlying render; `particle_burst` scatters radial particles that resolve into the figlet. `bounce_in` / `elastic_in` use bounce/spring timing curves for a playful arrival; `checkerboard_in` reveals tiles in a checker pattern; `neon_flash` pulses through a bright hue before settling. Unknown names fall back to `fade_in` rather than failing the widget.",
     },
     OptionSchema {
         name: "duration_ms",
@@ -216,6 +216,26 @@ fn build_effect(name: &str, duration_ms: u32) -> Effect {
             .with_pattern(DissolvePattern::new()),
         "particle_burst" => fx::evolve_into(EvolveSymbolSet::Shaded, timer)
             .with_pattern(RadialPattern::with_transition((0.5, 0.5), 8.0)),
+        "bounce_in" => fx::fade_from_fg(
+            Color::Black,
+            EffectTimer::from_ms(duration_ms, Interpolation::BounceOut),
+        )
+        .with_pattern(SweepPattern::up_to_down(6)),
+        "elastic_in" => fx::fade_from_fg(
+            Color::Black,
+            EffectTimer::from_ms(duration_ms, Interpolation::ElasticOut),
+        )
+        .with_pattern(RadialPattern::with_transition((0.5, 0.5), 4.0)),
+        "checkerboard_in" => fx::fade_from_fg(Color::Black, timer)
+            .with_pattern(CheckerboardPattern::with_cell_size(2)),
+        // Bright hue rotation + lightness lift during the window — reads as the neon
+        // warming up then settling back into the theme colour. The timer is
+        // SineInOut so the pulse is symmetric.
+        "neon_flash" => fx::hsl_shift(
+            Some([120.0, 20.0, 35.0]),
+            None,
+            EffectTimer::from_ms(duration_ms, Interpolation::SineInOut),
+        ),
         _ => fx::fade_from_fg(Color::Black, timer),
     }
 }
@@ -260,6 +280,10 @@ mod tests {
             "stagger_reveal_radial",
             "matrix_rain",
             "particle_burst",
+            "bounce_in",
+            "elastic_in",
+            "checkerboard_in",
+            "neon_flash",
         ] {
             let _ = build_effect(name, 800);
         }

--- a/src/render/animated_scanlines.rs
+++ b/src/render/animated_scanlines.rs
@@ -1,0 +1,235 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    widgets::Paragraph,
+};
+
+use crate::options::OptionSchema;
+use crate::payload::Body;
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::PANEL_TITLE, theme::TEXT];
+
+const DEFAULT_DURATION_MS: u64 = 1600;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "inner",
+        type_hint: "renderer name (e.g. \"text_ascii\")",
+        required: false,
+        default: Some("shape default renderer"),
+        description: "Renderer drawn underneath the scanline sweep. Falls back to the shape's natural default.",
+    },
+    OptionSchema {
+        name: "duration_ms",
+        type_hint: "milliseconds (u64)",
+        required: false,
+        default: Some("1600"),
+        description: "How long the scanline takes to traverse from top to bottom of the widget cell. Stays inside the 2s ANIMATION_WINDOW by default.",
+    },
+];
+
+/// CRT-style reveal. Renders the inner renderer once, then masks everything below a moving
+/// horizontal scanline. The scanline itself renders as a bright highlight row; rows below
+/// stay blank until the line passes them. Once the window closes, the inner render is left
+/// unmasked so the static frame is indistinguishable from a plain widget.
+///
+/// Accepts every shape: the compatibility check is delegated to the resolved inner renderer.
+pub struct AnimatedScanlinesRenderer;
+
+const ALL_SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::PointSeries,
+    Shape::Bars,
+    Shape::Image,
+    Shape::Calendar,
+    Shape::Heatmap,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+impl Renderer for AnimatedScanlinesRenderer {
+    fn name(&self) -> &str {
+        "animated_scanlines"
+    }
+    fn accepts(&self) -> &[Shape] {
+        ALL_SHAPES
+    }
+    fn animates(&self) -> bool {
+        true
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        registry: &Registry,
+    ) {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            frame.render_widget(
+                Paragraph::new(format!("unknown inner renderer: {inner_name}")),
+                area,
+            );
+            return;
+        };
+        if !inner.accepts().contains(&shape) {
+            frame.render_widget(
+                Paragraph::new(format!("inner {inner_name} cannot display {shape:?}")),
+                area,
+            );
+            return;
+        }
+        inner.render(frame, area, body, &inner_options(opts), theme, registry);
+
+        let total = opts.duration_ms.unwrap_or(DEFAULT_DURATION_MS).max(1) as u32;
+        let elapsed = elapsed_since_start_ms();
+        if elapsed >= total || area.height == 0 {
+            return;
+        }
+        apply_scanline(frame, area, elapsed, total, theme);
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        max_width: u16,
+        registry: &Registry,
+    ) -> u16 {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            return 1;
+        };
+        inner.natural_height(body, &inner_options(opts), max_width, registry)
+    }
+}
+
+fn apply_scanline(frame: &mut Frame, area: Rect, elapsed_ms: u32, total_ms: u32, theme: &Theme) {
+    let progress = (elapsed_ms as f32 / total_ms as f32).clamp(0.0, 1.0);
+    let travel = area.height as f32 + 2.0;
+    let scan_y = progress * travel;
+    let scan_row = scan_y.floor() as i32;
+    let buf = frame.buffer_mut();
+
+    for y in 0..area.height {
+        let row = (area.y + y) as i32;
+        let abs_y = y as i32;
+        if abs_y > scan_row {
+            blank_row(buf, area, y);
+        } else if abs_y == scan_row && row >= area.y as i32 {
+            highlight_row(buf, area, y, theme);
+        }
+    }
+}
+
+fn blank_row(buf: &mut ratatui::buffer::Buffer, area: Rect, y: u16) {
+    for x in 0..area.width {
+        if let Some(cell) = buf.cell_mut((area.x + x, area.y + y)) {
+            cell.set_symbol(" ");
+            cell.set_style(Style::default());
+        }
+    }
+}
+
+fn highlight_row(buf: &mut ratatui::buffer::Buffer, area: Rect, y: u16, theme: &Theme) {
+    let style = Style::default()
+        .fg(theme.panel_title)
+        .add_modifier(Modifier::BOLD);
+    for x in 0..area.width {
+        if let Some(cell) = buf.cell_mut((area.x + x, area.y + y))
+            && cell.symbol().trim().is_empty()
+        {
+            cell.set_symbol("─");
+            cell.set_style(style);
+        }
+    }
+}
+
+fn inner_options(opts: &RenderOptions) -> RenderOptions {
+    RenderOptions {
+        inner: None,
+        effect: None,
+        duration_ms: None,
+        boot_lines: None,
+        font_sequence: None,
+        ..opts.clone()
+    }
+}
+
+fn elapsed_since_start_ms() -> u32 {
+    let elapsed = process_start().elapsed().as_millis();
+    elapsed.min(u32::MAX as u128) as u32
+}
+
+fn process_start() -> Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    *START.get_or_init(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, TextData};
+    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+
+    #[test]
+    fn inner_options_strips_wrapper_fields() {
+        let opts = RenderOptions {
+            inner: Some("text_ascii".into()),
+            duration_ms: Some(1500),
+            style: Some("figlet".into()),
+            ..RenderOptions::default()
+        };
+        let inner = inner_options(&opts);
+        assert!(inner.inner.is_none());
+        assert!(inner.duration_ms.is_none());
+        assert_eq!(inner.style.as_deref(), Some("figlet"));
+    }
+
+    #[test]
+    fn renders_without_panic() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData { value: "hi".into() }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_scanlines".into(),
+            options: RenderOptions {
+                inner: Some("text_ascii".into()),
+                style: Some("figlet".into()),
+                duration_ms: Some(400),
+                ..RenderOptions::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        let _ = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 40, 10);
+    }
+}

--- a/src/render/animated_splitflap.rs
+++ b/src/render/animated_splitflap.rs
@@ -1,0 +1,247 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    widgets::Paragraph,
+};
+
+use crate::options::OptionSchema;
+use crate::payload::Body;
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::PANEL_TITLE, theme::TEXT];
+
+const DEFAULT_DURATION_MS: u64 = 1600;
+
+const FLAP_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!?*#@%&/=+-<>:;^~.,'\"";
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "inner",
+        type_hint: "renderer name (e.g. \"text_ascii\")",
+        required: false,
+        default: Some("shape default renderer"),
+        description: "Renderer drawn as the resting frame once every cell has settled. Falls back to the shape's natural default.",
+    },
+    OptionSchema {
+        name: "duration_ms",
+        type_hint: "milliseconds (u64)",
+        required: false,
+        default: Some("1600"),
+        description: "Total cycling duration. Earlier cells settle first; the last cell lands right as the window closes. Kept inside the 2s ANIMATION_WINDOW by default.",
+    },
+];
+
+/// Split-flap reveal — like the departures board at a train station. Each cell in the widget's
+/// rectangle cycles through an A-Z / 0-9 / punctuation set, landing on its final glyph at a
+/// position-dependent settle time. Columns to the left land first so the text reads
+/// left-to-right as it resolves.
+///
+/// Accepts every shape: the compatibility check is delegated to the resolved inner renderer.
+/// Static post-window frame = the inner render, unchanged.
+pub struct AnimatedSplitflapRenderer;
+
+const ALL_SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::PointSeries,
+    Shape::Bars,
+    Shape::Image,
+    Shape::Calendar,
+    Shape::Heatmap,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+impl Renderer for AnimatedSplitflapRenderer {
+    fn name(&self) -> &str {
+        "animated_splitflap"
+    }
+    fn accepts(&self) -> &[Shape] {
+        ALL_SHAPES
+    }
+    fn animates(&self) -> bool {
+        true
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        registry: &Registry,
+    ) {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            frame.render_widget(
+                Paragraph::new(format!("unknown inner renderer: {inner_name}")),
+                area,
+            );
+            return;
+        };
+        if !inner.accepts().contains(&shape) {
+            frame.render_widget(
+                Paragraph::new(format!("inner {inner_name} cannot display {shape:?}")),
+                area,
+            );
+            return;
+        }
+        inner.render(frame, area, body, &inner_options(opts), theme, registry);
+
+        let total = opts.duration_ms.unwrap_or(DEFAULT_DURATION_MS).max(1) as u32;
+        let elapsed = elapsed_since_start_ms();
+        if elapsed >= total {
+            return;
+        }
+        apply_flap(frame, area, elapsed, total, theme);
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        max_width: u16,
+        registry: &Registry,
+    ) -> u16 {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            return 1;
+        };
+        inner.natural_height(body, &inner_options(opts), max_width, registry)
+    }
+}
+
+fn apply_flap(frame: &mut Frame, area: Rect, elapsed_ms: u32, total_ms: u32, theme: &Theme) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let buf = frame.buffer_mut();
+    let settle_style = Style::default()
+        .fg(theme.panel_title)
+        .add_modifier(Modifier::BOLD);
+    for y in 0..area.height {
+        for x in 0..area.width {
+            let settle_at = cell_settle_ms(x, y, area.width, area.height, total_ms);
+            if elapsed_ms >= settle_at {
+                continue;
+            }
+            let Some(cell) = buf.cell_mut((area.x + x, area.y + y)) else {
+                continue;
+            };
+            // Blank cells stay blank during cycling; a row of flapping background
+            // characters would dwarf the actual figlet shape and read as noise.
+            if cell.symbol().trim().is_empty() {
+                continue;
+            }
+            let glyph = flap_glyph(x, y, elapsed_ms);
+            cell.set_symbol(&glyph.to_string());
+            cell.set_style(settle_style);
+        }
+    }
+}
+
+/// Per-cell settle time. Columns to the left settle first (text reads left-to-right), with a
+/// small per-row offset so adjacent rows don't flip in lockstep.
+fn cell_settle_ms(x: u16, y: u16, width: u16, height: u16, total_ms: u32) -> u32 {
+    let width = width.max(1) as u32;
+    let height = height.max(1) as u32;
+    let col_share = 0.80;
+    let row_share = 0.15;
+    let col = (x as u32 * total_ms) / width;
+    let row = (y as u32 * total_ms) / height;
+    let settle = (col as f32 * col_share + row as f32 * row_share) as u32 + total_ms / 12;
+    settle.min(total_ms)
+}
+
+fn flap_glyph(x: u16, y: u16, elapsed_ms: u32) -> char {
+    // Rotate the character set on a short clock so each cell appears to flip several times
+    // per second. The (x, y) offset keeps neighbours on different glyphs on the same tick.
+    let tick = (elapsed_ms / 45) as usize + (x as usize * 7 + y as usize * 13);
+    FLAP_CHARS[tick % FLAP_CHARS.len()] as char
+}
+
+fn inner_options(opts: &RenderOptions) -> RenderOptions {
+    RenderOptions {
+        inner: None,
+        effect: None,
+        duration_ms: None,
+        boot_lines: None,
+        font_sequence: None,
+        ..opts.clone()
+    }
+}
+
+fn elapsed_since_start_ms() -> u32 {
+    let elapsed = process_start().elapsed().as_millis();
+    elapsed.min(u32::MAX as u128) as u32
+}
+
+fn process_start() -> Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    *START.get_or_init(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, TextData};
+    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+
+    #[test]
+    fn left_cells_settle_before_right_cells() {
+        let left = cell_settle_ms(0, 0, 20, 5, 1600);
+        let right = cell_settle_ms(19, 0, 20, 5, 1600);
+        assert!(left < right, "left={left} right={right}");
+    }
+
+    #[test]
+    fn flap_glyph_is_printable_ascii() {
+        let g = flap_glyph(3, 2, 900);
+        assert!(g.is_ascii_graphic(), "got {g:?}");
+    }
+
+    #[test]
+    fn renders_without_panic() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "ready".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_splitflap".into(),
+            options: RenderOptions {
+                inner: Some("text_ascii".into()),
+                style: Some("figlet".into()),
+                duration_ms: Some(400),
+                ..RenderOptions::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        let _ = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 40, 10);
+    }
+}

--- a/src/render/animated_wave.rs
+++ b/src/render/animated_wave.rs
@@ -1,0 +1,237 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    widgets::Paragraph,
+};
+
+use crate::options::OptionSchema;
+use crate::payload::Body;
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::PANEL_TITLE, theme::TEXT];
+
+const DEFAULT_DURATION_MS: u64 = 1600;
+
+const WAVE_CREST_WIDTH: u16 = 6;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "inner",
+        type_hint: "renderer name (e.g. \"text_ascii\")",
+        required: false,
+        default: Some("shape default renderer"),
+        description: "Renderer drawn as the resting frame once the wave has passed through every column. Falls back to the shape's natural default.",
+    },
+    OptionSchema {
+        name: "duration_ms",
+        type_hint: "milliseconds (u64)",
+        required: false,
+        default: Some("1600"),
+        description: "Total sweep duration. The wave enters from the left at t=0 and exits past the right edge at t=duration.",
+    },
+];
+
+/// Wave reveal — a bright vertical crest travels left-to-right across the widget. Columns the
+/// crest has passed are revealed; columns ahead of it stay blank; the column at the crest is
+/// highlighted with the accent colour. Reads as "a wave of signal washes over the hero".
+///
+/// Accepts every shape: the compatibility check is delegated to the resolved inner renderer.
+/// Static post-window frame = the inner render, unchanged.
+pub struct AnimatedWaveRenderer;
+
+const ALL_SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::PointSeries,
+    Shape::Bars,
+    Shape::Image,
+    Shape::Calendar,
+    Shape::Heatmap,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+impl Renderer for AnimatedWaveRenderer {
+    fn name(&self) -> &str {
+        "animated_wave"
+    }
+    fn accepts(&self) -> &[Shape] {
+        ALL_SHAPES
+    }
+    fn animates(&self) -> bool {
+        true
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        registry: &Registry,
+    ) {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            frame.render_widget(
+                Paragraph::new(format!("unknown inner renderer: {inner_name}")),
+                area,
+            );
+            return;
+        };
+        if !inner.accepts().contains(&shape) {
+            frame.render_widget(
+                Paragraph::new(format!("inner {inner_name} cannot display {shape:?}")),
+                area,
+            );
+            return;
+        }
+        inner.render(frame, area, body, &inner_options(opts), theme, registry);
+
+        let total = opts.duration_ms.unwrap_or(DEFAULT_DURATION_MS).max(1) as u32;
+        let elapsed = elapsed_since_start_ms();
+        if elapsed >= total {
+            return;
+        }
+        apply_wave(frame, area, elapsed, total, theme);
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        max_width: u16,
+        registry: &Registry,
+    ) -> u16 {
+        let shape = shape_of(body);
+        let inner_name = opts
+            .inner
+            .as_deref()
+            .unwrap_or_else(|| default_renderer_for(shape));
+        let Some(inner) = registry.get(inner_name) else {
+            return 1;
+        };
+        inner.natural_height(body, &inner_options(opts), max_width, registry)
+    }
+}
+
+fn apply_wave(frame: &mut Frame, area: Rect, elapsed_ms: u32, total_ms: u32, theme: &Theme) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let progress = (elapsed_ms as f32 / total_ms as f32).clamp(0.0, 1.0);
+    let travel = area.width as i32 + WAVE_CREST_WIDTH as i32 * 2;
+    let crest_x = (progress * travel as f32) as i32 - WAVE_CREST_WIDTH as i32;
+    let buf = frame.buffer_mut();
+    let crest_style = Style::default()
+        .fg(theme.panel_title)
+        .add_modifier(Modifier::BOLD);
+
+    for y in 0..area.height {
+        for x in 0..area.width {
+            let x_i = x as i32;
+            if x_i > crest_x + WAVE_CREST_WIDTH as i32 {
+                blank_cell(buf, area, x, y);
+            } else if (x_i - crest_x).abs() <= WAVE_CREST_WIDTH as i32 / 2 {
+                highlight_cell(buf, area, x, y, crest_style);
+            }
+        }
+    }
+}
+
+fn blank_cell(buf: &mut ratatui::buffer::Buffer, area: Rect, x: u16, y: u16) {
+    if let Some(cell) = buf.cell_mut((area.x + x, area.y + y)) {
+        cell.set_symbol(" ");
+        cell.set_style(Style::default());
+    }
+}
+
+fn highlight_cell(buf: &mut ratatui::buffer::Buffer, area: Rect, x: u16, y: u16, style: Style) {
+    if let Some(cell) = buf.cell_mut((area.x + x, area.y + y))
+        && !cell.symbol().trim().is_empty()
+    {
+        cell.set_style(style);
+    }
+}
+
+fn inner_options(opts: &RenderOptions) -> RenderOptions {
+    RenderOptions {
+        inner: None,
+        effect: None,
+        duration_ms: None,
+        boot_lines: None,
+        font_sequence: None,
+        ..opts.clone()
+    }
+}
+
+fn elapsed_since_start_ms() -> u32 {
+    let elapsed = process_start().elapsed().as_millis();
+    elapsed.min(u32::MAX as u128) as u32
+}
+
+fn process_start() -> Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    *START.get_or_init(Instant::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, TextData};
+    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+
+    #[test]
+    fn inner_options_strips_wrapper_fields() {
+        let opts = RenderOptions {
+            inner: Some("text_ascii".into()),
+            duration_ms: Some(1500),
+            style: Some("figlet".into()),
+            ..RenderOptions::default()
+        };
+        let inner = inner_options(&opts);
+        assert!(inner.inner.is_none());
+        assert!(inner.duration_ms.is_none());
+        assert_eq!(inner.style.as_deref(), Some("figlet"));
+    }
+
+    #[test]
+    fn renders_without_panic() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "wave".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_wave".into(),
+            options: RenderOptions {
+                inner: Some("text_ascii".into()),
+                style: Some("figlet".into()),
+                duration_ms: Some(400),
+                ..RenderOptions::default()
+            },
+        };
+        let registry = super::super::Registry::with_builtins();
+        let _ = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 40, 10);
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -14,6 +14,8 @@ use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::theme::{ColorKey, Theme};
 
+mod animated_boot;
+mod animated_figlet_morph;
 mod animated_postfx;
 mod animated_typewriter;
 mod chart_bar;
@@ -230,6 +232,16 @@ pub struct RenderOptions {
     /// static for the remainder.
     #[serde(default)]
     pub duration_ms: Option<u64>,
+    /// animated_figlet_morph: ordered list of figlet font names to step through. Each phase
+    /// takes `duration_ms / N` and crossfades into the next; the final entry is the resting
+    /// font once the animation completes. None falls back to `["small", "banner", "ansi_shadow"]`.
+    #[serde(default)]
+    pub font_sequence: Option<Vec<String>>,
+    /// animated_boot: ordered list of boot-log lines scrolled in one by one before the hero
+    /// settles. None uses a small default set; an empty list disables the boot lines and
+    /// falls straight to the inner render.
+    #[serde(default)]
+    pub boot_lines: Option<Vec<String>>,
 }
 
 /// What the TOML accepts for `render`. Short form `render = "text_plain"` uses defaults; long
@@ -331,6 +343,8 @@ impl Registry {
         r.register(Arc::new(text_ascii::TextAsciiRenderer));
         r.register(Arc::new(animated_typewriter::AnimatedTypewriterRenderer));
         r.register(Arc::new(animated_postfx::AnimatedPostfxRenderer));
+        r.register(Arc::new(animated_figlet_morph::AnimatedFigletMorphRenderer));
+        r.register(Arc::new(animated_boot::AnimatedBootRenderer));
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
@@ -545,6 +559,8 @@ mod tests {
             "text_ascii",
             "animated_typewriter",
             "animated_postfx",
+            "animated_figlet_morph",
+            "animated_boot",
             "status_badge",
             "list_plain",
             "list_timeline",

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -18,7 +18,9 @@ mod animated_boot;
 mod animated_figlet_morph;
 mod animated_postfx;
 mod animated_scanlines;
+mod animated_splitflap;
 mod animated_typewriter;
+mod animated_wave;
 mod chart_bar;
 mod chart_line;
 mod chart_pie;
@@ -347,6 +349,8 @@ impl Registry {
         r.register(Arc::new(animated_figlet_morph::AnimatedFigletMorphRenderer));
         r.register(Arc::new(animated_boot::AnimatedBootRenderer));
         r.register(Arc::new(animated_scanlines::AnimatedScanlinesRenderer));
+        r.register(Arc::new(animated_splitflap::AnimatedSplitflapRenderer));
+        r.register(Arc::new(animated_wave::AnimatedWaveRenderer));
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
@@ -564,6 +568,8 @@ mod tests {
             "animated_figlet_morph",
             "animated_boot",
             "animated_scanlines",
+            "animated_splitflap",
+            "animated_wave",
             "status_badge",
             "list_plain",
             "list_timeline",

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -17,6 +17,7 @@ use crate::theme::{ColorKey, Theme};
 mod animated_boot;
 mod animated_figlet_morph;
 mod animated_postfx;
+mod animated_scanlines;
 mod animated_typewriter;
 mod chart_bar;
 mod chart_line;
@@ -345,6 +346,7 @@ impl Registry {
         r.register(Arc::new(animated_postfx::AnimatedPostfxRenderer));
         r.register(Arc::new(animated_figlet_morph::AnimatedFigletMorphRenderer));
         r.register(Arc::new(animated_boot::AnimatedBootRenderer));
+        r.register(Arc::new(animated_scanlines::AnimatedScanlinesRenderer));
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
@@ -561,6 +563,7 @@ mod tests {
             "animated_postfx",
             "animated_figlet_morph",
             "animated_boot",
+            "animated_scanlines",
             "status_badge",
             "list_plain",
             "list_timeline",

--- a/src/templates/home_splash.toml
+++ b/src/templates/home_splash.toml
@@ -11,7 +11,13 @@
 [[widget]]
 id = "hero"
 fetcher = "system"
-render = { type = "animated_postfx", inner = "text_ascii", effect = "sweep_in", duration_ms = 1200, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
+# Signature opening: particles radiate in from the centre and resolve into the figlet.
+# Swap `effect = "..."` to audition the siblings: `stagger_reveal`, `stagger_reveal_radial`,
+# `matrix_rain`. For the boot-log reveal swap the whole spec to
+# `{ type = "animated_boot", inner = "text_ascii", duration_ms = 1800, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }`.
+# For the figlet-font morph swap to
+# `{ type = "animated_figlet_morph", duration_ms = 1800, color = "panel_title", align = "center" }`.
+render = { type = "animated_postfx", inner = "text_ascii", effect = "particle_burst", duration_ms = 1500, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
   [widget.options]
   kind = "terminal"
 

--- a/src/templates/project_github_activity.toml
+++ b/src/templates/project_github_activity.toml
@@ -13,7 +13,7 @@
 [[widget]]
 id = "hero"
 fetcher = "git_repo_name"
-render = { type = "animated_postfx", inner = "text_ascii", effect = "coalesce", duration_ms = 1500, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
+render = { type = "text_ascii", style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
 
 # Subtitle: `github_repo` emits TextBlock (slug / description / license on their own rows).
 # `text_plain` renders via ratatui's `Paragraph` which centers each line individually,

--- a/xtask/src/dashboard_snapshot.rs
+++ b/xtask/src/dashboard_snapshot.rs
@@ -196,6 +196,26 @@ fn deanimate(spec: RenderSpec) -> RenderSpec {
             type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
             options: options.clone(),
         },
+        RenderSpec::Short(ref name) if name == "animated_splitflap" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_splitflap" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
+        RenderSpec::Short(ref name) if name == "animated_wave" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_wave" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
         RenderSpec::Short(ref name) if name == "animated_figlet_morph" => RenderSpec::Full {
             type_name: "text_ascii".into(),
             options: RenderOptions {

--- a/xtask/src/dashboard_snapshot.rs
+++ b/xtask/src/dashboard_snapshot.rs
@@ -186,6 +186,16 @@ fn deanimate(spec: RenderSpec) -> RenderSpec {
             type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
             options: options.clone(),
         },
+        RenderSpec::Short(ref name) if name == "animated_scanlines" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_scanlines" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
         RenderSpec::Short(ref name) if name == "animated_figlet_morph" => RenderSpec::Full {
             type_name: "text_ascii".into(),
             options: RenderOptions {

--- a/xtask/src/dashboard_snapshot.rs
+++ b/xtask/src/dashboard_snapshot.rs
@@ -21,7 +21,9 @@ use splashboard::config::{Config, DashboardConfig, SettingsConfig, WidgetConfig}
 use splashboard::fetcher::{FetchContext, RegisteredFetcher, Registry as FetcherRegistry};
 use splashboard::layout as layout_engine;
 use splashboard::payload::{Body, Payload, TextBlockData, TextData};
-use splashboard::render::{Registry as RenderRegistry, RenderSpec, Shape, default_renderer_for};
+use splashboard::render::{
+    Registry as RenderRegistry, RenderOptions, RenderSpec, Shape, default_renderer_for,
+};
 use splashboard::theme::Theme;
 
 use crate::html_snapshot::buffer_to_html;
@@ -174,6 +176,44 @@ fn deanimate(spec: RenderSpec) -> RenderSpec {
             type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
             options: options.clone(),
         },
+        RenderSpec::Short(ref name) if name == "animated_boot" => {
+            RenderSpec::Short("text_plain".into())
+        }
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_boot" => RenderSpec::Full {
+            type_name: options.inner.clone().unwrap_or_else(|| "text_plain".into()),
+            options: options.clone(),
+        },
+        RenderSpec::Short(ref name) if name == "animated_figlet_morph" => RenderSpec::Full {
+            type_name: "text_ascii".into(),
+            options: RenderOptions {
+                style: Some("figlet".into()),
+                font: Some("ansi_shadow".into()),
+                ..RenderOptions::default()
+            },
+        },
+        RenderSpec::Full {
+            ref type_name,
+            ref options,
+        } if type_name == "animated_figlet_morph" => {
+            let resting_font = options
+                .font_sequence
+                .as_ref()
+                .and_then(|seq| seq.last().cloned())
+                .unwrap_or_else(|| "ansi_shadow".into());
+            RenderSpec::Full {
+                type_name: "text_ascii".into(),
+                options: RenderOptions {
+                    style: Some("figlet".into()),
+                    font: Some(resting_font),
+                    color: options.color.clone(),
+                    align: options.align.clone(),
+                    ..RenderOptions::default()
+                },
+            }
+        }
         other => other,
     }
 }


### PR DESCRIPTION
Closes #97. Ticks the renderer roadmap on #61.

## Summary

- Ship five motion primitives so `home_splash`'s first-paint moment reads as crafted rather than a stock tachyonfx reveal:
  - `stagger_reveal` / `stagger_reveal_radial` — per-cell diagonal / radial fade-in effects on `animated_postfx`.
  - `matrix_rain` — `evolve_into(BlocksVertical)` + `DissolvePattern`; random glyphs settle into the underlying figlet.
  - `particle_burst` — `evolve_into(Shaded)` + `RadialPattern`; particles radiate in from the centre and resolve into the hero. Wired as the new `home_splash` hero default.
  - `animated_figlet_morph` renderer — steps the text through a figlet-font sequence (`small` → `banner` → `ansi_shadow`) with crossfades between phases. Delegates to `text_ascii` per phase so the word-wrap path is reused.
  - `animated_boot` renderer — scrolls `[ OK ] …` boot-log lines for the first 70% of the window, then hands off to the inner renderer.
- Trim animation back to `home_splash` only: `project_github_activity` (template + dogfood `.splashboard/dashboard.toml`) renders its hero via plain `text_ascii`. Keeps the daily presets calm.
- Preview de-animation (`install::preview`) + xtask dashboard-snapshot de-animation handle the two new renderers so the install picker and the docs-site gallery show the resting state.

## Test plan

- [x] `cargo test` green (494 passed)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask` regenerates reference + rendered HTML without errors; new renderer docs (`animated_boot.md`, `animated_figlet_morph.md`) written
- [ ] Side-by-side motion preview via `/tmp/splash-compare` sandbox — visual confirmation from the maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)