### PR TITLE
feat(ops): surface fetch errors in UI and log file (closes #95)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2545,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "maybe-async"
@@ -3217,6 +3241,17 @@ name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3467,6 +3502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3620,9 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "tui-big-text",
  "tui-piechart",
  "url",
@@ -3626,6 +3673,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3740,6 +3793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3760,12 +3822,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3773,6 +3837,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3947,7 +4021,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3957,6 +4056,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ sysinfo = "0.38.4"
 gix = { version = "0.82", default-features = false, features = ["revision", "status", "blob-diff", "max-performance-safe", "comfort", "sha1"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
 url = "2"
+tracing = { version = "0.1", default-features = false, features = ["std", "attributes"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
+tracing-appender = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -13,18 +13,38 @@ static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
 const STALE_LOCK_THRESHOLD: Duration = Duration::from_secs(30);
 
+/// Outcome of the fetch that produced this cache entry. Surfaced so rendering and diagnostics
+/// can tell a successful fetch from one that failed or timed out without peeking at the body.
+/// Serialized in lowercase (`"ok"`, `"err"`, `"timeout"`); missing from an older cache file
+/// deserializes back to `Ok` via `#[serde(default)]` on the [`CacheEntry::kind`] field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheEntryKind {
+    #[default]
+    Ok,
+    Err,
+    Timeout,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CacheEntry {
     pub refreshed_at: u64,
     pub ttl_seconds: u64,
+    #[serde(default)]
+    pub kind: CacheEntryKind,
     pub payload: Payload,
 }
 
 impl CacheEntry {
     pub fn new(payload: Payload, ttl_seconds: u64) -> Self {
+        Self::new_with_kind(payload, ttl_seconds, CacheEntryKind::Ok)
+    }
+
+    pub fn new_with_kind(payload: Payload, ttl_seconds: u64, kind: CacheEntryKind) -> Self {
         Self {
             refreshed_at: now_secs(),
             ttl_seconds,
+            kind,
             payload,
         }
     }
@@ -198,6 +218,38 @@ mod tests {
     }
 
     #[test]
+    fn new_defaults_kind_to_ok() {
+        let entry = CacheEntry::new(sample(), 60);
+        assert_eq!(entry.kind, CacheEntryKind::Ok);
+    }
+
+    #[test]
+    fn new_with_kind_carries_error_kind_through() {
+        let entry = CacheEntry::new_with_kind(sample(), 30, CacheEntryKind::Err);
+        assert_eq!(entry.kind, CacheEntryKind::Err);
+    }
+
+    #[test]
+    fn legacy_entry_without_kind_field_deserializes_as_ok() {
+        // Back-compat: any cache file written before the kind field existed must round-trip
+        // unchanged so users don't lose their warm cache on upgrade. #[serde(default)] on the
+        // field is the invariant under test.
+        // Build the "legacy" shape by serializing a current CacheEntry and stripping the kind
+        // field — avoids hand-coding the payload body tag/content conventions.
+        let entry = CacheEntry::new(sample(), 60);
+        let mut json: serde_json::Value = serde_json::to_value(&entry).unwrap();
+        json.as_object_mut().unwrap().remove("kind");
+        let reparsed: CacheEntry = serde_json::from_value(json).expect("legacy json must parse");
+        assert_eq!(reparsed.kind, CacheEntryKind::Ok);
+    }
+
+    #[test]
+    fn cache_entry_kind_serializes_lowercase() {
+        let json = serde_json::to_string(&CacheEntryKind::Timeout).unwrap();
+        assert_eq!(json, "\"timeout\"");
+    }
+
+    #[test]
     fn entry_is_stale_when_ttl_zero() {
         let entry = CacheEntry::new(sample(), 0);
         assert!(!entry.is_fresh());
@@ -208,6 +260,7 @@ mod tests {
         let entry = CacheEntry {
             refreshed_at: 0,
             ttl_seconds: 60,
+            kind: CacheEntryKind::Ok,
             payload: sample(),
         };
         assert!(!entry.is_fresh());

--- a/src/fetcher/github/action_history.rs
+++ b/src/fetcher/github/action_history.rs
@@ -12,9 +12,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{
-    RepoSlug, cache_key, parse_options, parse_timestamp, payload, placeholder, resolve_repo,
-};
+use super::common::{RepoSlug, cache_key, parse_options, parse_timestamp, payload, resolve_repo};
 
 const SHAPES: &[Shape] = &[Shape::NumberSeries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 30;
@@ -88,14 +86,8 @@ impl Fetcher for GithubActionHistory {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 100);
         let mut path = format!(
             "/repos/{}/{}/actions/runs?per_page={limit}",

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
+use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
 const SHAPES: &[Shape] = &[Shape::Badge, Shape::Text];
 
@@ -72,14 +72,8 @@ impl Fetcher for GithubActionStatus {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let mut path = format!(
             "/repos/{}/{}/actions/runs?per_page=1",
             slug.owner, slug.name

--- a/src/fetcher/github/assigned_issues.rs
+++ b/src/fetcher/github/assigned_issues.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{cache_key, parse_options, payload, placeholder};
+use super::common::{cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
@@ -73,10 +73,7 @@ impl Fetcher for GithubAssignedIssues {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
         let path = format!(
             "/search/issues?q=is%3Aissue+is%3Aopen+assignee%3A%40me&per_page={limit}&sort=updated"

--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 
 use crate::options::OptionSchema;
 use crate::paths;
-use crate::payload::{Body, ImageData, Payload, TextData};
+use crate::payload::{Body, ImageData, Payload};
 use crate::render::Shape;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
@@ -80,19 +80,10 @@ impl Fetcher for GithubAvatar {
         None
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let user = match resolve_user(opts.user.as_deref()) {
-            Ok(u) => u,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let user = resolve_user(opts.user.as_deref()).map_err(FetchError::Failed)?;
         let size = opts.size.unwrap_or(DEFAULT_SIZE);
-        let path = match download_avatar(&user, size).await {
-            Ok(p) => p,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let path = download_avatar(&user, size).await?;
         Ok(payload(Body::Image(ImageData {
             path: path.to_string_lossy().into_owned(),
         })))
@@ -172,12 +163,6 @@ fn payload(body: Body) -> Payload {
         format: None,
         body,
     }
-}
-
-fn placeholder(msg: &str) -> Payload {
-    payload(Body::Text(TextData {
-        value: format!("⚠ {msg}"),
-    }))
 }
 
 #[cfg(test)]

--- a/src/fetcher/github/client.rs
+++ b/src/fetcher/github/client.rs
@@ -41,7 +41,8 @@ pub fn resolve_token() -> Result<String, FetchError> {
 }
 
 /// REST GET → deserialize JSON. Non-2xx responses surface the GitHub-reported `message` when
-/// present (`{"message":"Not Found"}`) so the placeholder is actionable.
+/// present (`{"message":"Not Found"}`) so the runtime's error placeholder and the log line
+/// are both actionable.
 pub async fn rest_get<T: DeserializeOwned>(path: &str) -> Result<T, FetchError> {
     let token = resolve_token()?;
     let url = format!("{API_BASE}{path}");

--- a/src/fetcher/github/common.rs
+++ b/src/fetcher/github/common.rs
@@ -22,17 +22,6 @@ pub fn text_block_body(values: Vec<String>) -> Body {
     Body::TextBlock(TextBlockData { lines: values })
 }
 
-/// Two-line warning body — mirrors `clock::common::placeholder` so misconfigured widgets look
-/// consistent across fetcher families.
-pub fn placeholder(msg: &str) -> Payload {
-    payload(Body::TextBlock(TextBlockData {
-        lines: vec![
-            format!("⚠ {msg}"),
-            "check [widget.options] or set GH_TOKEN".into(),
-        ],
-    }))
-}
-
 pub fn parse_options<T: serde::de::DeserializeOwned + Default>(
     raw: Option<&toml::Value>,
 ) -> Result<T, String> {

--- a/src/fetcher/github/contributions.rs
+++ b/src/fetcher/github/contributions.rs
@@ -13,7 +13,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::graphql;
-use super::common::{cache_key, parse_options, payload, placeholder};
+use super::common::{cache_key, parse_options, payload};
 
 const SHAPES: &[Shape] = &[Shape::Heatmap];
 
@@ -70,10 +70,7 @@ impl Fetcher for GithubContributions {
         }
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let calendar = match opts.login.as_deref() {
             None => fetch_viewer().await?,
             Some(login) => fetch_user(login).await?,

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -13,7 +13,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::{http, resolve_token};
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
+use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
 const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries];
 const DEFAULT_LIMIT: u32 = 10;
@@ -86,19 +86,13 @@ impl Fetcher for GithubContributorsMonthly {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30) as usize;
         let days = opts.days.unwrap_or(30).clamp(7, 365) as i64;
         match fetch_stats(&slug).await? {
-            StatsOutcome::Computing => Ok(placeholder(
-                "github: stats warming up (refresh in a minute)",
+            StatsOutcome::Computing => Err(FetchError::Failed(
+                "github: stats warming up (refresh in a minute)".into(),
             )),
             StatsOutcome::Ready(stats) => {
                 let rows = top_contributors(&stats, days, limit);

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -1,6 +1,7 @@
 //! `github_contributors_monthly` — who's shipping this month, ranked by commit count. Uses the
-//! stats endpoint, which returns 202 while GitHub computes the aggregate; we surface a
-//! transient placeholder rather than blocking.
+//! stats endpoint, which returns 202 while GitHub computes the aggregate; we return `Err` so
+//! the runtime surfaces a transient warning placeholder and re-checks on the next refresh
+//! rather than blocking the render.
 
 use async_trait::async_trait;
 use chrono::{Duration, Utc};

--- a/src/fetcher/github/good_first_issues.rs
+++ b/src/fetcher/github/good_first_issues.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder};
+use super::common::{RepoSlug, cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
@@ -98,10 +98,7 @@ impl Fetcher for GithubGoodFirstIssues {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
         let label = opts
             .label

--- a/src/fetcher/github/languages.rs
+++ b/src/fetcher/github/languages.rs
@@ -15,7 +15,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
+use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
 const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries];
 
@@ -78,14 +78,8 @@ impl Fetcher for GithubLanguages {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let limit = opts
             .limit
             .map(|n| n as usize)

--- a/src/fetcher/github/my_prs.rs
+++ b/src/fetcher/github/my_prs.rs
@@ -12,7 +12,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{cache_key, parse_options, payload, placeholder};
+use super::common::{cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
@@ -78,10 +78,7 @@ impl Fetcher for GithubMyPrs {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
         let path = format!(
             "/search/issues?q=is%3Apr+is%3Aopen+author%3A%40me&per_page={limit}&sort=updated"

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -13,7 +13,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{cache_key, parse_options, parse_timestamp, payload, placeholder};
+use super::common::{cache_key, parse_options, parse_timestamp, payload};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 10;
@@ -85,10 +85,7 @@ impl Fetcher for GithubNotifications {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 50);
         let all = opts.all.unwrap_or(false);
         let path = format!("/notifications?per_page={limit}&all={all}");

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -12,9 +12,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{
-    RepoSlug, cache_key, parse_options, parse_timestamp, payload, placeholder, resolve_repo,
-};
+use super::common::{RepoSlug, cache_key, parse_options, parse_timestamp, payload, resolve_repo};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
 const DEFAULT_LIMIT: u32 = 5;
@@ -79,14 +77,8 @@ impl Fetcher for GithubRecentReleases {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 20);
         let path = format!(
             "/repos/{}/{}/releases?per_page={limit}",

--- a/src/fetcher/github/repo.rs
+++ b/src/fetcher/github/repo.rs
@@ -57,10 +57,7 @@ impl Fetcher for GithubRepo {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let slug = match resolve_repo(None) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let slug = resolve_repo(None)?;
         let info: RepoInfo = rest_get(&format!("/repos/{}/{}", slug.owner, slug.name)).await?;
         let meta = Metadata {
             slug: Some(format!("{}/{}", slug.owner, slug.name)),
@@ -159,17 +156,6 @@ fn payload(body: Body) -> Payload {
         status: None,
         format: None,
         body,
-    }
-}
-
-fn placeholder(msg: &str) -> Payload {
-    Payload {
-        icon: None,
-        status: None,
-        format: None,
-        body: Body::Text(TextData {
-            value: format!("⚠ {msg}"),
-        }),
     }
 }
 

--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
+use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 use super::items::{IssueItem, render_items};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
@@ -79,14 +79,8 @@ impl Fetcher for GithubRepoIssues {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
         // Over-fetch to compensate for pulls mixed into the response — the endpoint has no
         // server-side "issues only" flag. Cap at 100 (max per_page) so the fix-up never has to

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
+use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 use super::items::{IssueItem, render_items};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
@@ -85,14 +85,8 @@ impl Fetcher for GithubRepoPrs {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
         let path = format!(
             "/repos/{}/{}/pulls?state=open&sort=updated&direction=desc&per_page={limit}",

--- a/src/fetcher/github/repo_stars.rs
+++ b/src/fetcher/github/repo_stars.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{RepoSlug, cache_key, parse_options, payload, placeholder, resolve_repo};
+use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
 const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
 
@@ -63,14 +63,8 @@ impl Fetcher for GithubRepoStars {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let slug = match resolve_repo(opts.repo.as_deref()) {
-            Ok(s) => s,
-            Err(e) => return Ok(placeholder(&e.to_string())),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let slug = resolve_repo(opts.repo.as_deref())?;
         let path = format!("/repos/{}/{}", slug.owner, slug.name);
         let repo: RepoInfo = rest_get(&path).await?;
         let body = match ctx.shape.unwrap_or(Shape::Text) {

--- a/src/fetcher/github/review_requests.rs
+++ b/src/fetcher/github/review_requests.rs
@@ -11,7 +11,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{cache_key, parse_options, payload, placeholder};
+use super::common::{cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
 const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
@@ -77,10 +77,7 @@ impl Fetcher for GithubReviewRequests {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
         let path = format!(
             "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me&per_page={limit}&sort=updated"

--- a/src/fetcher/github/user.rs
+++ b/src/fetcher/github/user.rs
@@ -13,7 +13,7 @@ use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
-use super::common::{cache_key, parse_options, payload, placeholder};
+use super::common::{cache_key, parse_options, payload};
 
 // TextBlock is listed first so the default renderer (text_plain accepts both Text and
 // TextBlock) picks the 3-line profile block — that's the header-band use case. Users
@@ -78,14 +78,8 @@ impl Fetcher for GithubUser {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: Options = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
-        let user = match resolve_user(opts.user.as_deref()) {
-            Ok(u) => u,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let user = resolve_user(opts.user.as_deref()).map_err(FetchError::Failed)?;
         let info: UserInfo = rest_get(&format!("/users/{user}")).await?;
         let body = match ctx.shape.unwrap_or(Shape::TextBlock) {
             Shape::Text => Body::Text(TextData {

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -146,6 +146,33 @@ pub fn shape_mismatch_placeholder(err: &ShapeMismatch) -> Payload {
     }
 }
 
+/// Payload rendered in place of a widget whose fetch returned `Err`. One-line `⚠ <msg>`, with a
+/// follow-up pointer to the log file so the user can track structured details (error chain,
+/// cache key, fetcher name) without forcing a second line into the splash for every error.
+pub fn error_placeholder(msg: &str) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body: Body::TextBlock(TextBlockData {
+            lines: vec![format!("⚠ {msg}"), "see $HOME/.splashboard/logs".into()],
+        }),
+    }
+}
+
+/// Payload rendered in place of a widget whose fetch exceeded the runtime deadline. Kept
+/// separate from [`error_placeholder`] so users can tell "slow" from "broken" at a glance.
+pub fn timeout_placeholder() -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body: Body::TextBlock(TextBlockData {
+            lines: vec!["⏱ timed out".into(), "see $HOME/.splashboard/logs".into()],
+        }),
+    }
+}
+
 pub fn default_cache_key(name: &str, ctx: &FetchContext) -> String {
     use sha2::{Digest, Sha256};
     let raw = format!("{}|{}", name, ctx.format.as_deref().unwrap_or(""));

--- a/src/fetcher/weather.rs
+++ b/src/fetcher/weather.rs
@@ -98,10 +98,8 @@ impl Fetcher for WeatherFetcher {
         })
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
-        let opts: WeatherOptions = match parse_options(ctx.options.as_ref()) {
-            Ok(o) => o,
-            Err(msg) => return Ok(placeholder(&msg)),
-        };
+        let opts: WeatherOptions =
+            parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let units = opts.units.unwrap_or_default();
         let report = fetch_report(opts.latitude, opts.longitude, units).await?;
         let body = match ctx.shape.unwrap_or(Shape::Entries) {
@@ -279,12 +277,6 @@ fn payload(body: Body) -> Payload {
         format: None,
         body,
     }
-}
-
-fn placeholder(msg: &str) -> Payload {
-    payload(Body::Text(TextData {
-        value: format!("⚠ {msg}"),
-    }))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod daemon;
 pub mod fetcher;
 pub mod install;
 pub mod layout;
+pub mod logging;
 pub mod options;
 pub mod paths;
 pub mod payload;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,111 @@
+//! `tracing` initialization for splashboard.
+//!
+//! Writes structured log lines to `$HOME/.splashboard/logs/splashboard.log.<date>` via
+//! `tracing-appender`'s daily-rotating file appender, keeping the latest 3 files. The
+//! `SPLASHBOARD_LOG` env var controls the filter (defaults to `error` so the log stays quiet
+//! until something goes wrong). Multiple calls in the same process are a no-op — the first
+//! caller wins.
+//!
+//! Separate from `stderr` / `stdout` on purpose: the main splashboard invocation owns the
+//! terminal (inline viewport + prompt handoff), and the daemon runs detached with null stdio.
+//! A file appender is the only sink that works in both.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::{Builder, Rotation};
+use tracing_subscriber::EnvFilter;
+
+use crate::paths;
+
+const LOG_FILENAME_PREFIX: &str = "splashboard";
+const LOG_FILENAME_SUFFIX: &str = "log";
+const MAX_LOG_FILES: usize = 3;
+const DEFAULT_FILTER: &str = "error";
+
+/// Holds the `tracing-appender` worker guard for the lifetime of the process. Dropped on
+/// process exit — the `WorkerGuard` flushes the non-blocking writer's buffer, so a process
+/// crashing mid-fetch still lands its error line in the log.
+static GUARD: OnceLock<WorkerGuard> = OnceLock::new();
+
+/// Initializes the tracing subscriber. Safe to call from both the main CLI and the fetch-only
+/// daemon; the first caller wins. Silent failure — if the log directory can't be created (no
+/// `$HOME`, read-only fs) the subscriber is simply not installed and `tracing::error!` calls
+/// become no-ops.
+pub fn init() {
+    if GUARD.get().is_some() {
+        return;
+    }
+    let Some(dir) = paths::logs_dir() else {
+        return;
+    };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let Some(appender) = build_appender(&dir) else {
+        return;
+    };
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    let filter = EnvFilter::try_from_env("SPLASHBOARD_LOG")
+        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(writer)
+        .with_ansi(false)
+        .with_target(false);
+    // Use `try_init` so a second subscriber install (e.g. tests racing the daemon) doesn't
+    // panic; the existing subscriber keeps receiving events.
+    if subscriber.try_init().is_ok() {
+        let _ = GUARD.set(guard);
+    }
+}
+
+fn build_appender(dir: &PathBuf) -> Option<tracing_appender::rolling::RollingFileAppender> {
+    Builder::new()
+        .rotation(Rotation::DAILY)
+        .filename_prefix(LOG_FILENAME_PREFIX)
+        .filename_suffix(LOG_FILENAME_SUFFIX)
+        .max_log_files(MAX_LOG_FILES)
+        .build(dir)
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tracing_appender::non_blocking;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[test]
+    fn build_appender_creates_a_file_on_first_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let appender = build_appender(&dir.path().to_path_buf()).expect("appender builds");
+        let (writer, _guard) = non_blocking(appender);
+        {
+            let mut w = writer.make_writer();
+            use std::io::Write;
+            writeln!(w, "hello from tests").unwrap();
+        }
+        drop(_guard);
+        // The appender rotates daily; the current day's file starts with our prefix.
+        let mut found = false;
+        for _ in 0..40 {
+            let any = std::fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .any(|e| {
+                    e.file_name()
+                        .to_string_lossy()
+                        .starts_with(LOG_FILENAME_PREFIX)
+                });
+            if any {
+                found = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert!(found, "log file must be created under {:?}", dir.path());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use splashboard::config::{
 use splashboard::daemon::{self, DashboardKind};
 use splashboard::fetcher::{Registry, Safety};
 use splashboard::install::{self, InstallOptions};
+use splashboard::logging;
 use splashboard::paths;
 use splashboard::render::Registry as RenderRegistry;
 use splashboard::runtime;
@@ -119,6 +120,7 @@ enum CatalogTarget {
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> io::Result<()> {
     let cli = Cli::parse();
+    logging::init();
     match cli.command {
         Some(Command::Init { shell }) => {
             print!("{}", shell::init_snippet(shell));

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -46,6 +46,12 @@ pub fn read_store_dir() -> Option<PathBuf> {
     splashboard_home().map(|d| d.join("store"))
 }
 
+/// Directory for the `tracing` file appender. Created lazily by the logging init path so
+/// invocations that never log don't touch the disk.
+pub fn logs_dir() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("logs"))
+}
+
 /// Shared mutex guarding any test that mutates `SPLASHBOARD_HOME`. Without this, parallel
 /// tests in different modules can see each other's temporary values through the process-wide
 /// env var. Exposed at crate level so other test modules (`fetcher::read_store`, etc.) can
@@ -85,6 +91,7 @@ mod tests {
         assert_eq!(trust_store_path(), Some(path.join("trust.toml")));
         assert_eq!(cache_dir(), Some(path.join("cache")));
         assert_eq!(read_store_dir(), Some(path.join("store")));
+        assert_eq!(logs_dir(), Some(path.join("logs")));
         unsafe {
             match previous {
                 Some(v) => std::env::set_var("SPLASHBOARD_HOME", v),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,7 +14,7 @@ use ratatui::{
 };
 use tokio::task::JoinSet;
 
-use crate::cache::{Cache, CacheEntry};
+use crate::cache::{Cache, CacheEntry, CacheEntryKind};
 use crate::config::{Config, WidgetConfig};
 use crate::daemon;
 use crate::fetcher::{self, FetchContext, Registry, ShapeMismatch};
@@ -523,6 +523,11 @@ fn entries_to_payloads(entries: &HashMap<WidgetId, CacheEntry>) -> HashMap<Widge
         .collect()
 }
 
+/// Short TTL for error/timeout cache entries so a transient blip doesn't pin the widget on the
+/// warning placeholder for long. Set well below the 60s default refresh so the next tick
+/// retries; long enough that back-to-back renders don't re-run a fetch that just failed.
+const ERROR_CACHE_TTL_SECS: u64 = 30;
+
 async fn fetch_all(
     registry: &Registry,
     cache: Option<&Cache>,
@@ -550,23 +555,54 @@ async fn fetch_all(
         };
         let id = w.id.clone();
         let ttl = w.refresh_interval.unwrap_or(DEFAULT_REFRESH_SECS);
+        let fetcher_name = fetcher.name().to_string();
         set.spawn(async move {
             let _lock = lock;
-            let payload = tokio::time::timeout(deadline, fetcher.fetch(&ctx))
-                .await
-                .ok()?
-                .ok()?;
-            Some((id, cache_key, ttl, payload))
+            match tokio::time::timeout(deadline, fetcher.fetch(&ctx)).await {
+                Ok(Ok(payload)) => (id, cache_key, ttl, CacheEntryKind::Ok, payload),
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        widget = %id,
+                        fetcher = %fetcher_name,
+                        cache_key = %cache_key,
+                        error = %e,
+                        "fetch failed"
+                    );
+                    (
+                        id,
+                        cache_key,
+                        ERROR_CACHE_TTL_SECS,
+                        CacheEntryKind::Err,
+                        fetcher::error_placeholder(&e.to_string()),
+                    )
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        widget = %id,
+                        fetcher = %fetcher_name,
+                        cache_key = %cache_key,
+                        timeout_ms = deadline.as_millis() as u64,
+                        "fetch timed out"
+                    );
+                    (
+                        id,
+                        cache_key,
+                        ERROR_CACHE_TTL_SECS,
+                        CacheEntryKind::Timeout,
+                        fetcher::timeout_placeholder(),
+                    )
+                }
+            }
         });
     }
 
     let mut out = HashMap::new();
     while let Some(joined) = set.join_next().await {
-        let Ok(Some((id, key, ttl, payload))) = joined else {
+        let Ok((id, key, ttl, kind, payload)) = joined else {
             continue;
         };
         if let Some(c) = cache {
-            let _ = c.store(&key, &CacheEntry::new(payload.clone(), ttl));
+            let _ = c.store(&key, &CacheEntry::new_with_kind(payload.clone(), ttl, kind));
         }
         out.insert(id, payload);
     }
@@ -902,6 +938,7 @@ mod tests {
     use super::*;
     use crate::layout::Layout as LayoutTree;
     use crate::payload::{Body, TextBlockData, TextData};
+    use async_trait::async_trait;
     use ratatui::{Terminal, backend::TestBackend};
 
     fn text_payload(line: &str) -> Payload {
@@ -1169,6 +1206,7 @@ mod tests {
             CacheEntry {
                 refreshed_at: 0,
                 ttl_seconds: 60,
+                kind: CacheEntryKind::Ok,
                 payload: text_payload("x"),
             },
         );
@@ -1344,6 +1382,128 @@ mod tests {
         )
         .await;
         assert!(fresh.is_empty());
+    }
+
+    /// Returning `Err` from a fetcher must surface a placeholder payload *and* write the failure
+    /// to the cache (with `CacheEntryKind::Err` and a short TTL) so the next render sees the `⚠`
+    /// instead of stale success data. Regression for #95 — pre-fix this path silently dropped the
+    /// error via `.ok()?.ok()?`.
+    #[tokio::test]
+    async fn fetch_all_lifts_err_to_placeholder_and_cache() {
+        struct Boom;
+
+        #[async_trait]
+        impl fetcher::Fetcher for Boom {
+            fn name(&self) -> &str {
+                "boom"
+            }
+            fn safety(&self) -> fetcher::Safety {
+                fetcher::Safety::Safe
+            }
+            fn shapes(&self) -> &[Shape] {
+                &[Shape::Text]
+            }
+            async fn fetch(
+                &self,
+                _: &fetcher::FetchContext,
+            ) -> Result<Payload, fetcher::FetchError> {
+                Err(fetcher::FetchError::Failed("boom".into()))
+            }
+        }
+
+        let mut registry = Registry::default();
+        registry.register(std::sync::Arc::new(Boom));
+        let dir = tempfile::tempdir().unwrap();
+        let cache = Cache::open(dir.path().to_path_buf()).unwrap();
+        let widgets = vec![widget("x", "boom")];
+
+        let fresh = fetch_all(
+            &registry,
+            Some(&cache),
+            &widgets,
+            &HashMap::new(),
+            &HashMap::new(),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        let payload = fresh.get("x").expect("error must surface as a payload");
+        match &payload.body {
+            Body::TextBlock(t) => assert!(
+                t.lines.iter().any(|l| l.contains("boom")),
+                "error message must appear in the placeholder: {:?}",
+                t.lines
+            ),
+            other => panic!("expected TextBlock error placeholder, got {other:?}"),
+        }
+
+        let key = registry
+            .get_cached("boom")
+            .unwrap()
+            .cache_key(&fetch_context(&widgets[0], None, Duration::from_secs(0)));
+        let stored = cache.load(&key).expect("error entry must be cached");
+        assert_eq!(stored.kind, CacheEntryKind::Err);
+        assert_eq!(stored.ttl_seconds, ERROR_CACHE_TTL_SECS);
+    }
+
+    /// Deadline expiry turns into a distinct `CacheEntryKind::Timeout` placeholder so diagnostics
+    /// can tell "slow" from "broken".
+    #[tokio::test]
+    async fn fetch_all_lifts_timeout_to_placeholder_and_cache() {
+        struct Slow;
+
+        #[async_trait]
+        impl fetcher::Fetcher for Slow {
+            fn name(&self) -> &str {
+                "slow"
+            }
+            fn safety(&self) -> fetcher::Safety {
+                fetcher::Safety::Safe
+            }
+            fn shapes(&self) -> &[Shape] {
+                &[Shape::Text]
+            }
+            async fn fetch(
+                &self,
+                _: &fetcher::FetchContext,
+            ) -> Result<Payload, fetcher::FetchError> {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                unreachable!("deadline must fire before the sleep resolves")
+            }
+        }
+
+        let mut registry = Registry::default();
+        registry.register(std::sync::Arc::new(Slow));
+        let dir = tempfile::tempdir().unwrap();
+        let cache = Cache::open(dir.path().to_path_buf()).unwrap();
+        let widgets = vec![widget("x", "slow")];
+
+        let fresh = fetch_all(
+            &registry,
+            Some(&cache),
+            &widgets,
+            &HashMap::new(),
+            &HashMap::new(),
+            Duration::from_millis(10),
+        )
+        .await;
+
+        let payload = fresh.get("x").expect("timeout must surface as a payload");
+        match &payload.body {
+            Body::TextBlock(t) => assert!(
+                t.lines.iter().any(|l| l.contains("timed out")),
+                "timeout message must appear: {:?}",
+                t.lines
+            ),
+            other => panic!("expected TextBlock timeout placeholder, got {other:?}"),
+        }
+
+        let key = registry
+            .get_cached("slow")
+            .unwrap()
+            .cache_key(&fetch_context(&widgets[0], None, Duration::from_secs(0)));
+        let stored = cache.load(&key).expect("timeout entry must be cached");
+        assert_eq!(stored.kind, CacheEntryKind::Timeout);
     }
 
     fn widget_with_render(id: &str, fetcher: &str, renderer: Option<&str>) -> WidgetConfig {
@@ -1528,6 +1688,7 @@ mod tests {
             CacheEntry {
                 refreshed_at: 0,
                 ttl_seconds: 60,
+                kind: CacheEntryKind::Ok,
                 payload: text_payload("last-run"),
             },
         );


### PR DESCRIPTION
## Summary

Resolves #95. Fetch failures used to be silent — `runtime.rs`'s `.ok()?.ok()?` dropped both `FetchError::Failed` and deadline timeouts on the floor, so a failing widget stayed blank until its TTL rolled over and nothing was logged anywhere.

- **Runtime lift**: `fetch_all` now turns `Err(FetchError)` into a `⚠ <msg>` placeholder and `tokio::time::Elapsed` into a `⏱ timed out` placeholder. Both paths `tracing::error!` / `tracing::warn!` the failure and write the outcome to the cache with a 30s error TTL (`ERROR_CACHE_TTL_SECS`), so the next render sees the warning instead of stale success data.
- **`tracing` wiring**: `tracing-subscriber` + `tracing-appender` (daily rotation, keep 3 files) under `$HOME/.splashboard/logs/`. `SPLASHBOARD_LOG=debug|info|error` toggles verbosity; defaults to `error` so the log only fills when something actually breaks.
- **`CacheEntry.kind`**: new `CacheEntryKind { Ok, Err, Timeout }`. `#[serde(default)]` keeps back-compat — legacy cache files without the field deserialize as `Ok`.
- **Fetcher cleanup**: every cached fetcher's `Ok(placeholder(...))` bail-out becomes `return Err(FetchError::Failed(...))`. Per-fetcher `placeholder()` helpers in `github/common.rs`, `weather.rs`, `github/avatar.rs`, and `github/repo.rs` are gone, replaced by the one `fetcher::error_placeholder` + `timeout_placeholder` pair. Realtime fetchers (`clock/*`, `system.rs`) keep their inline placeholders — their trait signature is infallible by design.

Out of scope (deliberate, tracked in #95 as follow-ups): variant B (`last_ok` + `last_err` cache + renderer-side compositor), panic-hook capture, remote telemetry, the `splashboard logs` subcommand, and the docs-site "Debugging" cookbook page.

## Test plan

- [x] `cargo test` — 492 unit + 12 bin tests pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests cover: `CacheEntryKind` legacy deserialize, runtime lifts `Err` → placeholder + `CacheEntryKind::Err` cache write, runtime lifts timeout → placeholder + `CacheEntryKind::Timeout` cache write, log appender writes a file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global logging system with environment-based configuration
  * Improved error propagation across all fetcher operations

* **Bug Fixes**
  * Fetchers now properly report errors instead of rendering placeholder content
  * Error and timeout responses are cached with shorter expiration times for faster recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->