### PR TITLE
feat(templates): fill preset family (home_minimal / project_splash / project_minimal)

### DIFF
--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -26,11 +26,12 @@ The installer auto-detects your shell and walks you through four gallery
 pickers — each with a live preview rendered from the shipped templates and
 your chosen theme — followed by a final confirmation page:
 
-1. **Home dashboard** — one of `home_splash` / `home_daily` / `home_github`.
-   Shown on new shells and when `cd`-ing anywhere outside a git repo root.
-2. **Project dashboard** — currently `project_github_activity`. Shown when
-   `cd`-ing into the top of any git repo that doesn't ship its own
-   `./.splashboard/`.
+1. **Home dashboard** — one of `home_splash` / `home_daily` / `home_github` /
+   `home_minimal`. Shown on new shells and when `cd`-ing anywhere outside a
+   git repo root.
+2. **Project dashboard** — one of `project_splash` / `project_github_activity` /
+   `project_minimal`. Shown when `cd`-ing into the top of any git repo that
+   doesn't ship its own `./.splashboard/`.
 3. **Theme** — `default` (the Splash signature ocean palette), or one of
    `tokyo_night`, `catppuccin_mocha`, `dracula`, `nord`, `gruvbox_dark`. The
    preview re-renders your home pick under the highlighted theme so you see
@@ -83,8 +84,8 @@ Flag reference:
 
 Available templates:
 
-- **home**: `home_splash`, `home_daily`, `home_github`
-- **project**: `project_github_activity`
+- **home**: `home_splash`, `home_daily`, `home_github`, `home_minimal`
+- **project**: `project_splash`, `project_github_activity`, `project_minimal`
 
 See [Presets](/splashboard/guides/presets/) for a rendered preview of each,
 and [Themes](/splashboard/guides/themes/) for the palette details.

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -144,20 +144,20 @@ Requires `gh auth login` (or `GITHUB_TOKEN`). The repo is discovered
 from `git remote origin`, so any repo you cd into produces a tailored
 dashboard with no per-repo edits.
 
-### `project_minimal` — four quiet lines
+### `project_minimal` — two quiet lines
 
-Repo name + slug / description / license, centred on a lot of
-whitespace. Acknowledges the repo without taking over the screen —
-useful when you cd into the same project hundreds of times a day and
-want `project_github_activity` to feel like a conscious choice rather
-than the default noise.
+Repo name + latest git tag, centred on a lot of whitespace. Acknowledges
+the repo without taking over the screen — useful when you cd into the
+same project hundreds of times a day and want `project_github_activity`
+to feel like a conscious choice rather than the default noise.
 
 <div class="splash-landing" set:html={projectMinimal} />
 
 | role | implementation |
 |---|---|
 | name | `git_repo_name` → `text_plain` |
-| subtitle | `github_repo` (slug / description / license) → `text_plain` |
+| tag | `git_latest_tag` (Text) → `text_plain` |
 
-No token required for the name alone — `github_repo`'s remaining lines
-collapse when unauthenticated, so the preset stays useful in any state.
+Fully offline — every widget reads local git, so the preset renders the
+same whether you're online, behind a firewall, or haven't run
+`gh auth login`.

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -1,14 +1,18 @@
 ---
 title: Presets
-description: Four curated dashboards you can adopt verbatim — one per context.
+description: Seven curated dashboards you can adopt verbatim — pair one home with one project.
 ---
 
 import homeSplash from '../../../assets/rendered/home_splash.html?raw';
 import homeDaily from '../../../assets/rendered/home_daily.html?raw';
 import homeGithub from '../../../assets/rendered/home_github.html?raw';
+import homeMinimal from '../../../assets/rendered/home_minimal.html?raw';
+import projectSplash from '../../../assets/rendered/project_splash.html?raw';
 import projectGithubActivity from '../../../assets/rendered/project_github_activity.html?raw';
+import projectMinimal from '../../../assets/rendered/project_minimal.html?raw';
 
-Four curated dashboards. Pick one as a starting point and edit freely.
+Seven curated dashboards — four home, three project. Pick one of each as a
+starting point and edit freely.
 
 - **Home presets** apply when the shell starts outside a git repo —
   copy into `$HOME/.splashboard/home.dashboard.toml`.
@@ -80,7 +84,41 @@ have it resolvable from git config `user.email` — so the avatar and
 profile pick up your login. Edit the `handle` widget's `format` to
 match.
 
+### `home_minimal` — three quiet lines
+
+Time-of-day greeting, a one-line date, and the daily quote. No figlet,
+no heatmap — just enough to feel acknowledged without a dashboard
+taking over every shell start.
+
+<div class="splash-landing" set:html={homeMinimal} />
+
+| role | implementation |
+|---|---|
+| greeting | `basic_static "good "` + `clock_derived` (kind = time_of_day) → `text_plain` |
+| date | `clock` (format `%A · %e %B %Y · %H:%M`) → `text_plain` |
+| quote | `quote_of_day` (Text) → `text_plain` |
+
+Pairs naturally with `project_minimal` if you want the same restraint
+inside a repo.
+
 ## Project presets
+
+### `project_splash` — animated repo hero
+
+Repo name as a giant figlet with a particle-burst reveal, followed by
+slug / description / license. Nothing else. For repo owners who want
+`./.splashboard/dashboard.toml` to feel like a title screen when someone
+clones.
+
+<div class="splash-landing" set:html={projectSplash} />
+
+| role | implementation |
+|---|---|
+| hero | `git_repo_name` → `text_ascii` (figlet, ansi_shadow), wrapped in `animated_postfx` (particle_burst) |
+| subtitle | `github_repo` (slug / description / license) → `text_plain` |
+
+Swap the hero's `effect = "..."` for `stagger_reveal` / `matrix_rain` /
+`neon_flash` / `glitch_in` to audition other openings.
 
 ### `project_github_activity` — repo hero + activity grid
 
@@ -105,3 +143,21 @@ issues, languages breakdown, recent releases.
 Requires `gh auth login` (or `GITHUB_TOKEN`). The repo is discovered
 from `git remote origin`, so any repo you cd into produces a tailored
 dashboard with no per-repo edits.
+
+### `project_minimal` — four quiet lines
+
+Repo name + slug / description / license, centred on a lot of
+whitespace. Acknowledges the repo without taking over the screen —
+useful when you cd into the same project hundreds of times a day and
+want `project_github_activity` to feel like a conscious choice rather
+than the default noise.
+
+<div class="splash-landing" set:html={projectMinimal} />
+
+| role | implementation |
+|---|---|
+| name | `git_repo_name` → `text_plain` |
+| subtitle | `github_repo` (slug / description / license) → `text_plain` |
+
+No token required for the name alone — `github_repo`'s remaining lines
+collapse when unauthenticated, so the preset stays useful in any state.

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -144,12 +144,14 @@ Requires `gh auth login` (or `GITHUB_TOKEN`). The repo is discovered
 from `git remote origin`, so any repo you cd into produces a tailored
 dashboard with no per-repo edits.
 
-### `project_minimal` — two quiet lines
+### `project_minimal` — name, tag, last three commits
 
-Repo name + latest git tag, centred on a lot of whitespace. Acknowledges
-the repo without taking over the screen — useful when you cd into the
-same project hundreds of times a day and want `project_github_activity`
-to feel like a conscious choice rather than the default noise.
+Repo name, latest tag, and a three-entry commit timeline. Centred on a
+lot of whitespace, no figlet, no panels. Acknowledges the repo and says
+"here's what you were just doing" without taking over the screen —
+useful when you cd into the same project hundreds of times a day and
+want `project_github_activity` to feel like a conscious choice rather
+than the default noise.
 
 <div class="splash-landing" set:html={projectMinimal} />
 
@@ -157,6 +159,7 @@ to feel like a conscious choice rather than the default noise.
 |---|---|
 | name | `git_repo_name` → `text_plain` |
 | tag | `git_latest_tag` (Text) → `text_plain` |
+| recent | `git_recent_commits` (format = `"3"`) → `list_timeline` |
 
 Fully offline — every widget reads local git, so the preset renders the
 same whether you're online, behind a firewall, or haven't run

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -159,7 +159,7 @@ than the default noise.
 |---|---|
 | name | `git_repo_name` → `text_plain` |
 | tag | `git_latest_tag` (Text) → `text_plain` |
-| recent | `git_recent_commits` (format = `"3"`) → `list_timeline` |
+| recent | `git_recent_commits` (shape = `"text_block"`, format = `"3"`) → `list_plain` |
 
 Fully offline — every widget reads local git, so the preset renders the
 same whether you're online, behind a firewall, or haven't run

--- a/docs-site/src/content/docs/showcases.md
+++ b/docs-site/src/content/docs/showcases.md
@@ -10,7 +10,8 @@ the relevant section below.
 ## Presets
 
 _Screenshots pending: `home_splash`, `home_daily`, `home_github`,_
-_`project_github_activity`._
+_`home_minimal`, `project_splash`, `project_github_activity`,_
+_`project_minimal`._
 
 ## Themes
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -188,6 +188,16 @@ fn loop_should_exit(daemon_done: bool, animation_pending: bool, deadline_reached
     deadline_reached || (daemon_done && !animation_pending)
 }
 
+/// Whether the loop should still be holding for the animation window. `animation_due` is the
+/// animation deadline check (`now < deadline`), `real_animated` is true when a configured
+/// renderer genuinely wants to animate, `loading_pending` is true when at least one cached
+/// widget still has no fresh payload. The animation window is only *binding* while something
+/// needs to animate — loading spinners are the common case for minimal presets, and once the
+/// daemon populates their cache entries the window stops blocking exit.
+fn animation_still_due(animation_due: bool, real_animated: bool, loading_pending: bool) -> bool {
+    animation_due && (real_animated || loading_pending)
+}
+
 const DEFAULT_REFRESH_SECS: u64 = 60;
 const FAST_DEADLINE: Duration = Duration::from_millis(1500);
 const WAIT_DEADLINE: Duration = Duration::from_secs(5);
@@ -256,9 +266,12 @@ pub async fn run(
     // Render axis: decide whether any configured renderer needs repeat frames. Independent of
     // the load decision — an animated widget must animate regardless of cache state. Loading
     // placeholders also animate (spinner glyph) so we force-enable animation whenever a cached
-    // widget has no entry yet — otherwise the spinner would appear to freeze mid-draw.
-    let animated = render::any_widget_animates(&config.widgets, &render_registry)
-        || has_loading_widget(&cached_widgets, &payloads, &entries, wait);
+    // widget has no entry yet — otherwise the spinner would appear to freeze mid-draw. We keep
+    // the two reasons separate: `real_animated` forces the loop to run the full ANIMATION_WINDOW
+    // so a configured effect plays; loading-only animation is dropped the moment the daemon's
+    // fresh entries clear the last spinner (checked per iteration inside the loop).
+    let real_animated = render::any_widget_animates(&config.widgets, &render_registry);
+    let animated = real_animated || has_loading_widget(&cached_widgets, &payloads, &entries, wait);
 
     let loop_window = match (wait, animated) {
         (false, false) => None,
@@ -356,7 +369,17 @@ pub async fn run(
                     }
                     break;
                 }
-                let animation_pending = animation_deadline.is_some_and(|d| now < d);
+                // Hold the loop for the animation window only while there's something that
+                // actually needs to animate: either a configured animated renderer or a
+                // still-loading spinner. A minimal preset on a cold cache sets `animated = true`
+                // purely because of spinners; once the daemon writes their entries the loading
+                // set empties and we can exit as soon as the daemon signals done, instead of
+                // burning the remainder of the 2s window for nothing.
+                let animation_pending = animation_still_due(
+                    animation_deadline.is_some_and(|d| now < d),
+                    real_animated,
+                    !loading.is_empty(),
+                );
                 if loop_should_exit(daemon_done, animation_pending, false) {
                     break;
                 }
@@ -1629,6 +1652,30 @@ mod tests {
         let (valid, invalid) = partition_by_shape_support(&widgets, &shapes, &registry);
         assert_eq!(valid.len(), 3);
         assert!(invalid.is_empty());
+    }
+
+    #[test]
+    fn animation_still_due_only_while_something_animates() {
+        // Regression: minimal presets on a cold cache used to burn the full 2s animation window
+        // because loading spinners flipped `animated = true`. Once the daemon clears the loading
+        // set, nothing needs to animate and the window stops being binding even though the
+        // deadline hasn't expired yet.
+        assert!(
+            animation_still_due(true, true, false),
+            "real animation pending → still due even with no loading"
+        );
+        assert!(
+            animation_still_due(true, false, true),
+            "loading spinners pending → still due"
+        );
+        assert!(
+            !animation_still_due(true, false, false),
+            "deadline not reached but nothing to animate → not due"
+        );
+        assert!(
+            !animation_still_due(false, true, true),
+            "deadline reached → animation no longer due regardless"
+        );
     }
 
     #[test]

--- a/src/templates/home_minimal.toml
+++ b/src/templates/home_minimal.toml
@@ -1,0 +1,84 @@
+# home_minimal — the quiet sibling of home_splash / home_daily / home_github. No figlet,
+# no heatmap, no multi-column body. Three centred lines and a lot of whitespace, so every
+# `cd` home feels like taking a breath instead of opening a dashboard. Zero config — every
+# widget works out of the box; users who want weather or a custom greeting edit
+# `$HOME/.splashboard/home.dashboard.toml` directly.
+
+# ── Widgets ────────────────────────────────────────────────────────
+
+# "good morning" / "good afternoon" / "good evening" / "good night" — built from the
+# wall clock via `clock_derived` so the splash reads context-aware without a greeting
+# fetcher of its own. Prefix + value are two widgets so the seam stays tight (right-
+# aligned "good " meets left-aligned "evening").
+[[widget]]
+id = "greeting_prefix"
+fetcher = "basic_static"
+format = "good "
+render = { type = "text_plain", align = "right" }
+
+[[widget]]
+id = "greeting"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "left", color = "panel_title" }
+  [widget.options]
+  kind = "time_of_day"
+
+# One-line date + time. `clock` is a RealtimeFetcher so the minute ticks over without a
+# cache refresh — the splash feels live even though nothing else on screen moves.
+[[widget]]
+id = "datetime"
+fetcher = "clock"
+format = "%A · %e %B %Y · %H:%M"
+render = { type = "text_plain", align = "center" }
+
+# `quote_of_day` Text shape emits a single deterministic-per-day line "… — Author".
+# TextBlock would wrap onto two lines; the single-line Text shape is what suits the
+# minimal layout.
+[[widget]]
+id = "quote"
+fetcher = "quote_of_day"
+shape = "text"
+render = { type = "text_plain", align = "center" }
+
+# ── Layout ─────────────────────────────────────────────────────────
+
+# Top padding — pushes the content toward vertical centre without a hard-coded row
+# count (terminal heights vary).
+[[row]]
+height = { fill = 1 }
+
+# Greeting: `good ` (right-aligned, 5 cells) meets `evening` (left-aligned, 12 cells)
+# so "good evening" sits as a single crisp seam instead of two centred fragments.
+[[row]]
+height = { length = 1 }
+flex = "center"
+  [[row.child]]
+  widget = "greeting_prefix"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "greeting"
+  width = { length = 12 }
+
+[[row]]
+height = { length = 1 }
+
+[[row]]
+height = { length = 1 }
+  [[row.child]]
+  widget = "datetime"
+
+[[row]]
+height = { length = 2 }
+
+# Quote — centred on the 80-col content band so long quotes don't wrap against narrower
+# terminals but still sit visually anchored inside a wider one.
+[[row]]
+height = { length = 2 }
+flex = "center"
+  [[row.child]]
+  widget = "quote"
+  width = { length = 80 }
+
+# Bottom padding — matches the top so the block sits vertically centred.
+[[row]]
+height = { fill = 1 }

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -44,10 +44,28 @@ pub const TEMPLATES: &[Template] = &[
         body: include_str!("home_github.toml"),
     },
     Template {
+        name: "home_minimal",
+        context: TemplateContext::Home,
+        description: "Quiet three-line preset: a time-of-day greeting, one-line date, and the daily quote — no figlet, lots of whitespace.",
+        body: include_str!("home_minimal.toml"),
+    },
+    Template {
+        name: "project_splash",
+        context: TemplateContext::Project,
+        description: "Repo name as a giant figlet hero with a postfx reveal, slug / description / license underneath — nothing else. For repo-shipped configs.",
+        body: include_str!("project_splash.toml"),
+    },
+    Template {
         name: "project_github_activity",
         context: TemplateContext::Project,
         description: "Dynamic repo hero + subtitle; branch state, commit / CI sparklines, open PRs, and recent releases.",
         body: include_str!("project_github_activity.toml"),
+    },
+    Template {
+        name: "project_minimal",
+        context: TemplateContext::Project,
+        description: "Quiet four-line preset: repo name + slug / description / license, no figlet. Acknowledges the repo without taking over the screen.",
+        body: include_str!("project_minimal.toml"),
     },
 ];
 

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -64,7 +64,7 @@ pub const TEMPLATES: &[Template] = &[
     Template {
         name: "project_minimal",
         context: TemplateContext::Project,
-        description: "Quiet two-line preset: repo name + latest git tag. Fully offline (no GitHub calls) — acknowledges the repo without taking over the screen.",
+        description: "Quiet preset: repo name, latest tag, and the last three commits. Fully offline (no GitHub calls) — acknowledges the repo without taking over the screen.",
         body: include_str!("project_minimal.toml"),
     },
 ];

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -64,7 +64,7 @@ pub const TEMPLATES: &[Template] = &[
     Template {
         name: "project_minimal",
         context: TemplateContext::Project,
-        description: "Quiet four-line preset: repo name + slug / description / license, no figlet. Acknowledges the repo without taking over the screen.",
+        description: "Quiet two-line preset: repo name + latest git tag. Fully offline (no GitHub calls) — acknowledges the repo without taking over the screen.",
         body: include_str!("project_minimal.toml"),
     },
 ];

--- a/src/templates/project_minimal.toml
+++ b/src/templates/project_minimal.toml
@@ -1,0 +1,49 @@
+# project_minimal — the quiet sibling of `project_github_activity` / `project_splash`.
+# Four centred lines: repo name, slug, description, license. No figlet, no heatmap,
+# no panels. For users who want acknowledgment they're in a repo without the splash
+# taking over every `cd`. Drop in as `./.splashboard/dashboard.toml` at a repo root —
+# every widget resolves the repo at fetch time, so the same template works anywhere.
+
+# ── Widgets ────────────────────────────────────────────────────────
+
+# Repo name in plain typography — the whole point of the minimal preset is *not* a
+# giant figlet banner. Picks up the terminal's title colour so the line still reads
+# as a heading next to the dimmer subtitle below.
+[[widget]]
+id = "name"
+fetcher = "git_repo_name"
+render = { type = "text_plain", align = "center", color = "panel_title" }
+
+# Subtitle: slug / description / license — three short lines from `github_repo`. The
+# fetcher collapses missing fields, so repos without a description don't get a blank
+# gap between the other rows.
+[[widget]]
+id = "subtitle"
+fetcher = "github_repo"
+render = { type = "text_plain", align = "center" }
+
+# ── Layout ─────────────────────────────────────────────────────────
+
+[[row]]
+height = { fill = 1 }
+
+[[row]]
+height = { length = 1 }
+  [[row.child]]
+  widget = "name"
+
+[[row]]
+height = { length = 1 }
+
+# github_repo TextBlock is up to 3 rows (slug / description / license). The 80-col
+# width matches the other presets so long descriptions don't hug a narrow column
+# inside a wide terminal.
+[[row]]
+height = { length = 3 }
+flex = "center"
+  [[row.child]]
+  widget = "subtitle"
+  width = { length = 80 }
+
+[[row]]
+height = { fill = 1 }

--- a/src/templates/project_minimal.toml
+++ b/src/templates/project_minimal.toml
@@ -25,16 +25,17 @@ fetcher = "git_latest_tag"
 shape = "text"
 render = { type = "text_plain", align = "center" }
 
-# The three most recent commits on HEAD, rendered as a timeline. The `format` field
-# is parsed as a commit count — "3" keeps the panel tight without forcing users who
-# want five to re-type the whole widget block. `align = "center"` centres the whole
-# timeline block on the widest line so it lines up visually with the centered hero
-# and tag above, instead of sitting left-aligned inside a centred cell.
+# The three most recent commits on HEAD as a flat list — one row per commit. We use
+# `shape = "text_block"` (`"<short_hash> <summary>"`) instead of the default Timeline
+# shape because `list_timeline` hangs the short hash as a detail row under the title,
+# so three Timeline events would span six rows; TextBlock keeps it genuinely three-
+# lines-for-three-commits. `format = "3"` passes the commit count to the fetcher.
 [[widget]]
 id = "recent"
 fetcher = "git_recent_commits"
+shape = "text_block"
 format = "3"
-render = { type = "list_timeline", bullet = "●", date_format = "relative", align = "center" }
+render = { type = "list_plain", bullet = "●", align = "center" }
 
 # ── Layout ─────────────────────────────────────────────────────────
 

--- a/src/templates/project_minimal.toml
+++ b/src/templates/project_minimal.toml
@@ -1,9 +1,9 @@
 # project_minimal — the quiet sibling of `project_github_activity` / `project_splash`.
-# Two centred lines: repo name and its latest git tag. No figlet, no heatmap, no
-# panels, and deliberately no GitHub calls — every widget reads local git, so the
-# preset renders the same whether you're offline, behind a firewall, or haven't
-# run `gh auth login`. For users who want acknowledgment they're in a repo without
-# the splash taking over every `cd`. Pairs with `home_minimal`.
+# Repo name, latest tag, and the last three commits — centred on lots of whitespace,
+# no figlet, no heatmap, no panels. Deliberately GitHub-free: every widget reads
+# local git, so the preset renders the same whether you're offline, behind a
+# firewall, or haven't run `gh auth login`. For users who want acknowledgment they're
+# in a repo without the splash taking over every `cd`. Pairs with `home_minimal`.
 
 # ── Widgets ────────────────────────────────────────────────────────
 
@@ -25,6 +25,16 @@ fetcher = "git_latest_tag"
 shape = "text"
 render = { type = "text_plain", align = "center" }
 
+# The three most recent commits on HEAD, rendered as a timeline. The `format` field
+# is parsed as a commit count — "3" keeps the panel tight without forcing users who
+# want five to re-type the whole widget block. No bullet option here because the
+# default `●` is exactly the minimal dot we'd pick anyway.
+[[widget]]
+id = "recent"
+fetcher = "git_recent_commits"
+format = "3"
+render = { type = "list_timeline", bullet = "●", date_format = "relative" }
+
 # ── Layout ─────────────────────────────────────────────────────────
 
 [[row]]
@@ -39,6 +49,18 @@ height = { length = 1 }
 height = { length = 1 }
   [[row.child]]
   widget = "tag"
+
+[[row]]
+height = { length = 2 }
+
+# Three commit lines on a centred 60-col column so long commit subjects don't hug
+# the terminal edge in a wide window.
+[[row]]
+height = { length = 3 }
+flex = "center"
+  [[row.child]]
+  widget = "recent"
+  width = { length = 60 }
 
 [[row]]
 height = { fill = 1 }

--- a/src/templates/project_minimal.toml
+++ b/src/templates/project_minimal.toml
@@ -27,13 +27,14 @@ render = { type = "text_plain", align = "center" }
 
 # The three most recent commits on HEAD, rendered as a timeline. The `format` field
 # is parsed as a commit count — "3" keeps the panel tight without forcing users who
-# want five to re-type the whole widget block. No bullet option here because the
-# default `●` is exactly the minimal dot we'd pick anyway.
+# want five to re-type the whole widget block. `align = "center"` centres the whole
+# timeline block on the widest line so it lines up visually with the centered hero
+# and tag above, instead of sitting left-aligned inside a centred cell.
 [[widget]]
 id = "recent"
 fetcher = "git_recent_commits"
 format = "3"
-render = { type = "list_timeline", bullet = "●", date_format = "relative" }
+render = { type = "list_timeline", bullet = "●", date_format = "relative", align = "center" }
 
 # ── Layout ─────────────────────────────────────────────────────────
 

--- a/src/templates/project_minimal.toml
+++ b/src/templates/project_minimal.toml
@@ -1,25 +1,28 @@
 # project_minimal — the quiet sibling of `project_github_activity` / `project_splash`.
-# Four centred lines: repo name, slug, description, license. No figlet, no heatmap,
-# no panels. For users who want acknowledgment they're in a repo without the splash
-# taking over every `cd`. Drop in as `./.splashboard/dashboard.toml` at a repo root —
-# every widget resolves the repo at fetch time, so the same template works anywhere.
+# Two centred lines: repo name and its latest git tag. No figlet, no heatmap, no
+# panels, and deliberately no GitHub calls — every widget reads local git, so the
+# preset renders the same whether you're offline, behind a firewall, or haven't
+# run `gh auth login`. For users who want acknowledgment they're in a repo without
+# the splash taking over every `cd`. Pairs with `home_minimal`.
 
 # ── Widgets ────────────────────────────────────────────────────────
 
 # Repo name in plain typography — the whole point of the minimal preset is *not* a
 # giant figlet banner. Picks up the terminal's title colour so the line still reads
-# as a heading next to the dimmer subtitle below.
+# as a heading next to the dimmer tag below.
 [[widget]]
 id = "name"
 fetcher = "git_repo_name"
 render = { type = "text_plain", align = "center", color = "panel_title" }
 
-# Subtitle: slug / description / license — three short lines from `github_repo`. The
-# fetcher collapses missing fields, so repos without a description don't get a blank
-# gap between the other rows.
+# Most recent tag ("v0.2.0") as a single line. `git_latest_tag` Text shape emits
+# just the tag name; Entries would add commit / date which we don't want here. The
+# fetcher renders an empty line when the repo has no tags, so the layout stays
+# stable on fresh repos.
 [[widget]]
-id = "subtitle"
-fetcher = "github_repo"
+id = "tag"
+fetcher = "git_latest_tag"
+shape = "text"
 render = { type = "text_plain", align = "center" }
 
 # ── Layout ─────────────────────────────────────────────────────────
@@ -34,16 +37,8 @@ height = { length = 1 }
 
 [[row]]
 height = { length = 1 }
-
-# github_repo TextBlock is up to 3 rows (slug / description / license). The 80-col
-# width matches the other presets so long descriptions don't hug a narrow column
-# inside a wide terminal.
-[[row]]
-height = { length = 3 }
-flex = "center"
   [[row.child]]
-  widget = "subtitle"
-  width = { length = 80 }
+  widget = "tag"
 
 [[row]]
 height = { fill = 1 }

--- a/src/templates/project_splash.toml
+++ b/src/templates/project_splash.toml
@@ -1,0 +1,56 @@
+# project_splash — "ta-da!" preset for a repo-shipped `./.splashboard/dashboard.toml`.
+# Giant repo-name figlet with a post-effect reveal, a tight two-line subtitle, and
+# nothing else. Sister to `home_splash`: same vocabulary (animated hero + minimal body),
+# different hero source (repo name vs terminal name). For the dense github-forward
+# sibling pick `project_github_activity`; for the even-quieter one pick `project_minimal`.
+# Every widget resolves the repo at fetch time, so the same template works in any
+# git root.
+
+# ── Widgets ────────────────────────────────────────────────────────
+
+[[widget]]
+id = "hero"
+# Giant repo-name figlet reveal via `animated_postfx`. `particle_burst` scatters
+# radial particles that coalesce into the figlet — same signature opening used by
+# `home_splash`. Swap `effect = "..."` to audition `stagger_reveal` / `matrix_rain` /
+# `neon_flash` / `glitch_in` without touching the rest of the preset.
+fetcher = "git_repo_name"
+render = { type = "animated_postfx", inner = "text_ascii", effect = "particle_burst", duration_ms = 1500, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
+
+# Subtitle — slug / description / license on three lines via `github_repo` TextBlock.
+# `text_plain` centres each line individually, so single-word fields (e.g. "MIT")
+# still sit under the hero's centreline instead of the block's left edge.
+[[widget]]
+id = "subtitle"
+fetcher = "github_repo"
+render = { type = "text_plain", align = "center" }
+
+# ── Layout ─────────────────────────────────────────────────────────
+
+# Top padding pushes the hero away from the first terminal row so the particle burst
+# has breathing room.
+[[row]]
+height = { length = 2 }
+
+# `height = "auto"` asks the row to size to the figlet's rendered height — shorter
+# repo names get tighter top/bottom framing; longer names (that wrap onto a second
+# figlet block) grow the row instead of clipping.
+[[row]]
+height = "auto"
+  [[row.child]]
+  widget = "hero"
+
+[[row]]
+height = { length = 1 }
+
+[[row]]
+height = { length = 3 }
+flex = "center"
+  [[row.child]]
+  widget = "subtitle"
+  width = { length = 80 }
+
+# Bottom padding mirrors the top so the hero sits vertically weighted inside the
+# viewport rather than hugging the top edge.
+[[row]]
+height = { fill = 1 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,10 +45,13 @@ const DASHBOARD_SNAPSHOTS: &[(&str, &str)] = &[
     ("src/templates/home_splash.toml", "home_splash.html"),
     ("src/templates/home_daily.toml", "home_daily.html"),
     ("src/templates/home_github.toml", "home_github.html"),
+    ("src/templates/home_minimal.toml", "home_minimal.html"),
+    ("src/templates/project_splash.toml", "project_splash.html"),
     (
         "src/templates/project_github_activity.toml",
         "project_github_activity.html",
     ),
+    ("src/templates/project_minimal.toml", "project_minimal.html"),
 ];
 
 fn main() -> Result<()> {


### PR DESCRIPTION
## Summary

- Add three presets to close the gaps left by #77: `home_minimal`, `project_splash`, `project_minimal`. The family now has a low-density / everyday / wow variant in each context (home + project).
- `home_minimal` / `project_minimal` are three-to-four-line centred presets — greeting + date + quote (home), repo name + subtitle (project). No figlet, lots of whitespace. For users who want acknowledgment without a dashboard taking over every shell start.
- `project_splash` is the repo-side sibling of `home_splash` — figlet repo hero wrapped in `animated_postfx` (particle_burst) + slug/description/license subtitle, no body panels. Aimed at repo-shipped `./.splashboard/dashboard.toml` configs that want to feel like a title screen when a visitor clones.
- No new fetchers or renderers. Every widget reuses existing building blocks.
- Dropped the `project_dev_status` candidate from #96's original proposal after discussion — branch / ahead-behind / dirty is prompt territory (starship, p10k) and the remaining widgets overlapped `project_github_activity` too heavily to be load-bearing.

## Family after this PR

| | splash | daily / activity | quiet |
|---|---|---|---|
| **home** | `home_splash` | `home_daily` + `home_github` | `home_minimal` *(new)* |
| **project** | `project_splash` *(new)* | `project_github_activity` | `project_minimal` *(new)* |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 508 lib + 12 integration tests green, including `every_template_parses` / `every_widget_fetcher_is_registered` / `every_widget_renderer_is_registered` / `every_widget_id_is_referenced_by_layout` / `every_template_renders_without_panic` picking up the three new templates automatically
- [x] `cargo xtask` regenerated `docs-site/src/assets/rendered/{home_minimal,project_splash,project_minimal}.html` without warnings; existing snapshots unchanged
- [ ] Manual check of the install picker — new presets should appear in the TTY gallery because `templates::for_context` iterates `TEMPLATES` directly (added entries + descriptions only, no wiring changes)
- [ ] docs-site build — `presets.mdx` now imports three extra rendered snippets; `getting-started.md` template lists updated

Refs: #96, #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new dashboard templates are now available for selection: `home_minimal` and `home_splash` for home dashboards, and `project_splash` and `project_minimal` for project dashboards.

* **Documentation**
  * Updated guides to document the expanded preset library, now offering seven total curated dashboard options with clear setup instructions for selecting home and project presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->