### PR TITLE
fix(github): auto-detect login from token + fix home_github avatar sizing

### DIFF
--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -19,7 +19,7 @@ use crate::payload::{Body, ImageData, Payload};
 use crate::render::Shape;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::client::http;
+use super::client::{http, resolve_authenticated_user};
 use super::common::cache_key;
 
 const AVATAR_BASE: &str = "https://github.com";
@@ -30,8 +30,8 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
         name: "user",
         type_hint: "string (github login)",
         required: false,
-        default: Some("$GITHUB_USER env var"),
-        description: "GitHub login to fetch the avatar for. Falls back to the `GITHUB_USER` env var.",
+        default: Some("authenticated token user"),
+        description: "GitHub login to fetch the avatar for. Falls back to the `GITHUB_USER` env var, then to the login that owns `GH_TOKEN` / `GITHUB_TOKEN`.",
     },
     OptionSchema {
         name: "size",
@@ -81,7 +81,9 @@ impl Fetcher for GithubAvatar {
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
-        let user = resolve_user(opts.user.as_deref()).map_err(FetchError::Failed)?;
+        let user = resolve_user(opts.user.as_deref())
+            .await
+            .map_err(FetchError::Failed)?;
         let size = opts.size.unwrap_or(DEFAULT_SIZE);
         let path = download_avatar(&user, size).await?;
         Ok(payload(Body::Image(ImageData {
@@ -132,7 +134,7 @@ fn avatar_dir() -> Option<PathBuf> {
     paths::cache_dir().map(|d| d.join("avatars"))
 }
 
-fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
+async fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
     if let Some(u) = explicit.filter(|s| !s.is_empty()) {
         return Ok(u.into());
     }
@@ -141,7 +143,9 @@ fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
     {
         return Ok(u);
     }
-    Err("set `user = \"<login>\"` or the GITHUB_USER env var".into())
+    resolve_authenticated_user()
+        .await
+        .map_err(|e| format!("resolve github user: {e}"))
 }
 
 fn parse_options<T: serde::de::DeserializeOwned + Default>(
@@ -208,29 +212,33 @@ mod tests {
         }
     }
 
-    #[test]
-    fn resolve_user_prefers_explicit_option() {
+    #[tokio::test]
+    async fn resolve_user_prefers_explicit_option() {
         let _g = EnvGuard::set(&[("GITHUB_USER", Some("from-env"))]);
-        assert_eq!(resolve_user(Some("from-opt")).unwrap(), "from-opt");
+        assert_eq!(resolve_user(Some("from-opt")).await.unwrap(), "from-opt");
     }
 
-    #[test]
-    fn resolve_user_falls_back_to_env() {
+    #[tokio::test]
+    async fn resolve_user_falls_back_to_env() {
         let _g = EnvGuard::set(&[("GITHUB_USER", Some("env-user"))]);
-        assert_eq!(resolve_user(None).unwrap(), "env-user");
+        assert_eq!(resolve_user(None).await.unwrap(), "env-user");
     }
 
-    #[test]
-    fn resolve_user_empty_option_falls_through_to_env() {
+    #[tokio::test]
+    async fn resolve_user_empty_option_falls_through_to_env() {
         let _g = EnvGuard::set(&[("GITHUB_USER", Some("env-user"))]);
-        assert_eq!(resolve_user(Some("")).unwrap(), "env-user");
+        assert_eq!(resolve_user(Some("")).await.unwrap(), "env-user");
     }
 
-    #[test]
-    fn resolve_user_fails_when_neither_supplied() {
-        let _g = EnvGuard::set(&[("GITHUB_USER", None)]);
-        let err = resolve_user(None).unwrap_err();
-        assert!(err.contains("GITHUB_USER"));
+    #[tokio::test]
+    async fn resolve_user_without_env_or_token_surfaces_token_hint() {
+        let _g = EnvGuard::set(&[
+            ("GITHUB_USER", None),
+            ("GH_TOKEN", None),
+            ("GITHUB_TOKEN", None),
+        ]);
+        let err = resolve_user(None).await.unwrap_err();
+        assert!(err.contains("GH_TOKEN"), "unexpected error: {err}");
     }
 
     #[test]

--- a/src/fetcher/github/client.rs
+++ b/src/fetcher/github/client.rs
@@ -6,7 +6,7 @@
 //! The rest helpers accept a path like `"/user"` or `"/repos/foo/bar"`; the base URL is joined
 //! here so fetchers stay free of URL plumbing. GraphQL goes through a single POST helper.
 
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
@@ -38,6 +38,27 @@ pub fn resolve_token() -> Result<String, FetchError> {
     std::env::var("GH_TOKEN")
         .or_else(|_| std::env::var("GITHUB_TOKEN"))
         .map_err(|_| FetchError::Failed("GH_TOKEN / GITHUB_TOKEN not set".into()))
+}
+
+/// Login of the token-authenticated user. Resolved lazily via `GET /user` and memoised for the
+/// rest of the process so we never spend more than one roundtrip on a value that never changes
+/// within a session. Lets `github_avatar` / `github_user` work with zero config when a token is
+/// already set.
+pub async fn resolve_authenticated_user() -> Result<String, FetchError> {
+    static CACHED: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+    let slot = CACHED.get_or_init(|| Mutex::new(None));
+    if let Some(cached) = slot.lock().ok().and_then(|g| g.clone()) {
+        return Ok(cached);
+    }
+    #[derive(Deserialize)]
+    struct Me {
+        login: String,
+    }
+    let me: Me = rest_get("/user").await?;
+    if let Ok(mut g) = slot.lock() {
+        *g = Some(me.login.clone());
+    }
+    Ok(me.login)
 }
 
 /// REST GET → deserialize JSON. Non-2xx responses surface the GitHub-reported `message` when

--- a/src/fetcher/github/user.rs
+++ b/src/fetcher/github/user.rs
@@ -12,7 +12,7 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::client::rest_get;
+use super::client::{resolve_authenticated_user, rest_get};
 use super::common::{cache_key, parse_options, payload};
 
 // TextBlock is listed first so the default renderer (text_plain accepts both Text and
@@ -25,8 +25,8 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     name: "user",
     type_hint: "string (github login)",
     required: false,
-    default: Some("$GITHUB_USER env var"),
-    description: "GitHub login to fetch. Falls back to the `GITHUB_USER` env var when omitted.",
+    default: Some("authenticated token user"),
+    description: "GitHub login to fetch. Falls back to the `GITHUB_USER` env var, then to the login that owns `GH_TOKEN` / `GITHUB_TOKEN`.",
 }];
 
 pub struct GithubUser;
@@ -79,7 +79,9 @@ impl Fetcher for GithubUser {
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
-        let user = resolve_user(opts.user.as_deref()).map_err(FetchError::Failed)?;
+        let user = resolve_user(opts.user.as_deref())
+            .await
+            .map_err(FetchError::Failed)?;
         let info: UserInfo = rest_get(&format!("/users/{user}")).await?;
         let body = match ctx.shape.unwrap_or(Shape::TextBlock) {
             Shape::Text => Body::Text(TextData {
@@ -109,11 +111,13 @@ fn one_liner(info: &UserInfo) -> String {
     parts.join(" · ")
 }
 
-/// 3-line block for subtitle use: display name / bio / location + join year. Empty
-/// fields collapse so users without a bio don't see a stranded blank line.
+/// Up-to-4-line block for subtitle use: `@login` / display name / bio / location + join year.
+/// Empty fields collapse so users without a bio don't see a stranded blank line.
 fn text_block_lines(info: &UserInfo) -> Vec<String> {
-    let name = nonempty(&info.name).cloned().unwrap_or(info.login.clone());
-    let mut lines = vec![name];
+    let mut lines = vec![format!("@{}", info.login)];
+    if let Some(name) = nonempty(&info.name) {
+        lines.push(name.clone());
+    }
     if let Some(bio) = nonempty(&info.bio) {
         lines.push(bio.clone());
     }
@@ -171,7 +175,7 @@ fn join_year(created_at: &Option<String>) -> Option<String> {
         .map(String::from)
 }
 
-fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
+async fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
     if let Some(u) = explicit.filter(|s| !s.is_empty()) {
         return Ok(u.into());
     }
@@ -180,7 +184,9 @@ fn resolve_user(explicit: Option<&str>) -> Result<String, String> {
     {
         return Ok(u);
     }
-    Err("set `user = \"<login>\"` or the GITHUB_USER env var".into())
+    resolve_authenticated_user()
+        .await
+        .map_err(|e| format!("resolve github user: {e}"))
 }
 
 fn user_for_key(ctx: &FetchContext) -> String {
@@ -251,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn text_block_uses_name_then_bio_then_tail() {
+    fn text_block_leads_with_login_then_name_bio_tail() {
         let i = info(
             Some("Yuji Ueki"),
             Some("TUI hacker"),
@@ -262,7 +268,8 @@ mod tests {
         assert_eq!(
             text_block_lines(&i),
             vec![
-                "Yuji Ueki".to_string(),
+                "@unhappychoice".to_string(),
+                "Yuji Ueki".into(),
                 "TUI hacker".into(),
                 "Tokyo · member since 2013".into(),
             ]
@@ -270,9 +277,9 @@ mod tests {
     }
 
     #[test]
-    fn text_block_falls_back_to_login_when_name_missing() {
+    fn text_block_collapses_to_just_login_when_all_else_missing() {
         let i = info(None, None, None, None, None);
-        assert_eq!(text_block_lines(&i), vec!["unhappychoice".to_string()]);
+        assert_eq!(text_block_lines(&i), vec!["@unhappychoice".to_string()]);
     }
 
     #[test]

--- a/src/templates/home_github.toml
+++ b/src/templates/home_github.toml
@@ -1,11 +1,11 @@
-# home_github — "my github" preset. Avatar on the left + a plain-text handle and bio
-# (pulled from `/users/{login}`) on the right, then three stacked sections: contributions
-# heatmap, attention lane (open PRs / review queue), and recent notifications. All body
-# rows sit inside the 70-col content band used by the other 0.x presets.
+# home_github — "my github" preset. Avatar on the left, a 4-line profile (handle / name /
+# bio / location · member since YYYY) on the right, then three stacked sections:
+# contributions heatmap, attention lane (open PRs / review queue), and recent notifications.
+# All body rows sit inside the 70-col content band used by the other 0.x presets.
 #
-# Set `GITHUB_USER` (or git config `user.email`) so `github_avatar` and `github_user`
-# know which login to pull. Requires `gh auth login` (or `GITHUB_TOKEN`) for the
-# `github_*` fetchers.
+# Requires `gh auth login` (or `GH_TOKEN` / `GITHUB_TOKEN`) — the login is inferred from the
+# authenticated token so no `GITHUB_USER` setup is needed. Explicit `options.user = "<login>"`
+# on each `github_*` widget still wins if you want to point the preset at someone else.
 
 # ── Widgets ────────────────────────────────────────────────────────
 
@@ -14,19 +14,10 @@ id = "avatar"
 fetcher = "github_avatar"
 render = { type = "media_image", fit = "contain", max_width = 14, max_height = 7, align = "center" }
 
-# Handle as plain text — crisp text_plain line keeps the identity obvious. Users
-# with different logins edit `format` here. (github_avatar + github_user auto-detect
-# from `GITHUB_USER` / git config; the handle string on screen is the one place we
-# want readable typography over another API call.)
-[[widget]]
-id = "handle"
-fetcher = "basic_static"
-format = "@unhappychoice"
-render = { type = "text_plain", align = "left", color = "panel_title" }
-
-# Profile: `github_user` with TextBlock shape — 3 lines (name / bio / location ·
-# member since YYYY). Missing fields collapse so users with no bio don't see a
-# stranded blank line.
+# Profile: `github_user` with TextBlock shape — up to 4 lines (handle / name / bio /
+# location · member since YYYY). Missing fields collapse so users with no bio don't see a
+# stranded blank line. The `@login` header line doubles as the handle so no separate
+# widget is needed.
 [[widget]]
 id = "profile"
 fetcher = "github_user"
@@ -63,22 +54,11 @@ render = "text_plain"
 [[row]]
 height = { length = 1 }
 
-# Header band: avatar (fixed 16 cells) + handle one-liner + profile block underneath.
-# The handle takes the first content row; the profile (name / bio / location · year)
-# fills the remaining three, so the text sits vertically centred next to the 7-row
-# avatar image.
+# Header band: avatar (fixed 16 cells tall-and-wide enough to read) + the 4-line profile
+# block next to it. Row height is 7 so the square avatar actually has room to render at a
+# useful size; the 4 profile lines sit vertically within the same band.
 [[row]]
-height = { length = 1 }
-flex = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 16 }
-  [[row.child]]
-  widget = "handle"
-  width = { length = 54 }
-
-[[row]]
-height = { length = 4 }
+height = { length = 7 }
 flex = "center"
   [[row.child]]
   widget = "avatar"


### PR DESCRIPTION
## Summary
- `home_github` preset no longer requires `GITHUB_USER` — `github_avatar` and `github_user` fall back to `GET /user` (memoised) so the token-authenticated login is used automatically.
- Fix the avatar image not rendering in the `home_github` preset: the header row was 4 rows tall while the widget requested `max_height = 7`, so the square image collapsed. Row is now 7 rows tall to match.
- Drop the hardcoded `@unhappychoice` handle widget; `github_user` TextBlock now leads with `@login`, so the header band shows the viewer's own handle in the same 4-line block (handle / name / bio / location · member since YYYY).

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo xtask` to refresh the reference + rendered snapshot
- [ ] Manual smoke: run `splashboard` with `GH_TOKEN` set and no `GITHUB_USER`, verify avatar renders and `@login` shows up

🤖 Generated with [Claude Code](https://claude.com/claude-code)