### PR TITLE
feat(config): layout spacers via optional widget + row gap sugar

### DIFF
--- a/docs-site/src/content/docs/guides/configuration.md
+++ b/docs-site/src/content/docs/guides/configuration.md
@@ -151,16 +151,22 @@ Rows stack vertically. Each row's children stack horizontally.
 height = { length = 6 }     # cells — or { fill = 1 }, { min = 3 }, { percentage = 50 }
 bg = "subtle"               # "default" or "subtle" (paints theme.bg_subtle)
 flex = "center"             # how children distribute when they don't fill the row
+gap = 2                     # cells of blank space between sibling children
 title = "system"            # optional row-level title (goes with a row border)
 border = "top"              # "none" | "plain" | "rounded" | "thick" | "double" | "top"
 
   [[row.child]]
-  widget = "clock"          # widget id from [[widget]]
+  widget = "clock"          # widget id from [[widget]] — omit for a pure layout spacer
   width = { length = 30 }   # same size shapes as row height
   title = "now"             # optional child-level title
   border = "rounded"        # optional child-level chrome
   bg = "subtle"             # optional per-child bg
 ```
+
+Two ways to carve whitespace between children: `gap = N` on the row (sugar
+for the common case) auto-splices `N`-cell spacers between every pair; or
+drop a `[[row.child]]` with `width = { length = N }` and **no `widget =`**
+for an explicit spacer you can place anywhere in the row.
 
 Size forms (`height`, `width`):
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,11 @@ pub struct RowConfig {
     /// visually off the main content.
     #[serde(default)]
     pub bg: Option<BgSpec>,
+    /// Horizontal gap inserted between sibling children, in cells. Sugar for the common
+    /// 2/3-column case — `gap = 2` auto-splices empty spacers between children so configs
+    /// don't have to declare a `basic_static` "gap" widget just to carve whitespace.
+    #[serde(default)]
+    pub gap: Option<u16>,
     #[serde(default, rename = "child")]
     pub children: Vec<ChildConfig>,
 }
@@ -154,7 +159,11 @@ pub enum FlexSpec {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChildConfig {
-    pub widget: String,
+    /// Referenced widget id. Absent means this child is a pure layout spacer — the slot
+    /// reserves its `width` but paints nothing. Preferred over the historical
+    /// `basic_static`-with-empty-format hack for gap columns.
+    #[serde(default)]
+    pub widget: Option<String>,
     #[serde(default)]
     pub width: Option<SizeSpec>,
     #[serde(default)]
@@ -396,13 +405,28 @@ fn row_height_estimate(size: Option<SizeSpec>) -> u16 {
 }
 
 fn to_row_child(row: &RowConfig) -> Child {
-    let mut inner = Layout::cols(row.children.iter().map(to_col_child).collect());
+    let cols = intersperse_gaps(row.children.iter().map(to_col_child).collect(), row.gap);
+    let mut inner = Layout::cols(cols);
     if let Some(f) = row.flex {
         inner = inner.flexed(to_flex(f));
     }
     let decorated = apply_panel(inner, row.title.as_deref(), row.border, row.title_align);
     let decorated = apply_bg(decorated, row.bg);
     make_child(row.height, decorated)
+}
+
+fn intersperse_gaps(children: Vec<Child>, gap: Option<u16>) -> Vec<Child> {
+    let Some(n) = gap.filter(|n| *n > 0) else {
+        return children;
+    };
+    let mut out = Vec::with_capacity(children.len() * 2);
+    for (i, c) in children.into_iter().enumerate() {
+        if i > 0 {
+            out.push(Child::length(n, Layout::Empty));
+        }
+        out.push(c);
+    }
+    out
 }
 
 fn to_flex(f: FlexSpec) -> Flex {
@@ -417,7 +441,10 @@ fn to_flex(f: FlexSpec) -> Flex {
 }
 
 fn to_col_child(c: &ChildConfig) -> Child {
-    let leaf = Layout::widget(c.widget.clone());
+    let leaf = match c.widget.as_deref() {
+        Some(id) => Layout::widget(id.to_string()),
+        None => Layout::Empty,
+    };
     let decorated = apply_panel(leaf, c.title.as_deref(), c.border, c.title_align);
     let decorated = apply_bg(decorated, c.bg);
     make_child(c.width, decorated)
@@ -769,6 +796,101 @@ widget = "x"
         // Sub-directory: even though an ancestor is a git root, `resolve_from` must not walk
         // up — that's what keeps cd into src/ from re-triggering the project splash.
         assert!(resolve_from(&sub, true).is_none());
+    }
+
+    #[test]
+    fn child_without_widget_is_layout_spacer() {
+        // `[[row.child]]` with no `widget = ...` is a pure layout spacer — it reserves its
+        // `width` but renders nothing. Replaces the historical `basic_static` gap hack.
+        let toml = r#"
+[[widget]]
+id = "a"
+fetcher = "basic_static"
+render = "text_plain"
+
+[[row]]
+height = { length = 3 }
+[[row.child]]
+width = { length = 2 }
+[[row.child]]
+widget = "a"
+"#;
+        let d = DashboardConfig::parse(toml).unwrap();
+        assert!(d.rows[0].children[0].widget.is_none());
+        let layout = Config::from_parts(SettingsConfig::default(), d).to_layout();
+        let cols = match layout {
+            Layout::Stack { children, .. } => match &children[0].layout {
+                Layout::Stack { children: cs, .. } => cs.clone(),
+                _ => panic!("expected inner cols stack"),
+            },
+            _ => panic!("expected rows at root"),
+        };
+        assert!(matches!(cols[0].layout, Layout::Empty));
+        assert!(matches!(cols[1].layout, Layout::Widget { .. }));
+    }
+
+    #[test]
+    fn row_gap_splices_spacers_between_children() {
+        let toml = r#"
+[[widget]]
+id = "a"
+fetcher = "basic_static"
+render = "text_plain"
+
+[[widget]]
+id = "b"
+fetcher = "basic_static"
+render = "text_plain"
+
+[[row]]
+height = { length = 3 }
+gap = 2
+[[row.child]]
+widget = "a"
+[[row.child]]
+widget = "b"
+"#;
+        let d = DashboardConfig::parse(toml).unwrap();
+        assert_eq!(d.rows[0].gap, Some(2));
+        let layout = Config::from_parts(SettingsConfig::default(), d).to_layout();
+        let cols = match layout {
+            Layout::Stack { children, .. } => match &children[0].layout {
+                Layout::Stack { children: cs, .. } => cs.clone(),
+                _ => panic!("expected inner cols stack"),
+            },
+            _ => panic!("expected rows at root"),
+        };
+        assert_eq!(cols.len(), 3);
+        assert!(matches!(cols[0].layout, Layout::Widget { .. }));
+        assert!(matches!(cols[1].layout, Layout::Empty));
+        assert!(matches!(cols[2].layout, Layout::Widget { .. }));
+        assert!(matches!(cols[1].size, crate::layout::Size::Length(2)));
+    }
+
+    #[test]
+    fn row_gap_zero_is_noop() {
+        let toml = r#"
+[[widget]]
+id = "a"
+fetcher = "basic_static"
+
+[[row]]
+gap = 0
+[[row.child]]
+widget = "a"
+[[row.child]]
+widget = "a"
+"#;
+        let d = DashboardConfig::parse(toml).unwrap();
+        let layout = Config::from_parts(SettingsConfig::default(), d).to_layout();
+        let cols = match layout {
+            Layout::Stack { children, .. } => match &children[0].layout {
+                Layout::Stack { children: cs, .. } => cs.clone(),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        };
+        assert_eq!(cols.len(), 2);
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -30,7 +30,8 @@ pub enum Layout {
         panel: Option<Panel>,
         bg: BgLevel,
     },
-    #[allow(dead_code)]
+    /// Reserves its slot but paints nothing. Used by config spacers
+    /// (`[[row.child]]` without a `widget`, or `[[row]] gap = N` between siblings).
     Empty,
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -472,19 +472,25 @@ fn render_empty_state(frame: &mut Frame, area: Rect, theme: &Theme) {
     if area.width == 0 || area.height == 0 {
         return;
     }
+    // Two lines if there's room (icon + caption), otherwise collapse to the caption alone.
+    // Centered both axes via a Fill / Length / Fill vertical layout.
+    let (lines_src, min_width): (&[&str], u16) = if area.height >= 2 {
+        (&["◌", "nothing here yet"], 16)
+    } else {
+        (&["◌ nothing here yet"], 18)
+    };
+    // Skip rendering when the caption can't fit — a narrow spacer (e.g. 2-cell `basic_static`
+    // gap) should read as absent space, not leak truncated "no…" fragments into neighbors.
+    if area.width < min_width {
+        return;
+    }
     let dim = Style::default()
         .fg(theme.text_dim)
         .add_modifier(Modifier::ITALIC);
-    // Two lines if there's room (icon + caption), otherwise collapse to the caption alone.
-    // Centered both axes via a Fill / Length / Fill vertical layout.
-    let lines: Vec<Line> = if area.height >= 2 {
-        vec![
-            Line::from("◌").style(dim),
-            Line::from("nothing here yet").style(dim),
-        ]
-    } else {
-        vec![Line::from("◌ nothing here yet").style(dim)]
-    };
+    let lines: Vec<Line> = lines_src
+        .iter()
+        .map(|s| Line::from(*s).style(dim))
+        .collect();
     let content_height = lines.len() as u16;
     let chunks = Layout::vertical([
         Constraint::Fill(1),
@@ -682,6 +688,31 @@ mod tests {
         assert!(
             joined.contains("nothing here yet"),
             "missing caption: {joined:?}"
+        );
+    }
+
+    #[test]
+    fn empty_placeholder_skipped_when_area_too_narrow() {
+        // Regression: 2-cell `basic_static` gap widgets used as horizontal spacers were
+        // rendering a truncated "no…" fragment from the "nothing here yet" caption, spilling
+        // the artifact into the neighboring widget's column.
+        use crate::payload::{Payload, TextData};
+        use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+        let p = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: String::new(),
+            }),
+        };
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("text_plain".into());
+        let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 2, 6);
+        let joined: String = (0..6).map(|y| line_text(&buf, y)).collect();
+        assert!(
+            !joined.contains("no") && !joined.contains('◌'),
+            "narrow area should render nothing, got: {joined:?}"
         );
     }
 

--- a/src/templates/home_daily.toml
+++ b/src/templates/home_daily.toml
@@ -103,12 +103,6 @@ render = { type = "gauge_line", label = "day  ", value_format = "percent" }
   [widget.options]
   period = "day"
 
-[[widget]]
-id = "gap"
-fetcher = "basic_static"
-format = " "
-render = "text_plain"
-
 # ── Layout ─────────────────────────────────────────────────────────
 
 [[row]]
@@ -145,15 +139,13 @@ height = { length = 1 }
 [[row]]
 height = { length = 8 }
 flex = "center"
+gap = 2
   [[row.child]]
   widget = "calendar"
   width = { length = 34 }
   border = "top"
   title = "  this month  "
   title_align = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 2 }
   [[row.child]]
   widget = "almanac"
   width = { length = 34 }
@@ -168,15 +160,13 @@ height = { length = 1 }
 [[row]]
 height = { length = 7 }
 flex = "center"
+gap = 2
   [[row.child]]
   widget = "world_clock"
   width = { length = 34 }
   border = "top"
   title = "  world clock  "
   title_align = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 2 }
   [[row.child]]
   widget = "system"
   width = { length = 34 }

--- a/src/templates/home_github.toml
+++ b/src/templates/home_github.toml
@@ -43,12 +43,6 @@ id = "notifications"
 fetcher = "github_notifications"
 render = { type = "list_timeline", bullet = "●", date_format = "relative", max_items = 5 }
 
-[[widget]]
-id = "gap"
-fetcher = "basic_static"
-format = " "
-render = "text_plain"
-
 # ── Layout ─────────────────────────────────────────────────────────
 
 [[row]]
@@ -88,15 +82,13 @@ height = { length = 1 }
 [[row]]
 height = { length = 5 }
 flex = "center"
+gap = 2
   [[row.child]]
   widget = "my_prs"
   width = { length = 34 }
   border = "top"
   title = "  my PRs  "
   title_align = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 2 }
   [[row.child]]
   widget = "review_queue"
   width = { length = 34 }

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -184,11 +184,14 @@ mod tests {
                 d.widgets.iter().map(|w| w.id.clone()).collect();
             for row in &d.rows {
                 for child in &row.children {
+                    let Some(id) = child.widget.as_deref() else {
+                        continue;
+                    };
                     assert!(
-                        defined.contains(&child.widget),
+                        defined.contains(id),
                         "{}: layout references unknown widget `{}`",
                         t.name,
-                        child.widget,
+                        id,
                     );
                 }
             }

--- a/src/templates/project_github.toml
+++ b/src/templates/project_github.toml
@@ -59,14 +59,6 @@ id = "releases"
 fetcher = "github_recent_releases"
 render = { type = "list_timeline", bullet = "●", date_format = "relative", max_items = 3 }
 
-# Horizontal spacer between sibling containers — a `static` with a single space
-# renders a blank line, the `width = { length = … }` in the row carves the gap.
-[[widget]]
-id = "gap"
-fetcher = "basic_static"
-format = " "
-render = "text_plain"
-
 # ── Layout ──────────────────────────────────────────────────────────
 
 [[row]]
@@ -110,15 +102,13 @@ height = { length = 1 }
 [[row]]
 height = { length = 6 }
 flex = "center"
+gap = 2
   [[row.child]]
   widget = "languages"
   width = { length = 34 }
   border = "top"
   title = "  languages  "
   title_align = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 2 }
   [[row.child]]
   widget = "releases"
   width = { length = 34 }
@@ -133,15 +123,13 @@ height = { length = 1 }
 [[row]]
 height = { length = 9 }
 flex = "center"
+gap = 2
   [[row.child]]
   widget = "repo_prs"
   width = { length = 34 }
   border = "top"
   title = "  PRs  "
   title_align = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 2 }
   [[row.child]]
   widget = "repo_issues"
   width = { length = 34 }
@@ -158,15 +146,13 @@ height = { length = 1 }
 [[row]]
 height = { length = 10 }
 flex = "center"
+gap = 2
   [[row.child]]
   widget = "commits_heatmap"
   width = { length = 34 }
   border = "top"
   title = "  commits  "
   title_align = "center"
-  [[row.child]]
-  widget = "gap"
-  width = { length = 2 }
   [[row.child]]
   widget = "top_contributors"
   width = { length = 34 }


### PR DESCRIPTION
## Summary

- **Two new layout primitives reachable from TOML**
  - `[[row.child]]` with `widget` omitted → pure spacer (maps to `Layout::Empty`, which was already defined internally but marked `dead_code` — now reachable from config)
  - `[[row]] gap = N` → auto-splices `N`-cell spacers between sibling children
- **Drops the `basic_static` + empty-format "gap widget" hack** from the 3 bundled dashboard templates that used it (`home_daily.toml`, `home_github.toml`, `project_github.toml`). No more `id = \"gap\"` pseudo-widgets.
- **`render_empty_state` width guard** — skips the `◌ nothing here yet` placeholder when the area is too narrow to fit the caption. A 2-cell gap slot was painting a truncated "no…" fragment into the neighbouring column; this is the user-visible bug that surfaced the underlying design gap.

### Why the primitive, not just the width guard?

A spacer is a layout concern, not a data concern. Routing it through the widget / fetcher / renderer pipeline (re-fetching empty text every refresh, fighting the placeholder heuristic) is the wrong axis. `Layout::Empty` already existed — it just wasn't reachable from config.

### Config diff

Before:
```toml
[[widget]]
id = "gap"
fetcher = "basic_static"
format = ""
render = "text_plain"

[[row]]
  [[row.child]]
  widget = "languages"
  [[row.child]]
  widget = "gap"
  width = { length = 2 }
  [[row.child]]
  widget = "releases"
```

After:
```toml
[[row]]
gap = 2
  [[row.child]]
  widget = "languages"
  [[row.child]]
  widget = "releases"
```

Or, for explicit per-slot spacers:
```toml
[[row.child]]
width = { length = 2 }   # no `widget =` → spacer
```

## Test plan

- [x] `cargo test` — 513 passed (4 new tests: `child_without_widget_is_layout_spacer`, `row_gap_splices_spacers_between_children`, `row_gap_zero_is_noop`, `empty_placeholder_skipped_when_area_too_narrow`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `every_template_renders_without_panic` template smoke test exercises the migrated dashboards
- [x] Rebased onto latest `main` (includes the `project_github` rename and the `.splashboard/dashboard.toml` drop from #107)

🤖 Generated with [Claude Code](https://claude.com/claude-code)