### PR TITLE
docs(site): move docs to splashboard.unhappychoice.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ echo 'Invoke-Expression (& splashboard init powershell | Out-String)' >> $PROFIL
 
 ## Docs
 
-📖 **<https://unhappychoice.github.io/splashboard/>**
+📖 **<https://splashboard.unhappychoice.com/>**
 
-- [Getting started](https://unhappychoice.github.io/splashboard/guides/getting-started/) — install, wire your shell, render your first splash
-- [Concepts](https://unhappychoice.github.io/splashboard/guides/concepts/) — the mental model (Widget = Fetcher + Renderer + Layout slot)
-- [Configuration](https://unhappychoice.github.io/splashboard/guides/configuration/) — the full TOML schema
-- [Presets](https://unhappychoice.github.io/splashboard/guides/presets/) & [Themes](https://unhappychoice.github.io/splashboard/guides/themes/) — curated dashboards and palettes
-- [Trust model](https://unhappychoice.github.io/splashboard/guides/trust/) — how per-directory configs are sandboxed
-- [Reference](https://unhappychoice.github.io/splashboard/reference/matrix/) — every fetcher and renderer with options and compatible shapes
+- [Getting started](https://splashboard.unhappychoice.com/guides/getting-started/) — install, wire your shell, render your first splash
+- [Concepts](https://splashboard.unhappychoice.com/guides/concepts/) — the mental model (Widget = Fetcher + Renderer + Layout slot)
+- [Configuration](https://splashboard.unhappychoice.com/guides/configuration/) — the full TOML schema
+- [Presets](https://splashboard.unhappychoice.com/guides/presets/) & [Themes](https://splashboard.unhappychoice.com/guides/themes/) — curated dashboards and palettes
+- [Trust model](https://splashboard.unhappychoice.com/guides/trust/) — how per-directory configs are sandboxed
+- [Reference](https://splashboard.unhappychoice.com/reference/matrix/) — every fetcher and renderer with options and compatible shapes
 
 ## Status
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -2,11 +2,8 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
-// Base path matches the GH Pages project URL (unhappychoice.github.io/splashboard/).
-// Internal links in content are relative, so they're unaffected; only the public URL uses this.
 export default defineConfig({
-  site: 'https://unhappychoice.github.io',
-  base: '/splashboard',
+  site: 'https://splashboard.unhappychoice.com',
   // Disable smart-quote / em-dash substitution. The llms-*.txt outputs are derived from
   // the rendered markdown, so smartypants would splatter U+2019 / U+2014 into what's
   // supposed to be a plain-text feed — valid UTF-8 but ugly on any client that assumes
@@ -26,14 +23,14 @@ export default defineConfig({
           tag: 'meta',
           attrs: {
             property: 'og:image',
-            content: 'https://unhappychoice.github.io/splashboard/og.png',
+            content: 'https://splashboard.unhappychoice.com/og.png',
           },
         },
         {
           tag: 'meta',
           attrs: {
             name: 'twitter:image',
-            content: 'https://unhappychoice.github.io/splashboard/og.png',
+            content: 'https://splashboard.unhappychoice.com/og.png',
           },
         },
       ],

--- a/docs-site/public/CNAME
+++ b/docs-site/public/CNAME
@@ -1,0 +1,1 @@
+splashboard.unhappychoice.com

--- a/docs-site/scripts/copy-markdown.mjs
+++ b/docs-site/scripts/copy-markdown.mjs
@@ -3,7 +3,7 @@
 // HTML — same approach as the `llms.txt` family but per-page.
 //
 // `src/content/docs/guides/getting-started.md` → `dist/guides/getting-started.md`,
-// served at `/splashboard/guides/getting-started.md` on GH Pages.
+// served at `/guides/getting-started.md`.
 
 import { readdir, mkdir, copyFile } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';

--- a/docs-site/src/content/docs/404.md
+++ b/docs-site/src/content/docs/404.md
@@ -4,4 +4,4 @@ description: The page you were looking for doesn't exist.
 ---
 
 The page you were looking for doesn't exist. Head back to the
-[overview](/splashboard/).
+[overview](/).

--- a/docs-site/src/content/docs/guides/concepts/fetcher.md
+++ b/docs-site/src/content/docs/guides/concepts/fetcher.md
@@ -129,7 +129,7 @@ Home-scoped configs (`$HOME/.splashboard/*.dashboard.toml`) are
 implicitly trusted — you own HOME, so anything you put there is
 authoritative. The trust gate only applies to project-local dashboards
 that travel with a cloned repo. See
-[Trust model](/splashboard/guides/trust/) for the full threat model.
+[Trust model](/guides/trust/) for the full threat model.
 
 ### What counts as "fixed host"?
 
@@ -190,7 +190,7 @@ Two built-in fetchers cover custom widgets without code:
 
 - **`basic_read_store`** — reads
   `$HOME/.splashboard/store/<id>.<ext>` and deserialises it as the
-  [shape](/splashboard/guides/concepts/shape/) the paired renderer
+  [shape](/guides/concepts/shape/) the paired renderer
   accepts. The filename matches the widget's `id`; `file_format` picks
   the encoding (`"json"`, `"toml"`, or `"text"`). Ideal for "I want a
   widget for X and don't want to write a fetcher".
@@ -203,7 +203,7 @@ Two built-in fetchers cover custom widgets without code:
   render = { type = "chart_sparkline" }   # pins the shape to NumberSeries
   ```
 
-  See [ReadStore](/splashboard/guides/read-store/).
+  See [ReadStore](/guides/read-store/).
 
 The rule of thumb:
 

--- a/docs-site/src/content/docs/guides/concepts/index.md
+++ b/docs-site/src/content/docs/guides/concepts/index.md
@@ -36,18 +36,18 @@ the shape matches.
 
 Each piece has its own page:
 
-- [Widget](/splashboard/guides/concepts/widget/) — how a widget is
+- [Widget](/guides/concepts/widget/) — how a widget is
   assembled from config, what its lifecycle looks like across cold /
   warm / animated frames, and how placeholders substitute when things
   go sideways.
-- [Shape](/splashboard/guides/concepts/shape/) — the 12 variants
+- [Shape](/guides/concepts/shape/) — the 12 variants
   splashboard ships today, with the Rust `Body` struct, an example
   payload, the renderers that accept it, and typical fetchers that
   emit it.
-- [Fetcher](/splashboard/guides/concepts/fetcher/) — the Cached
+- [Fetcher](/guides/concepts/fetcher/) — the Cached
   vs Realtime contract, the Safety classification, options / cache
   keys / sample bodies, and how to add your own.
-- [Renderer](/splashboard/guides/concepts/renderer/) — the trait's
+- [Renderer](/guides/concepts/renderer/) — the trait's
   surface (`accepts` / `animates` / `render`), how alignment and
   empty-state handling work, and the naming convention that keeps
   related renderers clustered in the catalog.
@@ -118,7 +118,7 @@ problems that bound the whole tool.
 
 The one escape hatch for "I want a widget no built-in fetcher provides"
 is
-[ReadStore](/splashboard/guides/read-store/):
+[ReadStore](/guides/read-store/):
 you write a payload file, splashboard deserialises it into any supported
 shape, any compatible renderer draws it. Perfect for habit trackers,
 goal progress, custom metrics — anything you can shell-script to a file.
@@ -128,9 +128,9 @@ lands as a built-in fetcher PR instead.
 
 ## Next
 
-- [Configuration](/splashboard/guides/configuration/) — the TOML schema
+- [Configuration](/guides/configuration/) — the TOML schema
   now that the model makes sense.
-- [Reference](/splashboard/reference/matrix/) — every built-in fetcher
+- [Reference](/reference/matrix/) — every built-in fetcher
   and renderer with its options and compatible shapes. Browse it as a
   catalog once you're thinking in terms of "what shape do I need, who
   emits it, who draws it".

--- a/docs-site/src/content/docs/guides/concepts/renderer.md
+++ b/docs-site/src/content/docs/guides/concepts/renderer.md
@@ -51,7 +51,7 @@ A single renderer can accept multiple shapes — `text_plain` draws
 both `Text` and `TextBlock`, `grid_table` draws `Entries` and
 `Badge`, `chart_bar` draws both `NumberSeries` and `Bars`. The
 accepts list is the source of truth for the compatibility matrix on
-the [reference overview](/splashboard/reference/matrix/).
+the [reference overview](/reference/matrix/).
 
 ### `animates()` — runtime hinting
 
@@ -181,7 +181,7 @@ effect shader on top. The final rested frame is whatever the inner
 renderer would have drawn without the wrapper.
 
 `animated_postfx` ships with a menu of effect names (full list in the
-[renderer reference](/splashboard/reference/renderers/animated/animated_postfx/)):
+[renderer reference](/reference/renderers/animated/animated_postfx/)):
 
 - `fade_in` / `fade_out` / `dissolve` / `coalesce` / `hsl_shift` — stock
   tachyonfx reveals.

--- a/docs-site/src/content/docs/guides/concepts/shape.md
+++ b/docs-site/src/content/docs/guides/concepts/shape.md
@@ -47,7 +47,7 @@ every fetcher emitting it.
 | [`Timeline`](#timeline) | `list_timeline` | — | chronological events |
 
 The authoritative compatibility matrix is in the
-[reference overview](/splashboard/reference/matrix/) — generated from
+[reference overview](/reference/matrix/) — generated from
 each renderer's `accepts()`, so it can't drift.
 
 ## `Text`

--- a/docs-site/src/content/docs/guides/concepts/widget.md
+++ b/docs-site/src/content/docs/guides/concepts/widget.md
@@ -105,7 +105,7 @@ the background fetch. The next render picks up the fresh payload.
 For local project dashboards (`./.splashboard/dashboard.toml`),
 `Network` fetchers are gated behind `splashboard trust`. An untrusted
 Network widget renders a `🔒 requires trust` placeholder instead of
-running. See [Trust model](/splashboard/guides/trust/).
+running. See [Trust model](/guides/trust/).
 
 ### Empty-state placeholder
 

--- a/docs-site/src/content/docs/guides/configuration.md
+++ b/docs-site/src/content/docs/guides/configuration.md
@@ -4,7 +4,7 @@ description: The TOML schema for settings, dashboards, widgets, rows, and render
 ---
 
 This page is the TOML schema. If you haven't read
-[Concepts](/splashboard/guides/concepts/) yet, start there — every field
+[Concepts](/guides/concepts/) yet, start there — every field
 below is easier to understand once the Widget = Fetcher + Renderer +
 Layout slot equation has clicked.
 
@@ -103,7 +103,7 @@ panel_title = "#ff0088"
 ```
 
 Full theme token list and the `"reset"` escape hatch for light terminals:
-see [Themes](/splashboard/guides/themes/).
+see [Themes](/guides/themes/).
 
 ## Dashboard files
 
@@ -127,7 +127,7 @@ Fields:
 - **`id`** (required) — unique string used to reference the widget from
   rows.
 - **`fetcher`** (required) — registry name. Browse with
-  [`splashboard catalog fetcher`](/splashboard/reference/matrix/).
+  [`splashboard catalog fetcher`](/reference/matrix/).
 - **`render`** — renderer selection. Short form `render = "text_plain"` or
   long form `render = { type = "text_ascii", pixel_size = "quadrant" }`.
   Absent = pick the default renderer for the fetcher's shape.
@@ -137,7 +137,7 @@ Fields:
   Ignored by realtime fetchers.
 - **`file_format`** — `basic_read_store` only: `"json"`, `"toml"`, or
   `"text"`. The file is deserialized into the
-  [shape](/splashboard/guides/concepts/shape/) the paired renderer
+  [shape](/guides/concepts/shape/) the paired renderer
   expects.
 - **`[widget.options]`** — fetcher-specific nested options. See each
   fetcher's reference page for its schema.
@@ -207,7 +207,7 @@ about, others are ignored. The common ones:
   `chart_bar` options.
 - **`ring_thickness`**, **`label_position`** — `gauge_circle` options.
 
-See each renderer's [reference page](/splashboard/reference/matrix/) for the
+See each renderer's [reference page](/reference/matrix/) for the
 definitive list.
 
 ### A worked example

--- a/docs-site/src/content/docs/guides/cookbook.md
+++ b/docs-site/src/content/docs/guides/cookbook.md
@@ -52,11 +52,11 @@ Drop widgets in there to get a single "every repo root" splash without
 each repo carrying a config.
 
 Network widgets in a per-dir dashboard stay gated behind `splashboard
-trust` — see the [trust guide](/splashboard/guides/trust/).
+trust` — see the [trust guide](/guides/trust/).
 
 ## Custom widgets without code
 
-Use [ReadStore](/splashboard/guides/read-store/) — write a payload
+Use [ReadStore](/guides/read-store/) — write a payload
 file, pair it with a renderer, splashboard draws it. No code, no
 subprocess. Good for habit trackers, goal progress, and anything you
 can shell-script to a file.
@@ -79,7 +79,7 @@ palette_series = ["#7aa2f7", "#565f89"]
 ```
 
 Every renderer declares the tokens it reads on its
-[reference page](/splashboard/reference/matrix/), so you can work
+[reference page](/reference/matrix/), so you can work
 backward: "I want this widget to pop more" → open the widget's page →
 see which token it uses → override that.
 

--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -87,8 +87,8 @@ Available templates:
 - **home**: `home_splash`, `home_daily`, `home_github`, `home_minimal`
 - **project**: `project_splash`, `project_github`, `project_minimal`
 
-See [Presets](/splashboard/guides/presets/) for a rendered preview of each,
-and [Themes](/splashboard/guides/themes/) for the palette details.
+See [Presets](/guides/presets/) for a rendered preview of each,
+and [Themes](/guides/themes/) for the palette details.
 
 ### Prefer to own the rc edit yourself?
 
@@ -131,16 +131,16 @@ Run `splashboard` directly to re-render without waiting for a new shell.
 
 From here:
 
-- [Concepts](/splashboard/guides/concepts/) — the mental model (Widget =
+- [Concepts](/guides/concepts/) — the mental model (Widget =
   Fetcher + Renderer + Layout slot). Read this next if the TOML above
   looks a bit opaque; it unlocks the rest of the docs.
-- [Configuration](/splashboard/guides/configuration/) — the full TOML
+- [Configuration](/guides/configuration/) — the full TOML
   schema (settings, dashboards, widgets, rows, render options).
-- [Presets](/splashboard/guides/presets/) — curated dashboards you can
+- [Presets](/guides/presets/) — curated dashboards you can
   adopt verbatim.
-- [Themes](/splashboard/guides/themes/) — six built-in palettes plus
+- [Themes](/guides/themes/) — six built-in palettes plus
   per-token overrides.
-- The [reference](/splashboard/reference/matrix/) — the complete list of
+- The [reference](/reference/matrix/) — the complete list of
   fetchers and renderers with their options and compatible shapes.
 
 ## Troubleshooting
@@ -158,12 +158,12 @@ Unset the variable or widen the terminal and try again.
 
 **A widget renders `🔒 requires trust`.** The widget is classified as
 `Network` and the local dashboard it came from has not been trusted yet. See
-the [trust model guide](/splashboard/guides/trust/) for the consent flow —
+the [trust model guide](/guides/trust/) for the consent flow —
 `splashboard trust` is usually what you want.
 
 **A GitHub widget renders an error.** `github_*` fetchers need a token with
 read access. Export `GH_TOKEN` (or `GITHUB_TOKEN`) before starting the shell.
-See the [cookbook](/splashboard/guides/cookbook/#github-credentials) for the
+See the [cookbook](/guides/cookbook/#github-credentials) for the
 recommended place to put it.
 
 **I want to see fresh data, not cached.** Run `splashboard --wait` once. The

--- a/docs-site/src/content/docs/guides/read-store.md
+++ b/docs-site/src/content/docs/guides/read-store.md
@@ -6,14 +6,14 @@ description: Write a payload file, pick a shape, let splashboard draw it — the
 ReadStore is splashboard's one escape hatch for "I want a widget no
 built-in fetcher provides". You write the payload to a file, point a
 `basic_read_store` widget at it, and splashboard deserialises the file
-into whatever [shape](/splashboard/guides/concepts/shape/) the paired
+into whatever [shape](/guides/concepts/shape/) the paired
 renderer expects.
 
 - No code.
 - No subprocess.
 - Fixed path under `$HOME/.splashboard/store/` — config can't redirect
   the read, so it's
-  [Safe](/splashboard/guides/trust/#safety-classes) even in an
+  [Safe](/guides/trust/#safety-classes) even in an
   untrusted local dashboard.
 
 Use it when curated UX (auth, rate limits, stateful update) isn't
@@ -62,7 +62,7 @@ file as the inner data struct for the target shape, *not* the
 ```
 
 The envelope form is what you see on the
-[Shape page](/splashboard/guides/concepts/shape/) and inside
+[Shape page](/guides/concepts/shape/) and inside
 splashboard's cache files. ReadStore strips it so your file stays as
 short as possible — one concept per file, matching what you'd write if
 you'd just invented the format yourself.
@@ -98,18 +98,18 @@ Omit it for everything else → defaults to `"json"`.
 If the file doesn't exist, ReadStore returns an empty body for the
 declared shape (empty cells, `0.0` ratio, no entries, …) — the splash
 stays quiet rather than erroring. The shared
-[empty-state placeholder](/splashboard/guides/concepts/renderer/#empty-state-handling)
+[empty-state placeholder](/guides/concepts/renderer/#empty-state-handling)
 paints in the widget's slot.
 
 ## Supported shapes
 
 ReadStore supports every non-dynamic
-[shape](/splashboard/guides/concepts/shape/) — 10 of the 12 variants.
+[shape](/guides/concepts/shape/) — 10 of the 12 variants.
 The two exceptions:
 
-- [`Badge`](/splashboard/guides/concepts/shape/#badge) — status pills
+- [`Badge`](/guides/concepts/shape/#badge) — status pills
   are always "right now" values; use a built-in fetcher.
-- [`Timeline`](/splashboard/guides/concepts/shape/#timeline) — event
+- [`Timeline`](/guides/concepts/shape/#timeline) — event
   streams assume dynamic data; ReadStore is for snapshots.
 
 Concrete JSON per supported shape:
@@ -317,7 +317,7 @@ render = "grid_heatmap"
 - Files live at `$HOME/.splashboard/store/<widget-id>.<ext>`.
 - The widget `id` is sanitised — only `[A-Za-z0-9_-]` survive, so a
   hostile repo-local config can't traverse out of the store directory.
-- Classified `Safe` in the [trust model](/splashboard/guides/trust/) —
+- Classified `Safe` in the [trust model](/guides/trust/) —
   always runs, even from an untrusted local dashboard, because the
   read path is fixed.
 

--- a/docs-site/src/content/docs/guides/themes.md
+++ b/docs-site/src/content/docs/guides/themes.md
@@ -112,7 +112,7 @@ palette_heatmap = ["#111", "#333", "#666", "#999", "#fff"]
 
 ## Which tokens does this renderer use?
 
-Every renderer's [reference page](/splashboard/reference/matrix/) lists
+Every renderer's [reference page](/reference/matrix/) lists
 the tokens it reads. The list is generated from `ColorKey` declarations
 in the renderer itself, so it can't drift from what the code actually
 uses.

--- a/docs-site/src/content/docs/guides/trust.md
+++ b/docs-site/src/content/docs/guides/trust.md
@@ -102,4 +102,4 @@ widgets. It's **permanently unreachable** — subprocess plugins and
 `command = "..."` widgets were closed by design. splashboard is a
 curated renderer, not a shell script host. Custom widgets ship as
 built-in PRs or use the
-[ReadStore](/splashboard/guides/read-store/).
+[ReadStore](/guides/read-store/).

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -7,11 +7,11 @@ hero:
   tagline: A customizable terminal splash rendered on shell startup and on directory change. Per-directory configs so different repos get different splashes automatically.
   actions:
     - text: Getting started
-      link: /splashboard/guides/getting-started/
+      link: /guides/getting-started/
       icon: right-arrow
       variant: primary
     - text: Concepts
-      link: /splashboard/guides/concepts/
+      link: /guides/concepts/
       icon: open-book
       variant: secondary
     - text: GitHub
@@ -42,32 +42,32 @@ reshapes the splash to itself when you `cd` in. Competitor products
   <LinkCard
     title="Getting started"
     description="Install, wire into your shell, render your first splash."
-    href="/splashboard/guides/getting-started/"
+    href="/guides/getting-started/"
   />
   <LinkCard
     title="Concepts"
     description="The mental model — Widget = Fetcher + Renderer + Layout slot."
-    href="/splashboard/guides/concepts/"
+    href="/guides/concepts/"
   />
   <LinkCard
     title="Configuration"
     description="The TOML schema: settings, dashboards, widgets, rows, render options."
-    href="/splashboard/guides/configuration/"
+    href="/guides/configuration/"
   />
   <LinkCard
     title="Presets"
     description="Four curated dashboards you can copy verbatim."
-    href="/splashboard/guides/presets/"
+    href="/guides/presets/"
   />
   <LinkCard
     title="Themes"
     description="Six palettes plus per-token overrides."
-    href="/splashboard/guides/themes/"
+    href="/guides/themes/"
   />
   <LinkCard
     title="Cookbook"
     description="Credentials, per-repo splashes, custom widgets via ReadStore, light terminals."
-    href="/splashboard/guides/cookbook/"
+    href="/guides/cookbook/"
   />
 </CardGrid>
 
@@ -77,16 +77,16 @@ reshapes the splash to itself when you `cd` in. Competitor products
   <LinkCard
     title="Reference overview"
     description="Fetcher index, renderer index, and the shape × renderer compatibility matrix."
-    href="/splashboard/reference/matrix/"
+    href="/reference/matrix/"
   />
   <LinkCard
     title="Showcases"
     description="Screenshots of splashboard in the wild — presets, themes, community dashboards."
-    href="/splashboard/showcases/"
+    href="/showcases/"
   />
   <LinkCard
     title="Trust model"
     description="Per-widget consent for project-local dashboards that want to talk to the network."
-    href="/splashboard/guides/trust/"
+    href="/guides/trust/"
   />
 </CardGrid>


### PR DESCRIPTION
## Summary

- Point the docs site at the custom domain `splashboard.unhappychoice.com`. `astro.config.mjs` drops `base: '/splashboard'` and updates `site` + OG/Twitter card URLs.
- Ship `docs-site/public/CNAME` so each Pages deploy carries the custom-domain marker.
- Rewrite hardcoded `/splashboard/...` absolute links in `src/content/docs/**/*.{md,mdx}` (and the `copy-markdown.mjs` comment) to root-relative `/...` so they don't 404 once the base path is gone. GitHub URLs and unrelated paths (e.g. `~/.cache/splashboard/`) are left alone.
- Update README docs links to the new domain.

## Out-of-band setup (not in this PR)

- DNS: point `splashboard.unhappychoice.com` CNAME → `unhappychoice.github.io.`
- Repo Settings → Pages: set Custom domain to `splashboard.unhappychoice.com` and enable Enforce HTTPS once verified.

## Test plan

- [x] `cargo xtask` regenerates the reference pages cleanly.
- [x] `npm run build` in `docs-site/` succeeds (163 pages).
- [x] `dist/CNAME` ends up in the upload artifact.
- [x] No remaining `unhappychoice.github.io/splashboard` or `href="/splashboard/` strings in `dist/`.
- [ ] After DNS + Pages settings: confirm https://splashboard.unhappychoice.com/ resolves and internal links work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation site now hosted at custom domain (splashboard.unhappychoice.com)
  * Updated all internal documentation navigation links across guides and reference sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->