### PR TITLE
ops: add install.sh for curl-pipe-bash install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ brew install unhappychoice/tap/splashboard
 
 # cargo-binstall (prebuilt binaries from GitHub Releases)
 cargo binstall splashboard
+
+# One-liner install script (Linux / macOS)
+curl -fsSL https://raw.githubusercontent.com/unhappychoice/splashboard/main/install.sh | bash
 ```
 
 Prebuilt binaries for Linux (x86_64 / aarch64), macOS (x86_64 / aarch64), and Windows (x86_64) are also attached to each [GitHub Release](https://github.com/unhappychoice/splashboard/releases).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Instead of a blinking cursor, every new shell shows a dashboard of the things yo
 ## Install
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/unhappychoice/splashboard/main/install.sh | bash
+splashboard install
+```
+
+The install script detects your platform (Linux / macOS × x86_64 / aarch64), downloads the matching prebuilt binary from the latest [GitHub Release](https://github.com/unhappychoice/splashboard/releases), and drops it into `~/.local/bin` (override via `INSTALL_DIR=...`).
+
+`splashboard install` then detects your shell, walks you through template / theme pickers, and wires your rc for you.
+
+<details>
+<summary>Other install methods</summary>
+
+```bash
 # cargo
 cargo install splashboard
 
@@ -25,19 +37,14 @@ brew install unhappychoice/tap/splashboard
 # cargo-binstall (prebuilt binaries from GitHub Releases)
 cargo binstall splashboard
 
-# One-liner install script (Linux / macOS)
-curl -fsSL https://raw.githubusercontent.com/unhappychoice/splashboard/main/install.sh | bash
+# Nix flake
+nix run github:unhappychoice/splashboard
+nix profile install github:unhappychoice/splashboard
 ```
 
 Prebuilt binaries for Linux (x86_64 / aarch64), macOS (x86_64 / aarch64), and Windows (x86_64) are also attached to each [GitHub Release](https://github.com/unhappychoice/splashboard/releases).
 
-After install, run:
-
-```bash
-splashboard install
-```
-
-`splashboard install` detects your shell, walks you through template / theme pickers, and wires your rc for you.
+</details>
 
 Prefer to own the rc edit yourself? Append one line that re-sources `splashboard init <shell>` on every shell start — upgrades to splashboard ship an updated init snippet automatically:
 

--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -9,12 +9,39 @@ and verifying the first splash. It assumes nothing more than a working terminal.
 
 ## Install the binary
 
-splashboard is distributed on crates.io. A stable Rust toolchain is the only
-prerequisite.
+The one-liner below detects your platform (Linux / macOS × x86_64 / aarch64),
+pulls the matching prebuilt binary from the latest GitHub Release, and drops
+it into `~/.local/bin` (override via `INSTALL_DIR=...`). No Rust toolchain
+required.
 
 ```bash
-cargo install splashboard
+curl -fsSL https://raw.githubusercontent.com/unhappychoice/splashboard/main/install.sh | bash
 ```
+
+<details>
+<summary>Other install methods</summary>
+
+```bash
+# cargo (needs a stable Rust toolchain)
+cargo install splashboard
+
+# Homebrew (macOS / Linux)
+brew install unhappychoice/tap/splashboard
+
+# cargo-binstall (prebuilt from GitHub Releases)
+cargo binstall splashboard
+
+# Nix flake
+nix run github:unhappychoice/splashboard
+nix profile install github:unhappychoice/splashboard
+```
+
+Prebuilt binaries for Linux (x86_64 / aarch64), macOS (x86_64 / aarch64),
+and Windows (x86_64) are attached to each
+[GitHub Release](https://github.com/unhappychoice/splashboard/releases) —
+handy if you prefer to drop the binary in manually.
+
+</details>
 
 ## Run `splashboard install`
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+REPO="unhappychoice/splashboard"
+BINARY_NAME="splashboard"
+
+get_latest_release() {
+    curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+check_glibc_version() {
+    if ! command -v ldd &> /dev/null; then
+        return
+    fi
+
+    GLIBC_VERSION=$(ldd --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    REQUIRED_VERSION="2.17"
+
+    if [ -n "$GLIBC_VERSION" ]; then
+        if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$GLIBC_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+            echo ""
+            echo "WARNING: Your glibc version ($GLIBC_VERSION) is older than $REQUIRED_VERSION."
+            echo "The pre-built binary may not work on your system."
+            echo ""
+            echo "Options:"
+            echo "  1. Upgrade your OS to get a newer glibc"
+            echo "  2. Build from source: cargo install splashboard"
+            echo "  3. Continue anyway and see if it works"
+            echo ""
+            read -p "Continue with installation? [y/N] " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "Installation cancelled."
+                exit 0
+            fi
+        fi
+    fi
+}
+
+detect_platform() {
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Linux*)
+            check_glibc_version
+            case "$ARCH" in
+                x86_64)
+                    echo "x86_64-unknown-linux-gnu"
+                    ;;
+                aarch64|arm64)
+                    echo "aarch64-unknown-linux-gnu"
+                    ;;
+                *)
+                    echo "Unsupported architecture: $ARCH" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        Darwin*)
+            case "$ARCH" in
+                x86_64)
+                    echo "x86_64-apple-darwin"
+                    ;;
+                arm64)
+                    echo "aarch64-apple-darwin"
+                    ;;
+                *)
+                    echo "Unsupported architecture: $ARCH" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported OS: $OS" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main() {
+    VERSION="${1:-$(get_latest_release)}"
+    PLATFORM="$(detect_platform)"
+
+    if [ -z "$VERSION" ]; then
+        echo "Failed to detect latest version" >&2
+        exit 1
+    fi
+
+    echo "Installing $BINARY_NAME $VERSION for $PLATFORM..."
+
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/${BINARY_NAME}-${VERSION}-${PLATFORM}.tar.gz"
+    TEMP_DIR="$(mktemp -d)"
+
+    trap 'rm -rf "$TEMP_DIR"' EXIT
+
+    echo "Downloading from $DOWNLOAD_URL..."
+    curl -sL "$DOWNLOAD_URL" | tar xz -C "$TEMP_DIR"
+
+    INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+    mkdir -p "$INSTALL_DIR"
+
+    mv "$TEMP_DIR/$BINARY_NAME" "$INSTALL_DIR/"
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+    echo "Successfully installed $BINARY_NAME to $INSTALL_DIR/$BINARY_NAME"
+    echo ""
+    echo "Make sure $INSTALL_DIR is in your PATH:"
+    echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+    echo ""
+    echo "Then run '$BINARY_NAME install' to wire splashboard into your shell rc."
+}
+
+main "$@"


### PR DESCRIPTION
Follows gitlogue's install.sh pattern.

## Summary

- Detects platform: Linux/macOS × x86_64/aarch64 (Windows users fall back to cargo/binstall/GH Releases).
- Downloads the matching tarball from the latest GitHub Release.
- Drops the binary into \`\$HOME/.local/bin\` (overridable via \`INSTALL_DIR=...\`).
- Nudges toward \`splashboard install\` for shell-rc wiring.
- glibc check threshold = 2.17 (matches the cargo-zigbuild pin in release.yml, so the check is essentially a safety net for truly ancient systems).

README gains a fifth install channel pointing at \`curl -fsSL …/install.sh | bash\`.

## Test plan

- [ ] After the first \`v0.x.y\` tag ships, run the one-liner on Linux x86_64 and confirm the binary lands in \`~/.local/bin\` and \`splashboard --version\` prints.
- [ ] Repeat on macOS (aarch64) and Linux aarch64 if available.
- [ ] Confirm \`INSTALL_DIR=/tmp/sb-test bash install.sh\` installs to the override path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)