### PR TITLE
docs(readme): center hero image + badges, drop title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-# splashboard
-
-[![CI](https://github.com/unhappychoice/splashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/unhappychoice/splashboard/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/unhappychoice/splashboard/branch/main/graph/badge.svg)](https://codecov.io/gh/unhappychoice/splashboard)
-
 <p align="center">
-  <img src="docs/screenshots/project_github.png" alt="splashboard project_github preset" width="820">
+  <img src="docs/screenshots/project_github.png" alt="splashboard" width="820">
 </p>
 
-A customizable terminal splash rendered on shell startup and on `cd`.
+<p align="center">
+  <a href="https://crates.io/crates/splashboard"><img src="https://img.shields.io/crates/v/splashboard.svg?style=flat-square&color=E06B4B" alt="crates.io"></a>
+  <a href="https://github.com/unhappychoice/splashboard/releases"><img src="https://img.shields.io/github/v/release/unhappychoice/splashboard?style=flat-square&color=E0C14B&label=release" alt="release"></a>
+  <a href="https://github.com/unhappychoice/splashboard/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/unhappychoice/splashboard/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://codecov.io/gh/unhappychoice/splashboard"><img src="https://img.shields.io/codecov/c/github/unhappychoice/splashboard?style=flat-square" alt="coverage"></a>
+  <a href="https://github.com/unhappychoice/splashboard/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/splashboard.svg?style=flat-square" alt="license"></a>
+</p>
 
-> `splashboard` = `splash` + `dashboard`.
+<p align="center">
+  <strong>A customizable terminal splash rendered on shell startup and on <code>cd</code>.</strong><br>
+  <sub><code>splashboard</code> = <code>splash</code> + <code>dashboard</code></sub>
+</p>
 
 Instead of a blinking cursor, every new shell shows a dashboard of the things you actually care about — greetings, git status, CI health, PRs, a contributions heatmap, the moon phase. The killer feature: a repo that ships `./.splashboard/dashboard.toml` auto-reshapes the splash when you `cd` in, so different repos get different splashes for free.
 


### PR DESCRIPTION
The hero screenshot already reads "splashboard" — the markdown \`# splashboard\` heading above it was redundant and pushed the image below the fold on smaller browser widths.

## Changes

- Drop the \`# splashboard\` heading.
- Center the hero image (already was) and the badge row (was left-aligned).
- Center a one-line tagline + the \`splash + dashboard\` wordplay underneath the badges.
- Badge set now includes crates.io version / GitHub release / CI / codecov / license, all rendered in consistent \`flat-square\` style.

The crates.io / release badges will resolve to proper values once the first 0.1 tag ships; pre-release they show "no release" which is semantically accurate.

## Preview

See the before/after by toggling the rendered README on GitHub — the install / docs / related sections are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with an improved centered layout for enhanced visual organization and overall presentation.
  * Added comprehensive status badges displaying crates.io version, latest release information, CI workflow status, code coverage metrics, and license details.
  * Enhanced the project introduction with improved HTML formatting and clearer visual presentation of the splashboard feature definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->