### PR TITLE
feat(render): add gauge_battery renderer for Ratio shape

### DIFF
--- a/src/render/gauge_battery.rs
+++ b/src/render/gauge_battery.rs
@@ -1,0 +1,351 @@
+use ratatui::{
+    Frame,
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::options::OptionSchema;
+use crate::payload::{Body, RatioData};
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape};
+
+const COLOR_KEYS: &[ColorKey] = &[
+    theme::TEXT,
+    theme::TEXT_DIM,
+    theme::STATUS_OK,
+    theme::STATUS_WARN,
+    theme::STATUS_ERROR,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "label",
+    type_hint: "string",
+    required: false,
+    default: Some("payload.label"),
+    description: "Optional prefix shown before the battery, e.g. `\"BAT\"` → `BAT ▕████░▏▮ 75%`. Falls back to `RatioData.label`; omitted when neither is set.",
+}];
+
+/// Battery-icon renderer for `Ratio`. Compact on short slots, boxed on tall slots; fill colour
+/// follows level (low/mid/full → status_error/warn/ok). Pairs naturally with disk usage,
+/// laptop battery, quota progress.
+pub struct GaugeBatteryRenderer;
+
+const FILLED: &str = "█";
+const EMPTY: &str = "░";
+
+impl Renderer for GaugeBatteryRenderer {
+    fn name(&self) -> &str {
+        "gauge_battery"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::Ratio]
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        _registry: &Registry,
+    ) {
+        if let Body::Ratio(d) = body {
+            render_battery(frame, area, d, opts, theme);
+        }
+    }
+}
+
+fn render_battery(
+    frame: &mut Frame,
+    area: Rect,
+    data: &RatioData,
+    opts: &RenderOptions,
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let ratio = data.value.clamp(0.0, 1.0);
+    let prefix = resolve_prefix(opts, data);
+    let percent = format!("{}%", (ratio * 100.0).round() as u64);
+    let fill = level_color(ratio, theme);
+    if area.height < 3 {
+        render_compact(frame, area, ratio, &prefix, &percent, fill, theme);
+    } else {
+        render_boxed(frame, area, ratio, &prefix, &percent, fill, theme);
+    }
+}
+
+fn render_compact(
+    frame: &mut Frame,
+    area: Rect,
+    ratio: f64,
+    prefix: &str,
+    percent: &str,
+    fill: Color,
+    theme: &Theme,
+) {
+    let prefix_w = prefix_width(prefix);
+    let suffix_w = percent.chars().count() as u16 + 1;
+    let frame_w = 2u16; // "▕" + "▏"
+    let tip_w = 1u16; // "▮"
+    let cells = area
+        .width
+        .saturating_sub(prefix_w + suffix_w + frame_w + tip_w);
+    let filled = (f64::from(cells) * ratio).round() as u16;
+    let mut spans = Vec::with_capacity(8);
+    if !prefix.is_empty() {
+        spans.push(Span::styled(
+            format!("{prefix} "),
+            Style::default().fg(theme.text),
+        ));
+    }
+    spans.push(Span::styled("▕", Style::default().fg(theme.text)));
+    spans.push(Span::styled(
+        FILLED.repeat(filled as usize),
+        Style::default().fg(fill),
+    ));
+    spans.push(Span::styled(
+        EMPTY.repeat(cells.saturating_sub(filled) as usize),
+        Style::default().fg(theme.text_dim),
+    ));
+    spans.push(Span::styled("▏", Style::default().fg(theme.text)));
+    spans.push(Span::styled("▮", Style::default().fg(theme.text)));
+    spans.push(Span::styled(
+        format!(" {percent}"),
+        Style::default().fg(theme.text),
+    ));
+    let mid_y = area.y + area.height / 2;
+    let row = Rect::new(area.x, mid_y, area.width, 1);
+    frame.render_widget(Paragraph::new(Line::from(spans)), row);
+}
+
+fn render_boxed(
+    frame: &mut Frame,
+    area: Rect,
+    ratio: f64,
+    prefix: &str,
+    percent: &str,
+    fill: Color,
+    theme: &Theme,
+) {
+    let prefix_w = prefix_width(prefix);
+    let suffix = format!(" {percent}");
+    let suffix_w = suffix.chars().count() as u16;
+    let tip_w = 1u16;
+    let body_w = area
+        .width
+        .saturating_sub(prefix_w + suffix_w + tip_w)
+        .max(3);
+    let inner_w = body_w.saturating_sub(2); // borders
+    let filled_cells = (f64::from(inner_w) * ratio).round() as u16;
+    let body_h = area.height.min(3);
+    let top_y = area.y + (area.height - body_h) / 2;
+    let body_x = area.x + prefix_w;
+
+    if !prefix.is_empty() {
+        let label = Rect::new(area.x, top_y + body_h / 2, prefix_w, 1);
+        frame.render_widget(
+            Paragraph::new(prefix.to_string()).style(Style::default().fg(theme.text)),
+            label,
+        );
+    }
+
+    let buf = frame.buffer_mut();
+    paint_horizontal(buf, body_x, top_y, inner_w, "┌", "┐", theme.text);
+    paint_horizontal(
+        buf,
+        body_x,
+        top_y + body_h - 1,
+        inner_w,
+        "└",
+        "┘",
+        theme.text,
+    );
+    paint_sides(
+        buf,
+        body_x,
+        top_y + 1,
+        inner_w,
+        body_h.saturating_sub(2),
+        theme.text,
+    );
+    let fill_rect = Rect::new(body_x + 1, top_y + 1, inner_w, body_h.saturating_sub(2));
+    paint_fill(buf, fill_rect, filled_cells, fill, theme.text_dim);
+    paint_tip(buf, body_x + body_w, top_y, body_h, theme.text);
+
+    let suffix_rect = Rect::new(body_x + body_w + tip_w, top_y + body_h / 2, suffix_w, 1);
+    frame.render_widget(
+        Paragraph::new(suffix).style(Style::default().fg(theme.text)),
+        suffix_rect,
+    );
+}
+
+fn paint_horizontal(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    inner_w: u16,
+    left: &str,
+    right: &str,
+    color: Color,
+) {
+    set_cell(buf, x, y, left, color);
+    (0..inner_w).for_each(|i| set_cell(buf, x + 1 + i, y, "─", color));
+    set_cell(buf, x + 1 + inner_w, y, right, color);
+}
+
+fn paint_sides(buf: &mut Buffer, x: u16, y: u16, inner_w: u16, h: u16, color: Color) {
+    (0..h).for_each(|j| {
+        set_cell(buf, x, y + j, "│", color);
+        set_cell(buf, x + 1 + inner_w, y + j, "│", color);
+    });
+}
+
+fn paint_fill(buf: &mut Buffer, rect: Rect, filled: u16, fill: Color, empty: Color) {
+    (0..rect.height).for_each(|j| {
+        (0..rect.width).for_each(|i| {
+            let (glyph, color) = if i < filled {
+                (FILLED, fill)
+            } else {
+                (EMPTY, empty)
+            };
+            set_cell(buf, rect.x + i, rect.y + j, glyph, color);
+        });
+    });
+}
+
+fn paint_tip(buf: &mut Buffer, x: u16, top_y: u16, body_h: u16, color: Color) {
+    let mid = top_y + body_h / 2;
+    set_cell(buf, x, mid, "▮", color);
+}
+
+fn set_cell(buf: &mut Buffer, x: u16, y: u16, glyph: &str, color: Color) {
+    if let Some(cell) = buf.cell_mut((x, y)) {
+        cell.set_symbol(glyph);
+        cell.set_style(Style::default().fg(color));
+    }
+}
+
+fn resolve_prefix(opts: &RenderOptions, data: &RatioData) -> String {
+    opts.label
+        .clone()
+        .or_else(|| data.label.clone())
+        .unwrap_or_default()
+}
+
+fn prefix_width(prefix: &str) -> u16 {
+    if prefix.is_empty() {
+        0
+    } else {
+        prefix.chars().count() as u16 + 1
+    }
+}
+
+fn level_color(ratio: f64, theme: &Theme) -> Color {
+    if ratio < 0.20 {
+        theme.status_error
+    } else if ratio < 0.50 {
+        theme.status_warn
+    } else {
+        theme.status_ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, RatioData};
+    use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+    use crate::render::{Registry, RenderSpec};
+
+    fn payload(value: f64, label: Option<&str>) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Ratio(RatioData {
+                value,
+                label: label.map(String::from),
+                denominator: None,
+            }),
+        }
+    }
+
+    fn registry_and_spec() -> (Registry, RenderSpec) {
+        (
+            Registry::with_builtins(),
+            RenderSpec::Short("gauge_battery".into()),
+        )
+    }
+
+    #[test]
+    fn renders_compact_in_short_slot() {
+        let (registry, spec) = registry_and_spec();
+        let buf = render_to_buffer_with_spec(&payload(0.75, None), Some(&spec), &registry, 30, 1);
+        let row = line_text(&buf, 0);
+        assert!(row.contains("▕"), "missing left frame: {row:?}");
+        assert!(row.contains("▏"), "missing right frame: {row:?}");
+        assert!(row.contains("▮"), "missing tip: {row:?}");
+        assert!(row.contains("75%"), "missing percent: {row:?}");
+    }
+
+    #[test]
+    fn renders_boxed_in_tall_slot() {
+        let (registry, spec) = registry_and_spec();
+        let buf = render_to_buffer_with_spec(&payload(0.5, None), Some(&spec), &registry, 30, 5);
+        let joined: String = (0..5).map(|y| line_text(&buf, y)).collect();
+        assert!(joined.contains("┌"), "missing top-left corner: {joined:?}");
+        assert!(
+            joined.contains("┘"),
+            "missing bottom-right corner: {joined:?}"
+        );
+        assert!(joined.contains("▮"), "missing tip: {joined:?}");
+        assert!(joined.contains("50%"), "missing percent: {joined:?}");
+    }
+
+    #[test]
+    fn clamps_out_of_range() {
+        let (registry, spec) = registry_and_spec();
+        let _ = render_to_buffer_with_spec(&payload(1.7, None), Some(&spec), &registry, 30, 5);
+        let _ = render_to_buffer_with_spec(&payload(-0.2, None), Some(&spec), &registry, 30, 5);
+    }
+
+    #[test]
+    fn label_prefix_renders_when_provided() {
+        let (registry, _) = registry_and_spec();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(r#"render = { type = "gauge_battery", label = "BAT" }"#).unwrap();
+        let buf =
+            render_to_buffer_with_spec(&payload(0.4, None), Some(&w.render), &registry, 40, 1);
+        let row = line_text(&buf, 0);
+        assert!(row.starts_with("BAT"), "missing prefix: {row:?}");
+    }
+
+    #[test]
+    fn level_color_buckets() {
+        let theme = Theme::default();
+        assert_eq!(level_color(0.05, &theme), theme.status_error);
+        assert_eq!(level_color(0.30, &theme), theme.status_warn);
+        assert_eq!(level_color(0.80, &theme), theme.status_ok);
+    }
+
+    #[test]
+    fn empty_area_does_not_panic() {
+        let (registry, spec) = registry_and_spec();
+        let _ = render_to_buffer_with_spec(&payload(0.5, None), Some(&spec), &registry, 0, 0);
+    }
+}

--- a/src/render/gauge_battery.rs
+++ b/src/render/gauge_battery.rs
@@ -21,17 +21,26 @@ const COLOR_KEYS: &[ColorKey] = &[
     theme::STATUS_ERROR,
 ];
 
-const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
-    name: "label",
-    type_hint: "string",
-    required: false,
-    default: Some("payload.label"),
-    description: "Optional prefix shown before the battery, e.g. `\"BAT\"` → `BAT ▕████░▏▮ 75%`. Falls back to `RatioData.label`; omitted when neither is set.",
-}];
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "label",
+        type_hint: "string",
+        required: false,
+        default: Some("payload.label"),
+        description: "Optional prefix shown before the battery, e.g. `\"BAT\"` → `BAT ▕████░▏▮ 75%`. Falls back to `RatioData.label`; omitted when neither is set.",
+    },
+    OptionSchema {
+        name: "tone",
+        type_hint: "\"neutral\" | \"fill\" | \"drain\"",
+        required: false,
+        default: Some("\"neutral\""),
+        description: "How the fill colour follows the value. `neutral` is single `theme.text` (matches the rest of the `gauge_*` family). `fill` treats the value as how-full (low → status_error, high → status_ok) — right for battery / quota progress. `drain` inverts (high → status_error) — right for `system_disk_usage` / `system_memory` / `system_cpu` where the ratio is \"fraction used\".",
+    },
+];
 
-/// Battery-icon renderer for `Ratio`. Compact on short slots, boxed on tall slots; fill colour
-/// follows level (low/mid/full → status_error/warn/ok). Pairs naturally with disk usage,
-/// laptop battery, quota progress.
+/// Battery-icon renderer for `Ratio`. Compact on short slots, boxed on tall slots. The fill
+/// colour is theme-neutral by default; opt into a level-driven palette via `tone = "fill"` for
+/// battery-style readouts (low → red) or `tone = "drain"` for usage-style readouts (high → red).
 pub struct GaugeBatteryRenderer;
 
 const FILLED: &str = "█";
@@ -78,7 +87,7 @@ fn render_battery(
     let ratio = data.value.clamp(0.0, 1.0);
     let prefix = resolve_prefix(opts, data);
     let percent = format!("{}%", (ratio * 100.0).round() as u64);
-    let fill = level_color(ratio, theme);
+    let fill = tone_color(ratio, opts.tone.as_deref(), theme);
     if area.height < 3 {
         render_compact(frame, area, ratio, &prefix, &percent, fill, theme);
     } else {
@@ -252,6 +261,14 @@ fn prefix_width(prefix: &str) -> u16 {
     }
 }
 
+fn tone_color(ratio: f64, tone: Option<&str>, theme: &Theme) -> Color {
+    match tone.unwrap_or("neutral") {
+        "fill" => level_color(ratio, theme),
+        "drain" => level_color(1.0 - ratio, theme),
+        _ => theme.text,
+    }
+}
+
 fn level_color(ratio: f64, theme: &Theme) -> Color {
     if ratio < 0.20 {
         theme.status_error
@@ -336,11 +353,32 @@ mod tests {
     }
 
     #[test]
-    fn level_color_buckets() {
+    fn tone_neutral_is_default_and_uses_text_colour() {
         let theme = Theme::default();
-        assert_eq!(level_color(0.05, &theme), theme.status_error);
-        assert_eq!(level_color(0.30, &theme), theme.status_warn);
-        assert_eq!(level_color(0.80, &theme), theme.status_ok);
+        assert_eq!(tone_color(0.05, None, &theme), theme.text);
+        assert_eq!(tone_color(0.95, Some("neutral"), &theme), theme.text);
+    }
+
+    #[test]
+    fn tone_fill_maps_low_to_error() {
+        let theme = Theme::default();
+        assert_eq!(tone_color(0.05, Some("fill"), &theme), theme.status_error);
+        assert_eq!(tone_color(0.30, Some("fill"), &theme), theme.status_warn);
+        assert_eq!(tone_color(0.80, Some("fill"), &theme), theme.status_ok);
+    }
+
+    #[test]
+    fn tone_drain_inverts_for_usage_metrics() {
+        let theme = Theme::default();
+        assert_eq!(tone_color(0.95, Some("drain"), &theme), theme.status_error);
+        assert_eq!(tone_color(0.70, Some("drain"), &theme), theme.status_warn);
+        assert_eq!(tone_color(0.20, Some("drain"), &theme), theme.status_ok);
+    }
+
+    #[test]
+    fn unknown_tone_falls_back_to_neutral() {
+        let theme = Theme::default();
+        assert_eq!(tone_color(0.05, Some("garbage"), &theme), theme.text);
     }
 
     #[test]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -209,6 +209,12 @@ pub struct RenderOptions {
     /// grid_calendar: event marker glyph, same accepted values.
     #[serde(default)]
     pub marker: Option<String>,
+    /// gauge_battery: how the fill colour follows `Ratio.value`. "neutral" (default) is single
+    /// `theme.text`. "fill" treats the value as how-full (low → status_error, high → status_ok)
+    /// — right for battery / quota progress. "drain" inverts (high → status_error) — right for
+    /// disk / memory / cpu where the ratio is "fraction used".
+    #[serde(default)]
+    pub tone: Option<String>,
     /// gauge_circle: thickness of the ring in cells. None keeps the block-gauge default.
     #[serde(default)]
     pub ring_thickness: Option<u16>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -26,6 +26,7 @@ mod chart_line;
 mod chart_pie;
 mod chart_scatter;
 mod chart_sparkline;
+mod gauge_battery;
 mod gauge_circle;
 mod gauge_line;
 mod grid_calendar;
@@ -354,6 +355,7 @@ impl Registry {
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
+        r.register(Arc::new(gauge_battery::GaugeBatteryRenderer));
         r.register(Arc::new(gauge_circle::GaugeCircleRenderer));
         r.register(Arc::new(gauge_line::GaugeLineRenderer));
         r.register(Arc::new(chart_sparkline::ChartSparklineRenderer));
@@ -582,6 +584,7 @@ mod tests {
             "grid_table",
             "grid_heatmap",
             "grid_calendar",
+            "gauge_battery",
             "gauge_circle",
             "gauge_line",
             "chart_sparkline",

--- a/xtask/src/snapshots.rs
+++ b/xtask/src/snapshots.rs
@@ -65,6 +65,7 @@ fn renderer_dimensions(renderer: &str) -> (u16, u16) {
         "list_plain" => (40, 4),
         "status_badge" => (40, 1),
         "grid_table" => (40, 5),
+        "gauge_battery" => (40, 5),
         "gauge_circle" => (40, 3),
         "gauge_line" => (40, 1),
         "chart_sparkline" => (40, 3),


### PR DESCRIPTION
## Summary

- New `gauge_battery` renderer in the `gauge_*` family — consumes the `Ratio` shape, draws a battery-icon fill.
- Tall slots (height ≥ 3): boxed battery with a tip + inline `% ` label. Short slots: compact one-row form `▕████░░▏▮ 75%`.
- `tone = "neutral" | "fill" | "drain"` option (default `neutral`, single `theme.text` — matches the rest of the `gauge_*` family).
  - `fill` → battery semantic (low → red), pairs with battery / quota progress.
  - `drain` → inverted (high → red), pairs with `system_disk_usage` / `system_memory` / `system_cpu` where the ratio is "fraction used".

Ticks one box on #61.

## Reference page (auto-generated by `cargo xtask`)

> Equivalent of what will appear at `/reference/renderers/gauge/gauge_battery/` once the docs site rebuilds.

- **Accepts:** `ratio`
- **Animates:** no

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `label` | string | no | `payload.label` | Optional prefix shown before the battery, e.g. `"BAT"` → `BAT ▕████░▏▮ 75%`. Falls back to `RatioData.label`; omitted when neither is set. |
| `tone` | `"neutral" \| "fill" \| "drain"` | no | `"neutral"` | How the fill colour follows the value. `neutral` is single `theme.text` (matches the rest of the `gauge_*` family). `fill` treats the value as how-full (low → status_error, high → status_ok) — right for battery / quota progress. `drain` inverts (high → status_error) — right for `system_disk_usage` / `system_memory` / `system_cpu` where the ratio is "fraction used". |

### Theme tokens

Overridable via the `[theme]` section of `config.toml`.

| Key | Description |
| --- | --- |
| `text` | Primary body text colour. Used for the box outline, tip, label, and the `neutral` fill. |
| `text_dim` | Empty-cell colour for the unfilled portion of the bar. |
| `status_ok` | Healthy bucket (`tone = "fill"` ratio ≥ 0.5, `tone = "drain"` ratio ≤ 0.5). |
| `status_warn` | Mid bucket (0.2–0.5 / 0.5–0.8 depending on tone). |
| `status_error` | Critical bucket (< 0.2 fill / > 0.8 drain). |

### Compatible fetchers

| Shape | Fetchers |
| --- | --- |
| `ratio` | [`basic_read_store`](https://splashboard.unhappychoice.com/reference/fetchers/basic/basic_read_store/), [`clock_ratio`](https://splashboard.unhappychoice.com/reference/fetchers/clock/clock_ratio/), [`system_cpu`](https://splashboard.unhappychoice.com/reference/fetchers/system/system_cpu/), [`system_disk_usage`](https://splashboard.unhappychoice.com/reference/fetchers/system/system_disk_usage/), [`system_memory`](https://splashboard.unhappychoice.com/reference/fetchers/system/system_memory/) |

## Test plan

- [x] `cargo test` — 522 lib tests pass (9 new in `gauge_battery::tests`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask` — `gauge_battery.md` generates correctly under `renderers/gauge/`
- [x] `splashboard catalog renderer gauge_battery` — option schema + compatible fetcher list match
- [ ] Visual sanity check in a real splash (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)