### PR TITLE
feat(fetcher): add code_todos

### DIFF
--- a/src/fetcher/code.rs
+++ b/src/fetcher/code.rs
@@ -1,5 +1,9 @@
-//! Project-scoped fetchers — read state from the discovered git repo / worktree under CWD.
+//! Code-internal metric fetchers — grep / parse the source tree of the discovered git repo.
 //! All `Safety::Safe` (local file reads only).
+//!
+//! Distinct from the future `project_*` family in #62, which is for project-level operational
+//! state (test coverage, bundle size, dependency alerts, license check). `code_*` is "what's
+//! inside the source files".
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -16,7 +20,7 @@ use super::git::{fail, open_repo, payload, repo_cache_key};
 use super::{FetchContext, FetchError, Fetcher, Safety};
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(ProjectTodoInCode)]
+    vec![Arc::new(CodeTodos)]
 }
 
 const SHAPES: &[Shape] = &[Shape::Text, Shape::TextBlock, Shape::Entries, Shape::Bars];
@@ -26,6 +30,21 @@ const FILE_SIZE_CAP: u64 = 1024 * 1024;
 const MAX_FILES_SCANNED: usize = 5_000;
 const INTERNAL_HIT_CAP: usize = 500;
 const SNIPPET_CHARS: usize = 100;
+
+/// Path-segment prefixes that get skipped even when they're tracked. Covers the common case
+/// of vendored / generated trees that some projects commit (Go monorepos with `vendor/`,
+/// repos that ship a `dist/` build, accidental `node_modules/`). `.gitignore`-d trees are
+/// already filtered out by walking the index — this list is the second line of defense for
+/// committed-vendored code that would otherwise inflate hit counts with library `TODO`s.
+const EXCLUDED_DIRS: &[&str] = &[
+    "node_modules",
+    "vendor",
+    "third_party",
+    "target",
+    "dist",
+    "build",
+    ".git",
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -49,8 +68,10 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
 /// literals don't inflate the count. `Text` summarises `"N TODOs in M files"`; `TextBlock`
 /// lists `path:line: snippet`; `Entries` / `Bars` rank files by hit count. Walks the index
 /// of the repo discovered from CWD so untracked and `.gitignore`-d files are skipped
-/// automatically.
-pub struct ProjectTodoInCode;
+/// automatically; vendored / generated trees that happen to be committed (`node_modules/`,
+/// `vendor/`, `dist/`, `target/`, …) are skipped via [`EXCLUDED_DIRS`] so library TODOs
+/// don't bleed into the count.
+pub struct CodeTodos;
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -62,9 +83,9 @@ struct Options {
 }
 
 #[async_trait]
-impl Fetcher for ProjectTodoInCode {
+impl Fetcher for CodeTodos {
     fn name(&self) -> &str {
-        "project_todo_in_code"
+        "code_todos"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -199,6 +220,9 @@ fn scan_repo(repo: &gix::Repository, markers: &[String]) -> Result<ScanResult, F
         let Ok(path_str) = std::str::from_utf8(entry.path(&index)) else {
             continue;
         };
+        if is_in_excluded_dir(path_str) {
+            continue;
+        }
         let abs = workdir.join(path_str);
         let Ok(metadata) = std::fs::metadata(&abs) else {
             continue;
@@ -243,6 +267,13 @@ fn scan_repo(repo: &gix::Repository, markers: &[String]) -> Result<ScanResult, F
 fn is_regular_file(mode: gix::index::entry::Mode) -> bool {
     use gix::index::entry::Mode;
     matches!(mode, Mode::FILE | Mode::FILE_EXECUTABLE)
+}
+
+/// True iff any segment of `path` (slash-separated, as the index always stores it) matches a
+/// directory name in [`EXCLUDED_DIRS`]. Skips committed-vendored trees so library TODOs don't
+/// inflate the count.
+fn is_in_excluded_dir(path: &str) -> bool {
+    path.split('/').any(|seg| EXCLUDED_DIRS.contains(&seg))
 }
 
 fn looks_binary(bytes: &[u8]) -> bool {
@@ -475,6 +506,31 @@ mod tests {
     }
 
     #[test]
+    fn vendored_directories_are_excluded_even_when_committed() {
+        // `commit_touching` reuses the message as the appended file content, so we use
+        // distinct payloads with the marker baked into each.
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "src/main.rs", "// TODO: app marker");
+        commit_touching(&repo, "node_modules/foo.js", "// TODO: node marker");
+        commit_touching(&repo, "vendor/lib/x.go", "// TODO: vendor marker");
+        commit_touching(&repo, "src/dist/x.js", "// TODO: dist marker");
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 1);
+        assert_eq!(scan.hits[0].path, "src/main.rs");
+    }
+
+    #[test]
+    fn excluded_dir_check_only_matches_segments() {
+        // `vendor/x.go` excluded; `myvendor/x.go` and `vendor.go` are regular files.
+        assert!(is_in_excluded_dir("vendor/foo.go"));
+        assert!(is_in_excluded_dir("src/vendor/foo.go"));
+        assert!(is_in_excluded_dir("a/b/node_modules/c"));
+        assert!(!is_in_excluded_dir("myvendor/foo.go"));
+        assert!(!is_in_excluded_dir("src/vendor.go"));
+        assert!(!is_in_excluded_dir("README.md"));
+    }
+
+    #[test]
     fn custom_markers_supersede_defaults() {
         let (_tmp, repo) = make_repo();
         commit_touching(&repo, "x.rs", "// TODO: ignored\n// XXX: caught");
@@ -580,11 +636,11 @@ mod tests {
             widget_id: "w".into(),
             ..Default::default()
         };
-        let key_default = ProjectTodoInCode.cache_key(&ctx);
+        let key_default = CodeTodos.cache_key(&ctx);
         ctx.options = Some(toml::from_str(r#"markers = ["TODO"]"#).unwrap());
-        let key_a = ProjectTodoInCode.cache_key(&ctx);
+        let key_a = CodeTodos.cache_key(&ctx);
         ctx.options = Some(toml::from_str(r#"markers = ["FIXME"]"#).unwrap());
-        let key_b = ProjectTodoInCode.cache_key(&ctx);
+        let key_b = CodeTodos.cache_key(&ctx);
         assert_ne!(key_default, key_a);
         assert_ne!(key_a, key_b);
     }
@@ -596,9 +652,9 @@ mod tests {
             ..Default::default()
         };
         ctx.options = Some(toml::from_str(r#"markers = ["TODO", "FIXME"]"#).unwrap());
-        let a = ProjectTodoInCode.cache_key(&ctx);
+        let a = CodeTodos.cache_key(&ctx);
         ctx.options = Some(toml::from_str(r#"markers = ["TODO", "FIXME"]"#).unwrap());
-        let b = ProjectTodoInCode.cache_key(&ctx);
+        let b = CodeTodos.cache_key(&ctx);
         assert_eq!(a, b);
     }
 

--- a/src/fetcher/git/mod.rs
+++ b/src/fetcher/git/mod.rs
@@ -26,7 +26,7 @@ mod status;
 mod worktrees;
 
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![

--- a/src/fetcher/git/test_support.rs
+++ b/src/fetcher/git/test_support.rs
@@ -15,6 +15,10 @@ pub fn make_repo() -> (TempDir, gix::Repository) {
     run(tmp.path(), &["config", "user.name", "Test"]);
     run(tmp.path(), &["config", "commit.gpgsign", "false"]);
     run(tmp.path(), &["config", "tag.gpgsign", "false"]);
+    // Detach from the user's global excludes file so paths like `node_modules/` /
+    // `vendor/` / `dist/` (commonly ignored globally) aren't silently skipped by
+    // `git add` inside test repos.
+    run(tmp.path(), &["config", "core.excludesfile", "/dev/null"]);
     let repo = gix::discover(tmp.path()).expect("discover");
     (tmp, repo)
 }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -13,9 +13,9 @@ use crate::render::Shape;
 use crate::samples;
 
 pub mod clock;
+pub mod code;
 pub mod git;
 pub mod github;
-pub mod project;
 pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
@@ -269,7 +269,7 @@ impl Registry {
         for f in github::fetchers() {
             r.register(f);
         }
-        for f in project::fetchers() {
+        for f in code::fetchers() {
             r.register(f);
         }
         r

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -15,6 +15,7 @@ use crate::samples;
 pub mod clock;
 pub mod git;
 pub mod github;
+pub mod project;
 pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
@@ -266,6 +267,9 @@ impl Registry {
             r.register(f);
         }
         for f in github::fetchers() {
+            r.register(f);
+        }
+        for f in project::fetchers() {
             r.register(f);
         }
         r

--- a/src/fetcher/project.rs
+++ b/src/fetcher/project.rs
@@ -1,0 +1,515 @@
+//! Project-scoped fetchers — read state from the discovered git repo / worktree under CWD.
+//! All `Safety::Safe` (local file reads only).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::options::OptionSchema;
+use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload, TextBlockData, TextData};
+use crate::render::Shape;
+use crate::samples;
+
+use super::git::{fail, open_repo, payload, repo_cache_key};
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(ProjectTodoInCode)]
+}
+
+const SHAPES: &[Shape] = &[Shape::Text, Shape::TextBlock, Shape::Entries, Shape::Bars];
+const DEFAULT_MARKERS: &[&str] = &["TODO", "FIXME"];
+const DEFAULT_LIMIT: usize = 20;
+const FILE_SIZE_CAP: u64 = 1024 * 1024;
+const MAX_FILES_SCANNED: usize = 5_000;
+const INTERNAL_HIT_CAP: usize = 500;
+const SNIPPET_CHARS: usize = 100;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "markers",
+        type_hint: "array of strings",
+        required: false,
+        default: Some("[\"TODO\", \"FIXME\"]"),
+        description: "Markers grepped for. Each is matched as a whole-word ASCII token against tracked source files.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer",
+        required: false,
+        default: Some("20"),
+        description: "Cap on rendered hits (TextBlock) or rows (Entries / Bars). Total count surfaced by `Text` is unaffected.",
+    },
+];
+
+/// Greps tracked source files for `TODO` / `FIXME`-style markers. `Text` summarises
+/// `"N TODOs in M files"`; `TextBlock` lists `path:line: snippet`; `Entries` / `Bars` rank
+/// files by hit count. Walks the index of the repo discovered from CWD so untracked and
+/// `.gitignore`-d files (build artefacts, vendored deps) are skipped automatically.
+pub struct ProjectTodoInCode;
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    markers: Option<Vec<String>>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[async_trait]
+impl Fetcher for ProjectTodoInCode {
+    fn name(&self) -> &str {
+        "project_todo_in_code"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Text
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        repo_cache_key(self.name(), ctx)
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Text => samples::text("12 TODOs in 5 files"),
+            Shape::TextBlock => samples::text_block(&[
+                "src/render/mod.rs:120: TODO: handle empty body",
+                "src/fetcher/git.rs:88: FIXME: don't panic on detached head",
+                "src/main.rs:14: TODO: load config from $HOME",
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("src/render/mod.rs", "5"),
+                ("src/fetcher/git.rs", "3"),
+                ("src/main.rs", "2"),
+            ]),
+            Shape::Bars => samples::bars(&[
+                ("src/render/mod.rs", 5),
+                ("src/fetcher/git.rs", 3),
+                ("src/main.rs", 2),
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref())?;
+        let markers = resolve_markers(opts.markers.as_deref());
+        let limit = opts.limit.filter(|n| *n > 0).unwrap_or(DEFAULT_LIMIT);
+        let scan = scan_cwd(&markers)?;
+        Ok(payload(render_body(
+            scan,
+            ctx.shape.unwrap_or(Shape::Text),
+            limit,
+        )))
+    }
+}
+
+fn parse_options(raw: Option<&toml::Value>) -> Result<Options, FetchError> {
+    match raw {
+        None => Ok(Options::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<Options>()
+            .map_err(|e| FetchError::Failed(format!("invalid options: {e}"))),
+    }
+}
+
+fn resolve_markers(opt: Option<&[String]>) -> Vec<String> {
+    let custom: Vec<String> = opt
+        .map(|v| {
+            v.iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    if custom.is_empty() {
+        DEFAULT_MARKERS.iter().map(|s| (*s).into()).collect()
+    } else {
+        custom
+    }
+}
+
+#[derive(Debug, Default)]
+struct ScanResult {
+    hits: Vec<Hit>,
+    total: usize,
+    files_with_hits: usize,
+    file_counts: Vec<(String, u64)>,
+}
+
+#[derive(Debug)]
+struct Hit {
+    path: String,
+    line: usize,
+    text: String,
+}
+
+fn scan_cwd(markers: &[String]) -> Result<ScanResult, FetchError> {
+    let repo = open_repo()?;
+    scan_repo(&repo, markers)
+}
+
+fn scan_repo(repo: &gix::Repository, markers: &[String]) -> Result<ScanResult, FetchError> {
+    let Some(workdir) = repo.workdir().map(|p| p.to_path_buf()) else {
+        return Ok(ScanResult::default());
+    };
+    let index = match repo.index_or_load_from_head_or_empty() {
+        Ok(i) => i,
+        Err(e) => return Err(fail(e)),
+    };
+    let needles: Vec<&str> = markers.iter().map(String::as_str).collect();
+    let mut hits = Vec::new();
+    let mut counts: HashMap<String, u64> = HashMap::new();
+    let mut total = 0usize;
+    let mut scanned = 0usize;
+    for entry in index.entries() {
+        if scanned >= MAX_FILES_SCANNED {
+            break;
+        }
+        if !is_regular_file(entry.mode) {
+            continue;
+        }
+        scanned += 1;
+        let Ok(path_str) = std::str::from_utf8(entry.path(&index)) else {
+            continue;
+        };
+        let abs = workdir.join(path_str);
+        let Ok(metadata) = std::fs::metadata(&abs) else {
+            continue;
+        };
+        if !metadata.is_file() || metadata.len() > FILE_SIZE_CAP {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&abs) else {
+            continue;
+        };
+        if looks_binary(&bytes) {
+            continue;
+        }
+        let Ok(text) = std::str::from_utf8(&bytes) else {
+            continue;
+        };
+        for (idx, line) in text.lines().enumerate() {
+            if let Some(snippet) = match_marker(line, &needles) {
+                total += 1;
+                *counts.entry(path_str.to_string()).or_insert(0) += 1;
+                if hits.len() < INTERNAL_HIT_CAP {
+                    hits.push(Hit {
+                        path: path_str.to_string(),
+                        line: idx + 1,
+                        text: snippet,
+                    });
+                }
+            }
+        }
+    }
+    let files_with_hits = counts.len();
+    let mut file_counts: Vec<_> = counts.into_iter().collect();
+    file_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    Ok(ScanResult {
+        hits,
+        total,
+        files_with_hits,
+        file_counts,
+    })
+}
+
+fn is_regular_file(mode: gix::index::entry::Mode) -> bool {
+    use gix::index::entry::Mode;
+    matches!(mode, Mode::FILE | Mode::FILE_EXECUTABLE)
+}
+
+fn looks_binary(bytes: &[u8]) -> bool {
+    let head = &bytes[..bytes.len().min(8192)];
+    head.contains(&0)
+}
+
+fn match_marker(line: &str, markers: &[&str]) -> Option<String> {
+    let bytes = line.as_bytes();
+    let mut best: Option<usize> = None;
+    for needle in markers {
+        if let Some(pos) = find_word(bytes, needle.as_bytes())
+            && best.map(|b| pos < b).unwrap_or(true)
+        {
+            best = Some(pos);
+        }
+    }
+    best.map(|pos| truncate(line[pos..].trim_end(), SNIPPET_CHARS))
+}
+
+fn find_word(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    (0..=haystack.len() - needle.len()).find(|&i| {
+        haystack[i..i + needle.len()] == *needle
+            && (i == 0 || !is_word_byte(haystack[i - 1]))
+            && (i + needle.len() == haystack.len() || !is_word_byte(haystack[i + needle.len()]))
+    })
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max_chars).collect();
+        format!("{head}…")
+    }
+}
+
+fn render_body(scan: ScanResult, shape: Shape, limit: usize) -> Body {
+    match shape {
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: scan
+                .hits
+                .into_iter()
+                .take(limit)
+                .map(|h| format!("{}:{}: {}", h.path, h.line, h.text))
+                .collect(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: scan
+                .file_counts
+                .into_iter()
+                .take(limit)
+                .map(|(p, c)| Entry {
+                    key: p,
+                    value: Some(c.to_string()),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: scan
+                .file_counts
+                .into_iter()
+                .take(limit)
+                .map(|(p, c)| Bar { label: p, value: c })
+                .collect(),
+        }),
+        _ => text_summary(scan.total, scan.files_with_hits),
+    }
+}
+
+fn text_summary(total: usize, files: usize) -> Body {
+    let value = if total == 0 {
+        String::new()
+    } else {
+        format!(
+            "{total} TODO{} in {files} file{}",
+            if total == 1 { "" } else { "s" },
+            if files == 1 { "" } else { "s" },
+        )
+    };
+    Body::Text(TextData { value })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::git::test_support::{commit_touching, make_repo};
+    use super::*;
+
+    fn defaults() -> Vec<String> {
+        DEFAULT_MARKERS.iter().map(|s| (*s).into()).collect()
+    }
+
+    #[test]
+    fn empty_repo_returns_empty_scan() {
+        let (_tmp, repo) = make_repo();
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 0);
+        assert!(scan.hits.is_empty());
+    }
+
+    #[test]
+    fn picks_up_marker_in_tracked_file() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "src/main.rs", "// TODO: refactor this");
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 1);
+        let hit = scan.hits.first().expect("one hit");
+        assert_eq!(hit.path, "src/main.rs");
+        assert!(hit.text.starts_with("TODO"));
+    }
+
+    #[test]
+    fn untracked_file_is_ignored() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "tracked.rs", "nothing");
+        let workdir = repo.workdir().unwrap();
+        std::fs::write(workdir.join("untracked.rs"), "// TODO: should be skipped\n").unwrap();
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 0);
+    }
+
+    #[test]
+    fn ranks_files_by_hit_count() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "many.rs", "// TODO: a\n// TODO: b\n// TODO: c");
+        commit_touching(&repo, "few.rs", "// TODO: a");
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        let labels: Vec<_> = scan.file_counts.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(labels, vec!["many.rs", "few.rs"]);
+        assert_eq!(scan.file_counts[0].1, 3);
+        assert_eq!(scan.files_with_hits, 2);
+    }
+
+    #[test]
+    fn matcher_requires_word_boundary() {
+        // "TODOLIST" should not match the "TODO" marker.
+        assert!(match_marker("let TODOLIST = 1;", &["TODO"]).is_none());
+        assert!(match_marker("// TODO: x", &["TODO"]).is_some());
+        assert!(match_marker("/*TODO*/", &["TODO"]).is_some());
+    }
+
+    #[test]
+    fn matcher_picks_first_marker_in_line() {
+        // Snippet starts at the marker, dropping any preceding comment chars.
+        let snippet = match_marker("    // TODO: real text   ", &["TODO", "FIXME"]).unwrap();
+        assert_eq!(snippet, "TODO: real text");
+    }
+
+    #[test]
+    fn binary_files_are_skipped() {
+        let (tmp, repo) = make_repo();
+        let workdir = tmp.path();
+        std::fs::write(workdir.join("blob.bin"), b"\x00\x01\x02TODO\x00").unwrap();
+        // Track and commit the binary so the index sees it.
+        std::process::Command::new("git")
+            .args(["add", "blob.bin"])
+            .current_dir(workdir)
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-q", "-m", "bin"])
+            .current_dir(workdir)
+            .status()
+            .unwrap();
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 0);
+    }
+
+    #[test]
+    fn custom_markers_supersede_defaults() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "x.rs", "// TODO: ignored\n// XXX: caught");
+        let markers = vec!["XXX".to_string()];
+        let scan = scan_repo(&repo, &markers).unwrap();
+        assert_eq!(scan.total, 1);
+        assert!(scan.hits[0].text.starts_with("XXX"));
+    }
+
+    #[test]
+    fn text_summary_reports_total_and_file_count() {
+        let body = render_body(
+            ScanResult {
+                hits: vec![],
+                total: 3,
+                files_with_hits: 2,
+                file_counts: vec![("a".into(), 2), ("b".into(), 1)],
+            },
+            Shape::Text,
+            10,
+        );
+        match body {
+            Body::Text(d) => assert_eq!(d.value, "3 TODOs in 2 files"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_summary_handles_singular_grammar() {
+        let body = render_body(
+            ScanResult {
+                hits: vec![],
+                total: 1,
+                files_with_hits: 1,
+                file_counts: vec![("a".into(), 1)],
+            },
+            Shape::Text,
+            10,
+        );
+        match body {
+            Body::Text(d) => assert_eq!(d.value, "1 TODO in 1 file"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_summary_is_empty_when_no_hits() {
+        let body = render_body(ScanResult::default(), Shape::Text, 10);
+        match body {
+            Body::Text(d) => assert!(d.value.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_block_formats_path_line_snippet() {
+        let body = render_body(
+            ScanResult {
+                hits: vec![Hit {
+                    path: "src/main.rs".into(),
+                    line: 12,
+                    text: "TODO: x".into(),
+                }],
+                total: 1,
+                files_with_hits: 1,
+                file_counts: vec![("src/main.rs".into(), 1)],
+            },
+            Shape::TextBlock,
+            10,
+        );
+        match body {
+            Body::TextBlock(d) => assert_eq!(d.lines, vec!["src/main.rs:12: TODO: x"]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn limit_caps_rendered_rows() {
+        let scan = ScanResult {
+            hits: vec![],
+            total: 5,
+            files_with_hits: 5,
+            file_counts: (0..5).map(|i| (format!("f{i}.rs"), 1)).collect(),
+        };
+        let body = render_body(scan, Shape::Entries, 2);
+        match body {
+            Body::Entries(d) => assert_eq!(d.items.len(), 2),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn truncate_appends_ellipsis_when_over_max() {
+        let s = "x".repeat(120);
+        let out = truncate(&s, 100);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), 101);
+    }
+
+    #[test]
+    fn resolve_markers_falls_back_when_empty() {
+        let empty: Vec<String> = Vec::new();
+        let blanks: Vec<String> = vec!["  ".into(), "".into()];
+        let custom: Vec<String> = vec!["XXX".into()];
+        assert_eq!(resolve_markers(None), defaults());
+        assert_eq!(resolve_markers(Some(&empty)), defaults());
+        assert_eq!(resolve_markers(Some(&blanks)), defaults());
+        assert_eq!(resolve_markers(Some(&custom)), vec!["XXX".to_string()]);
+    }
+}

--- a/src/fetcher/project.rs
+++ b/src/fetcher/project.rs
@@ -33,7 +33,7 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
         type_hint: "array of strings",
         required: false,
         default: Some("[\"TODO\", \"FIXME\"]"),
-        description: "Markers grepped for. Each is matched as a whole-word ASCII token against tracked source files.",
+        description: "Markers grepped for. Each must appear as a whole-word ASCII token followed by `:` (or `(name):`) — `// TODO: refactor` matches, `## TODO` heading and `\"TODO\"` literals don't.",
     },
     OptionSchema {
         name: "limit",
@@ -44,10 +44,12 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
 ];
 
-/// Greps tracked source files for `TODO` / `FIXME`-style markers. `Text` summarises
-/// `"N TODOs in M files"`; `TextBlock` lists `path:line: snippet`; `Entries` / `Bars` rank
-/// files by hit count. Walks the index of the repo discovered from CWD so untracked and
-/// `.gitignore`-d files (build artefacts, vendored deps) are skipped automatically.
+/// Greps tracked source files for `TODO:` / `FIXME:`-style comment markers. The trailing
+/// colon (also accepting `TODO(name):`) is required so README headings, prose, and string
+/// literals don't inflate the count. `Text` summarises `"N TODOs in M files"`; `TextBlock`
+/// lists `path:line: snippet`; `Entries` / `Bars` rank files by hit count. Walks the index
+/// of the repo discovered from CWD so untracked and `.gitignore`-d files are skipped
+/// automatically.
 pub struct ProjectTodoInCode;
 
 #[derive(Debug, Default, serde::Deserialize)]
@@ -252,7 +254,7 @@ fn match_marker(line: &str, markers: &[&str]) -> Option<String> {
     let bytes = line.as_bytes();
     let mut best: Option<usize> = None;
     for needle in markers {
-        if let Some(pos) = find_word(bytes, needle.as_bytes())
+        if let Some(pos) = find_marker(bytes, needle.as_bytes())
             && best.map(|b| pos < b).unwrap_or(true)
         {
             best = Some(pos);
@@ -261,15 +263,40 @@ fn match_marker(line: &str, markers: &[&str]) -> Option<String> {
     best.map(|pos| truncate(line[pos..].trim_end(), SNIPPET_CHARS))
 }
 
-fn find_word(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+/// Find a marker followed by a `TODO:` / `TODO(name):` style colon. Word-boundary on the
+/// leading side so `TODOLIST` doesn't match; trailing `:` excludes README headings, prose,
+/// and string-literal hits like `"TODO"`. The optional `(...)` arm handles the `TODO(yuji):`
+/// author-tag convention. `::` (C++ namespace) is rejected explicitly.
+fn find_marker(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() || needle.len() > haystack.len() {
         return None;
     }
     (0..=haystack.len() - needle.len()).find(|&i| {
-        haystack[i..i + needle.len()] == *needle
+        let end = i + needle.len();
+        haystack[i..end] == *needle
             && (i == 0 || !is_word_byte(haystack[i - 1]))
-            && (i + needle.len() == haystack.len() || !is_word_byte(haystack[i + needle.len()]))
+            && (end < haystack.len() && !is_word_byte(haystack[end]))
+            && trailing_colon(haystack, end)
     })
+}
+
+fn trailing_colon(bytes: &[u8], mut i: usize) -> bool {
+    if bytes.get(i) == Some(&b'(') {
+        let mut depth = 1;
+        i += 1;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        if depth != 0 {
+            return false;
+        }
+    }
+    bytes.get(i) == Some(&b':') && bytes.get(i + 1) != Some(&b':')
 }
 
 fn is_word_byte(b: u8) -> bool {
@@ -361,6 +388,28 @@ mod tests {
     }
 
     #[test]
+    fn marker_without_trailing_colon_is_ignored() {
+        // README headings, prose, string literals: noise we explicitly want to filter out.
+        let (_tmp, repo) = make_repo();
+        commit_touching(
+            &repo,
+            "README.md",
+            "## TODO\nstill TODO somewhere\nlet x = \"TODO\";",
+        );
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 0);
+    }
+
+    #[test]
+    fn author_tagged_marker_is_recognised() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "src/lib.rs", "// TODO(yuji): wire this up");
+        let scan = scan_repo(&repo, &defaults()).unwrap();
+        assert_eq!(scan.total, 1);
+        assert!(scan.hits[0].text.starts_with("TODO(yuji):"));
+    }
+
+    #[test]
     fn untracked_file_is_ignored() {
         let (_tmp, repo) = make_repo();
         commit_touching(&repo, "tracked.rs", "nothing");
@@ -374,7 +423,7 @@ mod tests {
     fn ranks_files_by_hit_count() {
         let (_tmp, repo) = make_repo();
         commit_touching(&repo, "many.rs", "// TODO: a\n// TODO: b\n// TODO: c");
-        commit_touching(&repo, "few.rs", "// TODO: a");
+        commit_touching(&repo, "few.rs", "// TODO: only one");
         let scan = scan_repo(&repo, &defaults()).unwrap();
         let labels: Vec<_> = scan.file_counts.iter().map(|(p, _)| p.clone()).collect();
         assert_eq!(labels, vec!["many.rs", "few.rs"]);
@@ -383,11 +432,19 @@ mod tests {
     }
 
     #[test]
-    fn matcher_requires_word_boundary() {
-        // "TODOLIST" should not match the "TODO" marker.
+    fn matcher_requires_word_boundary_and_trailing_colon() {
+        // Word boundary: `TODOLIST` must not match.
         assert!(match_marker("let TODOLIST = 1;", &["TODO"]).is_none());
+        // Trailing colon: prose / headings / literals without `:` must not match.
+        assert!(match_marker("## TODO", &["TODO"]).is_none());
+        assert!(match_marker("/*TODO*/", &["TODO"]).is_none());
+        assert!(match_marker("let x = \"TODO\";", &["TODO"]).is_none());
+        // Canonical comment forms match.
         assert!(match_marker("// TODO: x", &["TODO"]).is_some());
-        assert!(match_marker("/*TODO*/", &["TODO"]).is_some());
+        assert!(match_marker("# TODO: x", &["TODO"]).is_some());
+        assert!(match_marker("// TODO(yuji): x", &["TODO"]).is_some());
+        // C++ namespace `std::TODO::foo` must not match.
+        assert!(match_marker("std::TODO::foo()", &["TODO"]).is_none());
     }
 
     #[test]
@@ -401,7 +458,7 @@ mod tests {
     fn binary_files_are_skipped() {
         let (tmp, repo) = make_repo();
         let workdir = tmp.path();
-        std::fs::write(workdir.join("blob.bin"), b"\x00\x01\x02TODO\x00").unwrap();
+        std::fs::write(workdir.join("blob.bin"), b"\x00\x01\x02TODO: x\x00").unwrap();
         // Track and commit the binary so the index sees it.
         std::process::Command::new("git")
             .args(["add", "blob.bin"])
@@ -424,7 +481,7 @@ mod tests {
         let markers = vec!["XXX".to_string()];
         let scan = scan_repo(&repo, &markers).unwrap();
         assert_eq!(scan.total, 1);
-        assert!(scan.hits[0].text.starts_with("XXX"));
+        assert!(scan.hits[0].text.starts_with("XXX:"));
     }
 
     #[test]

--- a/src/fetcher/project.rs
+++ b/src/fetcher/project.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use sha2::{Digest, Sha256};
 
 use crate::options::OptionSchema;
 use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload, TextBlockData, TextData};
@@ -73,7 +74,21 @@ impl Fetcher for ProjectTodoInCode {
         Shape::Text
     }
     fn cache_key(&self, ctx: &FetchContext) -> String {
-        repo_cache_key(self.name(), ctx)
+        // Mix `[widget.options]` into the key — markers / limit change what gets read, so two
+        // widgets pointing at this fetcher with different options must not share a cache slot.
+        // `toml = "0.8"` keeps tables in sorted order, so `Value::to_string()` is stable across runs.
+        let base = repo_cache_key(self.name(), ctx);
+        let opts = ctx
+            .options
+            .as_ref()
+            .map(toml::Value::to_string)
+            .unwrap_or_default();
+        if opts.is_empty() {
+            return base;
+        }
+        let digest = Sha256::digest(opts.as_bytes());
+        let hex: String = digest.iter().take(4).map(|b| format!("{b:02x}")).collect();
+        format!("{base}-{hex}")
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -500,6 +515,34 @@ mod tests {
         let out = truncate(&s, 100);
         assert!(out.ends_with('…'));
         assert_eq!(out.chars().count(), 101);
+    }
+
+    #[test]
+    fn cache_key_changes_with_options() {
+        let mut ctx = FetchContext {
+            widget_id: "w".into(),
+            ..Default::default()
+        };
+        let key_default = ProjectTodoInCode.cache_key(&ctx);
+        ctx.options = Some(toml::from_str(r#"markers = ["TODO"]"#).unwrap());
+        let key_a = ProjectTodoInCode.cache_key(&ctx);
+        ctx.options = Some(toml::from_str(r#"markers = ["FIXME"]"#).unwrap());
+        let key_b = ProjectTodoInCode.cache_key(&ctx);
+        assert_ne!(key_default, key_a);
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn cache_key_is_stable_for_equivalent_options() {
+        let mut ctx = FetchContext {
+            widget_id: "w".into(),
+            ..Default::default()
+        };
+        ctx.options = Some(toml::from_str(r#"markers = ["TODO", "FIXME"]"#).unwrap());
+        let a = ProjectTodoInCode.cache_key(&ctx);
+        ctx.options = Some(toml::from_str(r#"markers = ["TODO", "FIXME"]"#).unwrap());
+        let b = ProjectTodoInCode.cache_key(&ctx);
+        assert_eq!(a, b);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Greps tracked source files for `TODO` / `FIXME` markers via `gix` index, so `.gitignore`-d build artefacts and untracked files are skipped automatically — fits the per-directory killer feature angle (different repos, different unfinished work surfaced).
- Multi-shape: `Text` (`"12 TODOs in 5 files"`), `TextBlock` (`path:line: snippet`), `Entries` / `Bars` (files ranked by hit count).
- Options: `markers` (default `["TODO", "FIXME"]`) and `limit` (default 20). Bounded by 1 MB file-size cap, 5 000 file scan cap, and 500 internal hit cap so a giant repo doesn't blow up the splash.

Ticks the `project_todo_in_code` box in #62.

## Test plan
- [x] `cargo test` — 528 existing + 15 new (`fetcher::project`) passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask` regenerates `docs-site/.../fetchers/project/project_todo_in_code.md` (gitignored)
- [ ] Drop into a real repo with `fetcher = "project_todo_in_code"` configured under `./.splashboard/config.toml` and confirm the four shapes render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TODO counter that scans tracked repository files for configured marker tokens, excluding directories like `node_modules` and `vendor`, and displays results in multiple formats: summary counts, detailed file listings with line snippets, ranked hit counts, or visual bar charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->