### PR TITLE
feat(render): add gauge_segment renderer for Ratio shape

### DIFF
--- a/src/render/gauge_segment.rs
+++ b/src/render/gauge_segment.rs
@@ -1,0 +1,310 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::options::OptionSchema;
+use crate::payload::{Body, RatioData};
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape};
+
+const COLOR_KEYS: &[ColorKey] = &[
+    theme::TEXT,
+    theme::TEXT_DIM,
+    theme::STATUS_OK,
+    theme::STATUS_WARN,
+    theme::STATUS_ERROR,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "label",
+        type_hint: "string",
+        required: false,
+        default: Some("payload.label"),
+        description: "Optional prefix shown before the LED bar, e.g. `\"VOL\"` → `VOL ▰▰▰▱▱ 60%`. Falls back to `RatioData.label`; omitted when neither is set.",
+    },
+    OptionSchema {
+        name: "segments",
+        type_hint: "u16",
+        required: false,
+        default: Some("5"),
+        description: "Number of LED segments. Defaults to the canonical 5-LED silhouette; raise for finer granularity (e.g. 10) when there's room. Values below 1 are clamped to 1.",
+    },
+    OptionSchema {
+        name: "tone",
+        type_hint: "\"neutral\" | \"fill\" | \"drain\"",
+        required: false,
+        default: Some("\"neutral\""),
+        description: "How segment colour follows the value. `neutral` is single `theme.text`. `fill` treats the value as how-full (low → status_error, high → status_ok) — right for VU / quota progress. `drain` inverts (high → status_error) — right for usage-style readouts.",
+    },
+    OptionSchema {
+        name: "value_format",
+        type_hint: "\"percent\" | \"fraction\" | \"both\"",
+        required: false,
+        default: Some("\"percent\""),
+        description: "Suffix format. `fraction` and `both` require `RatioData.denominator` — otherwise they fall back to `percent`.",
+    },
+];
+
+const DEFAULT_SEGMENTS: u16 = 5;
+const FILLED: &str = "▰";
+const EMPTY: &str = "▱";
+
+/// 5-LED segmented bar for `Ratio`. Discrete chunks instead of a continuous fill — the
+/// retro-hardware sibling of `gauge_line`. Tone follows `gauge_battery` semantics: neutral
+/// (default) for theme-colour, `fill` for low-is-bad, `drain` for high-is-bad.
+pub struct GaugeSegmentRenderer;
+
+impl Renderer for GaugeSegmentRenderer {
+    fn name(&self) -> &str {
+        "gauge_segment"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::Ratio]
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        _registry: &Registry,
+    ) {
+        if let Body::Ratio(d) = body {
+            render_segment(frame, area, d, opts, theme);
+        }
+    }
+}
+
+fn render_segment(
+    frame: &mut Frame,
+    area: Rect,
+    data: &RatioData,
+    opts: &RenderOptions,
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let ratio = data.value.clamp(0.0, 1.0);
+    let prefix = resolve_prefix(opts, data);
+    let suffix = format_value(ratio, data.denominator, opts.value_format.as_deref());
+    let segments = resolve_segment_count(opts.segments);
+    let filled = (f64::from(segments) * ratio).round() as u16;
+    let fill = tone_color(ratio, opts.tone.as_deref(), theme);
+    let row = Rect::new(area.x, area.y + area.height / 2, area.width, 1);
+    let line = Line::from(compose_spans(
+        &prefix, &suffix, filled, segments, fill, theme,
+    ));
+    frame.render_widget(Paragraph::new(line), row);
+}
+
+fn compose_spans<'a>(
+    prefix: &str,
+    suffix: &str,
+    filled: u16,
+    segments: u16,
+    fill: ratatui::style::Color,
+    theme: &Theme,
+) -> Vec<Span<'a>> {
+    let mut spans = Vec::with_capacity(5);
+    if !prefix.is_empty() {
+        spans.push(Span::styled(
+            format!("{prefix} "),
+            Style::default().fg(theme.text),
+        ));
+    }
+    spans.push(Span::styled(
+        FILLED.repeat(filled as usize),
+        Style::default().fg(fill),
+    ));
+    spans.push(Span::styled(
+        EMPTY.repeat(segments.saturating_sub(filled) as usize),
+        Style::default().fg(theme.text_dim),
+    ));
+    spans.push(Span::styled(
+        format!(" {suffix}"),
+        Style::default().fg(theme.text),
+    ));
+    spans
+}
+
+fn resolve_prefix(opts: &RenderOptions, data: &RatioData) -> String {
+    opts.label
+        .clone()
+        .or_else(|| data.label.clone())
+        .unwrap_or_default()
+}
+
+fn resolve_segment_count(opt: Option<u16>) -> u16 {
+    opt.unwrap_or(DEFAULT_SEGMENTS).max(1)
+}
+
+fn format_value(ratio: f64, denominator: Option<u64>, mode: Option<&str>) -> String {
+    let pct = (ratio * 100.0).round() as u64;
+    match (mode.unwrap_or("percent"), denominator) {
+        ("fraction", Some(d)) => format!("{} of {d}", numerator(ratio, d)),
+        ("both", Some(d)) => format!("{pct}% ({} of {d})", numerator(ratio, d)),
+        _ => format!("{pct}%"),
+    }
+}
+
+fn numerator(ratio: f64, denominator: u64) -> u64 {
+    (ratio * denominator as f64).round() as u64
+}
+
+fn tone_color(ratio: f64, tone: Option<&str>, theme: &Theme) -> ratatui::style::Color {
+    match tone.unwrap_or("neutral") {
+        "fill" => level_color(ratio, theme),
+        "drain" => level_color(1.0 - ratio, theme),
+        _ => theme.text,
+    }
+}
+
+fn level_color(ratio: f64, theme: &Theme) -> ratatui::style::Color {
+    if ratio < 0.20 {
+        theme.status_error
+    } else if ratio < 0.50 {
+        theme.status_warn
+    } else {
+        theme.status_ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, RatioData};
+    use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+    use crate::render::{Registry, RenderSpec};
+
+    fn payload(value: f64, label: Option<&str>) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Ratio(RatioData {
+                value,
+                label: label.map(String::from),
+                denominator: None,
+            }),
+        }
+    }
+
+    fn registry_and_spec() -> (Registry, RenderSpec) {
+        (
+            Registry::with_builtins(),
+            RenderSpec::Short("gauge_segment".into()),
+        )
+    }
+
+    #[test]
+    fn renders_default_five_segments() {
+        let (registry, spec) = registry_and_spec();
+        let buf = render_to_buffer_with_spec(&payload(0.6, None), Some(&spec), &registry, 20, 1);
+        let row = line_text(&buf, 0);
+        let filled = row.matches(FILLED).count();
+        let empty = row.matches(EMPTY).count();
+        assert_eq!(filled + empty, DEFAULT_SEGMENTS as usize, "row: {row:?}");
+        assert_eq!(filled, 3, "60% of 5 should round to 3 filled: {row:?}");
+        assert!(row.contains("60%"), "missing percent suffix: {row:?}");
+    }
+
+    #[test]
+    fn segments_option_overrides_count() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(r#"render = { type = "gauge_segment", segments = 10 }"#).unwrap();
+        let buf =
+            render_to_buffer_with_spec(&payload(0.3, None), Some(&w.render), &registry, 30, 1);
+        let row = line_text(&buf, 0);
+        assert_eq!(row.matches(FILLED).count() + row.matches(EMPTY).count(), 10);
+    }
+
+    #[test]
+    fn label_prefix_renders_when_provided() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(r#"render = { type = "gauge_segment", label = "VOL" }"#).unwrap();
+        let buf =
+            render_to_buffer_with_spec(&payload(0.4, None), Some(&w.render), &registry, 30, 1);
+        let row = line_text(&buf, 0);
+        assert!(row.starts_with("VOL"), "missing prefix: {row:?}");
+    }
+
+    #[test]
+    fn payload_label_used_when_option_missing() {
+        let (registry, spec) = registry_and_spec();
+        let buf =
+            render_to_buffer_with_spec(&payload(0.5, Some("CPU")), Some(&spec), &registry, 30, 1);
+        let row = line_text(&buf, 0);
+        assert!(row.starts_with("CPU"), "missing payload label: {row:?}");
+    }
+
+    #[test]
+    fn clamps_out_of_range() {
+        let (registry, spec) = registry_and_spec();
+        let _ = render_to_buffer_with_spec(&payload(1.7, None), Some(&spec), &registry, 30, 1);
+        let _ = render_to_buffer_with_spec(&payload(-0.2, None), Some(&spec), &registry, 30, 1);
+    }
+
+    #[test]
+    fn segments_clamped_to_at_least_one() {
+        assert_eq!(resolve_segment_count(Some(0)), 1);
+        assert_eq!(resolve_segment_count(None), DEFAULT_SEGMENTS);
+        assert_eq!(resolve_segment_count(Some(8)), 8);
+    }
+
+    #[test]
+    fn tone_neutral_is_default_and_uses_text_colour() {
+        let theme = Theme::default();
+        assert_eq!(tone_color(0.05, None, &theme), theme.text);
+        assert_eq!(tone_color(0.95, Some("neutral"), &theme), theme.text);
+    }
+
+    #[test]
+    fn tone_fill_maps_low_to_error() {
+        let theme = Theme::default();
+        assert_eq!(tone_color(0.05, Some("fill"), &theme), theme.status_error);
+        assert_eq!(tone_color(0.30, Some("fill"), &theme), theme.status_warn);
+        assert_eq!(tone_color(0.80, Some("fill"), &theme), theme.status_ok);
+    }
+
+    #[test]
+    fn tone_drain_inverts_for_usage_metrics() {
+        let theme = Theme::default();
+        assert_eq!(tone_color(0.95, Some("drain"), &theme), theme.status_error);
+        assert_eq!(tone_color(0.70, Some("drain"), &theme), theme.status_warn);
+        assert_eq!(tone_color(0.20, Some("drain"), &theme), theme.status_ok);
+    }
+
+    #[test]
+    fn value_format_fraction_falls_back_without_denominator() {
+        assert_eq!(format_value(0.5, None, Some("fraction")), "50%");
+        assert_eq!(format_value(0.5, Some(10), Some("fraction")), "5 of 10");
+    }
+
+    #[test]
+    fn empty_area_does_not_panic() {
+        let (registry, spec) = registry_and_spec();
+        let _ = render_to_buffer_with_spec(&payload(0.5, None), Some(&spec), &registry, 0, 0);
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -29,6 +29,7 @@ mod chart_sparkline;
 mod gauge_battery;
 mod gauge_circle;
 mod gauge_line;
+mod gauge_segment;
 mod grid_calendar;
 mod grid_heatmap;
 mod grid_table;
@@ -209,12 +210,16 @@ pub struct RenderOptions {
     /// grid_calendar: event marker glyph, same accepted values.
     #[serde(default)]
     pub marker: Option<String>,
-    /// gauge_battery: how the fill colour follows `Ratio.value`. "neutral" (default) is single
-    /// `theme.text`. "fill" treats the value as how-full (low → status_error, high → status_ok)
-    /// — right for battery / quota progress. "drain" inverts (high → status_error) — right for
-    /// disk / memory / cpu where the ratio is "fraction used".
+    /// gauge_battery / gauge_segment: how the fill colour follows `Ratio.value`. "neutral"
+    /// (default) is single `theme.text`. "fill" treats the value as how-full (low →
+    /// status_error, high → status_ok) — right for battery / quota progress. "drain" inverts
+    /// (high → status_error) — right for disk / memory / cpu where the ratio is "fraction used".
     #[serde(default)]
     pub tone: Option<String>,
+    /// gauge_segment: number of LED segments rendered. None defaults to 5 — the canonical
+    /// "5-LED bar" silhouette. Values are clamped to at least 1.
+    #[serde(default)]
+    pub segments: Option<u16>,
     /// gauge_circle: thickness of the ring in cells. None keeps the block-gauge default.
     #[serde(default)]
     pub ring_thickness: Option<u16>,
@@ -364,6 +369,7 @@ impl Registry {
         r.register(Arc::new(gauge_battery::GaugeBatteryRenderer));
         r.register(Arc::new(gauge_circle::GaugeCircleRenderer));
         r.register(Arc::new(gauge_line::GaugeLineRenderer));
+        r.register(Arc::new(gauge_segment::GaugeSegmentRenderer));
         r.register(Arc::new(chart_sparkline::ChartSparklineRenderer));
         r.register(Arc::new(chart_line::ChartLineRenderer));
         r.register(Arc::new(chart_scatter::ChartScatterRenderer));
@@ -593,6 +599,7 @@ mod tests {
             "gauge_battery",
             "gauge_circle",
             "gauge_line",
+            "gauge_segment",
             "chart_sparkline",
             "chart_line",
             "chart_scatter",


### PR DESCRIPTION
## Summary

- New `gauge_segment` renderer — 5-LED segmented bar (`▰▰▰▱▱`) for the `Ratio` shape, complementing `gauge_circle` / `gauge_line` / `gauge_battery` with a retro-hardware silhouette.
- Reuses `gauge_battery`'s `tone` vocabulary (`neutral` / `fill` / `drain`) and the `value_format` suffix mode.
- Adds `segments` option (default 5, clamped to ≥ 1) to `RenderOptions` so authors can dial granularity beyond the canonical 5-LED look.
- Ticks `gauge_segment` on the `gauge_*` checklist in #61.

## Reference

- Accepts: `ratio`
- Animates: no

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `label` | string | no | payload.label | Optional prefix shown before the LED bar, e.g. `"VOL"` → `VOL ▰▰▰▱▱ 60%`. Falls back to `RatioData.label`; omitted when neither is set. |
| `segments` | u16 | no | 5 | Number of LED segments. Defaults to the canonical 5-LED silhouette; raise for finer granularity (e.g. 10) when there's room. Values below 1 are clamped to 1. |
| `tone` | "neutral" \| "fill" \| "drain" | no | "neutral" | How segment colour follows the value. `neutral` is single `theme.text`. `fill` treats the value as how-full (low → status_error, high → status_ok) — right for VU / quota progress. `drain` inverts (high → status_error) — right for usage-style readouts. |
| `value_format` | "percent" \| "fraction" \| "both" | no | "percent" | Suffix format. `fraction` and `both` require `RatioData.denominator` — otherwise they fall back to `percent`. |

### Theme tokens

| Key | Description |
| --- | --- |
| `text` | Primary body text colour. |
| `text_dim` | Empty-segment colour. |
| `status_ok` / `status_warn` / `status_error` | Tone palette for `fill` / `drain`. |

### Compatible fetchers

| Shape | Fetchers |
| --- | --- |
| `ratio` | [`basic_read_store`](https://splashboard.unhappychoice.com/reference/fetchers/basic/basic_read_store), [`clock_ratio`](https://splashboard.unhappychoice.com/reference/fetchers/clock/clock_ratio), [`system_cpu`](https://splashboard.unhappychoice.com/reference/fetchers/system/system_cpu), [`system_disk_usage`](https://splashboard.unhappychoice.com/reference/fetchers/system/system_disk_usage), [`system_memory`](https://splashboard.unhappychoice.com/reference/fetchers/system/system_memory) |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (555 passed)
- [x] `cargo run --bin splashboard -- catalog renderer gauge_segment` shows the option schema and compatible fetchers
- [x] Local TTY smoke-test with `MEM` (neutral) / `DAY` (fill) / `CPU` (drain) / `DISK` (drain, segments = 10) — visual check of LEDs + tone palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)