### PR TITLE
feat(fetcher): add system_battery realtime fetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +775,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
 ]
 
 [[package]]
@@ -2456,6 +2476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,6 +2666,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "no_std_io2"
@@ -2740,13 +2784,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-io-kit"
@@ -2754,7 +2817,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
+ "bitflags",
+ "block2",
+ "dispatch2",
  "libc",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -2846,6 +2913,19 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "png"
@@ -2968,6 +3048,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -3614,6 +3703,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "starship-battery",
  "sysinfo",
  "tachyonfx",
  "tempfile",
@@ -3633,6 +3723,25 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "starship-battery"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2aa96d3dc4e9714cd8d068e0848b1502c2ed24ae68bdb6ec31b1fb7aef1e42f"
+dependencies = [
+ "cfg-if",
+ "lazycell",
+ "libc",
+ "mach2",
+ "nix",
+ "num-traits",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "plist",
+ "uom",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -4170,6 +4279,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a739f83872836c82a4f2527d4e54b37007b3de68cafe7edde95fd695968bf4b9"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ sha2 = "0.10"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 chrono-tz = { version = "0.10", default-features = false }
 sysinfo = "0.38.4"
+starship-battery = "0.11"
 gix = { version = "0.82", default-features = false, features = ["revision", "status", "blob-diff", "max-performance-safe", "comfort", "sha1"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
 url = "2"

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -27,6 +27,7 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(UptimeFetcher),
         Arc::new(LoadAverageFetcher),
         Arc::new(ProcessTopFetcher::new()),
+        Arc::new(BatteryFetcher::new()),
     ]
 }
 
@@ -552,6 +553,258 @@ impl Fetcher for DiskFetcher {
     }
 }
 
+const BATTERY_OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "kind",
+        type_hint: "\"summary\" | \"percent\" | \"status\" | \"time_remaining\"",
+        required: false,
+        default: Some("\"summary\""),
+        description: "Selects the format of the `Text` shape. Ignored by `Ratio` / `Entries`.",
+    },
+    OptionSchema {
+        name: "index",
+        type_hint: "integer",
+        required: false,
+        default: Some("0"),
+        description: "Index of the battery to read on multi-battery systems.",
+    },
+];
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BatteryOptions {
+    #[serde(default)]
+    pub kind: Option<BatteryTextKind>,
+    #[serde(default)]
+    pub index: Option<usize>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BatteryTextKind {
+    #[default]
+    Summary,
+    Percent,
+    Status,
+    TimeRemaining,
+}
+
+#[derive(Clone, Copy)]
+enum BatteryState {
+    Charging,
+    Discharging,
+    Full,
+    Empty,
+    Unknown,
+}
+
+impl BatteryState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Charging => "Charging",
+            Self::Discharging => "Discharging",
+            Self::Full => "Full",
+            Self::Empty => "Empty",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+struct BatterySnapshot {
+    charge: f64,
+    state: BatteryState,
+    time_remaining_secs: Option<u64>,
+    cycle_count: Option<u32>,
+    health: Option<f64>,
+}
+
+/// Primary (or selected) battery state. `Ratio` pairs with `gauge_battery`; `Text` is a
+/// formatted summary (`kind` picks the field); `Entries` rolls up charge / state / time / cycles
+/// / health. Hosts without a battery (desktops, servers) render as a "full AC" stand-in so the
+/// widget doesn't disappear.
+pub struct BatteryFetcher {
+    manager: Mutex<Option<starship_battery::Manager>>,
+}
+
+impl BatteryFetcher {
+    pub fn new() -> Self {
+        Self {
+            manager: Mutex::new(starship_battery::Manager::new().ok()),
+        }
+    }
+}
+
+impl Default for BatteryFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RealtimeFetcher for BatteryFetcher {
+    fn name(&self) -> &str {
+        "system_battery"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[Shape::Ratio, Shape::Text, Shape::Entries]
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        BATTERY_OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Ratio => samples::ratio(0.87, "battery"),
+            Shape::Text => samples::text("87% • Charging • 1h 23m"),
+            Shape::Entries => samples::entries(&[
+                ("charge", "87%"),
+                ("state", "Charging"),
+                ("time_left", "1h 23m"),
+                ("cycles", "284"),
+                ("health", "97%"),
+            ]),
+            _ => return None,
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: BatteryOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return options_placeholder(&msg),
+        };
+        let snapshot = self.read_snapshot(opts.index.unwrap_or(0));
+        let shape = ctx.shape.unwrap_or(Shape::Ratio);
+        match (snapshot, shape) {
+            (Some(snap), Shape::Text) => payload(Body::Text(TextData {
+                value: format_battery_text(&snap, opts.kind.unwrap_or_default()),
+            })),
+            (Some(snap), Shape::Entries) => payload(Body::Entries(EntriesData {
+                items: battery_entries(&snap),
+            })),
+            (Some(snap), _) => payload(Body::Ratio(RatioData {
+                value: snap.charge,
+                label: Some(format!(
+                    "{} • {}",
+                    format_percent(snap.charge),
+                    snap.state.label()
+                )),
+                denominator: None,
+            })),
+            (None, shape) => no_battery_payload(shape, opts.kind.unwrap_or_default()),
+        }
+    }
+}
+
+impl BatteryFetcher {
+    fn read_snapshot(&self, index: usize) -> Option<BatterySnapshot> {
+        let manager = self.manager.lock().expect("battery manager mutex poisoned");
+        let manager = manager.as_ref()?;
+        let battery = manager.batteries().ok()?.nth(index)?.ok()?;
+        Some(snapshot_from(&battery))
+    }
+}
+
+fn snapshot_from(battery: &starship_battery::Battery) -> BatterySnapshot {
+    BatterySnapshot {
+        charge: f64::from(battery.state_of_charge().value).clamp(0.0, 1.0),
+        state: map_battery_state(battery.state()),
+        time_remaining_secs: time_remaining_secs(battery),
+        cycle_count: battery.cycle_count(),
+        health: battery_health(battery),
+    }
+}
+
+fn map_battery_state(s: starship_battery::State) -> BatteryState {
+    use starship_battery::State as S;
+    match s {
+        S::Charging => BatteryState::Charging,
+        S::Discharging => BatteryState::Discharging,
+        S::Full => BatteryState::Full,
+        S::Empty => BatteryState::Empty,
+        _ => BatteryState::Unknown,
+    }
+}
+
+fn time_remaining_secs(battery: &starship_battery::Battery) -> Option<u64> {
+    let dur = match battery.state() {
+        starship_battery::State::Charging => battery.time_to_full(),
+        starship_battery::State::Discharging => battery.time_to_empty(),
+        _ => None,
+    }?;
+    Some(dur.value.max(0.0) as u64)
+}
+
+fn battery_health(battery: &starship_battery::Battery) -> Option<f64> {
+    let full = f64::from(battery.energy_full().value);
+    let design = f64::from(battery.energy_full_design().value);
+    if design <= 0.0 {
+        None
+    } else {
+        Some((full / design).clamp(0.0, 1.0))
+    }
+}
+
+fn format_battery_text(snap: &BatterySnapshot, kind: BatteryTextKind) -> String {
+    match kind {
+        BatteryTextKind::Percent => format_percent(snap.charge),
+        BatteryTextKind::Status => snap.state.label().into(),
+        BatteryTextKind::TimeRemaining => snap
+            .time_remaining_secs
+            .map(format_uptime)
+            .unwrap_or_else(|| "—".into()),
+        BatteryTextKind::Summary => match snap.time_remaining_secs {
+            Some(secs) => format!(
+                "{} • {} • {}",
+                format_percent(snap.charge),
+                snap.state.label(),
+                format_uptime(secs)
+            ),
+            None => format!("{} • {}", format_percent(snap.charge), snap.state.label()),
+        },
+    }
+}
+
+fn battery_entries(snap: &BatterySnapshot) -> Vec<Entry> {
+    let mut items = vec![
+        entry("charge", &format_percent(snap.charge)),
+        entry("state", snap.state.label()),
+    ];
+    if let Some(secs) = snap.time_remaining_secs {
+        items.push(entry("time_left", &format_uptime(secs)));
+    }
+    if let Some(cycles) = snap.cycle_count {
+        items.push(entry("cycles", &cycles.to_string()));
+    }
+    if let Some(h) = snap.health {
+        items.push(entry("health", &format_percent(h)));
+    }
+    items
+}
+
+fn no_battery_payload(shape: Shape, kind: BatteryTextKind) -> Payload {
+    match shape {
+        Shape::Text => payload(Body::Text(TextData {
+            value: match kind {
+                BatteryTextKind::Percent => "100%".into(),
+                BatteryTextKind::TimeRemaining => "—".into(),
+                _ => "AC".into(),
+            },
+        })),
+        Shape::Entries => payload(Body::Entries(EntriesData {
+            items: vec![entry("power", "AC")],
+        })),
+        _ => payload(Body::Ratio(RatioData {
+            value: 1.0,
+            label: Some("AC".into()),
+            denominator: None,
+        })),
+    }
+}
+
+fn format_percent(ratio: f64) -> String {
+    format!("{:.0}%", ratio.clamp(0.0, 1.0) * 100.0)
+}
+
 fn payload(body: Body) -> Payload {
     Payload {
         icon: None,
@@ -862,6 +1115,117 @@ mod tests {
             panic!("expected entries");
         };
         assert!(e.items.len() <= PROCESS_TOP_COUNT);
+    }
+
+    fn snapshot(charge: f64, state: BatteryState, secs: Option<u64>) -> BatterySnapshot {
+        BatterySnapshot {
+            charge,
+            state,
+            time_remaining_secs: secs,
+            cycle_count: Some(284),
+            health: Some(0.97),
+        }
+    }
+
+    #[test]
+    fn battery_summary_includes_time_when_available() {
+        let snap = snapshot(0.87, BatteryState::Charging, Some(83 * 60));
+        assert_eq!(
+            format_battery_text(&snap, BatteryTextKind::Summary),
+            "87% • Charging • 1h 23m"
+        );
+    }
+
+    #[test]
+    fn battery_summary_omits_time_when_missing() {
+        let snap = snapshot(1.0, BatteryState::Full, None);
+        assert_eq!(
+            format_battery_text(&snap, BatteryTextKind::Summary),
+            "100% • Full"
+        );
+    }
+
+    #[test]
+    fn battery_text_kinds_pick_distinct_fields() {
+        let snap = snapshot(0.5, BatteryState::Discharging, Some(45 * 60));
+        assert_eq!(format_battery_text(&snap, BatteryTextKind::Percent), "50%");
+        assert_eq!(
+            format_battery_text(&snap, BatteryTextKind::Status),
+            "Discharging"
+        );
+        assert_eq!(
+            format_battery_text(&snap, BatteryTextKind::TimeRemaining),
+            "45m"
+        );
+    }
+
+    #[test]
+    fn battery_time_remaining_dash_when_missing() {
+        let snap = snapshot(1.0, BatteryState::Full, None);
+        assert_eq!(
+            format_battery_text(&snap, BatteryTextKind::TimeRemaining),
+            "—"
+        );
+    }
+
+    #[test]
+    fn battery_entries_include_optional_fields_only_when_present() {
+        let with = snapshot(0.5, BatteryState::Charging, Some(60));
+        let mut without = snapshot(0.5, BatteryState::Charging, None);
+        without.cycle_count = None;
+        without.health = None;
+        assert_eq!(battery_entries(&with).len(), 5);
+        assert_eq!(battery_entries(&without).len(), 2);
+    }
+
+    #[test]
+    fn no_battery_ratio_is_full_ac() {
+        let p = no_battery_payload(Shape::Ratio, BatteryTextKind::Summary);
+        let Body::Ratio(r) = p.body else {
+            panic!("expected ratio")
+        };
+        assert_eq!(r.value, 1.0);
+        assert_eq!(r.label.as_deref(), Some("AC"));
+    }
+
+    #[test]
+    fn no_battery_text_varies_by_kind() {
+        let summary = no_battery_payload(Shape::Text, BatteryTextKind::Summary);
+        let percent = no_battery_payload(Shape::Text, BatteryTextKind::Percent);
+        let time = no_battery_payload(Shape::Text, BatteryTextKind::TimeRemaining);
+        let extract = |p: Payload| match p.body {
+            Body::Text(t) => t.value,
+            _ => panic!(),
+        };
+        assert_eq!(extract(summary), "AC");
+        assert_eq!(extract(percent), "100%");
+        assert_eq!(extract(time), "—");
+    }
+
+    #[test]
+    fn battery_compute_never_panics_on_any_shape() {
+        let f = BatteryFetcher::new();
+        for shape in [
+            None,
+            Some(Shape::Ratio),
+            Some(Shape::Text),
+            Some(Shape::Entries),
+        ] {
+            let p = f.compute(&ctx_with_shape(shape));
+            // Each branch must produce *some* body; on hosts without a battery we land on the
+            // AC stand-in, on laptops we get the real reading. Both are valid.
+            assert!(!matches!(p.body, Body::Image(_)));
+        }
+    }
+
+    #[test]
+    fn battery_rejects_unknown_option_to_placeholder() {
+        let f = BatteryFetcher::new();
+        let p = f.compute(&ctx_text(Some("bogus = true")));
+        let Body::Text(t) = p.body else {
+            panic!("expected text placeholder")
+        };
+        assert!(t.value.starts_with("⚠"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `system_battery` realtime fetcher backed by `starship-battery`. Pairs with the existing `gauge_battery` renderer family.
- Three shapes: `Ratio` (charge 0..=1, default), `Text` (formatted via `kind` option), `Entries` (charge / state / time_left / cycles / health).
- Hosts without a battery (desktops, servers) render as a "full AC" stand-in (Ratio = 1.0, Text = `"AC"`, single `power = AC` entry) so the widget doesn't silently disappear.

Ticks the `system_battery` box on #62.

---

- Kind: realtime
- Safety: Safe
- Shapes: `ratio`, `text`, `entries`

## Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `kind` | "summary" \| "percent" \| "status" \| "time_remaining" | no | "summary" | Selects the format of the `Text` shape. Ignored by `Ratio` / `Entries`. |
| `index` | integer | no | 0 | Index of the battery to read on multi-battery systems. |

## Compatible renderers

| Shape | Renderers |
| --- | --- |
| `ratio` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`gauge_battery`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_battery/), [`gauge_circle`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_circle/), [`gauge_line`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_line/), [`gauge_segment`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_segment/) |
| `text` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_figlet_morph`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_figlet_morph/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_typewriter`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_typewriter/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/) |
| `entries` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/) |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (28 system tests pass — kind branches, shape branches, no-battery fallback, options error)
- [x] Smoke-tested via `cargo run --bin splashboard` with all four gauge renderers + three Text `kind` variants + `grid_table`

## Follow-up

While testing the smoke fixture I noticed unknown fetcher names silently drop widgets from the layout instead of rendering an in-band error like unknown renderers do — filed as #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)