### PR TITLE
fix(runtime): surface unknown fetcher names as in-band placeholders

### DIFF
--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -147,6 +147,24 @@ pub fn shape_mismatch_placeholder(err: &ShapeMismatch) -> Payload {
     }
 }
 
+/// Payload rendered in place of a widget whose configured fetcher name isn't registered. Mirrors
+/// the renderer side of the contract (`render_payload` draws `unknown renderer: <name>` for the
+/// same situation): the typical trigger is an installed binary older than the config it's reading,
+/// so the second line points at upgrading rather than the log file.
+pub fn unknown_fetcher_placeholder(name: &str) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body: Body::TextBlock(TextBlockData {
+            lines: vec![
+                format!("⚠ unknown fetcher: {name}"),
+                "upgrade splashboard?".into(),
+            ],
+        }),
+    }
+}
+
 /// Payload rendered in place of a widget whose fetch returned `Err`. One-line `⚠ <msg>`, with a
 /// follow-up pointer to the log file so the user can track structured details (error chain,
 /// cache key, fetcher name) without forcing a second line into the splash for every error.
@@ -477,5 +495,26 @@ mod tests {
     fn cache_key_is_prefixed_with_fetcher_name() {
         let k = default_cache_key("basic_static", &ctx_with(None));
         assert!(k.starts_with("basic_static-"));
+    }
+
+    #[test]
+    fn unknown_fetcher_placeholder_mentions_name_and_upgrade_hint() {
+        let p = unknown_fetcher_placeholder("system_battery");
+        match p.body {
+            Body::TextBlock(t) => {
+                assert!(
+                    t.lines[0].contains("system_battery"),
+                    "lines: {:?}",
+                    t.lines
+                );
+                assert!(t.lines[0].starts_with("⚠"), "lines: {:?}", t.lines);
+                assert!(
+                    t.lines.iter().any(|l| l.contains("upgrade")),
+                    "expected upgrade hint: {:?}",
+                    t.lines
+                );
+            }
+            other => panic!("expected TextBlock body, got {other:?}"),
+        }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -80,11 +80,26 @@ fn derive_shape(
     fetchers.get(&w.fetcher).map(|f| f.default_shape())
 }
 
+/// Partitions widgets into (known-fetcher, unknown-fetcher). Unknown fetcher names — typo,
+/// renamed widget, or a config newer than the installed binary — would otherwise drop silently
+/// in the realtime/cached dispatch and leave the slot blank. Diverting them at the runtime
+/// boundary mirrors the renderer side of the contract: an unknown name renders an in-band
+/// `⚠ unknown fetcher: <name>` placeholder so the user can see what to fix.
+fn partition_by_known_fetcher(
+    widgets: &[WidgetConfig],
+    registry: &Registry,
+) -> (Vec<WidgetConfig>, Vec<WidgetConfig>) {
+    widgets
+        .iter()
+        .cloned()
+        .partition(|w| registry.get(&w.fetcher).is_some())
+}
+
 /// Partitions widgets into (shape-valid, shape-invalid-with-reason). A widget whose renderer-
 /// derived shape isn't in the fetcher's `shapes()` is diverted to a placeholder rather than
 /// being dispatched — protects the same "never crash the splash" invariant as unknown-renderer
-/// handling in [`render::render_payload`]. Unknown fetcher names pass through; the fetch
-/// dispatch drops them separately.
+/// handling in [`render::render_payload`]. Unknown fetcher names are filtered out before this
+/// runs, so the unknown-fetcher branch is a defensive no-op.
 fn partition_by_shape_support(
     widgets: &[WidgetConfig],
     shapes: &HashMap<WidgetId, Shape>,
@@ -230,6 +245,9 @@ pub async fn run(
     // what needs unlocking.
     let decision = TrustStore::load().decide(config_ident);
     let (fetchable, gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
+    // Unknown fetcher names get diverted here so the silent-drop sites downstream
+    // (compute_realtime_payloads / fetch_all / load_entries) only ever see registered names.
+    let (fetchable, unknown) = partition_by_known_fetcher(&fetchable, &registry);
     // Derive the renderer-implied shape for each widget once, then reuse it in every downstream
     // step (validation, cache key, fetch, realtime compute) so the fetcher sees a single
     // consistent answer.
@@ -252,6 +270,12 @@ pub async fn run(
     ));
     for w in &gated {
         payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+    }
+    for w in &unknown {
+        payloads.insert(
+            w.id.clone(),
+            fetcher::unknown_fetcher_placeholder(&w.fetcher),
+        );
     }
     for (w, err) in &shape_invalid {
         payloads.insert(w.id.clone(), fetcher::shape_mismatch_placeholder(err));
@@ -337,6 +361,7 @@ pub async fn run(
             let buckets = WidgetBuckets {
                 cached: &cached_widgets,
                 gated: &gated,
+                unknown: &unknown,
                 shape_invalid: &shape_invalid,
             };
             let start = std::time::Instant::now();
@@ -456,6 +481,9 @@ pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &st
     let render_registry = render::Registry::with_builtins();
     let decision = TrustStore::load().decide(config_ident);
     let (fetchable, _gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
+    // Unknown fetcher names are surfaced by the main process as placeholders; the daemon has
+    // nothing to fetch for them.
+    let (fetchable, _unknown) = partition_by_known_fetcher(&fetchable, &registry);
     let shapes = derive_shapes(&config.widgets, &registry, &render_registry);
     // Shape-invalid widgets are rendered as placeholders by the main process; there's no value
     // in the daemon hitting their fetchers just to have the result discarded.
@@ -480,6 +508,7 @@ pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &st
 struct WidgetBuckets<'a> {
     cached: &'a [WidgetConfig],
     gated: &'a [WidgetConfig],
+    unknown: &'a [WidgetConfig],
     shape_invalid: &'a [(WidgetConfig, ShapeMismatch)],
 }
 
@@ -501,6 +530,12 @@ fn refresh_payloads(
     }
     for w in buckets.gated {
         payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+    }
+    for w in buckets.unknown {
+        payloads.insert(
+            w.id.clone(),
+            fetcher::unknown_fetcher_placeholder(&w.fetcher),
+        );
     }
     for (w, err) in buckets.shape_invalid {
         payloads.insert(w.id.clone(), fetcher::shape_mismatch_placeholder(err));
@@ -1635,6 +1670,46 @@ mod tests {
         let (valid, invalid) = partition_by_shape_support(&widgets, &shapes, &registry);
         assert_eq!(valid.len(), 1);
         assert!(invalid.is_empty());
+    }
+
+    #[test]
+    fn partition_by_known_fetcher_separates_unknown_names() {
+        let registry = Registry::with_builtins();
+        let widgets = vec![
+            widget("ok", "clock"),
+            widget("typo", "no_such_fetcher"),
+            widget("static", "basic_static"),
+        ];
+        let (known, unknown) = partition_by_known_fetcher(&widgets, &registry);
+        let known_ids: Vec<_> = known.iter().map(|w| w.id.clone()).collect();
+        let unknown_ids: Vec<_> = unknown.iter().map(|w| w.id.clone()).collect();
+        assert_eq!(known_ids, vec!["ok".to_string(), "static".to_string()]);
+        assert_eq!(unknown_ids, vec!["typo".to_string()]);
+    }
+
+    #[test]
+    fn refresh_payloads_surfaces_unknown_fetcher_placeholder() {
+        // Regression for #121: a typo'd or stale fetcher name used to drop the widget silently.
+        // After the fix, the widget keeps its slot and shows `⚠ unknown fetcher: <name>`.
+        let registry = Registry::with_builtins();
+        let unknown_widgets = vec![widget("typo", "no_such_fetcher")];
+        let buckets = WidgetBuckets {
+            cached: &[],
+            gated: &[],
+            unknown: &unknown_widgets,
+            shape_invalid: &[],
+        };
+        let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
+        let _ = refresh_payloads(&None, &registry, &buckets, &HashMap::new(), &mut payloads);
+        let payload = payloads.get("typo").expect("unknown fetcher must surface");
+        match &payload.body {
+            Body::TextBlock(t) => assert!(
+                t.lines.iter().any(|l| l.contains("no_such_fetcher")),
+                "placeholder must mention the unknown fetcher name: {:?}",
+                t.lines
+            ),
+            other => panic!("expected TextBlock placeholder, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Surfaces unknown fetcher names as a `⚠ unknown fetcher: <name>` / `upgrade splashboard?` placeholder instead of silently dropping the widget from the layout.
- Mirrors the renderer side of the contract (`render_payload` already does the equivalent for unknown renderer names).
- Partitioning happens at the runtime boundary, so the four downstream silent-drop sites (`derive_shapes`, `compute_realtime_payloads`, `fetch_all`, `load_entries`) only see registered names.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New unit tests cover the partition split, the placeholder copy, and the refresh-loop re-application path.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)