### PR TITLE
chore(ci): add dependabot config and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @unhappychoice

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
@@ -13,7 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "chore(ci)"
       include: "scope"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` で weekly に cargo / github-actions の依存を更新
- Add `.github/CODEOWNERS` で `@unhappychoice` をデフォルトレビュアーに設定

## Test plan
- [ ] Dependabot が有効化されて、初回スキャン後に PR が作られることを確認
- [ ] 新規 PR で `@unhappychoice` が自動レビュアーに付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)