### PR TITLE
feat: LinkedTextBlock shape with clickable rows (OSC 8) + hn_top fetcher

### DIFF
--- a/src/fetcher/github/assigned_issues.rs
+++ b/src/fetcher/github/assigned_issues.rs
@@ -14,7 +14,12 @@ use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -81,7 +86,7 @@ impl Fetcher for GithubAssignedIssues {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
             true,
         )))
     }

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -8,7 +8,9 @@ use chrono::{Duration, Utc};
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload};
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -16,7 +18,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::{http, resolve_token};
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Bars, Shape::LinkedTextBlock, Shape::Entries];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -189,6 +191,15 @@ fn render_body(rows: &[(String, u64)], shape: Shape) -> Body {
                     key: n.clone(),
                     value: Some(c.to_string()),
                     status: None,
+                })
+                .collect(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: rows
+                .iter()
+                .map(|(n, c)| LinkedLine {
+                    text: format!("{n}  {c}"),
+                    url: Some(format!("https://github.com/{n}")),
                 })
                 .collect(),
         }),

--- a/src/fetcher/github/good_first_issues.rs
+++ b/src/fetcher/github/good_first_issues.rs
@@ -14,7 +14,12 @@ use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -116,7 +121,7 @@ impl Fetcher for GithubGoodFirstIssues {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
             include_repo,
         )))
     }

--- a/src/fetcher/github/items.rs
+++ b/src/fetcher/github/items.rs
@@ -4,7 +4,10 @@
 
 use serde::Deserialize;
 
-use crate::payload::{Body, EntriesData, Entry, TextBlockData, TimelineData, TimelineEvent};
+use crate::payload::{
+    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, TextBlockData, TimelineData,
+    TimelineEvent,
+};
 use crate::render::Shape;
 
 use super::common::{RepoSlug, parse_timestamp};
@@ -37,10 +40,10 @@ pub fn repo_from_url(url: &str) -> Option<RepoSlug> {
     RepoSlug::parse(rest)
 }
 
-/// Renders issue / PR items to one of `TextBlock` / `Entries` / `Timeline`. When
-/// `include_repo` is true, each line/event is prefixed with `owner/name` — used by user-scope
-/// fetchers that return items across many repos. Per-repo fetchers pass `false` so the repo
-/// name isn't repeated on every row.
+/// Renders issue / PR items to one of `TextBlock` / `LinkedTextBlock` / `Entries` / `Timeline`.
+/// When `include_repo` is true, each line/event is prefixed with `owner/name` — used by
+/// user-scope fetchers that return items across many repos. Per-repo fetchers pass `false` so
+/// the repo name isn't repeated on every row.
 pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Body {
     match shape {
         Shape::Entries => Body::Entries(EntriesData {
@@ -50,6 +53,15 @@ pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Bo
                     key: entries_key(i, include_repo),
                     value: Some(i.title.clone()),
                     status: None,
+                })
+                .collect(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: items
+                .iter()
+                .map(|i| LinkedLine {
+                    text: format!("{} {}", short_label(i, include_repo), i.title),
+                    url: link_for(i),
                 })
                 .collect(),
         }),
@@ -70,6 +82,14 @@ pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Bo
                 .map(|i| format!("{} {}", short_label(i, include_repo), i.title))
                 .collect(),
         }),
+    }
+}
+
+fn link_for(i: &IssueItem) -> Option<String> {
+    if i.html_url.is_empty() {
+        None
+    } else {
+        Some(i.html_url.clone())
     }
 }
 

--- a/src/fetcher/github/my_prs.rs
+++ b/src/fetcher/github/my_prs.rs
@@ -15,7 +15,12 @@ use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -86,7 +91,7 @@ impl Fetcher for GithubMyPrs {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
             true,
         )))
     }

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent,
+    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, TextBlockData,
+    TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 use crate::samples;
@@ -15,7 +16,12 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{cache_key, parse_options, parse_timestamp, payload};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -92,7 +98,7 @@ impl Fetcher for GithubNotifications {
         let items: Vec<Notification> = rest_get(&path).await?;
         Ok(payload(render_body(
             &items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
         )))
     }
 }
@@ -108,6 +114,8 @@ struct Notification {
 #[derive(Debug, Deserialize)]
 struct Subject {
     title: String,
+    #[serde(default)]
+    url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -124,6 +132,18 @@ fn render_body(items: &[Notification], shape: Shape) -> Body {
                     key: short_repo(&n.repository.full_name),
                     value: Some(format!("{}: {}", n.reason, n.subject.title)),
                     status: None,
+                })
+                .collect(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: items
+                .iter()
+                .map(|n| LinkedLine {
+                    text: format!(
+                        "{} {}: {}",
+                        n.repository.full_name, n.reason, n.subject.title
+                    ),
+                    url: subject_html_url(n),
                 })
                 .collect(),
         }),
@@ -158,6 +178,15 @@ fn short_repo(full: &str) -> String {
         .unwrap_or_else(|| full.to_string())
 }
 
+/// Converts a notification's subject API URL (`api.github.com/repos/.../pulls/N`) to the
+/// browser-friendly HTML URL (`github.com/.../pulls/N`). Returns `None` when the URL is missing
+/// or doesn't match the expected prefix; callers fall back to leaving the row unlinked.
+fn subject_html_url(n: &Notification) -> Option<String> {
+    let url = n.subject.url.as_deref()?;
+    let rest = url.strip_prefix("https://api.github.com/repos/")?;
+    Some(format!("https://github.com/{rest}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -168,6 +197,7 @@ mod tests {
             updated_at: "2026-04-22T10:15:30Z".into(),
             subject: Subject {
                 title: "feat: heatmap".into(),
+                url: Some("https://api.github.com/repos/unhappychoice/splashboard/pulls/1".into()),
             },
             repository: Repo {
                 full_name: "unhappychoice/splashboard".into(),

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -5,7 +5,8 @@ use serde::Deserialize;
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    Body, EntriesData, Entry, Payload, TextBlockData, TimelineData, TimelineEvent,
+    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, TextBlockData,
+    TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 use crate::samples;
@@ -14,7 +15,12 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, parse_timestamp, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 5;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -87,7 +93,7 @@ impl Fetcher for GithubRecentReleases {
         let items: Vec<Release> = rest_get(&path).await?;
         Ok(payload(render_body(
             &items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
         )))
     }
 }
@@ -99,6 +105,8 @@ struct Release {
     name: Option<String>,
     #[serde(default)]
     published_at: Option<String>,
+    #[serde(default)]
+    html_url: String,
 }
 
 fn render_body(items: &[Release], shape: Shape) -> Body {
@@ -118,6 +126,15 @@ fn render_body(items: &[Release], shape: Shape) -> Body {
                             .into(),
                     ),
                     status: None,
+                })
+                .collect(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: items
+                .iter()
+                .map(|r| LinkedLine {
+                    text: format!("{}  {}", r.tag_name, release_date(r)),
+                    url: link_for(r),
                 })
                 .collect(),
         }),
@@ -145,6 +162,22 @@ fn render_body(items: &[Release], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
+    }
+}
+
+fn release_date(r: &Release) -> String {
+    r.published_at
+        .as_deref()
+        .and_then(|d| d.split('T').next())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn link_for(r: &Release) -> Option<String> {
+    if r.html_url.is_empty() {
+        None
+    } else {
+        Some(r.html_url.clone())
     }
 }
 

--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -14,7 +14,12 @@ use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 use super::items::{IssueItem, render_items};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -99,7 +104,7 @@ impl Fetcher for GithubRepoIssues {
             .collect();
         Ok(payload(render_items(
             &issues,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
             false,
         )))
     }

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -14,7 +14,12 @@ use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 use super::items::{IssueItem, render_items};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -95,7 +100,7 @@ impl Fetcher for GithubRepoPrs {
         let items: Vec<IssueItem> = rest_get(&path).await?;
         Ok(payload(render_items(
             &items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
             false,
         )))
     }

--- a/src/fetcher/github/review_requests.rs
+++ b/src/fetcher/github/review_requests.rs
@@ -14,7 +14,12 @@ use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload};
 use super::items::{SearchResult, render_items};
 
-const SHAPES: &[Shape] = &[Shape::TextBlock, Shape::Entries, Shape::Timeline];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -85,7 +90,7 @@ impl Fetcher for GithubReviewRequests {
         let res: SearchResult = rest_get(&path).await?;
         Ok(payload(render_items(
             &res.items,
-            ctx.shape.unwrap_or(Shape::TextBlock),
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
             true,
         )))
     }

--- a/src/fetcher/hackernews/client.rs
+++ b/src/fetcher/hackernews/client.rs
@@ -1,0 +1,44 @@
+//! Shared HTTP client + base URL for the `hackernews_*` family. Targets HN's read-only
+//! Firebase backend (`hacker-news.firebaseio.com/v0`) — fixed host, no auth, so every fetcher
+//! in the family stays Safety::Safe regardless of what config supplies.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+
+use crate::fetcher::FetchError;
+
+pub const API_BASE: &str = "https://hacker-news.firebaseio.com/v0";
+pub const HN_ITEM_URL: &str = "https://news.ycombinator.com/item?id=";
+pub const HN_USER_URL: &str = "https://news.ycombinator.com/user?id=";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub async fn get<T: DeserializeOwned>(url: &str) -> Result<T, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("hn request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("hn {status}")));
+    }
+    res.json()
+        .await
+        .map_err(|e| FetchError::Failed(format!("hn json parse: {e}")))
+}

--- a/src/fetcher/hackernews/mod.rs
+++ b/src/fetcher/hackernews/mod.rs
@@ -1,16 +1,27 @@
 //! `hackernews_*` fetcher family. Splits into:
 //!
 //! - `top` — story listings (top / new / best / ask / show / job)
+//! - `user` — profile rollup (login / karma / about / created / submission count)
+//! - `user_submissions` — recent stories submitted by a user
+//! - `user_comments` — recent comments by a user
 //!
 //! Shared HTTP client and base URLs live in `client`.
 
 pub mod client;
 pub mod top;
+pub mod user;
+pub mod user_comments;
+pub mod user_submissions;
 
 use std::sync::Arc;
 
 use crate::fetcher::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(top::HackernewsTopFetcher)]
+    vec![
+        Arc::new(top::HackernewsTopFetcher),
+        Arc::new(user::HackernewsUserFetcher),
+        Arc::new(user_submissions::HackernewsUserSubmissionsFetcher),
+        Arc::new(user_comments::HackernewsUserCommentsFetcher),
+    ]
 }

--- a/src/fetcher/hackernews/mod.rs
+++ b/src/fetcher/hackernews/mod.rs
@@ -1,0 +1,16 @@
+//! `hackernews_*` fetcher family. Splits into:
+//!
+//! - `top` — story listings (top / new / best / ask / show / job)
+//!
+//! Shared HTTP client and base URLs live in `client`.
+
+pub mod client;
+pub mod top;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(top::HackernewsTopFetcher)]
+}

--- a/src/fetcher/hackernews/top.rs
+++ b/src/fetcher/hackernews/top.rs
@@ -4,13 +4,11 @@
 //! the listing kind and how many stories to show, never the URL — there's no way for a config
 //! to redirect traffic off-host. No auth, no token leaves the machine.
 
-use std::sync::OnceLock;
-use std::time::Duration;
-
 use async_trait::async_trait;
-use reqwest::Client;
 use serde::Deserialize;
 
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{
     Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, TextBlockData,
@@ -18,12 +16,8 @@ use crate::payload::{
 use crate::render::Shape;
 use crate::samples;
 
-use super::github::common::{cache_key, parse_options, payload};
-use super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{API_BASE, HN_ITEM_URL, get};
 
-const API_BASE: &str = "https://hacker-news.firebaseio.com/v0";
-const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_COUNT: u32 = 10;
 const MIN_COUNT: u32 = 1;
 const MAX_COUNT: u32 = 30;
@@ -150,7 +144,7 @@ impl Fetcher for HackernewsTopFetcher {
 }
 
 async fn fetch_stories(kind: Kind, count: usize) -> Result<Vec<Item>, FetchError> {
-    let ids: Vec<u64> = http_get(&format!("{API_BASE}/{}.json", kind.endpoint())).await?;
+    let ids: Vec<u64> = get(&format!("{API_BASE}/{}.json", kind.endpoint())).await?;
     let handles: Vec<_> = ids
         .into_iter()
         .take(count)
@@ -166,22 +160,7 @@ async fn fetch_stories(kind: Kind, count: usize) -> Result<Vec<Item>, FetchError
 }
 
 async fn fetch_item(id: u64) -> Result<Item, FetchError> {
-    http_get(&format!("{API_BASE}/item/{id}.json")).await
-}
-
-async fn http_get<T: serde::de::DeserializeOwned>(url: &str) -> Result<T, FetchError> {
-    let res = http()
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| FetchError::Failed(format!("hn request failed: {e}")))?;
-    let status = res.status();
-    if !status.is_success() {
-        return Err(FetchError::Failed(format!("hn {status}")));
-    }
-    res.json()
-        .await
-        .map_err(|e| FetchError::Failed(format!("hn json parse: {e}")))
+    get(&format!("{API_BASE}/item/{id}.json")).await
 }
 
 #[derive(Debug, Deserialize)]
@@ -197,8 +176,6 @@ struct Item {
     #[serde(default)]
     url: Option<String>,
 }
-
-const HN_ITEM_URL: &str = "https://news.ycombinator.com/item?id=";
 
 fn link_for(it: &Item) -> Option<String> {
     it.url
@@ -244,18 +221,6 @@ fn meta_label(it: &Item) -> String {
     let score = it.score.unwrap_or(0);
     let comments = it.descendants.unwrap_or(0);
     format!("{score}pt {comments}c")
-}
-
-fn http() -> &'static Client {
-    static CLIENT: OnceLock<Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        Client::builder()
-            .user_agent(USER_AGENT)
-            .timeout(REQUEST_TIMEOUT)
-            .gzip(true)
-            .build()
-            .expect("reqwest client should build with default config")
-    })
 }
 
 #[cfg(test)]

--- a/src/fetcher/hackernews/top.rs
+++ b/src/fetcher/hackernews/top.rs
@@ -359,6 +359,71 @@ mod tests {
         assert!(t.lines.is_empty());
     }
 
+    #[test]
+    fn empty_items_renders_empty_linked_text_block() {
+        let body = render_body(&[], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items.is_empty());
+    }
+
+    #[test]
+    fn linked_text_block_drops_url_when_id_and_story_url_both_missing() {
+        let it = Item {
+            id: None,
+            title: Some("orphan".into()),
+            score: Some(1),
+            descendants: Some(0),
+            url: None,
+        };
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items[0].url.is_none());
+    }
+
+    #[test]
+    fn missing_score_and_comments_default_to_zero() {
+        let body = render_body(&[item(Some("x"), None, None)], Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines[0], "0pt 0c  x");
+    }
+
+    #[test]
+    fn kind_default_is_top_in_options_and_endpoint() {
+        let opts = Options::default();
+        assert!(opts.kind.is_none());
+        assert_eq!(Kind::default().endpoint(), "topstories");
+    }
+
+    #[test]
+    fn renders_each_kind_via_options() {
+        for raw in [
+            "kind = \"top\"",
+            "kind = \"new\"",
+            "kind = \"best\"",
+            "kind = \"ask\"",
+            "kind = \"show\"",
+            "kind = \"job\"",
+        ] {
+            let v: toml::Value = toml::from_str(raw).unwrap();
+            let _: Options = v.try_into().expect("kind variant should parse");
+        }
+    }
+
+    #[test]
+    fn count_clamps_extremes() {
+        // Fetch path uses `.clamp(MIN_COUNT, MAX_COUNT)` directly; verifying clamp semantics
+        // here means a future tweak to either bound stays consistent.
+        assert_eq!(0u32.clamp(MIN_COUNT, MAX_COUNT), MIN_COUNT);
+        assert_eq!(999u32.clamp(MIN_COUNT, MAX_COUNT), MAX_COUNT);
+        assert_eq!(DEFAULT_COUNT.clamp(MIN_COUNT, MAX_COUNT), DEFAULT_COUNT);
+    }
+
     /// Live smoke test — hits HN's Firebase API. `#[ignore]` keeps CI offline-safe; run with
     /// `cargo test -- --ignored fetcher::hackernews_top::tests::live` to verify real shape.
     #[tokio::test]

--- a/src/fetcher/hackernews/user.rs
+++ b/src/fetcher/hackernews/user.rs
@@ -1,0 +1,281 @@
+//! `hackernews_user` — profile rollup for an HN account via `/user/{login}.json`. Same read,
+//! three shapes:
+//!
+//! - `Text` — `"@login · Npt karma"` for hero / subtitle bands.
+//! - `Entries` — login / karma / created / submissions count, key/value rows.
+//! - `TextBlock` — bio block (login / about / created / karma) for sidebar use.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{API_BASE, HN_USER_URL, get};
+
+const SHAPES: &[Shape] = &[
+    Shape::Entries,
+    Shape::Text,
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "user",
+    type_hint: "string (HN login)",
+    required: true,
+    default: None,
+    description: "Hacker News login to fetch (e.g. `\"pg\"`).",
+}];
+
+/// Profile rollup for a single Hacker News account.
+pub struct HackernewsUserFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub user: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for HackernewsUserFetcher {
+    fn name(&self) -> &str {
+        "hackernews_user"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Text => samples::text("@pg · 156000pt karma"),
+            Shape::Entries => samples::entries(&[
+                ("login", "pg"),
+                ("karma", "156000"),
+                ("created", "2006-10-09"),
+                ("submissions", "1234"),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                "@pg",
+                "156000pt karma",
+                "joined 2006-10-09",
+                "Paul Graham, Y Combinator co-founder.",
+            ]),
+            Shape::LinkedTextBlock => samples::linked_text_block(&[(
+                "@pg · 156000pt karma",
+                Some("https://news.ycombinator.com/user?id=pg"),
+            )]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let login = opts
+            .user
+            .ok_or_else(|| FetchError::Failed("hackernews_user requires `user` option".into()))?;
+        let info: UserInfo = get(&format!("{API_BASE}/user/{login}.json")).await?;
+        Ok(payload(render_body(
+            &info,
+            ctx.shape.unwrap_or(Shape::Entries),
+        )))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserInfo {
+    id: String,
+    #[serde(default)]
+    karma: u64,
+    /// Unix seconds.
+    #[serde(default)]
+    created: i64,
+    #[serde(default)]
+    about: Option<String>,
+    #[serde(default)]
+    submitted: Vec<u64>,
+}
+
+fn render_body(info: &UserInfo, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => crate::payload::Body::Text(crate::payload::TextData {
+            value: format!("@{} · {}pt karma", info.id, info.karma),
+        }),
+        Shape::TextBlock => crate::payload::Body::TextBlock(crate::payload::TextBlockData {
+            lines: text_block_lines(info),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: vec![LinkedLine {
+                text: format!("@{} · {}pt karma", info.id, info.karma),
+                url: Some(format!("{HN_USER_URL}{}", info.id)),
+            }],
+        }),
+        _ => Body::Entries(EntriesData {
+            items: entries(info),
+        }),
+    }
+}
+
+fn entries(info: &UserInfo) -> Vec<Entry> {
+    let mut items = vec![
+        kv("login", info.id.clone()),
+        kv("karma", info.karma.to_string()),
+        kv("created", iso_date(info.created)),
+        kv("submissions", info.submitted.len().to_string()),
+    ];
+    if let Some(about) = info.about.as_deref().filter(|s| !s.is_empty()) {
+        items.push(kv("about", strip_tags(about)));
+    }
+    items
+}
+
+fn text_block_lines(info: &UserInfo) -> Vec<String> {
+    let mut lines = vec![
+        format!("@{}", info.id),
+        format!("{}pt karma", info.karma),
+        format!("joined {}", iso_date(info.created)),
+    ];
+    if let Some(about) = info.about.as_deref().filter(|s| !s.is_empty()) {
+        lines.push(strip_tags(about));
+    }
+    lines
+}
+
+fn kv(key: &str, value: String) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value),
+        status: None,
+    }
+}
+
+fn iso_date(unix_seconds: i64) -> String {
+    DateTime::<Utc>::from_timestamp(unix_seconds, 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_default()
+}
+
+/// HN's `about` field embeds raw HTML (`<p>`, `<a>`, `&#x2F;`). Strip the markup conservatively
+/// so the rollup stays text-only — replacing `<br>` / `<p>` with spaces and dropping the rest.
+/// This isn't a full HTML parser; it's a "best-effort make it readable on a splash" pass.
+fn strip_tags(raw: &str) -> String {
+    let with_breaks = raw.replace("<p>", " ").replace("<br>", " ");
+    let mut out = String::with_capacity(with_breaks.len());
+    let mut in_tag = false;
+    for ch in with_breaks.chars() {
+        match (ch, in_tag) {
+            ('<', _) => in_tag = true,
+            ('>', _) => in_tag = false,
+            (c, false) => out.push(c),
+            _ => {}
+        }
+    }
+    decode_entities(&out)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn decode_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#x27;", "'")
+        .replace("&#x2F;", "/")
+        .replace("&#39;", "'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info(about: Option<&str>) -> UserInfo {
+        UserInfo {
+            id: "pg".into(),
+            karma: 156000,
+            created: 1_160_418_092, // 2006-10-09
+            about: about.map(String::from),
+            submitted: vec![1, 2, 3, 4, 5],
+        }
+    }
+
+    #[test]
+    fn options_require_user() {
+        let opts: Options = toml::from_str("user = \"pg\"").unwrap();
+        assert_eq!(opts.user.as_deref(), Some("pg"));
+    }
+
+    #[test]
+    fn text_shape_combines_login_and_karma() {
+        let body = render_body(&info(None), Shape::Text);
+        let crate::payload::Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("@pg"));
+        assert!(t.value.contains("156000pt"));
+    }
+
+    #[test]
+    fn entries_shape_includes_canonical_rows() {
+        let body = render_body(&info(None), Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        let keys: Vec<_> = e.items.iter().map(|e| e.key.as_str()).collect();
+        assert!(keys.contains(&"login"));
+        assert!(keys.contains(&"karma"));
+        assert!(keys.contains(&"created"));
+        assert!(keys.contains(&"submissions"));
+    }
+
+    #[test]
+    fn entries_shape_appends_about_when_present() {
+        let body = render_body(&info(Some("Paul.")), Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert!(e.items.iter().any(|x| x.key == "about"));
+    }
+
+    #[test]
+    fn linked_text_block_shape_links_to_user_page() {
+        let body = render_body(&info(None), Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://news.ycombinator.com/user?id=pg")
+        );
+    }
+
+    #[test]
+    fn iso_date_formats_unix_seconds() {
+        assert_eq!(iso_date(1_160_418_092), "2006-10-09");
+    }
+
+    #[test]
+    fn strip_tags_drops_html_and_decodes_entities() {
+        let out = strip_tags("<p>Hello &amp; <a href=\"/x\">world</a></p>");
+        assert_eq!(out, "Hello & world");
+    }
+}

--- a/src/fetcher/hackernews/user.rs
+++ b/src/fetcher/hackernews/user.rs
@@ -274,8 +274,74 @@ mod tests {
     }
 
     #[test]
+    fn iso_date_falls_back_to_empty_for_invalid_timestamp() {
+        assert_eq!(iso_date(i64::MAX), "");
+    }
+
+    #[test]
     fn strip_tags_drops_html_and_decodes_entities() {
         let out = strip_tags("<p>Hello &amp; <a href=\"/x\">world</a></p>");
         assert_eq!(out, "Hello & world");
+    }
+
+    #[test]
+    fn strip_tags_collapses_whitespace_runs() {
+        // <p> becomes a single space, multiple internal spaces get folded by split_whitespace.
+        assert_eq!(strip_tags("a<p><p><p>b"), "a b");
+        assert_eq!(strip_tags("a    b\n\nc"), "a b c");
+    }
+
+    #[test]
+    fn decode_entities_handles_canonical_set() {
+        assert_eq!(
+            decode_entities("&amp;&lt;&gt;&quot;&#x27;&#x2F;&#39;"),
+            "&<>\"'/'"
+        );
+    }
+
+    #[test]
+    fn text_block_lines_omit_about_when_blank() {
+        let lines = text_block_lines(&info(None));
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "@pg");
+        assert!(lines[1].contains("156000pt"));
+        assert!(lines[2].starts_with("joined "));
+    }
+
+    #[test]
+    fn text_block_lines_append_about_when_present() {
+        let lines = text_block_lines(&info(Some("<p>Founder</p>")));
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[3], "Founder");
+    }
+
+    #[test]
+    fn entries_uses_submission_count_not_full_array() {
+        let body = render_body(&info(None), Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        let submissions = e.items.iter().find(|x| x.key == "submissions").unwrap();
+        assert_eq!(submissions.value.as_deref(), Some("5"));
+    }
+
+    #[test]
+    fn empty_about_is_treated_as_missing() {
+        let body = render_body(&info(Some("")), Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert!(e.items.iter().all(|x| x.key != "about"));
+    }
+
+    #[test]
+    fn user_info_deserializes_minimal_payload() {
+        let raw = r#"{"id":"pg"}"#;
+        let info: UserInfo = serde_json::from_str(raw).unwrap();
+        assert_eq!(info.id, "pg");
+        assert_eq!(info.karma, 0);
+        assert_eq!(info.created, 0);
+        assert!(info.about.is_none());
+        assert!(info.submitted.is_empty());
     }
 }

--- a/src/fetcher/hackernews/user_comments.rs
+++ b/src/fetcher/hackernews/user_comments.rs
@@ -1,0 +1,259 @@
+//! `hackernews_user_comments` — recent comments by an HN account. Walks `submitted`, filters
+//! to `type = "comment"`, and renders each one as `<snippet>` linked to its HN comment page.
+//! Comment bodies are HTML — we strip tags and truncate to keep the splash readable.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, LinkedLine, LinkedTextBlockData, Payload, TextBlockData};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{API_BASE, HN_ITEM_URL, get};
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 30;
+const SCAN_LIMIT: usize = 80;
+const SNIPPET_CHARS: usize = 100;
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string (HN login)",
+        required: true,
+        default: None,
+        description: "Hacker News login whose comments to list.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of comments to display.",
+    },
+];
+
+pub struct HackernewsUserCommentsFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for HackernewsUserCommentsFetcher {
+    fn name(&self) -> &str {
+        "hackernews_user_comments"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "Yes, that's exactly the problem with the current rate limiter ...",
+                    Some("https://news.ycombinator.com/item?id=1"),
+                ),
+                (
+                    "Have you tried running `cargo +nightly` to see if the issue ...",
+                    Some("https://news.ycombinator.com/item?id=2"),
+                ),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                "Yes, that's exactly the problem with the current rate limiter ...",
+                "Have you tried running `cargo +nightly` to see if the issue ...",
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let login = opts.user.ok_or_else(|| {
+            FetchError::Failed("hackernews_user_comments requires `user` option".into())
+        })?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let comments = fetch_comments(&login, count).await?;
+        Ok(payload(render_body(
+            &comments,
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
+        )))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserStub {
+    #[serde(default)]
+    submitted: Vec<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Item {
+    #[serde(default)]
+    id: Option<u64>,
+    #[serde(default, rename = "type")]
+    item_type: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+async fn fetch_comments(login: &str, want: usize) -> Result<Vec<Item>, FetchError> {
+    let user: UserStub = get(&format!("{API_BASE}/user/{login}.json")).await?;
+    let candidates: Vec<u64> = user.submitted.into_iter().take(SCAN_LIMIT).collect();
+    let handles: Vec<_> = candidates
+        .into_iter()
+        .map(|id| tokio::spawn(async move { fetch_item(id).await }))
+        .collect();
+    let mut comments = Vec::with_capacity(want);
+    for h in handles {
+        if comments.len() >= want {
+            break;
+        }
+        if let Ok(Ok(it)) = h.await
+            && it.item_type.as_deref() == Some("comment")
+        {
+            comments.push(it);
+        }
+    }
+    Ok(comments)
+}
+
+async fn fetch_item(id: u64) -> Result<Item, FetchError> {
+    get(&format!("{API_BASE}/item/{id}.json")).await
+}
+
+fn render_body(items: &[Item], shape: Shape) -> Body {
+    match shape {
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: items
+                .iter()
+                .map(|it| LinkedLine {
+                    text: snippet(it),
+                    url: it.id.map(|id| format!("{HN_ITEM_URL}{id}")),
+                })
+                .collect(),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: items.iter().map(snippet).collect(),
+        }),
+    }
+}
+
+fn snippet(it: &Item) -> String {
+    let raw = it.text.as_deref().unwrap_or("");
+    let stripped = strip_tags(raw);
+    truncate(&stripped, SNIPPET_CHARS)
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut out: String = s.chars().take(max_chars).collect();
+    if s.chars().count() > max_chars {
+        out.push_str(" ...");
+    }
+    out
+}
+
+/// Mirrors the strip in `user.rs::strip_tags` — HN embeds raw HTML in its comment / about
+/// fields, so we drop the markup and decode the common entities to keep the splash readable.
+fn strip_tags(raw: &str) -> String {
+    let with_breaks = raw.replace("<p>", " ").replace("<br>", " ");
+    let mut out = String::with_capacity(with_breaks.len());
+    let mut in_tag = false;
+    for ch in with_breaks.chars() {
+        match (ch, in_tag) {
+            ('<', _) => in_tag = true,
+            ('>', _) => in_tag = false,
+            (c, false) => out.push(c),
+            _ => {}
+        }
+    }
+    decode_entities(&out)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn decode_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#x27;", "'")
+        .replace("&#x2F;", "/")
+        .replace("&#39;", "'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comment(id: u64, text: &str) -> Item {
+        Item {
+            id: Some(id),
+            item_type: Some("comment".into()),
+            text: Some(text.into()),
+        }
+    }
+
+    #[test]
+    fn options_require_user() {
+        let opts: Options = toml::from_str("user = \"pg\"\ncount = 4").unwrap();
+        assert_eq!(opts.user.as_deref(), Some("pg"));
+        assert_eq!(opts.count, Some(4));
+    }
+
+    #[test]
+    fn snippet_strips_html_and_truncates() {
+        let it = comment(1, "<p>Hello <i>there</i> friend &amp; greetings.</p>");
+        assert_eq!(snippet(&it), "Hello there friend & greetings.");
+    }
+
+    #[test]
+    fn truncate_appends_ellipsis_when_too_long() {
+        let long = "x".repeat(200);
+        let out = truncate(&long, 10);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().filter(|c| *c == 'x').count(), 10);
+    }
+
+    #[test]
+    fn linked_text_block_links_to_hn_item_page() {
+        let it = comment(42, "hello");
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://news.ycombinator.com/item?id=42")
+        );
+        assert_eq!(b.items[0].text, "hello");
+    }
+}

--- a/src/fetcher/hackernews/user_comments.rs
+++ b/src/fetcher/hackernews/user_comments.rs
@@ -256,4 +256,78 @@ mod tests {
         );
         assert_eq!(b.items[0].text, "hello");
     }
+
+    #[test]
+    fn text_block_shape_emits_snippet_per_comment() {
+        let body = render_body(
+            &[comment(1, "<p>first</p>"), comment(2, "<p>second</p>")],
+            Shape::TextBlock,
+        );
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    #[test]
+    fn missing_text_emits_empty_snippet() {
+        let it = Item {
+            id: Some(1),
+            item_type: Some("comment".into()),
+            text: None,
+        };
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items[0].text, "");
+    }
+
+    #[test]
+    fn missing_id_drops_url() {
+        let it = Item {
+            id: None,
+            item_type: Some("comment".into()),
+            text: Some("orphan".into()),
+        };
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items[0].url.is_none());
+    }
+
+    #[test]
+    fn truncate_preserves_short_input() {
+        assert_eq!(truncate("short", 100), "short");
+        assert_eq!(truncate("", 10), "");
+    }
+
+    #[test]
+    fn snippet_handles_nested_tags_and_entities() {
+        let it = comment(1, "<p>this is <a href=\"/x\"><i>fine</i></a> &amp; ok</p>");
+        assert_eq!(snippet(&it), "this is fine & ok");
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("user = \"pg\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn empty_items_renders_empty_linked_text_block() {
+        let body = render_body(&[], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items.is_empty());
+    }
+
+    #[test]
+    fn unaccepted_shape_falls_through_to_text_block() {
+        // Entries isn't in SHAPES; render_body should default to the TextBlock branch.
+        let body = render_body(&[comment(1, "hi")], Shape::Entries);
+        assert!(matches!(body, Body::TextBlock(_)));
+    }
 }

--- a/src/fetcher/hackernews/user_submissions.rs
+++ b/src/fetcher/hackernews/user_submissions.rs
@@ -1,0 +1,267 @@
+//! `hackernews_user_submissions` — recent stories submitted by an HN account. Walks the
+//! `submitted` array on `/user/{login}.json`, fetches each item, and filters to story-shaped
+//! types (`story` / `show_hn` / `ask_hn` / `job`). Comments are emitted by `hackernews_user_comments`.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, TextBlockData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{API_BASE, HN_ITEM_URL, get};
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 30;
+/// HN's `submitted` array can be long; cap how many items we try before giving up so a
+/// stale-but-prolific account doesn't fan out hundreds of item requests just to find a
+/// handful of stories.
+const SCAN_LIMIT: usize = 80;
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Entries];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string (HN login)",
+        required: true,
+        default: None,
+        description: "Hacker News login whose submissions to list.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of stories to display.",
+    },
+];
+
+pub struct HackernewsUserSubmissionsFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for HackernewsUserSubmissionsFetcher {
+    fn name(&self) -> &str {
+        "hackernews_user_submissions"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "234pt 56c  Show HN: I built a thing",
+                    Some("https://example.com/show-hn"),
+                ),
+                (
+                    "187pt 41c  Why X over Y",
+                    Some("https://news.ycombinator.com/item?id=2"),
+                ),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                "234pt 56c  Show HN: I built a thing",
+                "187pt 41c  Why X over Y",
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("Show HN: I built a thing", "234pt 56c"),
+                ("Why X over Y", "187pt 41c"),
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let login = opts.user.ok_or_else(|| {
+            FetchError::Failed("hackernews_user_submissions requires `user` option".into())
+        })?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let stories = fetch_stories(&login, count).await?;
+        Ok(payload(render_body(
+            &stories,
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
+        )))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserStub {
+    #[serde(default)]
+    submitted: Vec<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Item {
+    #[serde(default)]
+    id: Option<u64>,
+    #[serde(default, rename = "type")]
+    item_type: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    score: Option<u64>,
+    #[serde(default)]
+    descendants: Option<u64>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+async fn fetch_stories(login: &str, want: usize) -> Result<Vec<Item>, FetchError> {
+    let user: UserStub = get(&format!("{API_BASE}/user/{login}.json")).await?;
+    let candidates: Vec<u64> = user.submitted.into_iter().take(SCAN_LIMIT).collect();
+    let handles: Vec<_> = candidates
+        .into_iter()
+        .map(|id| tokio::spawn(async move { fetch_item(id).await }))
+        .collect();
+    let mut stories = Vec::with_capacity(want);
+    for h in handles {
+        if stories.len() >= want {
+            break;
+        }
+        if let Ok(Ok(it)) = h.await
+            && is_story(&it)
+        {
+            stories.push(it);
+        }
+    }
+    Ok(stories)
+}
+
+async fn fetch_item(id: u64) -> Result<Item, FetchError> {
+    get(&format!("{API_BASE}/item/{id}.json")).await
+}
+
+fn is_story(it: &Item) -> bool {
+    matches!(
+        it.item_type.as_deref(),
+        Some("story") | Some("job") | Some("show_hn") | Some("ask_hn")
+    )
+}
+
+fn render_body(items: &[Item], shape: Shape) -> Body {
+    match shape {
+        Shape::Entries => Body::Entries(EntriesData {
+            items: items
+                .iter()
+                .map(|it| Entry {
+                    key: title_or_placeholder(it),
+                    value: Some(meta_label(it)),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: items
+                .iter()
+                .map(|it| LinkedLine {
+                    text: format!("{}  {}", meta_label(it), title_or_placeholder(it)),
+                    url: link_for(it),
+                })
+                .collect(),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: items
+                .iter()
+                .map(|it| format!("{}  {}", meta_label(it), title_or_placeholder(it)))
+                .collect(),
+        }),
+    }
+}
+
+fn title_or_placeholder(it: &Item) -> String {
+    it.title.clone().unwrap_or_else(|| "(no title)".into())
+}
+
+fn meta_label(it: &Item) -> String {
+    let score = it.score.unwrap_or(0);
+    let comments = it.descendants.unwrap_or(0);
+    format!("{score}pt {comments}c")
+}
+
+fn link_for(it: &Item) -> Option<String> {
+    it.url
+        .clone()
+        .or_else(|| it.id.map(|id| format!("{HN_ITEM_URL}{id}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(item_type: &str, title: Option<&str>) -> Item {
+        Item {
+            id: Some(1),
+            item_type: Some(item_type.into()),
+            title: title.map(String::from),
+            score: Some(10),
+            descendants: Some(2),
+            url: None,
+        }
+    }
+
+    #[test]
+    fn options_require_user() {
+        let opts: Options = toml::from_str("user = \"pg\"\ncount = 5").unwrap();
+        assert_eq!(opts.user.as_deref(), Some("pg"));
+        assert_eq!(opts.count, Some(5));
+    }
+
+    #[test]
+    fn is_story_accepts_story_job_show_ask() {
+        assert!(is_story(&item("story", Some("x"))));
+        assert!(is_story(&item("job", Some("x"))));
+        assert!(is_story(&item("show_hn", Some("x"))));
+        assert!(is_story(&item("ask_hn", Some("x"))));
+    }
+
+    #[test]
+    fn is_story_rejects_comment_and_poll() {
+        assert!(!is_story(&item("comment", None)));
+        assert!(!is_story(&item("poll", Some("x"))));
+    }
+
+    #[test]
+    fn linked_text_block_link_falls_back_to_hn_item_page() {
+        let it = item("story", Some("hello"));
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://news.ycombinator.com/item?id=1")
+        );
+    }
+}

--- a/src/fetcher/hackernews/user_submissions.rs
+++ b/src/fetcher/hackernews/user_submissions.rs
@@ -264,4 +264,83 @@ mod tests {
             Some("https://news.ycombinator.com/item?id=1")
         );
     }
+
+    #[test]
+    fn linked_text_block_prefers_explicit_story_url() {
+        let it = Item {
+            id: Some(1),
+            item_type: Some("story".into()),
+            title: Some("hi".into()),
+            score: Some(1),
+            descendants: Some(0),
+            url: Some("https://example.com/x".into()),
+        };
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items[0].url.as_deref(), Some("https://example.com/x"));
+    }
+
+    #[test]
+    fn text_block_shape_includes_meta_and_title() {
+        let body = render_body(&[item("story", Some("hello"))], Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines[0], "10pt 2c  hello");
+    }
+
+    #[test]
+    fn entries_shape_uses_title_as_key_and_meta_as_value() {
+        let body = render_body(&[item("story", Some("hello"))], Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "hello");
+        assert_eq!(e.items[0].value.as_deref(), Some("10pt 2c"));
+    }
+
+    #[test]
+    fn missing_title_falls_back_to_placeholder() {
+        let body = render_body(&[item("story", None)], Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert!(t.lines[0].contains("(no title)"));
+    }
+
+    #[test]
+    fn empty_items_renders_empty_body() {
+        let body = render_body(&[], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items.is_empty());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("user = \"pg\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn item_deserializes_real_story_payload() {
+        let raw = r#"{"id":42,"type":"story","title":"hi","score":99,"descendants":12,"url":"https://example.com"}"#;
+        let it: Item = serde_json::from_str(raw).unwrap();
+        assert_eq!(it.id, Some(42));
+        assert_eq!(it.item_type.as_deref(), Some("story"));
+        assert_eq!(it.title.as_deref(), Some("hi"));
+        assert_eq!(it.score, Some(99));
+        assert_eq!(it.descendants, Some(12));
+        assert_eq!(it.url.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn user_stub_deserializes_partial_payload() {
+        let raw = r#"{"id":"pg","submitted":[1,2,3]}"#;
+        let stub: UserStub = serde_json::from_str(raw).unwrap();
+        assert_eq!(stub.submitted, vec![1, 2, 3]);
+    }
 }

--- a/src/fetcher/hackernews_top.rs
+++ b/src/fetcher/hackernews_top.rs
@@ -1,4 +1,4 @@
-//! `hn_top` — Hacker News stories (top / new / best / ask / show / job).
+//! `hackernews_top` — Hacker News stories (top / new / best / ask / show / job).
 //!
 //! Safety::Safe because the host is hardcoded (HN's read-only Firebase backend). Config picks
 //! the listing kind and how many stories to show, never the URL — there's no way for a config
@@ -47,7 +47,7 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
 ];
 
-pub struct HnTopFetcher;
+pub struct HackernewsTopFetcher;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -84,9 +84,9 @@ impl Kind {
 }
 
 #[async_trait]
-impl Fetcher for HnTopFetcher {
+impl Fetcher for HackernewsTopFetcher {
     fn name(&self) -> &str {
-        "hn_top"
+        "hackernews_top"
     }
     fn safety(&self) -> Safety {
         Safety::Safe
@@ -395,7 +395,7 @@ mod tests {
     }
 
     /// Live smoke test — hits HN's Firebase API. `#[ignore]` keeps CI offline-safe; run with
-    /// `cargo test -- --ignored fetcher::hn_top::tests::live` to verify real shape.
+    /// `cargo test -- --ignored fetcher::hackernews_top::tests::live` to verify real shape.
     #[tokio::test]
     #[ignore]
     async fn live_top_returns_at_least_one_story() {

--- a/src/fetcher/hn_top.rs
+++ b/src/fetcher/hn_top.rs
@@ -1,0 +1,413 @@
+//! `hn_top` — Hacker News stories (top / new / best / ask / show / job).
+//!
+//! Safety::Safe because the host is hardcoded (HN's read-only Firebase backend). Config picks
+//! the listing kind and how many stories to show, never the URL — there's no way for a config
+//! to redirect traffic off-host. No auth, no token leaves the machine.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, TextBlockData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::github::common::{cache_key, parse_options, payload};
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+const API_BASE: &str = "https://hacker-news.firebaseio.com/v0";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 30;
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Entries];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Number of stories to display.",
+    },
+    OptionSchema {
+        name: "kind",
+        type_hint: "\"top\" | \"new\" | \"best\" | \"ask\" | \"show\" | \"job\"",
+        required: false,
+        default: Some("\"top\""),
+        description: "Which Hacker News listing to query.",
+    },
+];
+
+pub struct HnTopFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub count: Option<u32>,
+    #[serde(default)]
+    pub kind: Option<Kind>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    #[default]
+    Top,
+    New,
+    Best,
+    Ask,
+    Show,
+    Job,
+}
+
+impl Kind {
+    fn endpoint(self) -> &'static str {
+        match self {
+            Self::Top => "topstories",
+            Self::New => "newstories",
+            Self::Best => "beststories",
+            Self::Ask => "askstories",
+            Self::Show => "showstories",
+            Self::Job => "jobstories",
+        }
+    }
+}
+
+#[async_trait]
+impl Fetcher for HnTopFetcher {
+    fn name(&self) -> &str {
+        "hn_top"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::TextBlock => samples::text_block(&[
+                "234pt 56c  Show HN: I built a thing",
+                "187pt 41c  Why X over Y",
+                "152pt 88c  Ask HN: how do you ...",
+            ]),
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "234pt 56c  Show HN: I built a thing",
+                    Some("https://example.com/show-hn"),
+                ),
+                (
+                    "187pt 41c  Why X over Y",
+                    Some("https://example.com/article"),
+                ),
+                (
+                    "152pt 88c  Ask HN: how do you ...",
+                    Some("https://news.ycombinator.com/item?id=1"),
+                ),
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("Show HN: I built a thing", "234pt 56c"),
+                ("Why X over Y", "187pt 41c"),
+                ("Ask HN: how do you ...", "152pt 88c"),
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let kind = opts.kind.unwrap_or_default();
+        let items = fetch_stories(kind, count).await?;
+        Ok(payload(render_body(
+            &items,
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
+        )))
+    }
+}
+
+async fn fetch_stories(kind: Kind, count: usize) -> Result<Vec<Item>, FetchError> {
+    let ids: Vec<u64> = http_get(&format!("{API_BASE}/{}.json", kind.endpoint())).await?;
+    let handles: Vec<_> = ids
+        .into_iter()
+        .take(count)
+        .map(|id| tokio::spawn(async move { fetch_item(id).await }))
+        .collect();
+    let mut items = Vec::with_capacity(handles.len());
+    for h in handles {
+        if let Ok(Ok(it)) = h.await {
+            items.push(it);
+        }
+    }
+    Ok(items)
+}
+
+async fn fetch_item(id: u64) -> Result<Item, FetchError> {
+    http_get(&format!("{API_BASE}/item/{id}.json")).await
+}
+
+async fn http_get<T: serde::de::DeserializeOwned>(url: &str) -> Result<T, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("hn request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("hn {status}")));
+    }
+    res.json()
+        .await
+        .map_err(|e| FetchError::Failed(format!("hn json parse: {e}")))
+}
+
+#[derive(Debug, Deserialize)]
+struct Item {
+    #[serde(default)]
+    id: Option<u64>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    score: Option<u64>,
+    #[serde(default)]
+    descendants: Option<u64>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+const HN_ITEM_URL: &str = "https://news.ycombinator.com/item?id=";
+
+fn link_for(it: &Item) -> Option<String> {
+    it.url
+        .clone()
+        .or_else(|| it.id.map(|id| format!("{HN_ITEM_URL}{id}")))
+}
+
+fn render_body(items: &[Item], shape: Shape) -> Body {
+    match shape {
+        Shape::Entries => Body::Entries(EntriesData {
+            items: items
+                .iter()
+                .map(|it| Entry {
+                    key: title_or_placeholder(it),
+                    value: Some(meta_label(it)),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: items
+                .iter()
+                .map(|it| LinkedLine {
+                    text: format!("{}  {}", meta_label(it), title_or_placeholder(it)),
+                    url: link_for(it),
+                })
+                .collect(),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: items
+                .iter()
+                .map(|it| format!("{}  {}", meta_label(it), title_or_placeholder(it)))
+                .collect(),
+        }),
+    }
+}
+
+fn title_or_placeholder(it: &Item) -> String {
+    it.title.clone().unwrap_or_else(|| "(no title)".into())
+}
+
+fn meta_label(it: &Item) -> String {
+    let score = it.score.unwrap_or(0);
+    let comments = it.descendants.unwrap_or(0);
+    format!("{score}pt {comments}c")
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_to_none_for_both_fields() {
+        let opts = Options::default();
+        assert!(opts.count.is_none());
+        assert!(opts.kind.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_count_and_kind() {
+        let raw: toml::Value = toml::from_str("count = 5\nkind = \"new\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.count, Some(5));
+        assert!(matches!(opts.kind, Some(Kind::New)));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("count = 3\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn kind_endpoint_covers_every_variant() {
+        assert_eq!(Kind::Top.endpoint(), "topstories");
+        assert_eq!(Kind::New.endpoint(), "newstories");
+        assert_eq!(Kind::Best.endpoint(), "beststories");
+        assert_eq!(Kind::Ask.endpoint(), "askstories");
+        assert_eq!(Kind::Show.endpoint(), "showstories");
+        assert_eq!(Kind::Job.endpoint(), "jobstories");
+    }
+
+    fn item(title: Option<&str>, score: Option<u64>, descendants: Option<u64>) -> Item {
+        Item {
+            id: Some(1),
+            title: title.map(String::from),
+            score,
+            descendants,
+            url: None,
+        }
+    }
+
+    #[test]
+    fn text_block_line_includes_score_comments_and_title() {
+        let body = render_body(
+            &[item(Some("hello"), Some(123), Some(45))],
+            Shape::TextBlock,
+        );
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines, vec!["123pt 45c  hello".to_string()]);
+    }
+
+    #[test]
+    fn entries_use_title_as_key_and_meta_as_value() {
+        let body = render_body(&[item(Some("hello"), Some(7), None)], Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "hello");
+        assert_eq!(e.items[0].value.as_deref(), Some("7pt 0c"));
+    }
+
+    #[test]
+    fn linked_text_block_url_falls_back_to_hn_item_page_when_no_story_url() {
+        let body = render_body(
+            &[item(Some("ask"), Some(0), Some(0))],
+            Shape::LinkedTextBlock,
+        );
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://news.ycombinator.com/item?id=1")
+        );
+    }
+
+    #[test]
+    fn linked_text_block_url_prefers_story_url_when_present() {
+        let it = Item {
+            id: Some(42),
+            title: Some("show".into()),
+            score: Some(1),
+            descendants: Some(0),
+            url: Some("https://example.com/post".into()),
+        };
+        let body = render_body(&[it], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items[0].url.as_deref(), Some("https://example.com/post"));
+        assert!(b.items[0].text.contains("show"));
+        assert!(b.items[0].text.contains("1pt 0c"));
+    }
+
+    #[test]
+    fn missing_title_falls_back_to_placeholder() {
+        let body = render_body(&[item(None, Some(0), Some(0))], Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert!(t.lines[0].contains("(no title)"));
+    }
+
+    #[test]
+    fn item_deserializes_from_hn_payload() {
+        let raw = r#"{"by":"x","descendants":12,"id":1,"score":99,"time":1700000000,"title":"hi","type":"story","url":"https://example.com"}"#;
+        let it: Item = serde_json::from_str(raw).unwrap();
+        assert_eq!(it.title.as_deref(), Some("hi"));
+        assert_eq!(it.score, Some(99));
+        assert_eq!(it.descendants, Some(12));
+    }
+
+    #[test]
+    fn item_deserializes_when_optional_fields_are_missing() {
+        let raw = r#"{"id":1,"type":"job"}"#;
+        let it: Item = serde_json::from_str(raw).unwrap();
+        assert!(it.title.is_none());
+        assert!(it.score.is_none());
+        assert!(it.descendants.is_none());
+    }
+
+    #[test]
+    fn empty_items_renders_empty_body() {
+        let body = render_body(&[], Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert!(t.lines.is_empty());
+    }
+
+    /// Live smoke test — hits HN's Firebase API. `#[ignore]` keeps CI offline-safe; run with
+    /// `cargo test -- --ignored fetcher::hn_top::tests::live` to verify real shape.
+    #[tokio::test]
+    #[ignore]
+    async fn live_top_returns_at_least_one_story() {
+        let items = fetch_stories(Kind::Top, 3).await.unwrap();
+        assert!(!items.is_empty());
+        for it in &items {
+            eprintln!(
+                "{}pt {}c  {}",
+                it.score.unwrap_or(0),
+                it.descendants.unwrap_or(0),
+                it.title.as_deref().unwrap_or(""),
+            );
+        }
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -16,6 +16,7 @@ pub mod clock;
 pub mod code;
 pub mod git;
 pub mod github;
+pub mod hn_top;
 pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
@@ -271,6 +272,7 @@ impl Registry {
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
+        r.register(Arc::new(hn_top::HnTopFetcher));
         for f in clock::realtime_fetchers() {
             r.register_realtime(f);
         }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -16,7 +16,7 @@ pub mod clock;
 pub mod code;
 pub mod git;
 pub mod github;
-pub mod hn_top;
+pub mod hackernews_top;
 pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
@@ -272,7 +272,7 @@ impl Registry {
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
-        r.register(Arc::new(hn_top::HnTopFetcher));
+        r.register(Arc::new(hackernews_top::HackernewsTopFetcher));
         for f in clock::realtime_fetchers() {
             r.register_realtime(f);
         }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -16,7 +16,7 @@ pub mod clock;
 pub mod code;
 pub mod git;
 pub mod github;
-pub mod hackernews_top;
+pub mod hackernews;
 pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
@@ -272,7 +272,9 @@ impl Registry {
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
-        r.register(Arc::new(hackernews_top::HackernewsTopFetcher));
+        for f in hackernews::fetchers() {
+            r.register(f);
+        }
         for f in clock::realtime_fetchers() {
             r.register_realtime(f);
         }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -27,6 +27,12 @@ pub enum Body {
     /// Zero or more lines of text. Used by anything intrinsically multi-line: recent commits,
     /// worktrees, welcome notes, todo items.
     TextBlock(TextBlockData),
+    /// Zero or more lines of text where each line carries an optional URL. Renderers that
+    /// understand hyperlinks (`list_links`) wrap rows whose `url` is `Some(_)` in OSC 8 escape
+    /// sequences so modern terminals surface them as clickable. Renderers that don't honour
+    /// links can ignore the urls and render the text only. Right for feeds — HN top, GitHub
+    /// PRs/issues/releases — where each row has a canonical "open this" target.
+    LinkedTextBlock(LinkedTextBlockData),
     /// Key/value rows. Used by system info, env dumps, anything label:value shaped.
     Entries(EntriesData),
     /// A single 0..=1 value with an optional display label. Gauges, progress bars, donuts.
@@ -71,6 +77,18 @@ pub struct TextData {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TextBlockData {
     pub lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LinkedTextBlockData {
+    pub items: Vec<LinkedLine>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LinkedLine {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -270,6 +270,49 @@ mod tests {
     }
 
     #[test]
+    fn linked_text_block_round_trips() {
+        let p = bare(Body::LinkedTextBlock(LinkedTextBlockData {
+            items: vec![
+                LinkedLine {
+                    text: "234pt 56c  Show HN: x".into(),
+                    url: Some("https://example.com/x".into()),
+                },
+                LinkedLine {
+                    text: "no link here".into(),
+                    url: None,
+                },
+            ],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn linked_text_block_serializes_with_expected_shape_tag() {
+        let p = bare(Body::LinkedTextBlock(LinkedTextBlockData {
+            items: vec![LinkedLine {
+                text: "hello".into(),
+                url: Some("https://example.com".into()),
+            }],
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["shape"], "linked_text_block");
+        assert_eq!(v["data"]["items"][0]["text"], "hello");
+        assert_eq!(v["data"]["items"][0]["url"], "https://example.com");
+    }
+
+    #[test]
+    fn linked_text_block_omits_url_when_none() {
+        let p = bare(Body::LinkedTextBlock(LinkedTextBlockData {
+            items: vec![LinkedLine {
+                text: "hello".into(),
+                url: None,
+            }],
+        }));
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(!json.contains("\"url\""), "json: {json:?}");
+    }
+
+    #[test]
     fn entries_round_trips() {
         let p = bare(Body::Entries(EntriesData {
             items: vec![Entry {

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -30,7 +30,7 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
 /// Renders a `LinkedTextBlock` body one row per line, wrapping rows whose `url` is `Some(_)` in
 /// an OSC 8 hyperlink so modern terminals (iTerm2, kitty, WezTerm, recent Windows Terminal, etc.)
 /// surface the row as a clickable link. Rows without a url render as plain text. Pairs with feed
-/// fetchers (`hn_top`, `github_my_prs`, `github_recent_releases`, …) where each row has a
+/// fetchers (`hackernews_top`, `github_my_prs`, `github_recent_releases`, …) where each row has a
 /// canonical "open this" target.
 pub struct ListLinksRenderer;
 

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -1,0 +1,224 @@
+//! `list_links` — `LinkedTextBlock` rendered one row per line, wrapped in OSC 8 hyperlinks where
+//! the row carries a `url`. Rows without a url render as plain text.
+//!
+//! How the OSC 8 plumbing works: ratatui's `Buffer` stores per-cell symbol strings that the
+//! crossterm backend prints verbatim. We collapse the whole linked row into the first cell's
+//! symbol — `ESC ] 8 ; ; URL ESC \\ <text> ESC ] 8 ; ; ESC \\` — and mark the trailing cells with
+//! `skip = true` so ratatui's diff doesn't try to redraw them. That keeps the OSC 8 sequence
+//! atomic in the byte stream (no `MoveTo` interruption), and dodges `Buffer::diff`'s width
+//! calculation, which would otherwise count the printable characters inside the escape sequence
+//! as visible columns and incorrectly skip the cells immediately after the link.
+
+use ratatui::{Frame, buffer::Buffer, layout::Rect, style::Style};
+
+use crate::options::OptionSchema;
+use crate::payload::{Body, LinkedLine, LinkedTextBlockData};
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "max_items",
+    type_hint: "positive integer",
+    required: false,
+    default: Some("all rows"),
+    description: "Cap on rendered rows. Truncates from the end when the input has more rows than the cap.",
+}];
+
+/// Renders a `LinkedTextBlock` body one row per line, wrapping rows whose `url` is `Some(_)` in
+/// an OSC 8 hyperlink so modern terminals (iTerm2, kitty, WezTerm, recent Windows Terminal, etc.)
+/// surface the row as a clickable link. Rows without a url render as plain text. Pairs with feed
+/// fetchers (`hn_top`, `github_my_prs`, `github_recent_releases`, …) where each row has a
+/// canonical "open this" target.
+pub struct ListLinksRenderer;
+
+impl Renderer for ListLinksRenderer {
+    fn name(&self) -> &str {
+        "list_links"
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::LinkedTextBlock]
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        _registry: &Registry,
+    ) {
+        if let Body::LinkedTextBlock(d) = body {
+            render_links(frame, area, d, opts, theme);
+        }
+    }
+}
+
+fn render_links(
+    frame: &mut Frame,
+    area: Rect,
+    data: &LinkedTextBlockData,
+    opts: &RenderOptions,
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let cap = opts.max_items.unwrap_or(usize::MAX);
+    let style = Style::default().fg(theme.text);
+    let buf = frame.buffer_mut();
+    data.items
+        .iter()
+        .take(cap)
+        .take(area.height as usize)
+        .enumerate()
+        .for_each(|(i, line)| {
+            let y = area.y + i as u16;
+            write_row(buf, area.x, y, area.width, line, style);
+        });
+}
+
+fn write_row(buf: &mut Buffer, x: u16, y: u16, max_width: u16, line: &LinkedLine, style: Style) {
+    let (end_x, _) = buf.set_stringn(x, y, &line.text, max_width as usize, style);
+    let drawn = end_x.saturating_sub(x);
+    if drawn == 0 {
+        return;
+    }
+    if let Some(url) = line.url.as_deref() {
+        wrap_link(buf, x, y, end_x, url, style);
+    }
+}
+
+fn wrap_link(buf: &mut Buffer, x: u16, y: u16, end_x: u16, url: &str, style: Style) {
+    let visible: String = (x..end_x)
+        .filter_map(|col| buf.cell((col, y)).map(|c| c.symbol().to_string()))
+        .collect();
+    if let Some(cell) = buf.cell_mut((x, y)) {
+        cell.set_symbol(&format!("\x1b]8;;{url}\x1b\\{visible}\x1b]8;;\x1b\\"));
+        cell.set_style(style);
+    }
+    for col in (x + 1)..end_x {
+        if let Some(cell) = buf.cell_mut((col, y)) {
+            cell.set_skip(true);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{LinkedLine, LinkedTextBlockData, Payload};
+    use crate::render::test_utils::render_to_buffer_with_spec;
+    use crate::render::{Registry, RenderSpec};
+
+    fn payload(items: Vec<LinkedLine>) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::LinkedTextBlock(LinkedTextBlockData { items }),
+        }
+    }
+
+    fn line(text: &str, url: Option<&str>) -> LinkedLine {
+        LinkedLine {
+            text: text.into(),
+            url: url.map(String::from),
+        }
+    }
+
+    fn cells_concat(buf: &ratatui::buffer::Buffer, y: u16) -> String {
+        (buf.area.x..buf.area.right())
+            .map(|x| buf[(x, y)].symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn renders_unlinked_rows_as_plain_text() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![line("alpha 1pt", None)]),
+            Some(&spec),
+            &registry,
+            30,
+            2,
+        );
+        let row = cells_concat(&buf, 0);
+        assert!(row.contains("alpha 1pt"), "row: {row:?}");
+        assert!(!row.contains("\x1b]8;;"), "should not embed OSC 8: {row:?}");
+    }
+
+    #[test]
+    fn linked_row_wraps_first_cell_with_full_osc_8() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![line("hello", Some("https://example.com"))]),
+            Some(&spec),
+            &registry,
+            10,
+            1,
+        );
+        let row = cells_concat(&buf, 0);
+        assert!(
+            row.starts_with("\x1b]8;;https://example.com\x1b\\hello\x1b]8;;\x1b\\"),
+            "expected full OSC 8 wrap in cell 0: {row:?}",
+        );
+    }
+
+    #[test]
+    fn empty_body_does_not_panic() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(&payload(vec![]), Some(&spec), &registry, 10, 2);
+        // Empty body short-circuits to the shared placeholder, so we just assert no panic.
+        let _ = cells_concat(&buf, 0);
+    }
+
+    #[test]
+    fn narrow_area_truncates_without_breaking_link_close() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![line(
+                "very long title here",
+                Some("https://example.com"),
+            )]),
+            Some(&spec),
+            &registry,
+            8,
+            1,
+        );
+        let row = cells_concat(&buf, 0);
+        assert!(row.starts_with("\x1b]8;;"), "open missing: {row:?}");
+        assert!(row.contains("\x1b]8;;\x1b\\"), "close missing: {row:?}");
+    }
+
+    #[test]
+    fn max_items_caps_render() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(r#"render = { type = "list_links", max_items = 1 }"#).unwrap();
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![line("first", None), line("second", None)]),
+            Some(&w.render),
+            &registry,
+            20,
+            3,
+        );
+        assert!(cells_concat(&buf, 0).contains("first"));
+        assert!(!cells_concat(&buf, 1).contains("second"));
+    }
+}

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -221,4 +221,92 @@ mod tests {
         assert!(cells_concat(&buf, 0).contains("first"));
         assert!(!cells_concat(&buf, 1).contains("second"));
     }
+
+    #[test]
+    fn multiple_linked_rows_each_get_independent_osc_8() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![
+                line("first", Some("https://example.com/a")),
+                line("second", Some("https://example.com/b")),
+            ]),
+            Some(&spec),
+            &registry,
+            20,
+            2,
+        );
+        let row0 = cells_concat(&buf, 0);
+        let row1 = cells_concat(&buf, 1);
+        assert!(row0.contains("https://example.com/a"), "row0: {row0:?}");
+        assert!(row1.contains("https://example.com/b"), "row1: {row1:?}");
+    }
+
+    #[test]
+    fn mixed_linked_and_unlinked_rows_only_wrap_linked() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![
+                line("linked", Some("https://example.com")),
+                line("plain", None),
+            ]),
+            Some(&spec),
+            &registry,
+            20,
+            2,
+        );
+        let row0 = cells_concat(&buf, 0);
+        let row1 = cells_concat(&buf, 1);
+        assert!(row0.contains("\x1b]8;;"), "row0 should be linked: {row0:?}");
+        assert!(!row1.contains("\x1b]8;;"), "row1 should be plain: {row1:?}");
+        assert!(row1.contains("plain"));
+    }
+
+    #[test]
+    fn area_height_caps_rendered_rows() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![
+                line("a", None),
+                line("b", None),
+                line("c", None),
+                line("d", None),
+            ]),
+            Some(&spec),
+            &registry,
+            20,
+            2,
+        );
+        assert!(cells_concat(&buf, 0).contains("a"));
+        assert!(cells_concat(&buf, 1).contains("b"));
+        // Buffer is only 2 rows tall — c and d simply have no place to render.
+    }
+
+    #[test]
+    fn unicode_text_in_linked_row_keeps_osc_8_wrapper() {
+        // Wide-grapheme inputs (CJK) get a per-grapheme trailing-cell reset from `set_stringn`,
+        // so a literal `"こんにちは"` substring search on the cell concat won't work. We just
+        // assert the OSC 8 wrapper survives intact and each visible char shows up somewhere.
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_links".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![line("こんにちは world", Some("https://example.com"))]),
+            Some(&spec),
+            &registry,
+            30,
+            1,
+        );
+        let row = cells_concat(&buf, 0);
+        assert!(
+            row.starts_with("\x1b]8;;https://example.com\x1b\\"),
+            "missing OSC open: {row:?}",
+        );
+        assert!(row.contains("\x1b]8;;\x1b\\"), "missing OSC close: {row:?}");
+        for ch in ['こ', 'ん', 'に', 'ち', 'は'] {
+            assert!(row.contains(ch), "missing {ch}: {row:?}");
+        }
+        assert!(row.contains("world"));
+    }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -35,6 +35,7 @@ mod gauge_thermometer;
 mod grid_calendar;
 mod grid_heatmap;
 mod grid_table;
+mod list_links;
 mod list_plain;
 mod list_ranking;
 mod list_timeline;
@@ -54,6 +55,7 @@ pub mod test_utils;
 pub enum Shape {
     Text,
     TextBlock,
+    LinkedTextBlock,
     Entries,
     Ratio,
     NumberSeries,
@@ -70,6 +72,7 @@ pub fn shape_of(body: &Body) -> Shape {
     match body {
         Body::Text(_) => Shape::Text,
         Body::TextBlock(_) => Shape::TextBlock,
+        Body::LinkedTextBlock(_) => Shape::LinkedTextBlock,
         Body::Entries(_) => Shape::Entries,
         Body::Ratio(_) => Shape::Ratio,
         Body::NumberSeries(_) => Shape::NumberSeries,
@@ -90,6 +93,7 @@ impl Shape {
         match self {
             Self::Text => "text",
             Self::TextBlock => "text_block",
+            Self::LinkedTextBlock => "linked_text_block",
             Self::Entries => "entries",
             Self::Ratio => "ratio",
             Self::NumberSeries => "number_series",
@@ -377,6 +381,7 @@ impl Registry {
         r.register(Arc::new(animated_wave::AnimatedWaveRenderer));
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
+        r.register(Arc::new(list_links::ListLinksRenderer));
         r.register(Arc::new(list_ranking::ListRankingRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
         r.register(Arc::new(gauge_battery::GaugeBatteryRenderer));
@@ -417,6 +422,7 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
     match shape {
         Shape::Text => "text_plain",
         Shape::TextBlock => "text_plain",
+        Shape::LinkedTextBlock => "list_links",
         Shape::Entries => "grid_table",
         Shape::Ratio => "gauge_circle",
         Shape::NumberSeries => "chart_sparkline",
@@ -486,6 +492,7 @@ pub fn is_empty_body(body: &Body) -> bool {
     match body {
         Body::Text(d) => d.value.is_empty(),
         Body::TextBlock(d) => d.lines.is_empty() || d.lines.iter().all(|l| l.is_empty()),
+        Body::LinkedTextBlock(d) => d.items.is_empty() || d.items.iter().all(|i| i.text.is_empty()),
         Body::Entries(d) => d.items.is_empty(),
         Body::NumberSeries(d) => d.values.is_empty(),
         Body::PointSeries(d) => d.series.iter().all(|s| s.points.is_empty()),
@@ -607,6 +614,7 @@ mod tests {
             "animated_wave",
             "status_badge",
             "list_plain",
+            "list_links",
             "list_ranking",
             "list_timeline",
             "grid_table",

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -11,9 +11,9 @@
 //! any future CLI that wants to preview what a fetcher emits without hitting I/O.
 
 use crate::payload::{
-    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData,
-    NumberSeriesData, PointSeries, PointSeriesData, RatioData, Status, TextBlockData, TextData,
-    TimelineData, TimelineEvent,
+    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData, LinkedLine,
+    LinkedTextBlockData, NumberSeriesData, PointSeries, PointSeriesData, RatioData, Status,
+    TextBlockData, TextData, TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 
@@ -24,6 +24,10 @@ pub fn canonical_sample(shape: Shape) -> Option<Body> {
     Some(match shape {
         Shape::Text => text("splashboard"),
         Shape::TextBlock => text_block(&["splashboard", "greetings on cd"]),
+        Shape::LinkedTextBlock => linked_text_block(&[
+            ("splashboard greets on cd", Some("https://example.com/")),
+            ("recent commit landed", None),
+        ]),
         Shape::Entries => entries(&[("key", "value"), ("foo", "bar"), ("baz", "qux")]),
         Shape::Ratio => ratio(0.67, "used"),
         Shape::NumberSeries => {
@@ -52,6 +56,18 @@ pub fn text(s: &str) -> Body {
 pub fn text_block(ss: &[&str]) -> Body {
     Body::TextBlock(TextBlockData {
         lines: ss.iter().map(|s| (*s).to_string()).collect(),
+    })
+}
+
+pub fn linked_text_block(rows: &[(&str, Option<&str>)]) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: rows
+            .iter()
+            .map(|(text, url)| LinkedLine {
+                text: (*text).to_string(),
+                url: url.map(String::from),
+            })
+            .collect(),
     })
 }
 

--- a/src/templates/home_github.toml
+++ b/src/templates/home_github.toml
@@ -31,17 +31,17 @@ render = { type = "grid_heatmap", align = "center" }
 [[widget]]
 id = "my_prs"
 fetcher = "github_my_prs"
-render = { type = "list_plain", bullet = "•", max_items = 4 }
+render = { type = "list_links", max_items = 4 }
 
 [[widget]]
 id = "review_queue"
 fetcher = "github_review_requests"
-render = { type = "list_plain", bullet = "•", max_items = 4 }
+render = { type = "list_links", max_items = 4 }
 
 [[widget]]
 id = "notifications"
 fetcher = "github_notifications"
-render = { type = "list_timeline", bullet = "●", date_format = "relative", max_items = 5 }
+render = { type = "list_links", max_items = 5 }
 
 # ── Layout ─────────────────────────────────────────────────────────
 

--- a/src/templates/project_github.toml
+++ b/src/templates/project_github.toml
@@ -32,12 +32,12 @@ render = { type = "grid_table", layout = "inline", align = "center" }
 [[widget]]
 id = "repo_prs"
 fetcher = "github_repo_prs"
-render = { type = "list_plain", bullet = "•", max_items = 5 }
+render = { type = "list_links", max_items = 5 }
 
 [[widget]]
 id = "repo_issues"
 fetcher = "github_repo_issues"
-render = { type = "list_plain", bullet = "•", max_items = 5 }
+render = { type = "list_links", max_items = 5 }
 
 [[widget]]
 id = "commits_heatmap"
@@ -57,7 +57,7 @@ render = { type = "chart_bar", horizontal = true }
 [[widget]]
 id = "releases"
 fetcher = "github_recent_releases"
-render = { type = "list_timeline", bullet = "●", date_format = "relative", max_items = 3 }
+render = { type = "list_links", max_items = 3 }
 
 # ── Layout ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `LinkedTextBlock` shape — a `TextBlock` sibling whose rows carry an optional URL — and a new `list_links` renderer that wraps linked rows in OSC 8 escape sequences so modern terminals surface them as clickable hyperlinks. Rows without a URL fall through to plain text.
- Adds `hn_top` fetcher (Hacker News top / new / best / ask / show / job stories) over the public read-only Firebase API; rows link to the story URL or the HN comment page.
- Migrates 10 existing `github_*` feed fetchers (`my_prs`, `review_requests`, `assigned_issues`, `repo_prs`, `repo_issues`, `good_first_issues`, `recent_releases`, `notifications`, `contributors_monthly`, plus the shared `items.rs` path) to emit `LinkedTextBlock` when that shape is requested. Existing shapes (`TextBlock` / `Entries` / `Timeline` / `Bars`) keep working unchanged.
- Switches `home_github` (my_prs / review_queue / notifications) and `project_github` (repo_prs / repo_issues / releases) presets to `render = "list_links"` so the default templates ship with clickable rows.

Implementation note worth flagging for review: the OSC 8 sequence is collapsed into the **first cell's** symbol, with `skip = true` on the trailing cells of the linked region. ratatui's `Buffer::diff` computes per-cell width via `unicode_width::UnicodeWidthStr::width()`, which counts every printable byte inside the escape sequence as a visible column — without the `skip` workaround the cells immediately after the link silently drop. See `src/render/list_links.rs` module doc for the longer write-up.

Catalog: ticks the `hn_top` checkbox in #67. The 10 `github_*` fetchers were already shipped — this PR extends each with one more shape, no checkbox flip needed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (632 passed)
- [x] Local smoke test: `cargo run --bin splashboard` with a `.splashboard/dashboard.toml` exercising `hn_top`, `github_my_prs`, `github_review_requests`, `github_notifications`, `github_recent_releases` — confirmed clickable in the user's terminal.
- [ ] Verify rendering in a terminal that does NOT support OSC 8 — the rows should render as plain text without escape-code residue. (Not validated locally; review-time check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Hacker News as a new data source with support for top stories, user profiles, comments, and submissions
  * GitHub widgets now render with clickable links for improved navigation

* **Improvements**
  * Updated GitHub notification, pull request, and issue widgets to use link-based rendering by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->