### PR TITLE
feat(fetcher): add todoist_tasks with structured filters

### DIFF
--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -20,6 +20,7 @@ pub mod quote_of_day;
 pub mod read_store;
 pub mod static_text;
 pub mod system;
+pub mod todoist;
 pub mod weather;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -271,6 +272,9 @@ impl Registry {
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
+        for f in todoist::fetchers() {
+            r.register(f);
+        }
         for f in clock::realtime_fetchers() {
             r.register_realtime(f);
         }

--- a/src/fetcher/todoist.rs
+++ b/src/fetcher/todoist.rs
@@ -1,0 +1,622 @@
+//! `todoist_tasks` — Todoist task snapshot with structured filters.
+//!
+//! Safety::Safe: every request targets Todoist's fixed REST host (`api.todoist.com`), so
+//! config cannot redirect tokens to arbitrary origins.
+
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Datelike, Local, NaiveDate};
+use reqwest::Client;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, Payload, Status, TextBlockData, TextData, TimelineData,
+    TimelineEvent,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+const API_TASKS: &str = "https://api.todoist.com/api/v1/tasks";
+const API_TASKS_FILTER: &str = "https://api.todoist.com/api/v1/tasks/filter";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_MAX_ITEMS: usize = 10;
+const MAX_ITEMS_CAP: usize = 100;
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Timeline,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "token",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Todoist API token. If omitted, `TODOIST_TOKEN` env var is used.",
+    },
+    OptionSchema {
+        name: "filter_due",
+        type_hint: "\"today\" | \"overdue\" | \"upcoming\" | \"all\"",
+        required: false,
+        default: Some("\"all\""),
+        description: "Due-date window.",
+    },
+    OptionSchema {
+        name: "filter_include_overdue",
+        type_hint: "boolean",
+        required: false,
+        default: Some("true"),
+        description: "When `filter_due = \"today\"`, include overdue tasks too.",
+    },
+    OptionSchema {
+        name: "filter_projects",
+        type_hint: "array of strings",
+        required: false,
+        default: None,
+        description: "Project names matched as an OR clause (`#ProjectA | #ProjectB`).",
+    },
+    OptionSchema {
+        name: "filter_labels",
+        type_hint: "array of strings",
+        required: false,
+        default: None,
+        description: "Label names matched as an OR clause (`@urgent | @backend`).",
+    },
+    OptionSchema {
+        name: "filter_priorities",
+        type_hint: "array of integers (1..=4)",
+        required: false,
+        default: None,
+        description: "Priority filter matched as an OR clause (`p1 | p2`).",
+    },
+    OptionSchema {
+        name: "max_items",
+        type_hint: "integer (1..=100)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum rendered tasks for list-like shapes (TextBlock/Entries/Timeline).",
+    },
+];
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(TodoistTasks)]
+}
+
+pub struct TodoistTasks;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "due")]
+    filter_due: Option<DueWindow>,
+    #[serde(default)]
+    #[serde(alias = "include_overdue")]
+    filter_include_overdue: Option<bool>,
+    #[serde(default)]
+    #[serde(alias = "projects")]
+    filter_projects: Option<Vec<String>>,
+    #[serde(default)]
+    #[serde(alias = "labels")]
+    filter_labels: Option<Vec<String>>,
+    #[serde(default)]
+    #[serde(alias = "priorities")]
+    filter_priorities: Option<Vec<u8>>,
+    #[serde(default)]
+    max_items: Option<usize>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum DueWindow {
+    Today,
+    Overdue,
+    Upcoming,
+    #[default]
+    All,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiTask {
+    content: String,
+    priority: u8,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    due: Option<ApiDue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiTasksResponse {
+    results: Vec<ApiTask>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiDue {
+    date: String,
+    #[serde(default)]
+    datetime: Option<String>,
+}
+
+#[derive(Debug)]
+struct TaskView {
+    content: String,
+    priority: u8,
+    due_label: Option<String>,
+    due_sort_key: Option<i64>,
+    timeline_ts: Option<i64>,
+    is_overdue: bool,
+}
+
+#[async_trait]
+impl Fetcher for TodoistTasks {
+    fn name(&self) -> &str {
+        "todoist_tasks"
+    }
+
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+
+    fn default_shape(&self) -> Shape {
+        Shape::TextBlock
+    }
+
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx)
+    }
+
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Text => samples::text("todo 5 tasks (2 overdue)"),
+            Shape::TextBlock => samples::text_block(&[
+                "overdue · P4 Fix flaky CI",
+                "today · P3 Draft release notes",
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("Fix flaky CI", "overdue · P4"),
+                ("Draft release notes", "today · P3"),
+            ]),
+            Shape::Timeline => samples::timeline(&[
+                (1_776_630_000, "Fix flaky CI", Some("overdue · P4")),
+                (1_776_716_400, "Draft release notes", Some("today · P3")),
+            ]),
+            Shape::Badge => Body::Badge(BadgeData {
+                status: Status::Error,
+                label: "todo 5 (2 overdue)".into(),
+            }),
+            _ => return None,
+        })
+    }
+
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref())?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let tasks = fetch_tasks(&token, build_filter(&opts)).await?;
+        let now = Local::now();
+        let mut views: Vec<TaskView> = tasks.into_iter().map(|t| to_task_view(t, &now)).collect();
+        views.sort_by(cmp_views);
+        let max_items = opts
+            .max_items
+            .unwrap_or(DEFAULT_MAX_ITEMS)
+            .clamp(1, MAX_ITEMS_CAP);
+        Ok(payload(render_body(
+            &views,
+            ctx.shape.unwrap_or(Shape::TextBlock),
+            max_items,
+        )))
+    }
+}
+
+fn cache_key(name: &str, ctx: &FetchContext) -> String {
+    let shape = ctx.shape.map(|s| s.as_str()).unwrap_or("default");
+    let opts = ctx
+        .options
+        .as_ref()
+        .map(toml::Value::to_string)
+        .unwrap_or_default();
+    let raw = format!(
+        "{}|{}|{}|{}",
+        name,
+        shape,
+        ctx.format.as_deref().unwrap_or(""),
+        opts
+    );
+    let digest = Sha256::digest(raw.as_bytes());
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{name}-{hex}")
+}
+
+async fn fetch_tasks(token: &str, filter: Option<String>) -> Result<Vec<ApiTask>, FetchError> {
+    let (url, req) = match filter.as_deref() {
+        Some(q) => (
+            API_TASKS_FILTER,
+            http()
+                .get(API_TASKS_FILTER)
+                .bearer_auth(token)
+                .query(&[("query", q)]),
+        ),
+        None => (API_TASKS, http().get(API_TASKS).bearer_auth(token)),
+    };
+    let res = req
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("todoist request failed: {e}")))?;
+    let status = res.status();
+    let body = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("todoist response body: {e}")))?;
+    if !status.is_success() {
+        return Err(FetchError::Failed(todoist_error(status, &body)));
+    }
+    serde_json::from_slice::<ApiTasksResponse>(&body)
+        .map(|v| v.results)
+        .map_err(|e| FetchError::Failed(format!("todoist json parse ({url}): {e}")))
+}
+
+fn todoist_error(status: reqwest::StatusCode, body: &[u8]) -> String {
+    #[derive(Deserialize)]
+    struct ApiError {
+        #[serde(default)]
+        error: Option<String>,
+        #[serde(default)]
+        message: Option<String>,
+    }
+    let text = serde_json::from_slice::<ApiError>(body)
+        .ok()
+        .and_then(|e| e.error.or(e.message))
+        .or_else(|| {
+            std::str::from_utf8(body)
+                .ok()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(ToString::to_string)
+        });
+    text.map(|t| format!("todoist {status}: {t}"))
+        .unwrap_or_else(|| format!("todoist {status}"))
+}
+
+fn build_filter(opts: &Options) -> Option<String> {
+    let due = due_clause(
+        opts.filter_due.unwrap_or_default(),
+        opts.filter_include_overdue.unwrap_or(true),
+    );
+    let projects = scoped_or_clause('#', opts.filter_projects.as_deref());
+    let labels = scoped_or_clause('@', opts.filter_labels.as_deref());
+    let priorities = priorities_clause(opts.filter_priorities.as_deref());
+    let clauses: Vec<String> = [due, projects, labels, priorities]
+        .into_iter()
+        .flatten()
+        .collect();
+    (!clauses.is_empty()).then(|| clauses.join(" & "))
+}
+
+fn due_clause(due: DueWindow, include_overdue: bool) -> Option<String> {
+    match due {
+        DueWindow::Today => Some(if include_overdue {
+            "(today | overdue)".into()
+        } else {
+            "today".into()
+        }),
+        DueWindow::Overdue => Some("overdue".into()),
+        DueWindow::Upcoming => Some("7 days & !today".into()),
+        DueWindow::All => None,
+    }
+}
+
+fn scoped_or_clause(prefix: char, values: Option<&[String]>) -> Option<String> {
+    let terms: Vec<String> = values
+        .unwrap_or(&[])
+        .iter()
+        .map(|v| v.trim())
+        .filter(|v| !v.is_empty())
+        .map(|v| format!("{prefix}{}", escape_filter_atom(v)))
+        .collect();
+    or_clause(&terms)
+}
+
+fn priorities_clause(values: Option<&[u8]>) -> Option<String> {
+    let terms: Vec<String> = values
+        .unwrap_or(&[])
+        .iter()
+        .filter(|v| (1u8..=4u8).contains(v))
+        .map(|v| format!("p{v}"))
+        .collect();
+    or_clause(&terms)
+}
+
+fn or_clause(values: &[String]) -> Option<String> {
+    match values.len() {
+        0 => None,
+        1 => Some(values[0].clone()),
+        _ => Some(format!("({})", values.join(" | "))),
+    }
+}
+
+fn escape_filter_atom(value: &str) -> String {
+    let plain = value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if plain {
+        value.to_string()
+    } else {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    }
+}
+
+fn to_task_view(task: ApiTask, now: &DateTime<Local>) -> TaskView {
+    let created_ts = task
+        .created_at
+        .as_deref()
+        .and_then(parse_rfc3339_timestamp)
+        .unwrap_or_else(|| now.timestamp());
+    let (due_label, due_sort_key, timeline_ts, is_overdue) = task
+        .due
+        .as_ref()
+        .map(|d| parse_due(d, now))
+        .unwrap_or((None, None, None, false));
+    TaskView {
+        content: task.content,
+        priority: task.priority.clamp(1, 4),
+        due_label,
+        due_sort_key,
+        timeline_ts: timeline_ts.or(Some(created_ts)),
+        is_overdue,
+    }
+}
+
+fn parse_due(
+    due: &ApiDue,
+    now: &DateTime<Local>,
+) -> (Option<String>, Option<i64>, Option<i64>, bool) {
+    if let Some(dt) = due.datetime.as_deref().and_then(parse_rfc3339_timestamp) {
+        let today = now.date_naive();
+        let date_label = DateTime::from_timestamp(dt, 0)
+            .map(|d| d.with_timezone(&Local).date_naive())
+            .map(|d| due_label_from_date(d, today))
+            .unwrap_or_else(|| "scheduled".into());
+        return (Some(date_label), Some(dt), Some(dt), dt < now.timestamp());
+    }
+    NaiveDate::parse_from_str(&due.date, "%Y-%m-%d")
+        .ok()
+        .map(|date| {
+            let ts = date
+                .and_hms_opt(12, 0, 0)
+                .map(|v| v.and_utc().timestamp())
+                .unwrap_or(0);
+            (
+                Some(due_label_from_date(date, now.date_naive())),
+                Some(ts),
+                Some(ts),
+                date < now.date_naive(),
+            )
+        })
+        .unwrap_or((None, None, None, false))
+}
+
+fn due_label_from_date(date: NaiveDate, today: NaiveDate) -> String {
+    if date < today {
+        "overdue".into()
+    } else if date == today {
+        "today".into()
+    } else if date == today.succ_opt().unwrap_or(today) {
+        "tomorrow".into()
+    } else {
+        format!("{:02}-{:02}", date.month(), date.day())
+    }
+}
+
+fn parse_rfc3339_timestamp(raw: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
+fn cmp_views(a: &TaskView, b: &TaskView) -> std::cmp::Ordering {
+    a.due_sort_key
+        .unwrap_or(i64::MAX)
+        .cmp(&b.due_sort_key.unwrap_or(i64::MAX))
+        .then_with(|| b.priority.cmp(&a.priority))
+        .then_with(|| a.content.cmp(&b.content))
+}
+
+fn render_body(tasks: &[TaskView], shape: Shape, max_items: usize) -> Body {
+    let overdue_count = tasks.iter().filter(|t| t.is_overdue).count();
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: format!("todo {} tasks ({} overdue)", tasks.len(), overdue_count),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: tasks
+                .iter()
+                .take(max_items)
+                .map(|t| Entry {
+                    key: t.content.clone(),
+                    value: Some(task_meta(t)),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Timeline => Body::Timeline(TimelineData {
+            events: tasks
+                .iter()
+                .filter_map(|t| {
+                    t.timeline_ts.map(|ts| TimelineEvent {
+                        timestamp: ts,
+                        title: t.content.clone(),
+                        detail: Some(task_meta(t)),
+                        status: t.is_overdue.then_some(Status::Error),
+                    })
+                })
+                .take(max_items)
+                .collect(),
+        }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: badge_status(tasks.len(), overdue_count),
+            label: format!("todo {} ({} overdue)", tasks.len(), overdue_count),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: tasks.iter().take(max_items).map(task_line).collect(),
+        }),
+    }
+}
+
+fn badge_status(total: usize, overdue: usize) -> Status {
+    if overdue > 0 {
+        Status::Error
+    } else if total > 0 {
+        Status::Warn
+    } else {
+        Status::Ok
+    }
+}
+
+fn task_line(task: &TaskView) -> String {
+    format!("{} {}", task_meta(task), task.content)
+}
+
+fn task_meta(task: &TaskView) -> String {
+    let due = task.due_label.as_deref().unwrap_or("no due");
+    format!("{due} · P{}", task.priority)
+}
+
+fn parse_options(raw: Option<&toml::Value>) -> Result<Options, FetchError> {
+    raw.map(|v| {
+        v.clone()
+            .try_into::<Options>()
+            .map_err(|e| FetchError::Failed(format!("invalid options: {e}")))
+    })
+    .unwrap_or_else(|| Ok(Options::default()))
+}
+
+fn resolve_token(config_token: Option<&str>) -> Result<String, FetchError> {
+    config_token
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+        .or_else(|| std::env::var("TODOIST_TOKEN").ok())
+        .ok_or_else(|| {
+            FetchError::Failed("todoist token missing: set options.token or TODOIST_TOKEN".into())
+        })
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(raw: &str) -> Options {
+        let value: toml::Value = toml::from_str(raw).unwrap();
+        parse_options(Some(&value)).unwrap()
+    }
+
+    #[test]
+    fn build_filter_from_structured_options() {
+        let opts = options(
+            "filter_due = \"today\"\nfilter_projects = [\"Work\", \"Client A\"]\nfilter_labels = [\"urgent\"]\nfilter_priorities = [1, 2]\n",
+        );
+        assert_eq!(
+            build_filter(&opts),
+            Some("(today | overdue) & (#Work | #\"Client A\") & @urgent & (p1 | p2)".into())
+        );
+    }
+
+    #[test]
+    fn due_all_without_other_filters_produces_no_query() {
+        let opts = options("filter_due = \"all\"");
+        assert_eq!(build_filter(&opts), None);
+    }
+
+    #[test]
+    fn include_overdue_false_keeps_today_only() {
+        let opts = options("filter_due = \"today\"\nfilter_include_overdue = false");
+        assert_eq!(build_filter(&opts), Some("today".into()));
+    }
+
+    #[test]
+    fn priorities_clause_ignores_out_of_range_values() {
+        let opts = options("filter_priorities = [0, 1, 4, 9]");
+        assert_eq!(build_filter(&opts), Some("(p1 | p4)".into()));
+    }
+
+    #[test]
+    fn parse_due_labels_relative_days() {
+        let now = Local::now();
+        let today_date = now.date_naive();
+        let tomorrow_date = today_date.succ_opt().unwrap_or(today_date);
+        let overdue_date = today_date.pred_opt().unwrap_or(today_date);
+        let today = ApiDue {
+            date: today_date.to_string(),
+            datetime: None,
+        };
+        let tomorrow = ApiDue {
+            date: tomorrow_date.to_string(),
+            datetime: None,
+        };
+        let overdue = ApiDue {
+            date: overdue_date.to_string(),
+            datetime: None,
+        };
+        assert_eq!(parse_due(&today, &now).0.as_deref(), Some("today"));
+        assert_eq!(parse_due(&tomorrow, &now).0.as_deref(), Some("tomorrow"));
+        assert_eq!(parse_due(&overdue, &now).0.as_deref(), Some("overdue"));
+    }
+
+    #[test]
+    fn render_badge_reflects_overdue_status() {
+        let tasks = vec![TaskView {
+            content: "Fix bug".into(),
+            priority: 4,
+            due_label: Some("overdue".into()),
+            due_sort_key: Some(1),
+            timeline_ts: Some(1),
+            is_overdue: true,
+        }];
+        let body = render_body(&tasks, Shape::Badge, 10);
+        let Body::Badge(b) = body else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Error);
+        assert!(b.label.contains("overdue"));
+    }
+}

--- a/src/fetcher/todoist.rs
+++ b/src/fetcher/todoist.rs
@@ -665,6 +665,9 @@ mod tests {
             panic!("expected linked_text_block");
         };
         assert_eq!(b.items.len(), 1);
-        assert_eq!(b.items[0].url.as_deref(), Some("https://app.todoist.com/app/task/42"));
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://app.todoist.com/app/task/42")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a new cached `todoist_tasks` fetcher that targets Todoist API v1 (`/tasks` and `/tasks/filter`) and supports `Text` / `TextBlock` / `Entries` / `Timeline` / `Badge` output shapes
- introduce structured filter options (`filter_due`, `filter_include_overdue`, `filter_projects`, `filter_labels`, `filter_priorities`) and compose them into Todoist query syntax without requiring raw query strings
- register the new fetcher in the builtin registry and include parser/filter/render helper tests for due-window handling, clause composition, and badge/status behavior

## Test plan
- `cargo check`

## Catalog
- refs #66 (`todoist_today`) and implements the Todoist tasks integration as structured filtering via `todoist_tasks`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>