### PR TITLE
feat(fetcher): wikipedia_* family — on_this_day / featured / random

### DIFF
--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -22,6 +22,7 @@ pub mod read_store;
 pub mod static_text;
 pub mod system;
 pub mod weather;
+pub mod wikipedia;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Safety {
@@ -273,6 +274,9 @@ impl Registry {
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
         for f in hackernews::fetchers() {
+            r.register(f);
+        }
+        for f in wikipedia::fetchers() {
             r.register(f);
         }
         for f in clock::realtime_fetchers() {

--- a/src/fetcher/wikipedia/client.rs
+++ b/src/fetcher/wikipedia/client.rs
@@ -1,0 +1,305 @@
+//! Shared HTTP client + URL helpers for the `wikipedia_*` family. Targets the public
+//! Wikipedia REST API at `https://{lang}.wikipedia.org/api/rest_v1/...` — host stays inside
+//! `*.wikipedia.org` regardless of which language code the config supplies, so every fetcher
+//! in the family is Safety::Safe.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+use crate::fetcher::FetchError;
+use crate::payload::{Body, LinkedLine, LinkedTextBlockData, TextBlockData, TextData};
+use crate::render::Shape;
+
+pub const REST_API_PATH: &str = "/api/rest_v1";
+pub const DEFAULT_LANG: &str = "en";
+const USER_AGENT: &str = concat!(
+    "splashboard/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/unhappychoice/splashboard-2)"
+);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub fn rest_api_base(lang: &str) -> String {
+    format!("https://{lang}.wikipedia.org{REST_API_PATH}")
+}
+
+pub async fn get<T: DeserializeOwned>(url: &str) -> Result<T, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("wikipedia request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("wikipedia {status}")));
+    }
+    res.json()
+        .await
+        .map_err(|e| FetchError::Failed(format!("wikipedia json parse: {e}")))
+}
+
+/// Page summary returned by `/page/random/summary`, embedded inside `feed/featured`'s `tfa`
+/// block, and inside each on-this-day event's `pages[]`. Featured / random share the rendering
+/// helpers below; on-this-day uses only `url()` to wire up event links.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PageSummary {
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub extract: Option<String>,
+    #[serde(default)]
+    pub content_urls: Option<ContentUrls>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ContentUrls {
+    #[serde(default)]
+    pub desktop: Option<UrlsByPlatform>,
+    #[serde(default)]
+    pub mobile: Option<UrlsByPlatform>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UrlsByPlatform {
+    pub page: String,
+}
+
+impl PageSummary {
+    pub fn url(&self) -> Option<String> {
+        self.content_urls
+            .as_ref()
+            .and_then(|c| c.desktop.as_ref().or(c.mobile.as_ref()))
+            .map(|p| p.page.clone())
+    }
+
+    /// First sentence of the extract — split at the first `". "` so the Text shape can carry a
+    /// preview without the whole multi-paragraph body. Returns `None` when the extract is
+    /// missing or empty.
+    pub fn first_sentence(&self) -> Option<String> {
+        let extract = self.extract.as_deref()?.trim();
+        if extract.is_empty() {
+            return None;
+        }
+        let cut = extract.find(". ").map(|i| i + 1).unwrap_or(extract.len());
+        Some(extract[..cut].trim().to_string())
+    }
+}
+
+/// Shape-aware rendering for a single page summary — shared by `wikipedia_featured` and
+/// `wikipedia_random` since both fetchers expose the same `{title, extract, url}` triplet.
+pub fn render_page_summary(summary: &PageSummary, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: text_line(summary),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: text_block_lines(summary),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: vec![LinkedLine {
+                text: summary.title.clone(),
+                url: summary.url(),
+            }],
+        }),
+    }
+}
+
+fn text_line(summary: &PageSummary) -> String {
+    match summary.first_sentence() {
+        Some(sentence) => format!("{}: {sentence}", summary.title),
+        None => summary.title.clone(),
+    }
+}
+
+fn text_block_lines(summary: &PageSummary) -> Vec<String> {
+    let mut lines = vec![summary.title.clone()];
+    if let Some(extract) = summary.extract.as_deref().filter(|s| !s.is_empty()) {
+        for line in extract.lines().filter(|l| !l.trim().is_empty()) {
+            lines.push(line.to_string());
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary_with(extract: Option<&str>, page_url: Option<&str>) -> PageSummary {
+        PageSummary {
+            title: "Quokka".into(),
+            extract: extract.map(String::from),
+            content_urls: page_url.map(|p| ContentUrls {
+                desktop: Some(UrlsByPlatform { page: p.into() }),
+                mobile: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn rest_api_base_uses_lang_subdomain() {
+        assert_eq!(rest_api_base("ja"), "https://ja.wikipedia.org/api/rest_v1");
+    }
+
+    #[test]
+    fn url_prefers_desktop_over_mobile() {
+        let s = summary_with(None, Some("https://en.wikipedia.org/wiki/Quokka"));
+        assert_eq!(
+            s.url().as_deref(),
+            Some("https://en.wikipedia.org/wiki/Quokka")
+        );
+    }
+
+    #[test]
+    fn url_falls_back_to_mobile_when_desktop_absent() {
+        let s = PageSummary {
+            title: "x".into(),
+            extract: None,
+            content_urls: Some(ContentUrls {
+                desktop: None,
+                mobile: Some(UrlsByPlatform {
+                    page: "https://en.m.wikipedia.org/wiki/x".into(),
+                }),
+            }),
+        };
+        assert_eq!(
+            s.url().as_deref(),
+            Some("https://en.m.wikipedia.org/wiki/x")
+        );
+    }
+
+    #[test]
+    fn url_is_none_when_content_urls_absent() {
+        assert!(summary_with(None, None).url().is_none());
+    }
+
+    #[test]
+    fn first_sentence_splits_on_period_space() {
+        let s = summary_with(Some("Apollo 11 was a mission. It landed in 1969."), None);
+        assert_eq!(
+            s.first_sentence().as_deref(),
+            Some("Apollo 11 was a mission.")
+        );
+    }
+
+    #[test]
+    fn first_sentence_returns_full_extract_when_no_period_space() {
+        let s = summary_with(Some("Single fragment"), None);
+        assert_eq!(s.first_sentence().as_deref(), Some("Single fragment"));
+    }
+
+    #[test]
+    fn first_sentence_returns_none_when_extract_missing_or_blank() {
+        assert!(summary_with(None, None).first_sentence().is_none());
+        assert!(summary_with(Some("   "), None).first_sentence().is_none());
+    }
+
+    #[test]
+    fn render_text_combines_title_and_first_sentence() {
+        let s = summary_with(Some("It hops. It is fluffy."), None);
+        let body = render_page_summary(&s, Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "Quokka: It hops.");
+    }
+
+    #[test]
+    fn render_text_falls_back_to_title_when_extract_missing() {
+        let body = render_page_summary(&summary_with(None, None), Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "Quokka");
+    }
+
+    #[test]
+    fn render_text_block_emits_title_then_extract_lines() {
+        let s = summary_with(Some("Para one.\n\nPara two."), None);
+        let body = render_page_summary(&s, Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines, vec!["Quokka", "Para one.", "Para two."]);
+    }
+
+    #[test]
+    fn render_text_block_emits_title_only_when_extract_empty() {
+        let s = summary_with(Some(""), None);
+        let body = render_page_summary(&s, Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines, vec!["Quokka"]);
+    }
+
+    #[test]
+    fn render_linked_text_block_uses_summary_url() {
+        let s = summary_with(None, Some("https://en.wikipedia.org/wiki/Quokka"));
+        let body = render_page_summary(&s, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(b.items[0].text, "Quokka");
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://en.wikipedia.org/wiki/Quokka")
+        );
+    }
+
+    #[test]
+    fn render_linked_text_block_drops_url_when_absent() {
+        let body = render_page_summary(&summary_with(None, None), Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items[0].url.is_none());
+    }
+
+    #[test]
+    fn page_summary_deserializes_real_api_payload() {
+        let raw = r#"{
+            "title": "Quokka",
+            "extract": "The quokka is a small macropod.",
+            "content_urls": {
+                "desktop": { "page": "https://en.wikipedia.org/wiki/Quokka" }
+            }
+        }"#;
+        let s: PageSummary = serde_json::from_str(raw).unwrap();
+        assert_eq!(s.title, "Quokka");
+        assert_eq!(
+            s.extract.as_deref(),
+            Some("The quokka is a small macropod.")
+        );
+        assert_eq!(
+            s.url().as_deref(),
+            Some("https://en.wikipedia.org/wiki/Quokka")
+        );
+    }
+
+    #[test]
+    fn page_summary_deserializes_with_only_title() {
+        let raw = r#"{"title":"x"}"#;
+        let s: PageSummary = serde_json::from_str(raw).unwrap();
+        assert_eq!(s.title, "x");
+        assert!(s.extract.is_none());
+        assert!(s.url().is_none());
+    }
+}

--- a/src/fetcher/wikipedia/featured.rs
+++ b/src/fetcher/wikipedia/featured.rs
@@ -1,0 +1,154 @@
+//! `wikipedia_featured` — today's Featured Article (TFA) via the Wikipedia REST API
+//! `feed/featured/{YYYY}/{MM}/{DD}` endpoint.
+//!
+//! Safety::Safe: host is `*.wikipedia.org`. The TFA slot is best populated for `lang = "en"`;
+//! other languages may return an empty `tfa` block, which surfaces as a fetch error so the
+//! splash falls back to its `error_placeholder`.
+
+use async_trait::async_trait;
+use chrono::{Datelike, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{DEFAULT_LANG, PageSummary, get, render_page_summary, rest_api_base};
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Text];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "lang",
+    type_hint: "string (Wikipedia language code)",
+    required: false,
+    default: Some("\"en\""),
+    description: "Wikipedia language edition. The TFA endpoint is best populated for `\"en\"`.",
+}];
+
+pub struct WikipediaFeaturedFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub lang: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for WikipediaFeaturedFetcher {
+    fn name(&self) -> &str {
+        "wikipedia_featured"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[(
+                "Hyperion (poem)",
+                Some("https://en.wikipedia.org/wiki/Hyperion_(poem)"),
+            )]),
+            Shape::TextBlock => samples::text_block(&[
+                "Hyperion (poem)",
+                "Hyperion is an unfinished epic poem by John Keats, recounting the despair of the Titans after their defeat by the Olympians.",
+            ]),
+            Shape::Text => {
+                samples::text("Hyperion (poem): Hyperion is an unfinished epic poem by John Keats.")
+            }
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let lang = opts.lang.as_deref().unwrap_or(DEFAULT_LANG);
+        let summary = fetch_tfa(lang).await?;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        Ok(payload(render_page_summary(&summary, shape)))
+    }
+}
+
+async fn fetch_tfa(lang: &str) -> Result<PageSummary, FetchError> {
+    let now = Utc::now();
+    let url = format!(
+        "{}/feed/featured/{:04}/{:02}/{:02}",
+        rest_api_base(lang),
+        now.year(),
+        now.month(),
+        now.day()
+    );
+    let response: FeaturedResponse = get(&url).await?;
+    response
+        .tfa
+        .ok_or_else(|| FetchError::Failed("wikipedia featured: no `tfa` in response".into()))
+}
+
+#[derive(Debug, Deserialize)]
+struct FeaturedResponse {
+    #[serde(default)]
+    tfa: Option<PageSummary>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_lang_to_none() {
+        let opts = Options::default();
+        assert!(opts.lang.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_lang() {
+        let raw: toml::Value = toml::from_str("lang = \"ja\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.lang.as_deref(), Some("ja"));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("lang = \"en\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn featured_response_deserializes_with_tfa() {
+        let raw = r#"{"tfa":{"title":"Hyperion","extract":"x.","content_urls":{"desktop":{"page":"https://en.wikipedia.org/wiki/Hyperion"}}}}"#;
+        let r: FeaturedResponse = serde_json::from_str(raw).unwrap();
+        let tfa = r.tfa.unwrap();
+        assert_eq!(tfa.title, "Hyperion");
+    }
+
+    #[test]
+    fn featured_response_deserializes_without_tfa() {
+        let raw = r#"{"news":[]}"#;
+        let r: FeaturedResponse = serde_json::from_str(raw).unwrap();
+        assert!(r.tfa.is_none());
+    }
+
+    /// Live smoke test — hits Wikipedia REST API.
+    #[tokio::test]
+    #[ignore]
+    async fn live_returns_a_featured_article() {
+        let s = fetch_tfa("en").await.unwrap();
+        eprintln!("featured: {}", s.title);
+        assert!(!s.title.is_empty());
+    }
+}

--- a/src/fetcher/wikipedia/mod.rs
+++ b/src/fetcher/wikipedia/mod.rs
@@ -1,0 +1,25 @@
+//! `wikipedia_*` fetcher family. Splits into:
+//!
+//! - `on_this_day` — historical events for today's MM/DD via `feed/onthisday`.
+//! - `featured` — today's Featured Article (TFA) via `feed/featured`.
+//! - `random` — a random page summary via `page/random/summary`.
+//!
+//! Shared HTTP client, base URL builder, page-summary type, and shape-aware rendering for
+//! single-article fetchers live in `client`.
+
+pub mod client;
+pub mod featured;
+pub mod on_this_day;
+pub mod random;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        Arc::new(on_this_day::WikipediaOnThisDayFetcher),
+        Arc::new(featured::WikipediaFeaturedFetcher),
+        Arc::new(random::WikipediaRandomFetcher),
+    ]
+}

--- a/src/fetcher/wikipedia/on_this_day.rs
+++ b/src/fetcher/wikipedia/on_this_day.rs
@@ -1,0 +1,474 @@
+//! `wikipedia_on_this_day` — historical events that occurred on today's calendar date,
+//! linked to their Wikipedia articles.
+//!
+//! Safety::Safe: host is `*.wikipedia.org`. The `lang` option picks a language subdomain;
+//! it can't redirect traffic outside Wikipedia.
+
+use async_trait::async_trait;
+use chrono::{Datelike, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, LinkedLine, LinkedTextBlockData, Payload, TextBlockData, TextData};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{DEFAULT_LANG, PageSummary, get, rest_api_base};
+
+const DEFAULT_LIMIT: u32 = 5;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 30;
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Text];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "kind",
+        type_hint: "\"selected\" | \"events\" | \"births\" | \"deaths\" | \"holidays\" | \"all\"",
+        required: false,
+        default: Some("\"selected\""),
+        description: "Which slice of the on-this-day feed to fetch. `selected` is the curated highlights.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("5"),
+        description: "Maximum number of events to display.",
+    },
+    OptionSchema {
+        name: "lang",
+        type_hint: "string (Wikipedia language code, e.g. `\"en\"` / `\"ja\"`)",
+        required: false,
+        default: Some("\"en\""),
+        description: "Wikipedia language edition to query.",
+    },
+];
+
+pub struct WikipediaOnThisDayFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub kind: Option<Kind>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub lang: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    #[default]
+    Selected,
+    Events,
+    Births,
+    Deaths,
+    Holidays,
+    All,
+}
+
+impl Kind {
+    fn endpoint(self) -> &'static str {
+        match self {
+            Self::Selected => "selected",
+            Self::Events => "events",
+            Self::Births => "births",
+            Self::Deaths => "deaths",
+            Self::Holidays => "holidays",
+            Self::All => "all",
+        }
+    }
+}
+
+#[async_trait]
+impl Fetcher for WikipediaOnThisDayFetcher {
+    fn name(&self) -> &str {
+        "wikipedia_on_this_day"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "1969 — Apollo 11 lands on the Moon",
+                    Some("https://en.wikipedia.org/wiki/Apollo_11"),
+                ),
+                (
+                    "1492 — Columbus departs Palos de la Frontera",
+                    Some("https://en.wikipedia.org/wiki/Christopher_Columbus"),
+                ),
+                (
+                    "1989 — Tim Berners-Lee proposes the World Wide Web",
+                    Some("https://en.wikipedia.org/wiki/World_Wide_Web"),
+                ),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                "1969 — Apollo 11 lands on the Moon",
+                "1492 — Columbus departs Palos de la Frontera",
+                "1989 — Tim Berners-Lee proposes the World Wide Web",
+            ]),
+            Shape::Text => samples::text("1969 — Apollo 11 lands on the Moon"),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let kind = opts.kind.unwrap_or_default();
+        let lang = opts.lang.as_deref().unwrap_or(DEFAULT_LANG);
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT) as usize;
+        let events = fetch_events(lang, kind).await?;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        Ok(payload(render_body(&events, shape, limit)))
+    }
+}
+
+async fn fetch_events(lang: &str, kind: Kind) -> Result<Vec<EventEntry>, FetchError> {
+    let now = Utc::now();
+    let url = format!(
+        "{}/feed/onthisday/{}/{:02}/{:02}",
+        rest_api_base(lang),
+        kind.endpoint(),
+        now.month(),
+        now.day()
+    );
+    let response: OnThisDayResponse = get(&url).await?;
+    Ok(response.into_events(kind))
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct OnThisDayResponse {
+    #[serde(default)]
+    selected: Vec<RawEvent>,
+    #[serde(default)]
+    events: Vec<RawEvent>,
+    #[serde(default)]
+    births: Vec<RawEvent>,
+    #[serde(default)]
+    deaths: Vec<RawEvent>,
+    #[serde(default)]
+    holidays: Vec<RawEvent>,
+}
+
+impl OnThisDayResponse {
+    fn into_events(self, kind: Kind) -> Vec<EventEntry> {
+        let raw = match kind {
+            Kind::Selected => self.selected,
+            Kind::Events => self.events,
+            Kind::Births => self.births,
+            Kind::Deaths => self.deaths,
+            Kind::Holidays => self.holidays,
+            Kind::All => {
+                let mut all = self.selected;
+                all.extend(self.events);
+                all.extend(self.births);
+                all.extend(self.deaths);
+                all.extend(self.holidays);
+                all
+            }
+        };
+        raw.into_iter().map(EventEntry::from_raw).collect()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEvent {
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    year: Option<i32>,
+    #[serde(default)]
+    pages: Vec<PageSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EventEntry {
+    label: String,
+    url: Option<String>,
+}
+
+impl EventEntry {
+    fn from_raw(raw: RawEvent) -> Self {
+        let label = match raw.year {
+            Some(year) => format!("{year} — {}", raw.text),
+            None => raw.text,
+        };
+        let url = raw.pages.first().and_then(|p| p.url());
+        Self { label, url }
+    }
+}
+
+fn render_body(events: &[EventEntry], shape: Shape, limit: usize) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: events.first().map(|e| e.label.clone()).unwrap_or_default(),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: events.iter().take(limit).map(|e| e.label.clone()).collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: events
+                .iter()
+                .take(limit)
+                .map(|e| LinkedLine {
+                    text: e.label.clone(),
+                    url: e.url.clone(),
+                })
+                .collect(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fetcher::wikipedia::client::{ContentUrls, UrlsByPlatform};
+
+    fn page(title: &str, url: &str) -> PageSummary {
+        PageSummary {
+            title: title.into(),
+            extract: None,
+            content_urls: Some(ContentUrls {
+                desktop: Some(UrlsByPlatform { page: url.into() }),
+                mobile: None,
+            }),
+        }
+    }
+
+    fn raw_event(year: Option<i32>, text: &str, pages: Vec<PageSummary>) -> RawEvent {
+        RawEvent {
+            text: text.into(),
+            year,
+            pages,
+        }
+    }
+
+    #[test]
+    fn options_default_to_none_for_every_field() {
+        let opts = Options::default();
+        assert!(opts.kind.is_none());
+        assert!(opts.limit.is_none());
+        assert!(opts.lang.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_kind_lang_limit() {
+        let raw: toml::Value =
+            toml::from_str("kind = \"births\"\nlimit = 3\nlang = \"ja\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.kind, Some(Kind::Births));
+        assert_eq!(opts.limit, Some(3));
+        assert_eq!(opts.lang.as_deref(), Some("ja"));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("kind = \"selected\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn kind_endpoint_covers_every_variant() {
+        assert_eq!(Kind::Selected.endpoint(), "selected");
+        assert_eq!(Kind::Events.endpoint(), "events");
+        assert_eq!(Kind::Births.endpoint(), "births");
+        assert_eq!(Kind::Deaths.endpoint(), "deaths");
+        assert_eq!(Kind::Holidays.endpoint(), "holidays");
+        assert_eq!(Kind::All.endpoint(), "all");
+    }
+
+    #[test]
+    fn event_entry_prefixes_year_when_present() {
+        let e = EventEntry::from_raw(raw_event(Some(1969), "Apollo 11 lands.", vec![]));
+        assert_eq!(e.label, "1969 — Apollo 11 lands.");
+        assert!(e.url.is_none());
+    }
+
+    #[test]
+    fn event_entry_omits_year_dash_when_year_missing() {
+        // Holidays don't have a `year` field — label stays as the raw text.
+        let e = EventEntry::from_raw(raw_event(None, "Independence Day", vec![]));
+        assert_eq!(e.label, "Independence Day");
+    }
+
+    #[test]
+    fn event_entry_url_uses_first_page() {
+        let e = EventEntry::from_raw(raw_event(
+            Some(1969),
+            "Apollo 11.",
+            vec![
+                page("Apollo 11", "https://en.wikipedia.org/wiki/Apollo_11"),
+                page("Moon", "https://en.wikipedia.org/wiki/Moon"),
+            ],
+        ));
+        assert_eq!(
+            e.url.as_deref(),
+            Some("https://en.wikipedia.org/wiki/Apollo_11")
+        );
+    }
+
+    fn entry(label: &str, url: Option<&str>) -> EventEntry {
+        EventEntry {
+            label: label.into(),
+            url: url.map(String::from),
+        }
+    }
+
+    #[test]
+    fn linked_text_block_default_carries_per_event_url() {
+        let events = vec![
+            entry("1969 — A", Some("https://en.wikipedia.org/A")),
+            entry("1066 — B", None),
+        ];
+        let body = render_body(&events, Shape::LinkedTextBlock, 5);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 2);
+        assert_eq!(b.items[0].text, "1969 — A");
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://en.wikipedia.org/A")
+        );
+        assert!(b.items[1].url.is_none());
+    }
+
+    #[test]
+    fn text_block_drops_links_keeps_label_lines() {
+        let events = vec![
+            entry("1969 — A", Some("https://en.wikipedia.org/A")),
+            entry("1066 — B", None),
+        ];
+        let body = render_body(&events, Shape::TextBlock, 5);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines, vec!["1969 — A", "1066 — B"]);
+    }
+
+    #[test]
+    fn text_shape_emits_first_event_label() {
+        let events = vec![entry("1969 — A", None), entry("1066 — B", None)];
+        let body = render_body(&events, Shape::Text, 5);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "1969 — A");
+    }
+
+    #[test]
+    fn text_shape_is_empty_when_no_events() {
+        let body = render_body(&[], Shape::Text, 5);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.is_empty());
+    }
+
+    #[test]
+    fn limit_caps_emitted_rows() {
+        let events: Vec<_> = (0..10).map(|i| entry(&format!("e{i}"), None)).collect();
+        let body = render_body(&events, Shape::LinkedTextBlock, 3);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 3);
+    }
+
+    #[test]
+    fn empty_events_produce_empty_linked_text_block() {
+        let body = render_body(&[], Shape::LinkedTextBlock, 5);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items.is_empty());
+    }
+
+    #[test]
+    fn into_events_kind_selected_returns_only_selected_slice() {
+        let resp = OnThisDayResponse {
+            selected: vec![raw_event(Some(1), "s", vec![])],
+            events: vec![raw_event(Some(2), "e", vec![])],
+            ..Default::default()
+        };
+        let events = resp.into_events(Kind::Selected);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].label.contains("s"));
+    }
+
+    #[test]
+    fn into_events_kind_all_concatenates_every_slice() {
+        let resp = OnThisDayResponse {
+            selected: vec![raw_event(Some(1), "s", vec![])],
+            events: vec![raw_event(Some(2), "e", vec![])],
+            births: vec![raw_event(Some(3), "b", vec![])],
+            deaths: vec![raw_event(Some(4), "d", vec![])],
+            holidays: vec![raw_event(None, "h", vec![])],
+        };
+        let events = resp.into_events(Kind::All);
+        assert_eq!(events.len(), 5);
+    }
+
+    #[test]
+    fn limit_clamps_extremes() {
+        assert_eq!(0u32.clamp(MIN_LIMIT, MAX_LIMIT), MIN_LIMIT);
+        assert_eq!(999u32.clamp(MIN_LIMIT, MAX_LIMIT), MAX_LIMIT);
+        assert_eq!(DEFAULT_LIMIT.clamp(MIN_LIMIT, MAX_LIMIT), DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn response_deserializes_realistic_payload() {
+        let raw = r#"{
+            "selected": [
+                { "year": 1969, "text": "Apollo 11.", "pages": [
+                    { "title": "Apollo 11",
+                      "content_urls": { "desktop": { "page": "https://en.wikipedia.org/wiki/Apollo_11" } } }
+                ]}
+            ],
+            "holidays": [
+                { "text": "Independence Day", "pages": [] }
+            ]
+        }"#;
+        let r: OnThisDayResponse = serde_json::from_str(raw).unwrap();
+        let selected = r.into_events(Kind::Selected);
+        assert_eq!(selected[0].label, "1969 — Apollo 11.");
+        assert_eq!(
+            selected[0].url.as_deref(),
+            Some("https://en.wikipedia.org/wiki/Apollo_11")
+        );
+    }
+
+    /// Live smoke test — hits Wikipedia REST API. `#[ignore]` keeps CI offline-safe.
+    #[tokio::test]
+    #[ignore]
+    async fn live_returns_at_least_one_event() {
+        let events = fetch_events("en", Kind::Selected).await.unwrap();
+        assert!(!events.is_empty());
+        for e in &events {
+            eprintln!("{} → {}", e.label, e.url.as_deref().unwrap_or("(no url)"));
+        }
+    }
+}

--- a/src/fetcher/wikipedia/random.rs
+++ b/src/fetcher/wikipedia/random.rs
@@ -1,0 +1,121 @@
+//! `wikipedia_random` — a random page summary via `/page/random/summary`.
+//!
+//! Safety::Safe: host is `*.wikipedia.org`. Same `{title, extract, url}` triplet as
+//! `wikipedia_featured`, just with a non-curated picker on the server side. Cache TTL
+//! controls how often a new article is drawn — at the default `refresh_interval` the page
+//! sticks for the configured window rather than rotating on every splash open.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{DEFAULT_LANG, PageSummary, get, render_page_summary, rest_api_base};
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Text];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "lang",
+    type_hint: "string (Wikipedia language code)",
+    required: false,
+    default: Some("\"en\""),
+    description: "Wikipedia language edition.",
+}];
+
+pub struct WikipediaRandomFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub lang: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for WikipediaRandomFetcher {
+    fn name(&self) -> &str {
+        "wikipedia_random"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[(
+                "Quokka",
+                Some("https://en.wikipedia.org/wiki/Quokka"),
+            )]),
+            Shape::TextBlock => samples::text_block(&[
+                "Quokka",
+                "The quokka is a small macropod about the size of a domestic cat, native to small islands and a small mainland area of southwestern Australia.",
+            ]),
+            Shape::Text => {
+                samples::text("Quokka: A small macropod native to southwestern Australia.")
+            }
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let lang = opts.lang.as_deref().unwrap_or(DEFAULT_LANG);
+        let summary = fetch_random(lang).await?;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        Ok(payload(render_page_summary(&summary, shape)))
+    }
+}
+
+async fn fetch_random(lang: &str) -> Result<PageSummary, FetchError> {
+    let url = format!("{}/page/random/summary", rest_api_base(lang));
+    get::<PageSummary>(&url).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_lang_to_none() {
+        assert!(Options::default().lang.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_lang() {
+        let raw: toml::Value = toml::from_str("lang = \"ja\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.lang.as_deref(), Some("ja"));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("lang = \"en\"\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    /// Live smoke test — hits Wikipedia REST API.
+    #[tokio::test]
+    #[ignore]
+    async fn live_returns_a_random_article() {
+        let s = fetch_random("en").await.unwrap();
+        eprintln!("random: {}", s.title);
+        assert!(!s.title.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `wikipedia_*` fetcher family on top of the public Wikipedia REST
API. Three fetchers, one shared HTTP client, all Safety::Safe.

- **`wikipedia_on_this_day`** — historical events for today's MM/DD via
  `feed/onthisday/{kind}/{MM}/{DD}`.
- **`wikipedia_featured`** — today's Featured Article (TFA) via
  `feed/featured/{YYYY}/{MM}/{DD}`.
- **`wikipedia_random`** — a random page summary via
  `page/random/summary`.

Each fetcher emits **`LinkedTextBlock` (default) / `TextBlock` / `Text`** —
the link is the primary affordance, and the other shapes are opt-down
fallbacks for layouts that don't want OSC 8 chrome (TextBlock) or that
want a single-line distillation (Text).

### Why these three together

`hackernews_*` shipped with one client + several fetchers in the same PR
(#148). Same pattern here: one Wikipedia REST client, three sibling
fetchers. The shared `PageSummary` parses the `{title, extract,
content_urls, thumbnail}` triplet that featured / random / on_this_day
event-pages all return, so featured + random reuse a single rendering
helper and on_this_day reuses only `url()` for per-event links.

### Safety: why Safe, not Network

The host stays inside `*.wikipedia.org` regardless of the `lang` option —
config can pick a language subdomain (`en` / `ja` / etc.) but can't
redirect traffic outside Wikipedia. Same shape as `github_*` where
`repo` varies but the host stays `api.github.com`.

### Decisions worth flagging at review

- **`Text` shape for on_this_day = `selected[0]` headline.** Deterministic
  per `kind`, not random — matches the rest of splashboard's
  determinism-by-default posture (quote_of_day, calendar today). Holidays
  have no `year`, so the label drops the `YYYY — ` prefix instead of
  prefixing a stranded dash.
- **`Text` shape for featured / random = `"<title>: <first sentence>"`**
  using a naive `". "` split. Returns the trimmed extract verbatim if no
  period boundary is found.
- **Shape ordering.** `[LinkedTextBlock, TextBlock, Text]` so
  `default_shape()` lands on `LinkedTextBlock` for every fetcher.
- **`wikipedia_random` cache TTL.** Uses the runtime default
  (`refresh_interval`) — no per-fetcher tuning. Users who want a "did you
  know"-style sticky article set `refresh_interval` themselves.

Catalog: ticks `wikipedia_on_this_day` / `wikipedia_featured` /
`wikipedia_random` in #67. Unblocks #150 (home_feed body 2 = on_this_day +
weather; body 3 fallback uses featured).

## Reference (mirrors auto-generated docs)

### `wikipedia_on_this_day`

- Kind: cached
- Safety: Safe
- Shapes: `linked_text_block`, `text_block`, `text`

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `kind` | \`\"selected\" \| \"events\" \| \"births\" \| \"deaths\" \| \"holidays\" \| \"all\"\` | no | `\"selected\"` | Which slice of the on-this-day feed to fetch. `selected` is the curated highlights. |
| `limit` | integer (1..=30) | no | `5` | Maximum number of events to display. |
| `lang` | string (Wikipedia language code, e.g. `\"en\"` / `\"ja\"`) | no | `\"en\"` | Wikipedia language edition to query. |

Compatible renderers (per shape):
- `linked_text_block` → [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/)
- `text_block` → `animated_boot`, `animated_postfx`, `animated_scanlines`, `animated_splitflap`, `animated_wave`, [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/)
- `text` → `animated_boot`, `animated_figlet_morph`, `animated_postfx`, `animated_scanlines`, `animated_splitflap`, `animated_typewriter`, `animated_wave`, [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/)

### `wikipedia_featured`

- Kind: cached
- Safety: Safe
- Shapes: `linked_text_block`, `text_block`, `text`

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `lang` | string (Wikipedia language code) | no | `\"en\"` | Wikipedia language edition. The TFA endpoint is best populated for `\"en\"`. |

### `wikipedia_random`

- Kind: cached
- Safety: Safe
- Shapes: `linked_text_block`, `text_block`, `text`

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `lang` | string (Wikipedia language code) | no | `\"en\"` | Wikipedia language edition. |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (724 passed, 7 ignored)
- [x] Live smoke tests against the real Wikipedia REST API for all three
  endpoints (`cargo test wikipedia -- --ignored`) — confirmed payload
  shapes match `PageSummary` / `OnThisDayResponse` / `FeaturedResponse`.
- [x] Local smoke test: `cargo run --bin splashboard` with all three
  fetchers in three shapes each — confirmed clickable rows, extract
  preview, and headline distillation all render.
- [ ] Verify rendering with `lang = "ja"` on `wikipedia_featured` — TFA
  may be sparser; reviewer can sanity-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Wikipedia integration with three new fetchers: Featured Article (daily featured content), On This Day (historical events, births, deaths, and holidays), and Random Page summary.
  * Support for multiple languages and configurable output formats (text preview, text block, linked content).
  * Intelligent caching for improved performance and reduced API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->