### PR TITLE
feat(fetcher): add rss feed reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -956,6 +959,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "feed-rs"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml 0.37.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2703,6 +2723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,7 +3204,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3324,6 +3353,16 @@ dependencies = [
  "rayon",
  "ref-cast",
  "wide",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -4113,6 +4152,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "dirs",
+ "feed-rs",
  "figlet-rs",
  "gix",
  "image",
@@ -4857,6 +4897,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tracing = { version = "0.1", default-features = false, features = ["std", "attri
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
 tui-markdown = "0.3.7"
+feed-rs = { version = "2", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -22,6 +22,7 @@ pub mod github;
 pub mod hackernews;
 pub mod quote_of_day;
 pub mod read_store;
+pub mod rss;
 pub mod static_text;
 pub mod system;
 pub mod todoist;
@@ -315,6 +316,7 @@ impl Registry {
         let mut r = Self::default();
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
+        r.register(Arc::new(rss::RssFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
         for f in hackernews::fetchers() {
             r.register(f);

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -8,7 +8,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, Payload, TextBlockData};
+use crate::payload::{
+    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, Payload,
+    TextBlockData, TextData,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -134,18 +137,58 @@ pub struct ShapeMismatch {
     pub requested: Shape,
 }
 
+/// Build a placeholder body of the given shape from a list of message lines. Every text-shaped
+/// renderer can carry a 2-line hint, so trust / error / timeout / unknown-fetcher placeholders
+/// stay legible regardless of which renderer is configured. Non-text shapes fall back to
+/// `TextBlock` — the renderer will still reject it, but at least the message text shows up
+/// inside the resulting shape-mismatch warning rather than vanishing.
+pub fn placeholder_body(shape: Shape, lines: &[&str]) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: lines.join(" — "),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: lines.iter().map(|s| (*s).to_string()).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: lines.join("\n\n"),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: lines
+                .iter()
+                .map(|s| LinkedLine {
+                    text: (*s).to_string(),
+                    url: None,
+                })
+                .collect(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: lines
+                .iter()
+                .map(|s| Entry {
+                    key: (*s).to_string(),
+                    value: None,
+                    status: None,
+                })
+                .collect(),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: lines.iter().map(|s| (*s).to_string()).collect(),
+        }),
+    }
+}
+
 /// Structure mirrors [`crate::trust::requires_trust_placeholder`] — a two-line hint so the user
-/// can tell what's wrong without opening logs.
+/// can tell what's wrong without opening logs. The body matches the renderer's expected shape so
+/// the message renders inline rather than triggering a second-order shape-mismatch error.
 pub fn shape_mismatch_placeholder(err: &ShapeMismatch) -> Payload {
-    let lines = vec![
-        format!("⚠ {} can't emit {}", err.fetcher, err.requested.as_str()),
-        "check `render` in config".into(),
-    ];
+    let line1 = format!("⚠ {} can't emit {}", err.fetcher, err.requested.as_str());
+    let lines = [line1.as_str(), "check `render` in config"];
     Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::TextBlock(TextBlockData { lines }),
+        body: placeholder_body(err.requested, &lines),
     }
 }
 
@@ -153,44 +196,37 @@ pub fn shape_mismatch_placeholder(err: &ShapeMismatch) -> Payload {
 /// the renderer side of the contract (`render_payload` draws `unknown renderer: <name>` for the
 /// same situation): the typical trigger is an installed binary older than the config it's reading,
 /// so the second line points at upgrading rather than the log file.
-pub fn unknown_fetcher_placeholder(name: &str) -> Payload {
+pub fn unknown_fetcher_placeholder(shape: Shape, name: &str) -> Payload {
+    let line1 = format!("⚠ unknown fetcher: {name}");
     Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::TextBlock(TextBlockData {
-            lines: vec![
-                format!("⚠ unknown fetcher: {name}"),
-                "upgrade splashboard?".into(),
-            ],
-        }),
+        body: placeholder_body(shape, &[line1.as_str(), "upgrade splashboard?"]),
     }
 }
 
 /// Payload rendered in place of a widget whose fetch returned `Err`. One-line `⚠ <msg>`, with a
 /// follow-up pointer to the log file so the user can track structured details (error chain,
 /// cache key, fetcher name) without forcing a second line into the splash for every error.
-pub fn error_placeholder(msg: &str) -> Payload {
+pub fn error_placeholder(shape: Shape, msg: &str) -> Payload {
+    let line1 = format!("⚠ {msg}");
     Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::TextBlock(TextBlockData {
-            lines: vec![format!("⚠ {msg}"), "see $HOME/.splashboard/logs".into()],
-        }),
+        body: placeholder_body(shape, &[line1.as_str(), "see $HOME/.splashboard/logs"]),
     }
 }
 
 /// Payload rendered in place of a widget whose fetch exceeded the runtime deadline. Kept
 /// separate from [`error_placeholder`] so users can tell "slow" from "broken" at a glance.
-pub fn timeout_placeholder() -> Payload {
+pub fn timeout_placeholder(shape: Shape) -> Payload {
     Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::TextBlock(TextBlockData {
-            lines: vec!["⏱ timed out".into(), "see $HOME/.splashboard/logs".into()],
-        }),
+        body: placeholder_body(shape, &["⏱ timed out", "see $HOME/.splashboard/logs"]),
     }
 }
 
@@ -529,7 +565,7 @@ mod tests {
 
     #[test]
     fn unknown_fetcher_placeholder_mentions_name_and_upgrade_hint() {
-        let p = unknown_fetcher_placeholder("system_battery");
+        let p = unknown_fetcher_placeholder(Shape::TextBlock, "system_battery");
         match p.body {
             Body::TextBlock(t) => {
                 assert!(
@@ -546,5 +582,54 @@ mod tests {
             }
             other => panic!("expected TextBlock body, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn placeholder_body_adapts_to_shape() {
+        // TextBlock — straight passthrough.
+        let body = placeholder_body(Shape::TextBlock, &["hello", "world"]);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines, vec!["hello".to_string(), "world".to_string()]);
+
+        // LinkedTextBlock — text without URL so list_links can render the message.
+        let body = placeholder_body(Shape::LinkedTextBlock, &["hello", "world"]);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 2);
+        assert!(b.items.iter().all(|i| i.url.is_none()));
+
+        // Text — joined into one string so single-line renderers (`text_plain`) get a hint.
+        let body = placeholder_body(Shape::Text, &["hello", "world"]);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("hello") && t.value.contains("world"));
+
+        // Entries — each line becomes a key with no value, so grid_table renders rows.
+        let body = placeholder_body(Shape::Entries, &["hello"]);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "hello");
+        assert!(e.items[0].value.is_none());
+
+        // Non-text shape — falls back to TextBlock; the renderer will still warn but the
+        // message text is preserved rather than vanishing.
+        let body = placeholder_body(Shape::Ratio, &["x"]);
+        assert!(matches!(body, Body::TextBlock(_)));
+    }
+
+    #[test]
+    fn requires_trust_placeholder_via_fetcher_module_emits_link_shape() {
+        // Cross-module sanity: trust gate routes through `placeholder_body`, so a
+        // `LinkedTextBlock`-expecting renderer must see a `LinkedTextBlock` body.
+        let body = placeholder_body(
+            Shape::LinkedTextBlock,
+            &["🔒 requires trust", "run `splashboard trust`"],
+        );
+        assert!(matches!(body, Body::LinkedTextBlock(_)));
     }
 }

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -227,10 +227,17 @@ fn collapse_whitespace(s: &str) -> String {
 }
 
 fn link_for(entry: &Entry) -> Option<String> {
-    entry
+    // Atom entries can carry multiple <link> with `rel` discriminators (`alternate`, `self`,
+    // `enclosure`, `via`, …). Per RFC 4287 the article URL is `rel="alternate"`, which is also
+    // the default when `rel` is absent — matching RSS 2.0's single-link case. Picking the first
+    // non-empty href would otherwise grab `rel="self"` (a self-pointer back into the feed) on
+    // common Atom shapes.
+    let alternate = entry
         .links
         .iter()
-        .find(|l| !l.href.is_empty())
+        .find(|l| !l.href.is_empty() && matches!(l.rel.as_deref(), None | Some("alternate")));
+    alternate
+        .or_else(|| entry.links.iter().find(|l| !l.href.is_empty()))
         .map(|l| l.href.clone())
 }
 
@@ -467,6 +474,36 @@ mod tests {
     #[test]
     fn announces_network_safety() {
         assert_eq!(RssFetcher.safety(), Safety::Network);
+    }
+
+    /// Atom feeds frequently carry both `rel="self"` (feed-internal permalink) and
+    /// `rel="alternate"` (the article URL). Picking the first non-empty link would surface the
+    /// self-pointer; readers want the alternate.
+    const ATOM_MULTI_REL_FIXTURE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>multi rel</title>
+  <id>urn:atom:m</id>
+  <updated>2026-04-26T10:00:00Z</updated>
+  <entry>
+    <title>Pick the article URL</title>
+    <id>urn:atom:m:1</id>
+    <link rel="self" href="https://feed.example.com/entries/1"/>
+    <link rel="alternate" href="https://example.com/articles/1"/>
+    <updated>2026-04-26T10:00:00Z</updated>
+  </entry>
+</feed>"#;
+
+    #[test]
+    fn link_prefers_alternate_over_self_in_atom() {
+        let feed = parse(ATOM_MULTI_REL_FIXTURE);
+        let body = render_body(&feed, 5, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://example.com/articles/1")
+        );
     }
 
     /// Live smoke test — hits the Rust blog's feed. `#[ignore]` keeps CI offline-safe; run with

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -1,0 +1,488 @@
+//! `rss` — generic feed fetcher (RSS 2.0 / RSS 1.0 / Atom / JSON Feed via `feed-rs`).
+//!
+//! Safety::Network — the URL is config-provided, so the destination is whatever the user (or a
+//! local-config they trust) types. Local configs must be `splashboard trust`-ed before this
+//! widget runs; global config is implicitly trusted.
+//!
+//! Output shapes: `LinkedTextBlock` (default — clickable rows for `list_links`) and `TextBlock`
+//! (titles only). Lines are `MMM DD  Article title`, mirroring `hackernews_top`'s
+//! `234pt 56c  Title` rhythm so the same renderer slot stays visually consistent.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use feed_rs::model::{Entry, Feed};
+use feed_rs::parser;
+use reqwest::Client;
+use serde::Deserialize;
+use url::Url;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, LinkedLine, LinkedTextBlockData, Payload, TextBlockData};
+use crate::render::Shape;
+use crate::samples;
+
+const DEFAULT_COUNT: u32 = 5;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 20;
+
+/// Cap raw response bytes so a hostile / runaway feed can't OOM the daemon.
+const MAX_BYTES: usize = 5 * 1024 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+
+const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "url",
+        type_hint: "string (http / https)",
+        required: true,
+        default: None,
+        description: "Feed URL — RSS 2.0, RSS 1.0, Atom, or JSON Feed.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("5"),
+        description: "Number of feed entries to display.",
+    },
+];
+
+pub struct RssFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for RssFetcher {
+    fn name(&self) -> &str {
+        "rss"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Network
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                ("Apr 26  Why X over Y", Some("https://example.com/post-1")),
+                (
+                    "Apr 24  Release notes 0.42",
+                    Some("https://example.com/post-2"),
+                ),
+                ("Apr 22  A short note", Some("https://example.com/post-3")),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                "Apr 26  Why X over Y",
+                "Apr 24  Release notes 0.42",
+                "Apr 22  A short note",
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let url = validated_url(opts.url.as_deref())?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let bytes = fetch_bytes(&url).await?;
+        let feed = parser::parse(bytes.as_slice())
+            .map_err(|e| FetchError::Failed(format!("rss parse: {e}")))?;
+        Ok(payload(render_body(
+            &feed,
+            count,
+            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
+        )))
+    }
+}
+
+fn validated_url(raw: Option<&str>) -> Result<Url, FetchError> {
+    let raw = raw
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| FetchError::Failed("rss: option `url` is required".into()))?;
+    let parsed =
+        Url::parse(raw).map_err(|e| FetchError::Failed(format!("rss: invalid url: {e}")))?;
+    match parsed.scheme() {
+        "http" | "https" => Ok(parsed),
+        other => Err(FetchError::Failed(format!(
+            "rss: unsupported url scheme `{other}` (only http/https allowed)"
+        ))),
+    }
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+async fn fetch_bytes(url: &Url) -> Result<Vec<u8>, FetchError> {
+    let res = http()
+        .get(url.as_str())
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("rss request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("rss {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("rss read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "rss response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes.to_vec())
+}
+
+fn render_body(feed: &Feed, count: usize, shape: Shape) -> Body {
+    let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
+    match shape {
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: entries.iter().map(|e| line_text(e)).collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: entries
+                .iter()
+                .map(|e| LinkedLine {
+                    text: line_text(e),
+                    url: link_for(e),
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn line_text(entry: &Entry) -> String {
+    let date = date_label(entry);
+    let title = title_or_placeholder(entry);
+    if date.is_empty() {
+        title
+    } else {
+        format!("{date}  {title}")
+    }
+}
+
+fn date_label(entry: &Entry) -> String {
+    entry
+        .published
+        .or(entry.updated)
+        .map(format_short)
+        .unwrap_or_default()
+}
+
+fn format_short(dt: DateTime<Utc>) -> String {
+    dt.format("%b %d").to_string()
+}
+
+fn title_or_placeholder(entry: &Entry) -> String {
+    entry
+        .title
+        .as_ref()
+        .map(|t| collapse_whitespace(&t.content))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "(no title)".into())
+}
+
+fn collapse_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn link_for(entry: &Entry) -> Option<String> {
+    entry
+        .links
+        .iter()
+        .find(|l| !l.href.is_empty())
+        .map(|l| l.href.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.url.is_none());
+        assert!(opts.count.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_url_and_count() {
+        let raw: toml::Value =
+            toml::from_str("url = \"https://example.com/feed.xml\"\ncount = 7").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.url.as_deref(), Some("https://example.com/feed.xml"));
+        assert_eq!(opts.count, Some(7));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("url = \"https://e.com\"\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn missing_url_is_error() {
+        let err = validated_url(None).unwrap_err();
+        match err {
+            FetchError::Failed(m) => assert!(m.contains("required"), "msg: {m}"),
+            _ => panic!("expected Failed"),
+        }
+    }
+
+    #[test]
+    fn empty_url_is_error() {
+        assert!(validated_url(Some("   ")).is_err());
+    }
+
+    #[test]
+    fn rejects_non_http_schemes() {
+        for bad in ["file:///etc/passwd", "ftp://x", "data:,abc", "javascript:0"] {
+            let err = validated_url(Some(bad)).unwrap_err();
+            match err {
+                FetchError::Failed(m) => assert!(
+                    m.contains("scheme") || m.contains("invalid url"),
+                    "expected scheme rejection for {bad}: {m}"
+                ),
+                _ => panic!("expected Failed for {bad}"),
+            }
+        }
+    }
+
+    #[test]
+    fn accepts_http_and_https() {
+        assert!(validated_url(Some("http://example.com/feed")).is_ok());
+        assert!(validated_url(Some("https://example.com/feed")).is_ok());
+    }
+
+    const RSS_FIXTURE: &str = r#"<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Example</title>
+    <link>https://example.com</link>
+    <description>x</description>
+    <item>
+      <title>First post</title>
+      <link>https://example.com/1</link>
+      <pubDate>Sun, 26 Apr 2026 09:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Second post</title>
+      <link>https://example.com/2</link>
+      <pubDate>Fri, 24 Apr 2026 11:30:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>"#;
+
+    const ATOM_FIXTURE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Example</title>
+  <id>urn:atom:1</id>
+  <updated>2026-04-26T10:00:00Z</updated>
+  <entry>
+    <title>Atom one</title>
+    <id>urn:atom:1:1</id>
+    <link href="https://example.com/atom-1"/>
+    <updated>2026-04-26T10:00:00Z</updated>
+  </entry>
+</feed>"#;
+
+    fn parse(fixture: &str) -> Feed {
+        parser::parse(fixture.as_bytes()).expect("fixture must parse")
+    }
+
+    #[test]
+    fn rss_parses_into_linked_text_block_with_dates_and_urls() {
+        let feed = parse(RSS_FIXTURE);
+        let body = render_body(&feed, 5, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 2);
+        assert!(b.items[0].text.contains("First post"));
+        assert!(b.items[0].text.starts_with("Apr 26"));
+        assert_eq!(b.items[0].url.as_deref(), Some("https://example.com/1"));
+    }
+
+    #[test]
+    fn rss_parses_into_text_block_without_urls() {
+        let feed = parse(RSS_FIXTURE);
+        let body = render_body(&feed, 5, Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines.len(), 2);
+        assert!(t.lines[0].contains("First post"));
+    }
+
+    #[test]
+    fn atom_parses_with_link_and_date() {
+        let feed = parse(ATOM_FIXTURE);
+        let body = render_body(&feed, 5, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://example.com/atom-1")
+        );
+        assert!(b.items[0].text.contains("Atom one"));
+    }
+
+    #[test]
+    fn count_caps_entries() {
+        let feed = parse(RSS_FIXTURE);
+        let body = render_body(&feed, 1, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 1);
+    }
+
+    #[test]
+    fn empty_feed_renders_empty_body() {
+        let empty = Feed {
+            feed_type: feed_rs::model::FeedType::RSS2,
+            id: String::new(),
+            updated: None,
+            authors: vec![],
+            title: None,
+            description: None,
+            links: vec![],
+            categories: vec![],
+            contributors: vec![],
+            generator: None,
+            icon: None,
+            language: None,
+            logo: None,
+            published: None,
+            rating: None,
+            rights: None,
+            ttl: None,
+            entries: vec![],
+        };
+        let body = render_body(&empty, 5, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items.is_empty());
+    }
+
+    #[test]
+    fn missing_title_falls_back_to_placeholder() {
+        let mut feed = parse(RSS_FIXTURE);
+        feed.entries[0].title = None;
+        let body = render_body(&feed, 1, Shape::TextBlock);
+        let Body::TextBlock(t) = body else {
+            panic!("expected text block");
+        };
+        assert!(t.lines[0].contains("(no title)"));
+    }
+
+    #[test]
+    fn collapses_whitespace_in_titles() {
+        // RSS titles sometimes have embedded newlines / runs of spaces — render on one line.
+        assert_eq!(
+            collapse_whitespace("hello\n  world\t!"),
+            "hello world !".to_string()
+        );
+    }
+
+    #[test]
+    fn count_clamps_extremes() {
+        assert_eq!(0u32.clamp(MIN_COUNT, MAX_COUNT), MIN_COUNT);
+        assert_eq!(999u32.clamp(MIN_COUNT, MAX_COUNT), MAX_COUNT);
+        assert_eq!(DEFAULT_COUNT.clamp(MIN_COUNT, MAX_COUNT), DEFAULT_COUNT);
+    }
+
+    #[test]
+    fn cache_key_varies_with_url() {
+        let f = RssFetcher;
+        let parse_opts =
+            |raw: &str| -> toml::Value { toml::from_str(raw).expect("test toml must parse") };
+        let mut a = FetchContext {
+            widget_id: "w".into(),
+            ..Default::default()
+        };
+        let mut b = a.clone();
+        a.options = Some(parse_opts("url = \"https://a.example/feed\""));
+        b.options = Some(parse_opts("url = \"https://b.example/feed\""));
+        assert_ne!(f.cache_key(&a), f.cache_key(&b));
+    }
+
+    #[test]
+    fn sample_body_covers_both_shapes() {
+        let f = RssFetcher;
+        assert!(matches!(
+            f.sample_body(Shape::LinkedTextBlock),
+            Some(Body::LinkedTextBlock(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::TextBlock),
+            Some(Body::TextBlock(_))
+        ));
+        assert!(f.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn announces_network_safety() {
+        assert_eq!(RssFetcher.safety(), Safety::Network);
+    }
+
+    /// Live smoke test — hits the Rust blog's feed. `#[ignore]` keeps CI offline-safe; run with
+    /// `cargo test -- --ignored fetcher::rss::tests::live` to verify the real fetch path.
+    #[tokio::test]
+    #[ignore]
+    async fn live_rust_blog_feed_returns_at_least_one_entry() {
+        let url = validated_url(Some("https://blog.rust-lang.org/feed.xml")).unwrap();
+        let bytes = fetch_bytes(&url).await.unwrap();
+        let feed = parser::parse(bytes.as_slice()).unwrap();
+        assert!(!feed.entries.is_empty());
+        let body = render_body(&feed, 3, Shape::LinkedTextBlock);
+        if let Body::LinkedTextBlock(b) = body {
+            for it in &b.items {
+                eprintln!("{}  -> {:?}", it.text, it.url);
+            }
+        }
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -269,12 +269,14 @@ pub async fn run(
         &shapes,
     ));
     for w in &gated {
-        payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
+        payloads.insert(w.id.clone(), trust::requires_trust_placeholder(shape));
     }
     for w in &unknown {
+        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
         payloads.insert(
             w.id.clone(),
-            fetcher::unknown_fetcher_placeholder(&w.fetcher),
+            fetcher::unknown_fetcher_placeholder(shape, &w.fetcher),
         );
     }
     for (w, err) in &shape_invalid {
@@ -529,12 +531,14 @@ fn refresh_payloads(
         payloads.insert(id, payload);
     }
     for w in buckets.gated {
-        payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
+        payloads.insert(w.id.clone(), trust::requires_trust_placeholder(shape));
     }
     for w in buckets.unknown {
+        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
         payloads.insert(
             w.id.clone(),
-            fetcher::unknown_fetcher_placeholder(&w.fetcher),
+            fetcher::unknown_fetcher_placeholder(shape, &w.fetcher),
         );
     }
     for (w, err) in buckets.shape_invalid {
@@ -631,7 +635,10 @@ async fn fetch_all(
                         cache_key,
                         ERROR_CACHE_TTL_SECS,
                         CacheEntryKind::Err,
-                        fetcher::error_placeholder(&e.to_string()),
+                        fetcher::error_placeholder(
+                            ctx.shape.unwrap_or(Shape::TextBlock),
+                            &e.to_string(),
+                        ),
                     )
                 }
                 Err(_) => {
@@ -647,7 +654,7 @@ async fn fetch_all(
                         cache_key,
                         ERROR_CACHE_TTL_SECS,
                         CacheEntryKind::Timeout,
-                        fetcher::timeout_placeholder(),
+                        fetcher::timeout_placeholder(ctx.shape.unwrap_or(Shape::TextBlock)),
                     )
                 }
             }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use crate::cache::tmp_path_for;
 use crate::config::{DashboardConfig, WidgetConfig};
 use crate::fetcher::{Registry, Safety};
-use crate::payload::{Body, Payload, TextBlockData};
+use crate::payload::Payload;
 
 const TRUST_ALL_ENV: &str = "SPLASHBOARD_TRUST_ALL";
 
@@ -153,14 +153,15 @@ pub fn partition_by_trust(
         })
 }
 
-pub fn requires_trust_placeholder() -> Payload {
+pub fn requires_trust_placeholder(shape: crate::render::Shape) -> Payload {
     Payload {
         icon: None,
         status: None,
         format: None,
-        body: Body::TextBlock(TextBlockData {
-            lines: vec!["🔒 requires trust".into(), "run `splashboard trust`".into()],
-        }),
+        body: crate::fetcher::placeholder_body(
+            shape,
+            &["🔒 requires trust", "run `splashboard trust`"],
+        ),
     }
 }
 
@@ -415,13 +416,29 @@ mod tests {
 
     #[test]
     fn placeholder_has_lock_icon_in_first_line() {
-        let p = requires_trust_placeholder();
+        let p = requires_trust_placeholder(crate::render::Shape::TextBlock);
         match p.body {
-            Body::TextBlock(t) => {
+            crate::payload::Body::TextBlock(t) => {
                 assert!(t.lines[0].contains("🔒"));
                 assert!(t.lines[1].contains("splashboard trust"));
             }
             _ => panic!("expected text_block body"),
+        }
+    }
+
+    /// `list_links`-equipped widgets (the canonical home_feed / hackernews_top pair) need a
+    /// `LinkedTextBlock`-shaped placeholder; otherwise the trust gate's TextBlock body trips
+    /// the renderer's shape check and the user sees "renderer list_links cannot display
+    /// TextBlock" instead of the actual "🔒 requires trust" message.
+    #[test]
+    fn placeholder_emits_linked_text_block_for_link_renderer() {
+        let p = requires_trust_placeholder(crate::render::Shape::LinkedTextBlock);
+        match p.body {
+            crate::payload::Body::LinkedTextBlock(d) => {
+                assert!(d.items[0].text.contains("🔒"));
+                assert!(d.items.iter().all(|i| i.url.is_none()));
+            }
+            _ => panic!("expected linked_text_block body"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements `rss` fetcher (RSS 2.0 / RSS 1.0 / Atom / JSON Feed via `feed-rs`) — the canonical *read more main slot* candidate from #150 (`home_feed` morning briefing preset). First built-in `Network`-class fetcher, so this PR also fixes a latent UX issue surfaced by it: trust / error / timeout / unknown-fetcher placeholders all emitted `Body::TextBlock`, which `list_links` (and any other shape-strict renderer) rejected — users saw `renderer list_links cannot display TextBlock` instead of `🔒 requires trust`. Both fixes ship together because rss + `list_links` is the canonical pairing #150 specifies.

Refs #67 (Social & Media — RSS / news), #150 (home_feed preset).

### Commits

- `fix(runtime): make trust/error placeholders shape-aware` — adds `fetcher::placeholder_body(shape, lines)` helper; routes every placeholder constructor through it using each widget's renderer-derived shape.
- `feat(fetcher): add rss feed reader` — new `src/fetcher/rss.rs`, registered in `Registry::with_builtins`. `feed-rs = "2"` added to `Cargo.toml`.

## Reference page (preview)

> **Fetcher `rss`**
>
> - **Kind:** cached
> - **Safety:** Network *(local configs must be `splashboard trust`-ed before fetching)*
> - **Shapes:** `linked_text_block` (default), `text_block`
>
> **Options**
>
> | name | type | required | default | description |
> |---|---|---|---|---|
> | `url` | string (http / https) | required | – | Feed URL — RSS 2.0, RSS 1.0, Atom, or JSON Feed. |
> | `count` | integer (1..=20) | optional | `5` | Number of feed entries to display. |
>
> **Hardening**
>
> - URL scheme allowlist: `http` / `https` only (rejects `file://`, `data:`, etc.)
> - Response body capped at 5 MB to bound exposure to a runaway feed.
> - Cache key incorporates the URL hash so multiple `rss` widgets pointing at different feeds don't collide.
>
> **Compatible renderers** — `list_links` (LinkedTextBlock), plus the standard `text_block` family (`text_plain`, `list_plain`, animated_*).

## Test plan

- [x] `cargo test` — 726 passed (18 new for rss + 2 for placeholder shape adaptation).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run --bin splashboard -- catalog fetcher rss` prints schema + compatible renderers.
- [x] Local smoke test: 3-widget dashboard (`list_links` default + `count` override + `text_block` fallback) renders feed entries correctly under `SPLASHBOARD_TRUST_ALL=1`.
- [x] Without trust: all three widgets show `🔒 requires trust` (previously two of them showed `cannot display TextBlock`).
- [ ] `#[ignore]`'d live test against `https://blog.rust-lang.org/feed.xml` runs green (`cargo test -- --ignored fetcher::rss::tests::live`).

## Out of scope

- OPML import, per-feed filters, RSS authentication — follow-up work.
- Other fetchers from #150's checkbox list (`wikipedia_on_this_day`, `lobsters_top`, etc.) — separate PRs.
- Wiring `rss` into the `home_feed` preset itself — needs the other body-2 / body-3 fetchers first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)