### PR TITLE
feat(templates): add home_feed preset — morning briefing

### DIFF
--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -54,8 +54,8 @@ pickers — each with a live preview rendered from the shipped templates and
 your chosen theme — followed by a final confirmation page:
 
 1. **Home dashboard** — one of `home_splash` / `home_daily` / `home_github` /
-   `home_minimal`. Shown on new shells and when `cd`-ing anywhere outside a
-   git repo root.
+   `home_minimal` / `home_feed`. Shown on new shells and when `cd`-ing
+   anywhere outside a git repo root.
 2. **Project dashboard** — one of `project_splash` / `project_github` /
    `project_minimal`. Shown when `cd`-ing into the top of any git repo that
    doesn't ship its own `./.splashboard/`.
@@ -111,7 +111,7 @@ Flag reference:
 
 Available templates:
 
-- **home**: `home_splash`, `home_daily`, `home_github`, `home_minimal`
+- **home**: `home_splash`, `home_daily`, `home_github`, `home_minimal`, `home_feed`
 - **project**: `project_splash`, `project_github`, `project_minimal`
 
 See [Presets](/guides/presets/) for a rendered preview of each,

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -1,17 +1,18 @@
 ---
 title: Presets
-description: Seven curated dashboards you can adopt verbatim — pair one home with one project.
+description: Eight curated dashboards you can adopt verbatim — pair one home with one project.
 ---
 
 import homeSplash from '../../../assets/rendered/home_splash.html?raw';
 import homeDaily from '../../../assets/rendered/home_daily.html?raw';
 import homeGithub from '../../../assets/rendered/home_github.html?raw';
 import homeMinimal from '../../../assets/rendered/home_minimal.html?raw';
+import homeFeed from '../../../assets/rendered/home_feed.html?raw';
 import projectSplash from '../../../assets/rendered/project_splash.html?raw';
 import projectGithub from '../../../assets/rendered/project_github.html?raw';
 import projectMinimal from '../../../assets/rendered/project_minimal.html?raw';
 
-Seven curated dashboards — four home, three project. Pick one of each as a
+Eight curated dashboards — five home, three project. Pick one of each as a
 starting point and edit freely.
 
 - **Home presets** apply when the shell starts outside a git repo —
@@ -96,10 +97,40 @@ taking over every shell start.
 |---|---|
 | greeting | `basic_static "good "` + `clock_derived` (kind = time_of_day) → `text_plain` |
 | date | `clock` (format `%A · %e %B %Y · %H:%M`) → `text_plain` |
-| quote | `quote_of_day` (Text) → `text_plain` |
+| quote | `random_quote` (Text) → `text_plain` |
 
 Pairs naturally with `project_minimal` if you want the same restraint
 inside a repo.
+
+### `home_feed` — morning briefing
+
+A masthead with the date in figlet, a "good morning" greeting, live
+`Day · HH:MM`, and an almanac strip (moon · zodiac · day-of-year), all
+on a subtle header band. Body is 2 cols × 3 rows of curated feeds —
+HN | r/programming, Wired | BBC Tech, Engadget | Wikipedia on this
+day. Footer closes with a daily fortune.
+
+<div class="splash-landing" set:html={homeFeed} />
+
+| role | implementation |
+|---|---|
+| hero | `clock` (format `%a %e %b`) → `text_ascii` (blocks, quadrant) |
+| greeting | `basic_static "good "` + `clock_derived` (kind = time_of_day) → `text_plain` |
+| now | `clock` (format `%A · %H:%M`) → `text_plain` |
+| almanac | `clock_derived` × 3 (moon_phase / zodiac / day_of_year) → `text_plain` |
+| hacker news | `hackernews_top` → `list_links` |
+| r/programming | `reddit_subreddit_posts` → `list_links` |
+| wired | `rss` → `list_links` |
+| bbc tech | `rss` → `list_links` |
+| engadget | `rss` → `list_links` |
+| on this day | `wikipedia_on_this_day` → `list_links` |
+| fortune | `random_fortune` → `text_plain` |
+
+Network-class widgets (`rss`, `reddit_subreddit_posts`) render as a
+`🔒 requires trust` placeholder until the config is trusted. Installed
+to `$HOME/.splashboard/home.dashboard.toml` it's implicitly trusted;
+dropped into a project's `.splashboard/dashboard.toml` it needs
+`splashboard trust` first.
 
 ## Project presets
 

--- a/docs-site/src/content/docs/showcases.md
+++ b/docs-site/src/content/docs/showcases.md
@@ -10,7 +10,7 @@ the relevant section below.
 ## Presets
 
 _Screenshots pending: `home_splash`, `home_daily`, `home_github`,_
-_`home_minimal`, `project_splash`, `project_github`,_
+_`home_minimal`, `home_feed`, `project_splash`, `project_github`,_
 _`project_minimal`._
 
 ## Themes

--- a/src/render/text_plain.rs
+++ b/src/render/text_plain.rs
@@ -58,6 +58,22 @@ impl Renderer for TextPlainRenderer {
             .alignment(parse_align(opts.align.as_deref()));
         frame.render_widget(p, area);
     }
+    fn natural_height(
+        &self,
+        body: &Body,
+        _opts: &RenderOptions,
+        _max_width: u16,
+        _registry: &Registry,
+    ) -> u16 {
+        // text_plain doesn't wrap, so each `\n`-separated line takes exactly one row. Empty
+        // bodies still deserve a row of height so `length = "auto"` callers don't collapse.
+        let lines = match body {
+            Body::Text(d) => d.value.lines().count().max(1),
+            Body::TextBlock(d) => d.lines.len().max(1),
+            _ => 1,
+        };
+        u16::try_from(lines).unwrap_or(u16::MAX)
+    }
 }
 
 fn parse_align(s: Option<&str>) -> Alignment {
@@ -107,5 +123,55 @@ mod tests {
         let buf = render_to_buffer(&block_payload(&["first", "second"]), 30, 5);
         assert!(line_text(&buf, 0).contains("first"));
         assert!(line_text(&buf, 1).contains("second"));
+    }
+
+    #[test]
+    fn natural_height_text_counts_embedded_newlines() {
+        let r = TextPlainRenderer;
+        let registry = Registry::with_builtins();
+        let opts = RenderOptions::default();
+        assert_eq!(
+            r.natural_height(&text_payload("hello world").body, &opts, 30, &registry),
+            1
+        );
+        assert_eq!(
+            r.natural_height(&text_payload("a\nb\nc").body, &opts, 30, &registry),
+            3
+        );
+    }
+
+    #[test]
+    fn natural_height_textblock_uses_line_count() {
+        let r = TextPlainRenderer;
+        let registry = Registry::with_builtins();
+        let opts = RenderOptions::default();
+        assert_eq!(
+            r.natural_height(&block_payload(&["one"]).body, &opts, 30, &registry),
+            1
+        );
+        assert_eq!(
+            r.natural_height(
+                &block_payload(&["one", "two", "three"]).body,
+                &opts,
+                30,
+                &registry
+            ),
+            3
+        );
+    }
+
+    #[test]
+    fn natural_height_floors_at_one_for_empty_bodies() {
+        let r = TextPlainRenderer;
+        let registry = Registry::with_builtins();
+        let opts = RenderOptions::default();
+        assert_eq!(
+            r.natural_height(&text_payload("").body, &opts, 30, &registry),
+            1
+        );
+        assert_eq!(
+            r.natural_height(&block_payload(&[]).body, &opts, 30, &registry),
+            1
+        );
     }
 }

--- a/src/templates/home_feed.toml
+++ b/src/templates/home_feed.toml
@@ -1,0 +1,280 @@
+# home_feed — morning briefing. Hero band (lifted on `bg = "subtle"`): figlet date as
+# masthead, "good morning" greeting, live `Day · HH:MM`, and an almanac strip
+# (moon · zodiac · day-of-year). Body: 2 cols × 3 rows of curated feeds — HN | r/programming,
+# Wired | BBC Tech, Engadget | Wikipedia on this day. Footer: a daily fortune flourish.
+#
+# Trust: this preset wires Network-class widgets (`rss`, `reddit_subreddit_posts`). When
+# installed to `$HOME/.splashboard/home.dashboard.toml` (global config) it's implicitly
+# trusted; as a per-directory `.splashboard/dashboard.toml` it needs `splashboard trust`
+# before the network panels render.
+
+# ── Widgets ────────────────────────────────────────────────────────
+
+# Hero centerpiece — date in moderate text_ascii blocks (quadrant pixel size, ~3 rows tall),
+# colored with `panel_title` so it reads as the masthead.
+[[widget]]
+id = "hero_date"
+fetcher = "clock"
+format = "%a %e %b"
+render = { type = "text_ascii", style = "blocks", pixel_size = "quadrant", color = "panel_title", align = "center" }
+
+# Footer flourish — daily fortune. `length = "auto"` row sizes itself to whatever cookie was
+# drawn so 1-line fortunes hug the closing line and 4-line ones get the room they need.
+[[widget]]
+id = "fortune"
+fetcher = "random_fortune"
+render = { type = "text_plain", align = "center", color = "panel_title" }
+
+# Greeting seam — "good " (right) + time-of-day (left), home_minimal pattern.
+[[widget]]
+id = "greeting_prefix"
+fetcher = "basic_static"
+format = "good "
+render = { type = "text_plain", align = "right" }
+
+[[widget]]
+id = "greeting"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "left" }
+  [widget.options]
+  kind = "time_of_day"
+
+# Subtitle — full day name + current HH:MM. Different vocabulary from the figlet
+# ("Sun 26 Apr" → abbreviated; subtitle uses "Sunday · 14:23" for the live "right now"
+# read), so the band stops feeling like a date duplication.
+[[widget]]
+id = "now"
+fetcher = "clock"
+format = "%A · %H:%M"
+render = { type = "text_plain", align = "center" }
+
+# Almanac strip — moon · zodiac · day-of-year, centred. Three `clock_derived` values joined
+# by basic_static " · " separators so today's sky reads as one decorative line.
+[[widget]]
+id = "moon"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "right" }
+  [widget.options]
+  kind = "moon_phase"
+
+[[widget]]
+id = "sep1"
+fetcher = "basic_static"
+format = "  ·  "
+render = { type = "text_plain", align = "center" }
+
+[[widget]]
+id = "zodiac"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "center" }
+  [widget.options]
+  kind = "zodiac"
+
+[[widget]]
+id = "sep2"
+fetcher = "basic_static"
+format = "  ·  "
+render = { type = "text_plain", align = "center" }
+
+[[widget]]
+id = "day_of_year"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "left" }
+  [widget.options]
+  kind = "day_of_year"
+
+# Row 1 — Hacker News | Reddit r/programming
+[[widget]]
+id = "hn"
+fetcher = "hackernews_top"
+render = { type = "list_links", max_items = 5 }
+
+[[widget]]
+id = "reddit"
+fetcher = "reddit_subreddit_posts"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  subreddit = "programming"
+  type = "top"
+  period = "day"
+
+# Row 2 — Wired (rss) | BBC Tech (rss)
+[[widget]]
+id = "wired"
+fetcher = "rss"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  url = "https://www.wired.com/feed/rss"
+
+[[widget]]
+id = "bbc"
+fetcher = "rss"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  url = "https://feeds.bbci.co.uk/news/technology/rss.xml"
+
+# Row 3 — Engadget (rss) | Wikipedia on this day
+[[widget]]
+id = "engadget"
+fetcher = "rss"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  url = "https://www.engadget.com/rss.xml"
+
+[[widget]]
+id = "on_this_day"
+fetcher = "wikipedia_on_this_day"
+render = { type = "list_links", max_items = 5 }
+
+# ── Layout ─────────────────────────────────────────────────────────
+#
+# Hero band sits on `bg = "subtle"` so the date masthead / greeting / almanac strip read as
+# a header surface lifted off the body feeds. Footer band mirrors the same subtle bg with
+# the fortune flourish, closing the splash in the same visual register.
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+# Hero date — text_ascii blocks @ quadrant pixel size. Needs 4 rows for the 5×6 pixel font
+# rendered as quadrants (≈3 cells of glyph + 1 cell of breathing room above/below).
+[[row]]
+height = { length = 4 }
+bg = "subtle"
+  [[row.child]]
+  widget = "hero_date"
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+# Greeting seam.
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+flex = "center"
+  [[row.child]]
+  widget = "greeting_prefix"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "greeting"
+  width = { length = 12 }
+
+# Now — full day + live HH:MM. Complements the figlet without repeating the date.
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+  [[row.child]]
+  widget = "now"
+
+# Almanac strip — moon · zodiac · day_of_year.
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+flex = "center"
+  [[row.child]]
+  widget = "moon"
+  width = { length = 22 }
+  [[row.child]]
+  widget = "sep1"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "zodiac"
+  width = { length = 12 }
+  [[row.child]]
+  widget = "sep2"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "day_of_year"
+  width = { length = 12 }
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+[[row]]
+height = { length = 1 }
+
+# Body row 1 — HN | Reddit. 100-cell content band (49+gap2+49); 5 items + 1 border = 6.
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "hn"
+  width = { length = 49 }
+  border = "top"
+  title = "  HACKER NEWS  "
+  title_align = "center"
+  [[row.child]]
+  widget = "reddit"
+  width = { length = 49 }
+  border = "top"
+  title = "  R/PROGRAMMING  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Body row 2 — Wired | BBC Tech
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "wired"
+  width = { length = 49 }
+  border = "top"
+  title = "  WIRED  "
+  title_align = "center"
+  [[row.child]]
+  widget = "bbc"
+  width = { length = 49 }
+  border = "top"
+  title = "  BBC TECH  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Body row 3 — Engadget | Wikipedia on this day
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "engadget"
+  width = { length = 49 }
+  border = "top"
+  title = "  ENGADGET  "
+  title_align = "center"
+  [[row.child]]
+  widget = "on_this_day"
+  width = { length = 49 }
+  border = "top"
+  title = "  ON THIS DAY  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# ── Footer band ────────────────────────────────────────────────────
+#
+# Fortune flourish closes the splash on the default body bg — the hero alone wears the
+# subtle band, so the bottom feels like the splash settling rather than another header.
+
+[[row]]
+height = { length = 1 }
+
+[[row]]
+# Fortune cookies are capped at 3 lines in the bundled corpus. `length = "auto"` would be
+# nicer but text_plain's `natural_height` currently returns 1 regardless of TextBlock line
+# count, so a 3-line cookie gets truncated. Hard-code to 3 until the renderer is fixed.
+height = { length = 3 }
+flex = "center"
+  [[row.child]]
+  widget = "fortune"
+  width = { length = 80 }
+
+[[row]]
+height = { length = 1 }

--- a/src/templates/home_feed.toml
+++ b/src/templates/home_feed.toml
@@ -267,10 +267,9 @@ height = { length = 1 }
 height = { length = 1 }
 
 [[row]]
-# Fortune cookies are capped at 3 lines in the bundled corpus. `length = "auto"` would be
-# nicer but text_plain's `natural_height` currently returns 1 regardless of TextBlock line
-# count, so a 3-line cookie gets truncated. Hard-code to 3 until the renderer is fixed.
-height = { length = 3 }
+# `height = "auto"` — text_plain's `natural_height` returns the TextBlock line count, so
+# 1-line fortunes hug the closing line and multi-line cookies get the room they need.
+height = "auto"
 flex = "center"
   [[row.child]]
   widget = "fortune"

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -50,6 +50,12 @@ pub const TEMPLATES: &[Template] = &[
         body: include_str!("home_minimal.toml"),
     },
     Template {
+        name: "home_feed",
+        context: TemplateContext::Home,
+        description: "Morning briefing: time-of-day figlet, Hacker News top stories, on-this-day + sky panel, and today's Wikipedia featured article as the read-more lift.",
+        body: include_str!("home_feed.toml"),
+    },
+    Template {
         name: "project_splash",
         context: TemplateContext::Project,
         description: "Repo name as a giant figlet hero with a postfx reveal, slug / description / license underneath — nothing else. For repo-shipped configs.",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -46,6 +46,7 @@ const DASHBOARD_SNAPSHOTS: &[(&str, &str)] = &[
     ("src/templates/home_daily.toml", "home_daily.html"),
     ("src/templates/home_github.toml", "home_github.html"),
     ("src/templates/home_minimal.toml", "home_minimal.html"),
+    ("src/templates/home_feed.toml", "home_feed.html"),
     ("src/templates/project_splash.toml", "project_splash.html"),
     ("src/templates/project_github.toml", "project_github.html"),
     ("src/templates/project_minimal.toml", "project_minimal.html"),


### PR DESCRIPTION
## Summary
- Adds `home_feed` to the home preset gallery — fills the "outside content / 朝刊" axis (sibling of #77's home_splash / home_daily / home_github and #96's home_minimal).
- Hero band on `bg = "subtle"`: figlet date masthead, `good morning` greeting, live `Day · HH:MM`, and an almanac strip (moon · zodiac · day-of-year).
- Body: 2 cols × 3 rows of curated feeds — HN | r/programming, Wired | BBC Tech, Engadget | Wikipedia on this day.
- Footer: a daily `random_fortune` flourish on `height = "auto"` so 1-line cookies hug the closing line and multi-line ones get the room they need.
- Wires the new template into `TEMPLATES`, the xtask snapshot list, the docs-site presets / getting-started / showcases pages.
- Includes a renderer fix: `text_plain.natural_height` now counts TextBlock lines (and `\n`-separated Text lines) instead of falling through to the trait default of `1`. Without this, the fortune footer's `height = "auto"` collapsed to a single row and clipped multi-line cookies.

## Trust
`rss` and `reddit_subreddit_posts` are Network-class. Installed to `\$HOME/.splashboard/home.dashboard.toml` (global config) the preset is implicitly trusted; dropped into a per-directory `.splashboard/dashboard.toml` it needs `splashboard trust` before the network panels render.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (856 + 12 pass — includes the four `templates::tests` for the new template plus three new `text_plain::natural_height_*` cases)
- [x] cargo xtask regenerated `docs-site/src/assets/rendered/home_feed.html`
- [x] Live smoke-tested via `./.splashboard/dashboard.toml` after `splashboard trust`

## Related
- closes #150
- part of #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)