### PR TITLE
feat(reference): add description() to Fetcher and Renderer traits

### DIFF
--- a/src/fetcher/calendar/holidays.rs
+++ b/src/fetcher/calendar/holidays.rs
@@ -79,6 +79,9 @@ impl Fetcher for CalendarHolidaysFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Public holidays for a country (ISO 3166-1 alpha-2) via date.nager.at. `Calendar` highlights this month's holiday dates, `Text` shows today's holiday name when one matches, and `TextBlock` lists the next few upcoming holidays."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/almanac.rs
+++ b/src/fetcher/clock/almanac.rs
@@ -39,6 +39,9 @@ impl RealtimeFetcher for ClockAlmanacFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "A multi-row rollup of date-derived facts (moon phase, season, zodiac, chinese zodiac, ISO week, day of year). Use this when you want every almanac value at once; pick `clock_derived` instead to surface a single value on its own line."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/countdown.rs
+++ b/src/fetcher/clock/countdown.rs
@@ -75,6 +75,9 @@ impl RealtimeFetcher for ClockCountdownFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Time remaining until one configured `target` date or a list of labelled `targets`, formatted as `Nd Nh` / `Nh Nm` / `Nm`. Past targets keep rendering as `passed` so the widget survives the event boundary."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/derived.rs
+++ b/src/fetcher/clock/derived.rs
@@ -61,6 +61,9 @@ impl RealtimeFetcher for ClockDerivedFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "A single value derived from today's date, picked by `kind` (time of day, moon phase, zodiac, chinese zodiac, season, Japanese seasonal term, rokuyou, ISO week, day of year, Julian day, Unix epoch). Use `clock_almanac` to show several of these together as one block."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/mod.rs
+++ b/src/fetcher/clock/mod.rs
@@ -77,6 +77,9 @@ impl RealtimeFetcher for ClockFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Current local time. Renders as a formatted clock string, a key/value breakdown of year/month/day/hour/minute/second, or a month calendar grid with optional highlighted days."
+    }
     fn shapes(&self) -> &[Shape] {
         BASE_SHAPES
     }

--- a/src/fetcher/clock/ratio.rs
+++ b/src/fetcher/clock/ratio.rs
@@ -62,6 +62,9 @@ impl RealtimeFetcher for ClockRatioFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Fraction of the current period elapsed so far, as a `0..=1` value for gauge and progress-bar renderers. `period` selects which period (day, hour, week, month, quarter, year)."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/state.rs
+++ b/src/fetcher/clock/state.rs
@@ -40,6 +40,9 @@ impl RealtimeFetcher for ClockStateFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Whether the current moment falls inside a named temporal window (business hours, weekend, night), rendered as a status badge that flips between `Ok` and `Warn`. Pick `kind` to choose which window."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/sunrise.rs
+++ b/src/fetcher/clock/sunrise.rs
@@ -58,6 +58,9 @@ impl RealtimeFetcher for ClockSunriseFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Today's sunrise and sunset clock times for a configured `lat` / `lon`, computed offline from a NOAA-style approximation (no network). Renders as a one-line `↑ HH:MM  ↓ HH:MM` summary or split sunrise/sunset rows."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/clock/timezones.rs
+++ b/src/fetcher/clock/timezones.rs
@@ -58,6 +58,9 @@ impl RealtimeFetcher for ClockTimezonesFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "A world-clock strip showing the current time in each of the configured IANA `timezones`, one row per zone. Use this for at-a-glance multi-region time; pick the base `clock` fetcher for a single local time."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/code.rs
+++ b/src/fetcher/code.rs
@@ -90,6 +90,9 @@ impl Fetcher for CodeTodos {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Greps tracked source files in the discovered git repo for `TODO:` / `FIXME:` style markers (trailing colon required, vendored / generated dirs skipped). `Text` summarises `\"N TODOs in M files\"`, `TextBlock` lists `path:line: snippet`, and `Entries` / `Bars` rank files by hit count."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/blame_heatmap.rs
+++ b/src/fetcher/git/blame_heatmap.rs
@@ -33,6 +33,9 @@ impl Fetcher for GitBlameHeatmap {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Per-file churn over the last 52 weeks: rows are the seven most-touched files, columns are weeks, cells are commit counts. Use it to spot hotspots; pair with `git_commits_activity` if you want overall cadence instead of per-file breakdown."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/commits_activity.rs
+++ b/src/fetcher/git/commits_activity.rs
@@ -28,6 +28,9 @@ impl Fetcher for GitCommitsActivity {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "GitHub-style commit calendar for the last 52 weeks, with today's week in the rightmost column. Pick this for overall repo cadence; `git_blame_heatmap` breaks the same window down by file."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -29,6 +29,9 @@ impl Fetcher for GitContributors {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Top commit authors over the last N days (default 30, override with `format = \"N\"`), ranked by commit count and capped at ten. Useful for surfacing who's been active recently."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/latest_tag.rs
+++ b/src/fetcher/git/latest_tag.rs
@@ -22,6 +22,9 @@ impl Fetcher for GitLatestTag {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Most recent git tag by committer time, suitable as a \"latest release\" line. `Text` shows just the tag name; `Entries` adds the short commit hash and ISO date."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/recent_commits.rs
+++ b/src/fetcher/git/recent_commits.rs
@@ -25,6 +25,9 @@ impl Fetcher for GitRecentCommits {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Newest commits on HEAD, defaulting to ten (override with `format = \"N\"`). `Timeline` shows relative-ago labels; `TextBlock` is a flat `<short> <summary>` list."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/repo_name.rs
+++ b/src/fetcher/git/repo_name.rs
@@ -21,6 +21,9 @@ impl Fetcher for GitRepoName {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Repository name as a single line, suitable for a hero header. Derived from the `origin` remote (parsed as `owner/name`); falls back to the working directory's basename when no remote is configured."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Text]
     }

--- a/src/fetcher/git/stash_count.rs
+++ b/src/fetcher/git/stash_count.rs
@@ -21,6 +21,9 @@ impl Fetcher for GitStashCount {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Number of entries in the stash reflog, as a quiet reminder of work parked aside. `Text` collapses to empty when there are zero stashes; `Entries` always reports the count."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/status.rs
+++ b/src/fetcher/git/status.rs
@@ -22,6 +22,9 @@ impl Fetcher for GitStatus {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Working-tree snapshot: current branch, clean/dirty flag, and ahead/behind counts vs upstream. Choose `Entries` for a key/value panel, `Text` for a one-liner, or `Badge` for a clean/dirty traffic light."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/git/worktrees.rs
+++ b/src/fetcher/git/worktrees.rs
@@ -21,6 +21,9 @@ impl Fetcher for GitWorktrees {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Linked worktrees plus the main worktree, each with its checked-out branch and path. Useful when you juggle several feature branches in parallel checkouts."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/action_history.rs
+++ b/src/fetcher/github/action_history.rs
@@ -62,6 +62,9 @@ impl Fetcher for GithubActionHistory {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Recent CI workflow runs as a pass/fail sparkline or a timeline of the last N runs. Use `github_action_status` instead for just the current main-branch state."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -51,6 +51,9 @@ impl Fetcher for GithubActionStatus {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "The latest CI workflow run for a repo as a pass/fail badge or short text line. Use `github_action_history` for a series of recent runs rather than the single most recent one."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/assigned_issues.rs
+++ b/src/fetcher/github/assigned_issues.rs
@@ -47,6 +47,9 @@ impl Fetcher for GithubAssignedIssues {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Open issues assigned to the authenticated user across every repo. Pairs with `github_my_prs`, `github_review_requests`, and `github_notifications` to cover the personal queue."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -62,6 +62,9 @@ impl Fetcher for GithubAvatar {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "A GitHub user's avatar PNG, downloaded once per week and rendered as an image. Useful as the visual hero next to a `github_user` text block."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Image]
     }

--- a/src/fetcher/github/contributions.rs
+++ b/src/fetcher/github/contributions.rs
@@ -48,6 +48,9 @@ impl Fetcher for GithubContributions {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "The GitHub contribution calendar (kusa) as a year-long heatmap of daily commit counts. Defaults to the authenticated viewer; pass `login` to show another user."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -66,6 +66,9 @@ impl Fetcher for GithubContributorsMonthly {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Top contributors to a repo over the last N days, ranked by commit count, as bars or a list. Useful for the maintainer view of who has been shipping recently."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/good_first_issues.rs
+++ b/src/fetcher/github/good_first_issues.rs
@@ -67,6 +67,9 @@ impl Fetcher for GithubGoodFirstIssues {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Open issues labelled good-first-issue, either across all of GitHub or scoped to one repo via the `repo` option. Aimed at onboarding contributors and idle-browsing for something to pick up."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/languages.rs
+++ b/src/fetcher/github/languages.rs
@@ -57,6 +57,9 @@ impl Fetcher for GithubLanguages {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Language byte-count breakdown for a repo, sorted by size, as bars or percent rows. Languages beyond `limit` collapse into a single `other` bucket so totals stay honest."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/my_prs.rs
+++ b/src/fetcher/github/my_prs.rs
@@ -48,6 +48,9 @@ impl Fetcher for GithubMyPrs {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Open pull requests authored by the authenticated user across every repo. Use `github_repo_prs` instead to list PRs against one specific repo regardless of who opened them."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -60,6 +60,9 @@ impl Fetcher for GithubNotifications {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "The authenticated user's GitHub notification inbox, unread by default, with each row tagged by reason (mention, review_requested, etc.). Set `all = true` to include already-read notifications."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -59,6 +59,9 @@ impl Fetcher for GithubRecentReleases {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Latest published releases for a repo with their tags and dates. Good for the cd-into-project view of what shipped recently."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/repo.rs
+++ b/src/fetcher/github/repo.rs
@@ -25,6 +25,9 @@ impl Fetcher for GithubRepo {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Repo identity for the current directory: slug, description, and SPDX license. Use `github_repo_stars` instead for the social counters (stars, forks, watchers)."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Entries, Shape::TextBlock, Shape::Text]
     }

--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -58,6 +58,9 @@ impl Fetcher for GithubRepoIssues {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Open issues for a target repo, sorted by most recently updated, with pull requests filtered out client-side. Use `github_assigned_issues` for the personal queue across all repos."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -58,6 +58,9 @@ impl Fetcher for GithubRepoPrs {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Open pull requests for a target repo, sorted by most recently updated. Use `github_my_prs` instead for PRs authored by the authenticated user across all repos."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/repo_stars.rs
+++ b/src/fetcher/github/repo_stars.rs
@@ -40,6 +40,9 @@ impl Fetcher for GithubRepoStars {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Social counters for a repo: stargazers, forks, watchers, and open-issue count. Use `github_repo` instead for the identity fields (slug, description, license)."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/review_requests.rs
+++ b/src/fetcher/github/review_requests.rs
@@ -47,6 +47,9 @@ impl Fetcher for GithubReviewRequests {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Open pull requests where the authenticated user is a requested reviewer, across every repo. The other side of `github_my_prs` for the personal queue."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/github/user.rs
+++ b/src/fetcher/github/user.rs
@@ -46,6 +46,9 @@ impl Fetcher for GithubUser {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "GitHub profile data for a user (display name, bio, location, join year, follower counts), aimed at the hero / subtitle band of a home preset. Pair with `github_avatar` for the matching image."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/hackernews/top.rs
+++ b/src/fetcher/hackernews/top.rs
@@ -85,6 +85,9 @@ impl Fetcher for HackernewsTopFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Hacker News front-page listings — `top` / `new` / `best` / `ask` / `show` / `job`. Each row shows score, comment count, and title, linked to the story URL (or the HN comment page when there isn't one)."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/hackernews/user.rs
+++ b/src/fetcher/hackernews/user.rs
@@ -51,6 +51,9 @@ impl Fetcher for HackernewsUserFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Profile rollup for one Hacker News account — login, karma, join date, submission count, and bio. Use `hackernews_user_submissions` for that user's recent stories or `hackernews_user_comments` for their recent comments."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/hackernews/user_comments.rs
+++ b/src/fetcher/hackernews/user_comments.rs
@@ -58,6 +58,9 @@ impl Fetcher for HackernewsUserCommentsFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Recent comments by one Hacker News account, each truncated and linked to the comment page on HN. Pair with `hackernews_user_submissions` for stories by the same user, or `hackernews_user` for the profile rollup."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/hackernews/user_submissions.rs
+++ b/src/fetcher/hackernews/user_submissions.rs
@@ -62,6 +62,9 @@ impl Fetcher for HackernewsUserSubmissionsFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Recent stories submitted by one Hacker News account (story / show / ask / job — comments are excluded). Use `hackernews_user_comments` for that user's recent comments instead."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -78,6 +78,12 @@ pub struct FetchContext {
 pub trait Fetcher: Send + Sync {
     fn name(&self) -> &str;
     fn safety(&self) -> Safety;
+    /// One- or two-sentence summary surfaced in the generated reference docs. Should explain
+    /// what the fetcher shows and, where multiple siblings exist within the same family,
+    /// what makes this one different (`clock_almanac` vs `clock_sunrise`, `git_status` vs
+    /// `git_stash_count`). No leading verb tense convention; just write so a config author
+    /// scanning the catalog can decide whether this is the one they want.
+    fn description(&self) -> &'static str;
     /// Shapes this fetcher can emit. Single-shape fetchers (static_text, disk) return one
     /// variant; fetchers whose one physical read can be reshaped for different widgets (clock,
     /// read_store) list every variant they accept. Validated against the renderer-derived
@@ -119,6 +125,8 @@ pub trait Fetcher: Send + Sync {
 pub trait RealtimeFetcher: Send + Sync {
     fn name(&self) -> &str;
     fn safety(&self) -> Safety;
+    /// See [`Fetcher::description`] — same purpose for the realtime side of the registry.
+    fn description(&self) -> &'static str;
     fn shapes(&self) -> &[Shape];
     fn default_shape(&self) -> Shape {
         self.shapes()[0]
@@ -272,6 +280,12 @@ impl RegisteredFetcher {
             Self::Realtime(f) => f.safety(),
         }
     }
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Cached(f) => f.description(),
+            Self::Realtime(f) => f.description(),
+        }
+    }
     pub fn shapes(&self) -> Vec<Shape> {
         match self {
             Self::Cached(f) => f.shapes().to_vec(),
@@ -409,6 +423,9 @@ mod tests {
         fn safety(&self) -> Safety {
             self.1
         }
+        fn description(&self) -> &'static str {
+            "test fixture"
+        }
         fn shapes(&self) -> &[Shape] {
             &[Shape::Text]
         }
@@ -432,6 +449,9 @@ mod tests {
         }
         fn safety(&self) -> Safety {
             self.1
+        }
+        fn description(&self) -> &'static str {
+            "test fixture"
         }
         fn shapes(&self) -> &[Shape] {
             &[Shape::Text]

--- a/src/fetcher/random_fortune/mod.rs
+++ b/src/fetcher/random_fortune/mod.rs
@@ -29,6 +29,9 @@ impl RealtimeFetcher for RandomFortuneFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Picks one bundled Unix-style fortune cookie, advancing once per calendar day. Distinct from `random_quote`: cookies are anonymous and irreverent and may span multiple lines (haikus, short verses), with no attribution line."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/random_quote/mod.rs
+++ b/src/fetcher/random_quote/mod.rs
@@ -29,6 +29,9 @@ impl RealtimeFetcher for RandomQuoteFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Picks one quote-and-author pair from a bundled collection, advancing once per calendar day. Distinct from `random_fortune`, which serves anonymous Unix-style fortune cookies; this one always carries an attribution line."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -46,6 +46,9 @@ impl Fetcher for ReadStoreFetcher {
         // there's no path-traversal vector even in an untrusted local config.
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Reads a payload file the user maintains at `$HOME/.splashboard/store/<widget_id>.<ext>` (text / json / toml) and renders it as the declared shape. The escape hatch for ad-hoc widgets — populate the file from any cron, editor, or post-commit hook and splashboard surfaces whatever you wrote."
+    }
     fn shapes(&self) -> &[Shape] {
         READ_STORE_SHAPES
     }

--- a/src/fetcher/reddit/subreddit_posts.rs
+++ b/src/fetcher/reddit/subreddit_posts.rs
@@ -121,6 +121,9 @@ impl Fetcher for RedditSubredditPostsFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Posts from a single subreddit's public listing — `top` / `hot` / `new` / `rising`, with a `period` window for `top`. Pair with `reddit_user_posts` for one user's submissions or `reddit_user_comments` for their comments."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/reddit/user_comments.rs
+++ b/src/fetcher/reddit/user_comments.rs
@@ -80,6 +80,9 @@ impl Fetcher for RedditUserCommentsFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Recent comments by a single Reddit user, each prefixed with subreddit and score and linked to the comment's permalink. Use `reddit_user_posts` for that user's submissions or `reddit_subreddit_posts` for a subreddit's listing."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/reddit/user_posts.rs
+++ b/src/fetcher/reddit/user_posts.rs
@@ -53,6 +53,9 @@ impl Fetcher for RedditUserPostsFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Recent submissions by a single Reddit user. Use `reddit_user_comments` for that user's comments instead, or `reddit_subreddit_posts` to follow a subreddit rather than a person."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -73,6 +73,9 @@ impl Fetcher for RssFetcher {
     fn safety(&self) -> Safety {
         Safety::Network
     }
+    fn description(&self) -> &'static str {
+        "Generic feed reader for any RSS 2.0 / RSS 1.0 / Atom / JSON Feed URL, parsed via `feed-rs`. Each row shows the entry's published date and title, optionally linked. Trust-gated because the URL is config-controlled."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/static_text.rs
+++ b/src/fetcher/static_text.rs
@@ -20,6 +20,9 @@ impl Fetcher for StaticText {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Renders a constant string supplied by the widget's `format` option, split into lines on `\\n` for `TextBlock` and passed through verbatim for `Text` / `MarkdownTextBlock`. Use it for greetings, project banners, or fixed welcome notes that don't need a dedicated fetcher."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Text, Shape::TextBlock, Shape::MarkdownTextBlock]
     }

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -97,6 +97,9 @@ impl RealtimeFetcher for SystemFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Host identity rollup combining OS, hostname, uptime, load, CPU, and memory into one block. Use the `kind` option on the `Text` shape to extract a single field (terminal, OS, hostname, shell, arch) for hero or attribution lines."
+    }
     fn shapes(&self) -> &[Shape] {
         // Listed specific-to-broad so multi-shape renderers (text_plain, animated_postfx)
         // pick `Text` by default — that's the variant where `kind = "terminal" | "os" | …`
@@ -271,6 +274,9 @@ impl RealtimeFetcher for CpuLoadFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Aggregated CPU usage across all cores, sampled every frame. Pair with a gauge renderer for a live meter or use the `Text` shape for a plain percentage."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Ratio, Shape::Text]
     }
@@ -326,6 +332,9 @@ impl RealtimeFetcher for MemoryFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "RAM utilisation as a used/total ratio. `Text` formats as `\"6.4 GiB / 16 GiB\"` and `Entries` breaks it into used / total / free rows."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Ratio, Shape::Text, Shape::Entries]
     }
@@ -376,6 +385,9 @@ impl RealtimeFetcher for UptimeFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Time since the host last booted, formatted as a compact `\"3d 4h\"` / `\"2h 15m\"` / `\"45m\"` string."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Text]
     }
@@ -402,6 +414,9 @@ impl RealtimeFetcher for LoadAverageFetcher {
     }
     fn safety(&self) -> Safety {
         Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Unix 1 / 5 / 15-minute load averages. `Text` joins the three values on one line; `Entries` splits them into separate rows. Reads as `\"n/a (windows)\"` on Windows, which has no equivalent counter."
     }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Text, Shape::Entries]
@@ -463,6 +478,9 @@ impl RealtimeFetcher for ProcessTopFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Top five processes by current CPU usage, refreshed every frame. `Entries` pairs each process name with its percentage; `TextBlock` collapses to one process per line."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Entries, Shape::TextBlock]
     }
@@ -512,6 +530,9 @@ impl Fetcher for DiskFetcher {
     }
     fn safety(&self) -> Safety {
         Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Local disk usage. `Ratio` and `Text` summarise the largest mounted disk (used vs total); `Bars` lists every detected mount with its used bytes."
     }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Ratio, Shape::Text, Shape::Bars]
@@ -646,6 +667,9 @@ impl RealtimeFetcher for BatteryFetcher {
     }
     fn safety(&self) -> Safety {
         Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Charge level and state of the primary (or `index`-selected) battery. `Ratio` drives gauges, `Text` formats a summary line whose field is picked by `kind`, and `Entries` rolls up charge / state / time-left / cycles / health. Hosts without a battery render a steady `\"AC\"` placeholder."
     }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Ratio, Shape::Text, Shape::Entries]

--- a/src/fetcher/todoist.rs
+++ b/src/fetcher/todoist.rs
@@ -173,6 +173,10 @@ impl Fetcher for TodoistTasks {
         Safety::Safe
     }
 
+    fn description(&self) -> &'static str {
+        "Todoist task snapshot, sorted by due date and priority, with structured filters for due window, projects, labels, and priority. `Badge` summarises overdue/total counts; list shapes show each task with its due label and priority and link back to the Todoist app."
+    }
+
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/weather.rs
+++ b/src/fetcher/weather.rs
@@ -74,6 +74,9 @@ impl Fetcher for WeatherFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Current-conditions forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` shows condition / temperature / wind / humidity rows; `Text` collapses them into a single line. Metric or imperial units, no API key required."
+    }
     fn shapes(&self) -> &[Shape] {
         &[Shape::Entries, Shape::Text]
     }

--- a/src/fetcher/wikipedia/featured.rs
+++ b/src/fetcher/wikipedia/featured.rs
@@ -45,6 +45,9 @@ impl Fetcher for WikipediaFeaturedFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Today's English Wikipedia \"Today's Featured Article\" — the daily curated front-page pick, with title, summary, and link. Use `wikipedia_on_this_day` for historical events on this date or `wikipedia_random` for an arbitrary article."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/wikipedia/on_this_day.rs
+++ b/src/fetcher/wikipedia/on_this_day.rs
@@ -93,6 +93,9 @@ impl Fetcher for WikipediaOnThisDayFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "Events that happened on today's calendar date in history, sourced from Wikipedia's on-this-day feed (selected highlights, events, births, deaths, holidays, or all). Use `wikipedia_featured` for today's featured article or `wikipedia_random` for an arbitrary page."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/fetcher/wikipedia/random.rs
+++ b/src/fetcher/wikipedia/random.rs
@@ -44,6 +44,9 @@ impl Fetcher for WikipediaRandomFetcher {
     fn safety(&self) -> Safety {
         Safety::Safe
     }
+    fn description(&self) -> &'static str {
+        "An arbitrary Wikipedia page summary (title, extract, link), drawn from the language edition's random endpoint. Refresh interval controls how often a new article is picked. Use `wikipedia_featured` for the curated daily article or `wikipedia_on_this_day` for date-anchored history."
+    }
     fn shapes(&self) -> &[Shape] {
         SHAPES
     }

--- a/src/render/animated_boot.rs
+++ b/src/render/animated_boot.rs
@@ -89,6 +89,9 @@ impl Renderer for AnimatedBootRenderer {
     fn name(&self) -> &str {
         "animated_boot"
     }
+    fn description(&self) -> &'static str {
+        "Wrapper that scrolls a fake `[ OK ]` systemd-style boot log into the cell during the first ~70% of the window, then hands off to the inner renderer for the resting frame. Accepts every shape; pair with a hero renderer (e.g. `text_ascii`) on a tall cell."
+    }
     fn accepts(&self) -> &[Shape] {
         ALL_SHAPES
     }

--- a/src/render/animated_figlet_morph.rs
+++ b/src/render/animated_figlet_morph.rs
@@ -66,6 +66,9 @@ impl Renderer for AnimatedFigletMorphRenderer {
     fn name(&self) -> &str {
         "animated_figlet_morph"
     }
+    fn description(&self) -> &'static str {
+        "Hero text rendered through a sequence of figlet fonts, crossfading from one to the next so the typography visibly reshapes itself before settling on the final font. Accepts `Text` only; the resting frame matches a static `text_ascii` render in the last font of the sequence."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Text]
     }

--- a/src/render/animated_postfx.rs
+++ b/src/render/animated_postfx.rs
@@ -78,6 +78,9 @@ impl Renderer for AnimatedPostfxRenderer {
     fn name(&self) -> &str {
         "animated_postfx"
     }
+    fn description(&self) -> &'static str {
+        "Wrapper that draws the inner renderer and overlays a tachyonfx pixel-level effect (fade, dissolve, sweep, glitch, matrix rain, neon flash, and more — pick via `effect`) for the duration of the animation window. Accepts every shape; the resting frame is the unmodified inner render."
+    }
     fn accepts(&self) -> &[Shape] {
         ALL_SHAPES
     }

--- a/src/render/animated_scanlines.rs
+++ b/src/render/animated_scanlines.rs
@@ -69,6 +69,9 @@ impl Renderer for AnimatedScanlinesRenderer {
     fn name(&self) -> &str {
         "animated_scanlines"
     }
+    fn description(&self) -> &'static str {
+        "Wrapper that sweeps a bright horizontal CRT scanline from top to bottom over the inner renderer, hiding rows below the line until it passes them. Accepts every shape; reads as a vintage tube monitor warming up."
+    }
     fn accepts(&self) -> &[Shape] {
         ALL_SHAPES
     }

--- a/src/render/animated_splitflap.rs
+++ b/src/render/animated_splitflap.rs
@@ -72,6 +72,9 @@ impl Renderer for AnimatedSplitflapRenderer {
     fn name(&self) -> &str {
         "animated_splitflap"
     }
+    fn description(&self) -> &'static str {
+        "Wrapper that flips each cell through random A-Z / 0-9 / punctuation glyphs before settling on the inner renderer's final character, like a train station departures board. Columns settle left-to-right so the text resolves in reading order. Accepts every shape."
+    }
     fn accepts(&self) -> &[Shape] {
         ALL_SHAPES
     }

--- a/src/render/animated_typewriter.rs
+++ b/src/render/animated_typewriter.rs
@@ -40,6 +40,9 @@ impl Renderer for AnimatedTypewriterRenderer {
     fn name(&self) -> &str {
         "animated_typewriter"
     }
+    fn description(&self) -> &'static str {
+        "Reveals the text one character at a time at roughly 40 chars/sec, as if someone is typing it live. Accepts `Text` only; best for short single-line greetings rather than multi-line blocks."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Text]
     }

--- a/src/render/animated_wave.rs
+++ b/src/render/animated_wave.rs
@@ -71,6 +71,9 @@ impl Renderer for AnimatedWaveRenderer {
     fn name(&self) -> &str {
         "animated_wave"
     }
+    fn description(&self) -> &'static str {
+        "Wrapper that sweeps a bright vertical crest left-to-right across the inner renderer; columns ahead of the crest stay blank, columns behind are revealed, the crest itself is highlighted in the accent colour. Accepts every shape; reads as a wave of signal washing over the hero."
+    }
     fn accepts(&self) -> &[Shape] {
         ALL_SHAPES
     }

--- a/src/render/chart_bar.rs
+++ b/src/render/chart_bar.rs
@@ -66,6 +66,9 @@ impl Renderer for ChartBarRenderer {
     fn name(&self) -> &str {
         "chart_bar"
     }
+    fn description(&self) -> &'static str {
+        "Labelled bar chart from a `Bars` shape. Defaults to vertical bars with labels underneath; flip to horizontal rows via `horizontal = true` for narrow slots."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Bars]
     }

--- a/src/render/chart_histogram.rs
+++ b/src/render/chart_histogram.rs
@@ -59,6 +59,9 @@ impl Renderer for ChartHistogramRenderer {
     fn name(&self) -> &str {
         "chart_histogram"
     }
+    fn description(&self) -> &'static str {
+        "Vertical bar chart from a `NumberSeries`, binned into equal-width buckets. Optional `axis_labels` print the peak count along the top edge and the value range along the bottom; pairs with `chart_sparkline` when the same series should look bigger and shaped instead of compact."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::NumberSeries]
     }

--- a/src/render/chart_line.rs
+++ b/src/render/chart_line.rs
@@ -37,6 +37,9 @@ impl Renderer for ChartLineRenderer {
     fn name(&self) -> &str {
         "chart_line"
     }
+    fn description(&self) -> &'static str {
+        "Braille line plot of one or more `PointSeries` against shared x/y axes, with each series coloured from the palette. Pick this over `chart_scatter` when the trend between samples matters more than the individual points."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::PointSeries]
     }

--- a/src/render/chart_pie.rs
+++ b/src/render/chart_pie.rs
@@ -45,6 +45,9 @@ impl Renderer for ChartPieRenderer {
     fn name(&self) -> &str {
         "chart_pie"
     }
+    fn description(&self) -> &'static str {
+        "Pie chart of `Bars` slices with palette-cycled colours, percentages, and an adjacent legend. Use `donut = true` for a hollow centre, or pick `chart_bar` instead when exact comparisons between slices matter."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Bars]
     }

--- a/src/render/chart_scatter.rs
+++ b/src/render/chart_scatter.rs
@@ -50,6 +50,9 @@ impl Renderer for ChartScatterRenderer {
     fn name(&self) -> &str {
         "chart_scatter"
     }
+    fn description(&self) -> &'static str {
+        "Canvas scatter plot of `PointSeries` — dots only, no connecting line, with per-series palette colours and a configurable marker glyph. Pick this over `chart_line` when each observation matters more than the trend between them."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::PointSeries]
     }

--- a/src/render/chart_sparkline.rs
+++ b/src/render/chart_sparkline.rs
@@ -44,6 +44,9 @@ impl Renderer for ChartSparklineRenderer {
     fn name(&self) -> &str {
         "chart_sparkline"
     }
+    fn description(&self) -> &'static str {
+        "Compact in-line trend strip from a `NumberSeries`, showing only the most recent values that fit the slot. Defaults to block-glyph bars; switch to `style = \"line\"` for a single-row Braille line, and zero-value columns get a baseline tick so sparse stretches read as data instead of padding."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::NumberSeries]
     }

--- a/src/render/gauge_battery.rs
+++ b/src/render/gauge_battery.rs
@@ -50,6 +50,9 @@ impl Renderer for GaugeBatteryRenderer {
     fn name(&self) -> &str {
         "gauge_battery"
     }
+    fn description(&self) -> &'static str {
+        "Battery silhouette for `Ratio`: framed cell with internal fill bars, a tip cap on the right, and a percent label. Renders as a single-line pill in short slots and as a boxed three-row icon when the slot is tall enough."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Ratio]
     }

--- a/src/render/gauge_circle.rs
+++ b/src/render/gauge_circle.rs
@@ -44,6 +44,9 @@ impl Renderer for GaugeCircleRenderer {
     fn name(&self) -> &str {
         "gauge_circle"
     }
+    fn description(&self) -> &'static str {
+        "Full-height block bar for `Ratio` built on ratatui's `Gauge`, with the optional label centred inside the fill. The chunkiest member of the `gauge_*` family — pick `gauge_line` when you need something single-row."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Ratio]
     }

--- a/src/render/gauge_line.rs
+++ b/src/render/gauge_line.rs
@@ -42,6 +42,9 @@ impl Renderer for GaugeLineRenderer {
     fn name(&self) -> &str {
         "gauge_line"
     }
+    fn description(&self) -> &'static str {
+        "Single-row progress bar for `Ratio`: optional label, shaded fill across the available width, and a percent or fraction suffix. The lightest member of the `gauge_*` family — pick this for dense dashboards where `gauge_circle` is too tall."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Ratio]
     }

--- a/src/render/gauge_segment.rs
+++ b/src/render/gauge_segment.rs
@@ -71,6 +71,9 @@ impl Renderer for GaugeSegmentRenderer {
     fn name(&self) -> &str {
         "gauge_segment"
     }
+    fn description(&self) -> &'static str {
+        "Discrete LED-style bar for `Ratio`: by default five chunky pip blocks that light up in steps rather than a continuous fill. Pick this over `gauge_line` when you want a retro hardware look or coarser readability at a glance."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Ratio]
     }

--- a/src/render/gauge_thermometer.rs
+++ b/src/render/gauge_thermometer.rs
@@ -59,6 +59,9 @@ impl Renderer for GaugeThermometerRenderer {
     fn name(&self) -> &str {
         "gauge_thermometer"
     }
+    fn description(&self) -> &'static str {
+        "Vertical mercury tube for `Ratio`: rounded glass walls with a bulb at the bottom and a mercury column rising from it, with the label and percent on the mid row. The vertical sibling of `gauge_line` — pick this for tall, narrow slots where height carries the meaning."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Ratio]
     }

--- a/src/render/grid_calendar.rs
+++ b/src/render/grid_calendar.rs
@@ -57,6 +57,9 @@ impl Renderer for GridCalendarRenderer {
     fn name(&self) -> &str {
         "grid_calendar"
     }
+    fn description(&self) -> &'static str {
+        "Month-view grid with a centred month-name header, dim weekday labels, and date cells. The focused day is bolded in the today-accent colour; event days are tinted in the event-accent colour."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Calendar]
     }

--- a/src/render/grid_heatmap.rs
+++ b/src/render/grid_heatmap.rs
@@ -51,6 +51,9 @@ impl Renderer for GridHeatmapRenderer {
     fn name(&self) -> &str {
         "grid_heatmap"
     }
+    fn description(&self) -> &'static str {
+        "GitHub-contribution-style 2D grid of square-ish cells bucketed into five intensity levels from the heatmap palette, with optional column labels along the top. Right-aligns when the grid is wider than the slot so the most recent columns stay visible."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Heatmap]
     }

--- a/src/render/grid_table.rs
+++ b/src/render/grid_table.rs
@@ -62,6 +62,9 @@ impl Renderer for GridTableRenderer {
     fn name(&self) -> &str {
         "grid_table"
     }
+    fn description(&self) -> &'static str {
+        "Two-column key/value rows tinted by per-row status, with an `inline` layout that condenses the same entries into a single `key: value · key: value` line. The default look for entry-style payloads (system info, project metadata, env summaries)."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Entries]
     }

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -38,6 +38,9 @@ impl Renderer for ListLinksRenderer {
     fn name(&self) -> &str {
         "list_links"
     }
+    fn description(&self) -> &'static str {
+        "One row per entry, with rows that carry a URL wrapped in OSC-8 hyperlinks so modern terminals make them clickable. Use this for feed-style payloads (HN headlines, recent PRs, releases) where each row has a canonical destination."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::LinkedTextBlock]
     }

--- a/src/render/list_plain.rs
+++ b/src/render/list_plain.rs
@@ -64,6 +64,9 @@ impl Renderer for ListPlainRenderer {
     fn name(&self) -> &str {
         "list_plain"
     }
+    fn description(&self) -> &'static str {
+        "One line per entry, optionally prefixed with a bullet glyph and capped by `max_items`. Sibling to `text_plain` for `TextBlock` — pick this when you want list semantics (bullet marker, item cap) instead of a paragraph."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::TextBlock]
     }

--- a/src/render/list_ranking.rs
+++ b/src/render/list_ranking.rs
@@ -51,6 +51,9 @@ impl Renderer for ListRankingRenderer {
     fn name(&self) -> &str {
         "list_ranking"
     }
+    fn description(&self) -> &'static str {
+        "Top-N table sorted high-to-low: rank prefix (`1.` / `2.` numbers, 🥇/🥈/🥉 medals, or none), label, and right-aligned value column. The text-first sibling of `chart_bar` — pick this when the values matter more than their relative bar lengths."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Bars]
     }

--- a/src/render/list_timeline.rs
+++ b/src/render/list_timeline.rs
@@ -71,6 +71,9 @@ impl Renderer for ListTimelineRenderer {
     fn name(&self) -> &str {
         "list_timeline"
     }
+    fn description(&self) -> &'static str {
+        "Chronological events with a left-aligned time column (relative `3h` / `2d` or absolute ISO date) separated from the title by a vertical bar, and an optional indented detail row underneath. Status colours the title; pick this for commits, releases, notifications."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Timeline]
     }

--- a/src/render/media_image.rs
+++ b/src/render/media_image.rs
@@ -68,6 +68,9 @@ impl Renderer for MediaImageRenderer {
     fn name(&self) -> &str {
         "media_image"
     }
+    fn description(&self) -> &'static str {
+        "Embeds a raster image using the best protocol the terminal advertises (kitty, sixel, iTerm2) and falls back to half-block ASCII elsewhere. Honours `fit` (contain / cover / stretch) plus `max_width` / `max_height` / `padding` for placement."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Image]
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -280,6 +280,12 @@ impl RenderSpec {
 
 pub trait Renderer: Send + Sync {
     fn name(&self) -> &str;
+    /// One- or two-sentence summary surfaced in the generated reference docs. Should describe
+    /// the visual character (a hero block, a sparkline, a status pill) and, where multiple
+    /// siblings exist within the same family (`text_plain` vs `text_ascii`, `gauge_circle` vs
+    /// `gauge_segment`), what makes this one different. Read by config authors browsing the
+    /// catalog for the right look.
+    fn description(&self) -> &'static str;
     fn accepts(&self) -> &[Shape];
     /// Whether this renderer produces different output on repeated calls within one draw
     /// cycle. The runtime consults this: any true answer upgrades the draw phase from a single

--- a/src/render/status_badge.rs
+++ b/src/render/status_badge.rs
@@ -62,6 +62,9 @@ impl Renderer for StatusBadgeRenderer {
     fn name(&self) -> &str {
         "status_badge"
     }
+    fn description(&self) -> &'static str {
+        "A coloured dot (green / yellow / red, driven by status) followed by the badge label, optionally framed as a `( … )` or `[ … ]` pill. One indicator per widget — compose rows of badges through layout, not through this renderer."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Badge]
     }

--- a/src/render/text_ascii.rs
+++ b/src/render/text_ascii.rs
@@ -88,6 +88,9 @@ impl Renderer for TextAsciiRenderer {
     fn name(&self) -> &str {
         "text_ascii"
     }
+    fn description(&self) -> &'static str {
+        "Chunky multi-row big-text via half-block glyphs (`style = \"blocks\"`) or classic FIGlet ASCII art (`style = \"figlet\"`). The hero treatment for short strings like a clock or greeting; use `text_plain` for anything multi-line."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Text]
     }

--- a/src/render/text_markdown.rs
+++ b/src/render/text_markdown.rs
@@ -42,6 +42,9 @@ impl Renderer for TextMarkdownRenderer {
     fn name(&self) -> &str {
         "text_markdown"
     }
+    fn description(&self) -> &'static str {
+        "Wrapped markdown prose with themed headings, inline code, links, and blockquotes. Pick this when the source string carries Markdown syntax that should render as styled spans rather than literal characters."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::MarkdownTextBlock]
     }

--- a/src/render/text_plain.rs
+++ b/src/render/text_plain.rs
@@ -30,6 +30,9 @@ impl Renderer for TextPlainRenderer {
     fn name(&self) -> &str {
         "text_plain"
     }
+    fn description(&self) -> &'static str {
+        "Single-line or multi-line body text in the theme text colour, no decoration. The quiet default for any string payload — pick `text_ascii` when you want a hero block instead."
+    }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Text, Shape::TextBlock]
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1466,6 +1466,9 @@ mod tests {
             fn safety(&self) -> fetcher::Safety {
                 fetcher::Safety::Safe
             }
+            fn description(&self) -> &'static str {
+                "test fixture"
+            }
             fn shapes(&self) -> &[Shape] {
                 &[Shape::Text]
             }
@@ -1525,6 +1528,9 @@ mod tests {
             }
             fn safety(&self) -> fetcher::Safety {
                 fetcher::Safety::Safe
+            }
+            fn description(&self) -> &'static str {
+                "test fixture"
             }
             fn shapes(&self) -> &[Shape] {
                 &[Shape::Text]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -201,6 +201,9 @@ mod tests {
         fn safety(&self) -> Safety {
             self.safety
         }
+        fn description(&self) -> &'static str {
+            "test fixture"
+        }
         fn shapes(&self) -> &[Shape] {
             &[Shape::Text]
         }
@@ -220,6 +223,9 @@ mod tests {
         }
         fn safety(&self) -> Safety {
             self.safety
+        }
+        fn description(&self) -> &'static str {
+            "test fixture"
         }
         fn shapes(&self) -> &[Shape] {
             &[Shape::Text]

--- a/xtask/src/gen_matrix.rs
+++ b/xtask/src/gen_matrix.rs
@@ -101,17 +101,18 @@ fn overview(fetchers: &FetcherRegistry, renderers: &RenderRegistry) -> String {
 
 fn overview_fetcher_table(out: &mut String, fetchers: &FetcherRegistry) {
     out.push_str("## Fetchers\n\n");
-    out.push_str("| Name | Kind | Safety | Shapes |\n");
-    out.push_str("| --- | --- | --- | --- |\n");
+    out.push_str("| Name | Kind | Safety | Shapes | Description |\n");
+    out.push_str("| --- | --- | --- | --- | --- |\n");
     for f in fetchers.sorted() {
         let _ = writeln!(
             out,
-            "| [`{name}`]({link}) | {kind} | {safety} | {shapes} |",
+            "| [`{name}`]({link}) | {kind} | {safety} | {shapes} | {description} |",
             name = f.name(),
             link = rel_path("fetchers", f.name()),
             kind = kind_label(&f),
             safety = safety_label(f.safety()),
             shapes = shapes_list(&f.shapes()),
+            description = escape_pipe(f.description()),
         );
     }
     out.push('\n');
@@ -119,16 +120,17 @@ fn overview_fetcher_table(out: &mut String, fetchers: &FetcherRegistry) {
 
 fn overview_renderer_table(out: &mut String, renderers: &RenderRegistry) {
     out.push_str("## Renderers\n\n");
-    out.push_str("| Name | Accepts | Animates |\n");
-    out.push_str("| --- | --- | --- |\n");
+    out.push_str("| Name | Accepts | Animates | Description |\n");
+    out.push_str("| --- | --- | --- | --- |\n");
     for r in renderers.sorted() {
         let _ = writeln!(
             out,
-            "| [`{name}`]({link}) | {accepts} | {animates} |",
+            "| [`{name}`]({link}) | {accepts} | {animates} | {description} |",
             name = r.name(),
             link = rel_path("renderers", r.name()),
             accepts = shapes_list(r.accepts()),
             animates = if r.animates() { "yes" } else { "no" },
+            description = escape_pipe(r.description()),
         );
     }
     out.push('\n');
@@ -164,14 +166,8 @@ fn overview_shape_matrix(out: &mut String, renderers: &RenderRegistry) {
 
 fn fetcher_page(f: &RegisteredFetcher, renderers: &RenderRegistry) -> String {
     let mut out = String::new();
-    let description = format!(
-        "Fetcher `{}` — {} ({}). Emits {}.",
-        f.name(),
-        kind_label(f),
-        safety_label(f.safety()),
-        shapes_list(&f.shapes()),
-    );
-    push_frontmatter(&mut out, f.name(), &description);
+    push_frontmatter(&mut out, f.name(), f.description());
+    let _ = writeln!(out, "{}\n", f.description());
     let _ = writeln!(out, "- Kind: {}", kind_label(f));
     let _ = writeln!(out, "- Safety: {}", safety_label(f.safety()));
     let _ = writeln!(out, "- Shapes: {}\n", shapes_list(&f.shapes()));
@@ -204,12 +200,8 @@ fn render_previews(out: &mut String, fetcher: &RegisteredFetcher, renderers: &Re
 
 fn renderer_page(r: &Arc<dyn Renderer>, fetchers: &FetcherRegistry) -> String {
     let mut out = String::new();
-    let description = format!(
-        "Renderer `{}` — accepts {}.",
-        r.name(),
-        shapes_list(r.accepts()),
-    );
-    push_frontmatter(&mut out, r.name(), &description);
+    push_frontmatter(&mut out, r.name(), r.description());
+    let _ = writeln!(out, "{}\n", r.description());
     let _ = writeln!(out, "- Accepts: {}", shapes_list(r.accepts()));
     let _ = writeln!(
         out,


### PR DESCRIPTION
## Summary

- Generated reference pages (`/reference/fetchers/*`, `/reference/renderers/*`) previously only restated the metadata that was already visible in the matrix — name, shape, safety. A reader couldn't tell what `clock_almanac` actually shows, or how `gauge_circle` and `gauge_segment` differ, without opening the source.
- Adds a required `description() -> &'static str` to `Fetcher`, `RealtimeFetcher`, and `Renderer`. Every registered impl gets a 1–2 sentence summary that explains what it does and, where siblings exist, what makes it distinct. Required (no default) so a future fetcher / renderer landing without a description breaks the build instead of silently shipping a metadata-only page.
- `xtask gen-matrix` now opens each per-entry page with the description and adds a `Description` column to the matrix overview tables.

## Test plan

- [x] `cargo test --workspace` — 856 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask` — regenerates every reference page and matrix.md without errors
- [ ] Skim a sample of generated pages locally to confirm prose reads naturally and matches the actual behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Added descriptive documentation to all data sources (fetchers) and display formats (renderers)** — Each fetcher and renderer now includes a human-readable description explaining its purpose, behavior, output format, and when to use it alongside related alternatives.

* **Updated generated documentation** — Documentation tables now display descriptions for quick reference and comparison between options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->