### PR TITLE
feat(fetcher): add code_largest_files for refactor-candidate hunting

### DIFF
--- a/src/fetcher/code/largest_files.rs
+++ b/src/fetcher/code/largest_files.rs
@@ -1,0 +1,570 @@
+//! `code_largest_files` — ranks the top tracked files by line count or byte size. Headlines the
+//! single biggest file in `Text`; multi-row shapes (`TextBlock` / `Entries` / `Bars` /
+//! `MarkdownTextBlock` / `NumberSeries`) carry the per-file ranking. `Badge` flags whether the
+//! repo is harbouring a refactor-candidate-sized file (separate health signal from `code_loc`'s
+//! repo-total tier).
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, NumberSeriesData,
+    Payload, Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::super::git::{open_repo, payload, repo_cache_key};
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::scan::for_each_tracked_file;
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::NumberSeries,
+    Shape::Badge,
+];
+const DEFAULT_LIMIT: usize = 10;
+
+// Refactor-candidate tiers for `Badge`. Boundaries chosen for the LOC metric (single-file
+// review effort): under ~200 lines is comfortable, ~500 starts to feel heavy, ~1000+ is the
+// "split this up" zone. Bytes metric reuses the same tier names with KiB-scaled thresholds —
+// the qualitative read ("is anything in this repo too big?") stays consistent.
+const TIER_LOC_TIDY: u64 = 200;
+const TIER_LOC_BIG: u64 = 500;
+const TIER_LOC_BLOATED: u64 = 1_000;
+const TIER_BYTES_TIDY: u64 = 16 * 1024;
+const TIER_BYTES_BIG: u64 = 64 * 1024;
+const TIER_BYTES_BLOATED: u64 = 256 * 1024;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "metric",
+        type_hint: "`loc` | `bytes`",
+        required: false,
+        default: Some("loc"),
+        description: "What to rank files by: `loc` (text line count, binaries skipped) or `bytes` (raw file size). LOC suits refactor-candidate hunting; bytes suits asset-weight audits.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer",
+        required: false,
+        default: Some("10"),
+        description: "Cap on ranked rows (`TextBlock` / `MarkdownTextBlock` / `Entries` / `Bars` / `NumberSeries`). The `Text` headline always names just the single largest file.",
+    },
+];
+
+/// Ranks the largest tracked source files in the discovered git repo. Walks the `gix` index
+/// via the shared family helper, so untracked / `.gitignore`-d files plus committed-vendored
+/// trees, lockfiles, and binaries are skipped automatically.
+pub struct CodeLargestFiles;
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    metric: Option<Metric>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Metric {
+    #[default]
+    Loc,
+    Bytes,
+}
+
+#[async_trait]
+impl Fetcher for CodeLargestFiles {
+    fn name(&self) -> &str {
+        "code_largest_files"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Ranks the largest tracked source files in the discovered git repo. `metric = \"loc\"` (default) counts text lines per file; `metric = \"bytes\"` measures raw size. `Text` headlines the single biggest file; `TextBlock` / `MarkdownTextBlock` / `Entries` / `Bars` carry the per-file ranking; `NumberSeries` sketches the size distribution; `Badge` flags whether the repo holds a refactor-candidate-sized file (`tidy` / `big` / `bloated` / `monster`). Vendored / generated dirs, lockfiles, and binaries are skipped via the shared scan helper."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Entries
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let base = repo_cache_key(self.name(), ctx);
+        let opts = ctx
+            .options
+            .as_ref()
+            .map(toml::Value::to_string)
+            .unwrap_or_default();
+        if opts.is_empty() {
+            return base;
+        }
+        let digest = Sha256::digest(opts.as_bytes());
+        let hex: String = digest.iter().take(4).map(|b| format!("{b:02x}")).collect();
+        format!("{base}-{hex}")
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Text => samples::text("src/render/mod.rs (1,234 LOC)"),
+            Shape::TextBlock => samples::text_block(&[
+                "src/render/mod.rs (1,234)",
+                "src/fetcher/git/mod.rs (812)",
+                "src/payload.rs (640)",
+            ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- **src/render/mod.rs** — 1,234 LOC\n- **src/fetcher/git/mod.rs** — 812 LOC\n- **src/payload.rs** — 640 LOC",
+            ),
+            Shape::Entries => samples::entries(&[
+                ("src/render/mod.rs", "1,234"),
+                ("src/fetcher/git/mod.rs", "812"),
+                ("src/payload.rs", "640"),
+            ]),
+            Shape::Bars => samples::bars(&[
+                ("src/render/mod.rs", 1234),
+                ("src/fetcher/git/mod.rs", 812),
+                ("src/payload.rs", 640),
+            ]),
+            Shape::NumberSeries => samples::number_series(&[1234, 812, 640, 420, 280]),
+            Shape::Badge => samples::badge(Status::Warn, "bloated · src/render/mod.rs (1,234)"),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref())?;
+        let metric = opts.metric.unwrap_or_default();
+        let limit = opts.limit.filter(|n| *n > 0).unwrap_or(DEFAULT_LIMIT);
+        let scan = scan_cwd(metric)?;
+        Ok(payload(render_body(
+            scan,
+            ctx.shape.unwrap_or(Shape::Entries),
+            metric,
+            limit,
+        )))
+    }
+}
+
+fn parse_options(raw: Option<&toml::Value>) -> Result<Options, FetchError> {
+    match raw {
+        None => Ok(Options::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<Options>()
+            .map_err(|e| FetchError::Failed(format!("invalid options: {e}"))),
+    }
+}
+
+#[derive(Debug, Default)]
+struct Scan {
+    /// `(path, measure)` sorted by measure desc, then path asc.
+    by_file: Vec<(String, u64)>,
+}
+
+fn scan_cwd(metric: Metric) -> Result<Scan, FetchError> {
+    let repo = open_repo()?;
+    scan_repo(&repo, metric)
+}
+
+fn scan_repo(repo: &gix::Repository, metric: Metric) -> Result<Scan, FetchError> {
+    let mut by_file: Vec<(String, u64)> = Vec::new();
+    for_each_tracked_file(repo, |path, bytes| {
+        let measure = measure_file(metric, bytes);
+        if measure == 0 {
+            return;
+        }
+        by_file.push((path.to_string(), measure));
+    })?;
+    by_file.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    Ok(Scan { by_file })
+}
+
+fn measure_file(metric: Metric, bytes: &[u8]) -> u64 {
+    match metric {
+        Metric::Bytes => bytes.len() as u64,
+        Metric::Loc => match std::str::from_utf8(bytes) {
+            Ok(text) => text.lines().count() as u64,
+            Err(_) => 0,
+        },
+    }
+}
+
+fn render_body(scan: Scan, shape: Shape, metric: Metric, limit: usize) -> Body {
+    if scan.by_file.is_empty() {
+        return empty_body(shape);
+    }
+    match shape {
+        Shape::Text => text_body(&scan, metric),
+        Shape::TextBlock => text_block_body(&scan, limit),
+        Shape::MarkdownTextBlock => markdown_body(&scan, metric, limit),
+        Shape::Entries => entries_body(&scan, limit),
+        Shape::Bars => bars_body(scan, limit),
+        Shape::NumberSeries => number_series_body(&scan, limit),
+        Shape::Badge => badge_body(&scan, metric),
+        _ => text_body(&scan, metric),
+    }
+}
+
+fn empty_body(shape: Shape) -> Body {
+    match shape {
+        Shape::TextBlock => Body::TextBlock(TextBlockData { lines: vec![] }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: String::new(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData { items: vec![] }),
+        Shape::Bars => Body::Bars(BarsData { bars: vec![] }),
+        Shape::NumberSeries => Body::NumberSeries(NumberSeriesData { values: vec![] }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: Status::Ok,
+            label: "empty".into(),
+        }),
+        _ => Body::Text(TextData {
+            value: String::new(),
+        }),
+    }
+}
+
+fn text_body(scan: &Scan, metric: Metric) -> Body {
+    let (path, measure) = scan.by_file.first().expect("non-empty scan");
+    Body::Text(TextData {
+        value: format!("{path} ({})", format_measure(*measure, metric)),
+    })
+}
+
+fn text_block_body(scan: &Scan, limit: usize) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: scan
+            .by_file
+            .iter()
+            .take(limit)
+            .map(|(path, n)| format!("{path} ({})", format_with_commas(*n)))
+            .collect(),
+    })
+}
+
+fn markdown_body(scan: &Scan, metric: Metric, limit: usize) -> Body {
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: scan
+            .by_file
+            .iter()
+            .take(limit)
+            .map(|(path, n)| format!("- **{path}** — {}", format_measure(*n, metric)))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    })
+}
+
+fn entries_body(scan: &Scan, limit: usize) -> Body {
+    Body::Entries(EntriesData {
+        items: scan
+            .by_file
+            .iter()
+            .take(limit)
+            .map(|(path, n)| Entry {
+                key: path.clone(),
+                value: Some(format_with_commas(*n)),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+fn bars_body(scan: Scan, limit: usize) -> Body {
+    Body::Bars(BarsData {
+        bars: scan
+            .by_file
+            .into_iter()
+            .take(limit)
+            .map(|(path, n)| Bar {
+                label: path,
+                value: n,
+            })
+            .collect(),
+    })
+}
+
+fn number_series_body(scan: &Scan, limit: usize) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: scan.by_file.iter().take(limit).map(|(_, n)| *n).collect(),
+    })
+}
+
+fn badge_body(scan: &Scan, metric: Metric) -> Body {
+    let (path, measure) = scan.by_file.first().expect("non-empty scan");
+    let (tier, status) = tier_for(metric, *measure);
+    Body::Badge(BadgeData {
+        status,
+        label: format!("{tier} · {path} ({})", format_with_commas(*measure)),
+    })
+}
+
+fn tier_for(metric: Metric, measure: u64) -> (&'static str, Status) {
+    let (tidy, big, bloated) = match metric {
+        Metric::Loc => (TIER_LOC_TIDY, TIER_LOC_BIG, TIER_LOC_BLOATED),
+        Metric::Bytes => (TIER_BYTES_TIDY, TIER_BYTES_BIG, TIER_BYTES_BLOATED),
+    };
+    if measure < tidy {
+        ("tidy", Status::Ok)
+    } else if measure < big {
+        ("big", Status::Ok)
+    } else if measure < bloated {
+        ("bloated", Status::Warn)
+    } else {
+        ("monster", Status::Error)
+    }
+}
+
+fn format_measure(n: u64, metric: Metric) -> String {
+    let suffix = match metric {
+        Metric::Loc => "LOC",
+        Metric::Bytes => "bytes",
+    };
+    format!("{} {suffix}", format_with_commas(n))
+}
+
+fn format_with_commas(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::git::test_support::{commit_touching, make_repo};
+    use super::*;
+
+    fn fixed_scan() -> Scan {
+        Scan {
+            by_file: vec![
+                ("src/render/mod.rs".into(), 1_234),
+                ("src/fetcher/git/mod.rs".into(), 812),
+                ("src/payload.rs".into(), 640),
+            ],
+        }
+    }
+
+    #[test]
+    fn empty_repo_returns_empty_scan() {
+        let (_tmp, repo) = make_repo();
+        let scan = scan_repo(&repo, Metric::Loc).unwrap();
+        assert!(scan.by_file.is_empty());
+    }
+
+    #[test]
+    fn ranks_files_by_loc_descending() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "small.rs", "a");
+        commit_touching(&repo, "big.rs", "1\n2\n3\n4\n5");
+        commit_touching(&repo, "mid.rs", "x\ny\nz");
+        let scan = scan_repo(&repo, Metric::Loc).unwrap();
+        let names: Vec<_> = scan.by_file.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(names, vec!["big.rs", "mid.rs", "small.rs"]);
+    }
+
+    #[test]
+    fn lockfiles_and_vendored_excluded() {
+        let (_tmp, repo) = make_repo();
+        commit_touching(&repo, "src/main.rs", "fn main() {}");
+        commit_touching(
+            &repo,
+            "Cargo.lock",
+            "noise\nnoise\nnoise\nnoise\nnoise\nnoise",
+        );
+        commit_touching(&repo, "node_modules/big.js", "x\ny\nz\nw\nq\nr");
+        let scan = scan_repo(&repo, Metric::Loc).unwrap();
+        let paths: Vec<_> = scan.by_file.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["src/main.rs"]);
+    }
+
+    #[test]
+    fn bytes_metric_uses_raw_file_size() {
+        let (_tmp, repo) = make_repo();
+        // shorter content, more lines
+        commit_touching(&repo, "many.rs", "a\nb\nc\nd\ne");
+        // longer content, fewer lines
+        commit_touching(&repo, "long.rs", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+        let scan = scan_repo(&repo, Metric::Bytes).unwrap();
+        let head = scan.by_file.first().map(|(p, _)| p.as_str());
+        assert_eq!(head, Some("long.rs"));
+    }
+
+    #[test]
+    fn text_headlines_largest_file() {
+        match render_body(fixed_scan(), Shape::Text, Metric::Loc, 10) {
+            Body::Text(d) => assert_eq!(d.value, "src/render/mod.rs (1,234 LOC)"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_uses_metric_suffix() {
+        match render_body(fixed_scan(), Shape::Text, Metric::Bytes, 10) {
+            Body::Text(d) => assert_eq!(d.value, "src/render/mod.rs (1,234 bytes)"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_is_empty_when_no_files() {
+        match render_body(Scan::default(), Shape::Text, Metric::Loc, 10) {
+            Body::Text(d) => assert!(d.value.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_block_lists_ranked_files() {
+        match render_body(fixed_scan(), Shape::TextBlock, Metric::Loc, 10) {
+            Body::TextBlock(d) => assert_eq!(
+                d.lines,
+                vec![
+                    "src/render/mod.rs (1,234)",
+                    "src/fetcher/git/mod.rs (812)",
+                    "src/payload.rs (640)",
+                ]
+            ),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn entries_carry_path_and_count() {
+        match render_body(fixed_scan(), Shape::Entries, Metric::Loc, 10) {
+            Body::Entries(d) => {
+                assert_eq!(d.items[0].key, "src/render/mod.rs");
+                assert_eq!(d.items[0].value.as_deref(), Some("1,234"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn bars_carry_path_and_raw_value() {
+        match render_body(fixed_scan(), Shape::Bars, Metric::Loc, 10) {
+            Body::Bars(d) => {
+                assert_eq!(d.bars[0].label, "src/render/mod.rs");
+                assert_eq!(d.bars[0].value, 1234);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn markdown_emphasises_path_with_metric_suffix() {
+        match render_body(fixed_scan(), Shape::MarkdownTextBlock, Metric::Loc, 10) {
+            Body::MarkdownTextBlock(d) => assert_eq!(
+                d.value,
+                "- **src/render/mod.rs** — 1,234 LOC\n- **src/fetcher/git/mod.rs** — 812 LOC\n- **src/payload.rs** — 640 LOC"
+            ),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn number_series_emits_sorted_measures() {
+        match render_body(fixed_scan(), Shape::NumberSeries, Metric::Loc, 10) {
+            Body::NumberSeries(d) => assert_eq!(d.values, vec![1234, 812, 640]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn limit_caps_rendered_rows() {
+        match render_body(fixed_scan(), Shape::Entries, Metric::Loc, 2) {
+            Body::Entries(d) => assert_eq!(d.items.len(), 2),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn badge_tiers_by_largest_file_size_loc() {
+        assert_eq!(tier_for(Metric::Loc, 50), ("tidy", Status::Ok));
+        assert_eq!(tier_for(Metric::Loc, 300), ("big", Status::Ok));
+        assert_eq!(tier_for(Metric::Loc, 700), ("bloated", Status::Warn));
+        assert_eq!(tier_for(Metric::Loc, 5_000), ("monster", Status::Error));
+    }
+
+    #[test]
+    fn badge_tiers_by_largest_file_size_bytes() {
+        assert_eq!(tier_for(Metric::Bytes, 1024), ("tidy", Status::Ok));
+        assert_eq!(tier_for(Metric::Bytes, 32 * 1024), ("big", Status::Ok));
+        assert_eq!(
+            tier_for(Metric::Bytes, 100 * 1024),
+            ("bloated", Status::Warn)
+        );
+        assert_eq!(
+            tier_for(Metric::Bytes, 500 * 1024),
+            ("monster", Status::Error)
+        );
+    }
+
+    #[test]
+    fn badge_label_includes_tier_path_and_count() {
+        match render_body(fixed_scan(), Shape::Badge, Metric::Loc, 10) {
+            Body::Badge(d) => {
+                assert_eq!(d.status, Status::Error);
+                assert_eq!(d.label, "monster · src/render/mod.rs (1,234)");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn badge_handles_empty() {
+        match render_body(Scan::default(), Shape::Badge, Metric::Loc, 10) {
+            Body::Badge(d) => {
+                assert_eq!(d.status, Status::Ok);
+                assert_eq!(d.label, "empty");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn cache_key_changes_with_options() {
+        let mut ctx = FetchContext {
+            widget_id: "w".into(),
+            ..Default::default()
+        };
+        let k0 = CodeLargestFiles.cache_key(&ctx);
+        ctx.options = Some(toml::from_str(r#"limit = 5"#).unwrap());
+        let k1 = CodeLargestFiles.cache_key(&ctx);
+        ctx.options = Some(toml::from_str(r#"metric = "bytes""#).unwrap());
+        let k2 = CodeLargestFiles.cache_key(&ctx);
+        assert_ne!(k0, k1);
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_keys() {
+        let bad: toml::Value = toml::from_str(r#"unknown = 1"#).unwrap();
+        assert!(parse_options(Some(&bad)).is_err());
+    }
+
+    #[test]
+    fn parse_options_accepts_metric_variants() {
+        let loc: toml::Value = toml::from_str(r#"metric = "loc""#).unwrap();
+        assert_eq!(parse_options(Some(&loc)).unwrap().metric, Some(Metric::Loc));
+        let bytes: toml::Value = toml::from_str(r#"metric = "bytes""#).unwrap();
+        assert_eq!(
+            parse_options(Some(&bytes)).unwrap().metric,
+            Some(Metric::Bytes)
+        );
+    }
+}

--- a/src/fetcher/code/mod.rs
+++ b/src/fetcher/code/mod.rs
@@ -12,6 +12,7 @@ use super::Fetcher;
 mod files;
 mod language_logo;
 mod languages;
+mod largest_files;
 mod loc;
 mod logo_assets;
 mod scan;
@@ -19,6 +20,7 @@ mod todos;
 
 pub use files::CodeFiles;
 pub use language_logo::CodeLanguageLogo;
+pub use largest_files::CodeLargestFiles;
 pub use loc::CodeLoc;
 pub use todos::CodeTodos;
 
@@ -28,5 +30,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(CodeLoc),
         Arc::new(CodeLanguageLogo),
         Arc::new(CodeFiles),
+        Arc::new(CodeLargestFiles),
     ]
 }


### PR DESCRIPTION
## Summary

- Adds `code_largest_files` — ranks the largest tracked source files in the discovered git repo. Walks the `gix` index via the shared `for_each_tracked_file` helper, so untracked / `.gitignore`-d files plus committed-vendored trees, lockfiles, and binaries are skipped automatically.
- Seven shapes from one read: `Text` (headline), `TextBlock` / `MarkdownTextBlock` / `Entries` / `Bars` (per-file ranking), `NumberSeries` (size distribution), `Badge` (refactor-candidate tier — `tidy` / `big` / `bloated` / `monster`).
- Lands the body 5 "hotspots" slot of the upcoming `project_codebase` preset (#164). Sub-issue: #62.

## Reference page

Mirrors what `https://splashboard.unhappychoice.com/reference/fetchers/code/code_largest_files` will show after the docs site rebuilds.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `text`, `text_block`, `markdown_text_block`, `entries`, `bars`, `number_series`, `badge` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `metric` | `loc` \| `bytes` | no | loc | What to rank files by: `loc` (text line count, binaries skipped) or `bytes` (raw file size). LOC suits refactor-candidate hunting; bytes suits asset-weight audits. |
| `limit` | integer | no | 10 | Cap on ranked rows (`TextBlock` / `MarkdownTextBlock` / `Entries` / `Bars` / `NumberSeries`). The `Text` headline always names just the single largest file. |

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| `text` | [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii), `animated_*` |
| `text_block` | [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain), `animated_*` |
| `markdown_text_block` | [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown) |
| `entries` | [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table), `animated_*` |
| `bars` | [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar), [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie), [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking), `animated_*` |
| `number_series` | [`chart_histogram`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_histogram), [`chart_sparkline`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_sparkline), `animated_*` |
| `badge` | [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge), `animated_*` |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (985 passed)
- [x] `cargo run --bin splashboard -- catalog fetcher code_largest_files` — all 7 shapes + options + compatible renderers listed
- [x] Smoke-tested locally with `Text` / `Entries` (default + `metric = "bytes"`) / `Bars` (chart_bar) / `Badge` widget configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a code analysis tool that scans your repository and identifies the largest files ranked by either file size or line count. Supports multiple visualization formats including text summaries, detailed lists, progress bars, status badges, and numeric series. Configure your preferred metric and result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->