### PR TITLE
feat(fetcher): fill missing shape coverage across 14 fetchers

### DIFF
--- a/src/fetcher/clock/almanac.rs
+++ b/src/fetcher/clock/almanac.rs
@@ -158,6 +158,18 @@ mod tests {
         }
     }
 
+    /// Locks the fetcher's `now` to UTC so date-based assertions don't drift in CI hosts on
+    /// JST/PST etc. where local-vs-UTC straddle midnight.
+    fn ctx_utc(shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "a".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options: Some(toml::from_str("timezone = \"UTC\"").unwrap()),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn default_shape_entries_has_six_rows() {
         let p = ClockAlmanacFetcher.compute(&ctx(None));
@@ -178,7 +190,9 @@ mod tests {
 
     #[test]
     fn calendar_shape_pins_today() {
-        let p = ClockAlmanacFetcher.compute(&ctx(Some(Shape::Calendar)));
+        // Pin both sides to UTC — without this the test was flaky on hosts whose local date
+        // differs from UTC at the moment of execution (e.g. JST evening near year-end).
+        let p = ClockAlmanacFetcher.compute(&ctx_utc(Some(Shape::Calendar)));
         let Body::Calendar(d) = p.body else {
             panic!("expected calendar");
         };

--- a/src/fetcher/clock/almanac.rs
+++ b/src/fetcher/clock/almanac.rs
@@ -10,14 +10,14 @@ use chrono::{DateTime, Datelike, FixedOffset};
 use serde::Deserialize;
 
 use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
-use crate::payload::{Body, EntriesData, Entry, Payload};
+use crate::payload::{Body, CalendarData, EntriesData, Entry, Payload};
 use crate::render::Shape;
 use crate::samples;
 
 use super::common;
 use super::derived::{self, Hemisphere, Kind};
 
-const SHAPES: &[Shape] = &[Shape::Entries, Shape::TextBlock];
+const SHAPES: &[Shape] = &[Shape::Entries, Shape::TextBlock, Shape::Calendar];
 
 pub struct ClockAlmanacFetcher;
 
@@ -40,7 +40,7 @@ impl RealtimeFetcher for ClockAlmanacFetcher {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "A multi-row rollup of date-derived facts (moon phase, season, zodiac, chinese zodiac, ISO week, day of year). Use this when you want every almanac value at once; pick `clock_derived` instead to surface a single value on its own line."
+        "A multi-row rollup of date-derived facts (moon phase, season, zodiac, chinese zodiac, ISO week, day of year). Use this when you want every almanac value at once; pick `clock_derived` instead to surface a single value on its own line. `Calendar` highlights today within the current month so the same fetcher can drive a `grid_calendar` widget."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -63,6 +63,12 @@ impl RealtimeFetcher for ClockAlmanacFetcher {
                 "iso week:    2026-W17",
                 "day of year: 114 of 365",
             ]),
+            Shape::Calendar => Body::Calendar(CalendarData {
+                year: 2026,
+                month: 4,
+                day: Some(24),
+                events: Vec::new(),
+            }),
             _ => return None,
         })
     }
@@ -76,6 +82,12 @@ impl RealtimeFetcher for ClockAlmanacFetcher {
         let body = match ctx.shape.unwrap_or(Shape::Entries) {
             Shape::TextBlock => Body::TextBlock(crate::payload::TextBlockData {
                 lines: rows.iter().map(|(k, v)| format!("{k}: {v}")).collect(),
+            }),
+            Shape::Calendar => Body::Calendar(CalendarData {
+                year: now.year(),
+                month: now.month() as u8,
+                day: Some(now.day() as u8),
+                events: Vec::new(),
             }),
             _ => Body::Entries(EntriesData {
                 items: rows
@@ -162,6 +174,18 @@ mod tests {
         let rows = rollup(&at(2026, 4, 15), Hemisphere::South);
         let season = rows.iter().find(|(k, _)| *k == "season").unwrap();
         assert_eq!(season.1, "Autumn");
+    }
+
+    #[test]
+    fn calendar_shape_pins_today() {
+        let p = ClockAlmanacFetcher.compute(&ctx(Some(Shape::Calendar)));
+        let Body::Calendar(d) = p.body else {
+            panic!("expected calendar");
+        };
+        let now = Utc::now();
+        assert_eq!(d.year, now.year());
+        assert_eq!(d.month, now.month() as u8);
+        assert_eq!(d.day, Some(now.day() as u8));
     }
 
     #[test]

--- a/src/fetcher/clock/countdown.rs
+++ b/src/fetcher/clock/countdown.rs
@@ -2,18 +2,28 @@
 //! TextBlock / Entries). Past targets render as `"passed"` so the widget keeps rendering through
 //! the event boundary.
 
-use chrono::{DateTime, FixedOffset, NaiveDate, TimeZone, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, TimeZone, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TextData};
+use crate::payload::{
+    Body, CalendarData, EntriesData, Entry, Payload, RatioData, TextBlockData, TextData,
+};
 use crate::render::Shape;
 use crate::samples;
 
 use super::common;
 
-const SHAPES: &[Shape] = &[Shape::Text, Shape::TextBlock, Shape::Entries];
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::Calendar,
+];
+
+const DEFAULT_WINDOW_DAYS: u32 = 30;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -44,6 +54,13 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
         default: None,
         description: "Multiple labelled countdowns. Rendered as `TextBlock` by default or `Entries` when the renderer expects a key/value shape.",
     },
+    OptionSchema {
+        name: "window_days",
+        type_hint: "integer (1..=3650)",
+        required: false,
+        default: Some("30"),
+        description: "Approach window used by `Ratio`. Progress is `(now - (target - window))/window`, clamped to `0..=1`, so a 30-day window starts filling 30 days out from the target.",
+    },
 ];
 
 pub struct ClockCountdownFetcher;
@@ -59,6 +76,8 @@ pub struct Options {
     pub target_label: Option<String>,
     #[serde(default)]
     pub targets: Option<Vec<TargetEntry>>,
+    #[serde(default)]
+    pub window_days: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -76,7 +95,7 @@ impl RealtimeFetcher for ClockCountdownFetcher {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Time remaining until one configured `target` date or a list of labelled `targets`, formatted as `Nd Nh` / `Nh Nm` / `Nm`. Past targets keep rendering as `passed` so the widget survives the event boundary."
+        "Time remaining until one configured `target` date or a list of labelled `targets`, formatted as `Nd Nh` / `Nh Nm` / `Nm`. Past targets keep rendering as `passed` so the widget survives the event boundary. `Ratio` exposes a 30-day approach progress (override with `window_days`); `Calendar` highlights the target day within its month."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -89,6 +108,13 @@ impl RealtimeFetcher for ClockCountdownFetcher {
             Shape::Text => samples::text("Ship v2: 42d 3h"),
             Shape::TextBlock => samples::text_block(&["Ship v2: 42d 3h", "Release: 7d"]),
             Shape::Entries => samples::entries(&[("Ship v2", "42d 3h"), ("Release", "7d")]),
+            Shape::Ratio => samples::ratio(0.77, "Ship v2 · 7d to go"),
+            Shape::Calendar => Body::Calendar(CalendarData {
+                year: 2026,
+                month: 12,
+                day: Some(31),
+                events: Vec::new(),
+            }),
             _ => return None,
         })
     }
@@ -99,29 +125,48 @@ impl RealtimeFetcher for ClockCountdownFetcher {
         };
         let now = common::now_in(opts.timezone.as_deref());
         let shape = ctx.shape.unwrap_or(Shape::Text);
-        let body = match (&opts.targets, &opts.target, shape) {
-            (Some(list), _, Shape::Entries) => Body::Entries(EntriesData {
-                items: list
-                    .iter()
-                    .map(|t| Entry {
-                        key: t.label.clone(),
-                        value: Some(format_remaining(&now, &t.target)),
-                        status: None,
-                    })
-                    .collect(),
-            }),
-            (Some(list), _, _) => Body::TextBlock(TextBlockData {
-                lines: list
-                    .iter()
-                    .map(|t| format!("{}: {}", t.label, format_remaining(&now, &t.target)))
-                    .collect(),
-            }),
-            (None, Some(target), _) => Body::Text(TextData {
-                value: format_single(&now, target, opts.target_label.as_deref()),
-            }),
-            (None, None, _) => Body::Text(TextData {
-                value: "no target configured".into(),
-            }),
+        let window_days = opts
+            .window_days
+            .unwrap_or(DEFAULT_WINDOW_DAYS)
+            .clamp(1, 3650);
+        let primary_target = opts.target.as_deref().or_else(|| {
+            opts.targets
+                .as_ref()
+                .and_then(|v| v.first())
+                .map(|t| t.target.as_str())
+        });
+        let body = match shape {
+            Shape::Ratio => ratio_body(
+                &now,
+                primary_target,
+                opts.target_label.as_deref(),
+                &opts.targets,
+                window_days,
+            ),
+            Shape::Calendar => calendar_body(&now, primary_target, &opts.targets),
+            Shape::Entries => match &opts.targets {
+                Some(list) => Body::Entries(EntriesData {
+                    items: list
+                        .iter()
+                        .map(|t| Entry {
+                            key: t.label.clone(),
+                            value: Some(format_remaining(&now, &t.target)),
+                            status: None,
+                        })
+                        .collect(),
+                }),
+                None => single_text_body(&now, &opts),
+            },
+            Shape::TextBlock => match &opts.targets {
+                Some(list) => Body::TextBlock(TextBlockData {
+                    lines: list
+                        .iter()
+                        .map(|t| format!("{}: {}", t.label, format_remaining(&now, &t.target)))
+                        .collect(),
+                }),
+                None => single_text_body(&now, &opts),
+            },
+            _ => single_text_body(&now, &opts),
         };
         Payload {
             icon: None,
@@ -130,6 +175,98 @@ impl RealtimeFetcher for ClockCountdownFetcher {
             body,
         }
     }
+}
+
+fn single_text_body(now: &DateTime<FixedOffset>, opts: &Options) -> Body {
+    Body::Text(TextData {
+        value: match opts.target.as_deref() {
+            Some(target) => format_single(now, target, opts.target_label.as_deref()),
+            None => "no target configured".into(),
+        },
+    })
+}
+
+fn ratio_body(
+    now: &DateTime<FixedOffset>,
+    primary: Option<&str>,
+    label: Option<&str>,
+    targets: &Option<Vec<TargetEntry>>,
+    window_days: u32,
+) -> Body {
+    let Some(target_str) = primary else {
+        return Body::Ratio(RatioData {
+            value: 0.0,
+            label: Some("no target configured".into()),
+            denominator: None,
+        });
+    };
+    let Some(target) = parse_target(target_str) else {
+        return Body::Ratio(RatioData {
+            value: 0.0,
+            label: Some("invalid target".into()),
+            denominator: None,
+        });
+    };
+    let value = approach_ratio(now, &target, window_days);
+    let label = label
+        .map(String::from)
+        .or_else(|| {
+            targets
+                .as_ref()
+                .and_then(|v| v.first())
+                .map(|t| t.label.clone())
+        })
+        .map(|l| format!("{l} · {}", format_remaining(now, target_str)))
+        .unwrap_or_else(|| format_remaining(now, target_str));
+    Body::Ratio(RatioData {
+        value,
+        label: Some(label),
+        denominator: None,
+    })
+}
+
+fn approach_ratio(
+    now: &DateTime<FixedOffset>,
+    target: &DateTime<FixedOffset>,
+    window_days: u32,
+) -> f64 {
+    let secs = target.signed_duration_since(*now).num_seconds();
+    if secs <= 0 {
+        return 1.0;
+    }
+    let window = i64::from(window_days) * 86_400;
+    if window <= 0 {
+        return 0.0;
+    }
+    (1.0 - secs as f64 / window as f64).clamp(0.0, 1.0)
+}
+
+fn calendar_body(
+    now: &DateTime<FixedOffset>,
+    primary: Option<&str>,
+    targets: &Option<Vec<TargetEntry>>,
+) -> Body {
+    let primary_dt = primary.and_then(parse_target);
+    let (year, month, day) = match primary_dt {
+        Some(dt) => (dt.year(), dt.month() as u8, Some(dt.day() as u8)),
+        None => (now.year(), now.month() as u8, Some(now.day() as u8)),
+    };
+    let events = targets
+        .as_ref()
+        .map(|list| {
+            list.iter()
+                .filter_map(|t| parse_target(&t.target))
+                .filter(|dt| dt.year() == year && dt.month() == u32::from(month))
+                .map(|dt| dt.day() as u8)
+                .collect()
+        })
+        .unwrap_or_default();
+    Body::Calendar(CalendarData {
+        year,
+        month,
+        day,
+        events,
+    })
 }
 
 fn format_single(now: &DateTime<FixedOffset>, target: &str, label: Option<&str>) -> String {
@@ -227,5 +364,83 @@ mod tests {
         assert_eq!(humanize(45 * 60), "45m");
         assert_eq!(humanize(3 * 3600 + 5 * 60), "3h 5m");
         assert_eq!(humanize(2 * 86_400 + 3 * 3600), "2d 3h");
+    }
+
+    #[test]
+    fn approach_ratio_starts_at_zero_and_completes_at_target() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .unwrap()
+            .fixed_offset();
+        let far = Utc
+            .with_ymd_and_hms(2027, 1, 1, 0, 0, 0)
+            .unwrap()
+            .fixed_offset();
+        // 1 year out, 30-day window — completely outside the window so 0.0.
+        assert_eq!(approach_ratio(&now, &far, 30), 0.0);
+        let mid = Utc
+            .with_ymd_and_hms(2026, 1, 16, 0, 0, 0)
+            .unwrap()
+            .fixed_offset();
+        // 15 days out, 30-day window — half full.
+        assert!((approach_ratio(&now, &mid, 30) - 0.5).abs() < 1e-6);
+        // Past target → fully filled.
+        let past = Utc
+            .with_ymd_and_hms(2025, 12, 1, 0, 0, 0)
+            .unwrap()
+            .fixed_offset();
+        assert_eq!(approach_ratio(&now, &past, 30), 1.0);
+    }
+
+    #[test]
+    fn ratio_shape_emits_ratio_body() {
+        let p = ClockCountdownFetcher.compute(&ctx(Some(Shape::Ratio), "target = \"2099-12-31\""));
+        let Body::Ratio(d) = p.body else {
+            panic!("expected ratio")
+        };
+        assert!(d.value >= 0.0 && d.value <= 1.0);
+        assert!(d.label.is_some());
+    }
+
+    #[test]
+    fn ratio_with_no_target_label_says_so() {
+        let p = ClockCountdownFetcher.compute(&ctx(Some(Shape::Ratio), ""));
+        let Body::Ratio(d) = p.body else {
+            panic!("expected ratio")
+        };
+        assert_eq!(d.value, 0.0);
+        assert_eq!(d.label.as_deref(), Some("no target configured"));
+    }
+
+    #[test]
+    fn calendar_shape_pins_target_day() {
+        let p =
+            ClockCountdownFetcher.compute(&ctx(Some(Shape::Calendar), "target = \"2099-12-31\""));
+        let Body::Calendar(d) = p.body else {
+            panic!("expected calendar")
+        };
+        assert_eq!(d.year, 2099);
+        assert_eq!(d.month, 12);
+        assert_eq!(d.day, Some(31));
+    }
+
+    #[test]
+    fn calendar_with_multi_targets_marks_event_days_in_primary_month() {
+        let p = ClockCountdownFetcher.compute(&ctx(
+            Some(Shape::Calendar),
+            r#"targets = [
+                {label = "A", target = "2099-12-05"},
+                {label = "B", target = "2099-12-20"},
+                {label = "C", target = "2100-01-10"}
+            ]"#,
+        ));
+        let Body::Calendar(d) = p.body else {
+            panic!("expected calendar")
+        };
+        assert_eq!(d.year, 2099);
+        assert_eq!(d.month, 12);
+        assert_eq!(d.day, Some(5));
+        assert!(d.events.contains(&20));
+        assert!(!d.events.contains(&10));
     }
 }

--- a/src/fetcher/code/todos.rs
+++ b/src/fetcher/code/todos.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
 use crate::options::OptionSchema;
-use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload, TextBlockData, TextData};
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, TextBlockData,
+    TextData,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -12,7 +15,13 @@ use super::super::git::{open_repo, payload, repo_cache_key};
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::scan::for_each_tracked_file;
 
-const SHAPES: &[Shape] = &[Shape::Text, Shape::TextBlock, Shape::Entries, Shape::Bars];
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+];
 const DEFAULT_MARKERS: &[&str] = &["TODO", "FIXME"];
 const DEFAULT_LIMIT: usize = 20;
 const INTERNAL_HIT_CAP: usize = 500;
@@ -63,7 +72,7 @@ impl Fetcher for CodeTodos {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Greps tracked source files in the discovered git repo for `TODO:` / `FIXME:` style markers (trailing colon required, vendored / generated dirs skipped). `Text` summarises `\"N TODOs in M files\"`, `TextBlock` lists `path:line: snippet`, and `Entries` / `Bars` rank files by hit count."
+        "Greps tracked source files in the discovered git repo for `TODO:` / `FIXME:` style markers (trailing colon required, vendored / generated dirs skipped). `Text` summarises `\"N TODOs in M files\"`, `TextBlock` and `MarkdownTextBlock` list `path:line: snippet` (markdown variant uses inline-code formatting), and `Entries` / `Bars` rank files by hit count."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -99,6 +108,9 @@ impl Fetcher for CodeTodos {
                 "src/fetcher/git.rs:88: FIXME: don't panic on detached head",
                 "src/main.rs:14: TODO: load config from $HOME",
             ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- `src/render/mod.rs:120` — TODO: handle empty body\n- `src/fetcher/git.rs:88` — FIXME: don't panic on detached head\n- `src/main.rs:14` — TODO: load config from $HOME",
+            ),
             Shape::Entries => samples::entries(&[
                 ("src/render/mod.rs", "5"),
                 ("src/fetcher/git.rs", "3"),
@@ -276,6 +288,15 @@ fn render_body(scan: ScanResult, shape: Shape, limit: usize) -> Body {
                 .take(limit)
                 .map(|h| format!("{}:{}: {}", h.path, h.line, h.text))
                 .collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: scan
+                .hits
+                .into_iter()
+                .take(limit)
+                .map(|h| format!("- `{}:{}` — {}", h.path, h.line, h.text))
+                .collect::<Vec<_>>()
+                .join("\n"),
         }),
         Shape::Entries => Body::Entries(EntriesData {
             items: scan
@@ -516,6 +537,30 @@ mod tests {
         );
         match body {
             Body::TextBlock(d) => assert_eq!(d.lines, vec!["src/main.rs:12: TODO: x"]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn markdown_text_block_emits_path_line_snippet_as_list() {
+        let body = render_body(
+            ScanResult {
+                hits: vec![Hit {
+                    path: "src/main.rs".into(),
+                    line: 12,
+                    text: "TODO: x".into(),
+                }],
+                total: 1,
+                files_with_hits: 1,
+                file_counts: vec![("src/main.rs".into(), 1)],
+            },
+            Shape::MarkdownTextBlock,
+            10,
+        );
+        match body {
+            Body::MarkdownTextBlock(d) => {
+                assert!(d.value.contains("- `src/main.rs:12` — TODO: x"));
+            }
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/churn.rs
+++ b/src/fetcher/git/churn.rs
@@ -7,21 +7,28 @@ use gix::object::tree::diff::Change;
 use gix::revision::walk::Sorting;
 use gix::traverse::commit::simple::CommitTimeOrder;
 
-use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload};
+use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload};
 use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::{fail, open_repo, payload, repo_cache_key, text_block_body, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Entries, Shape::Bars, Shape::TextBlock, Shape::Text];
+const SHAPES: &[Shape] = &[
+    Shape::Entries,
+    Shape::Bars,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+];
 const DEFAULT_DAYS: u64 = 30;
 const TOP_FILES: usize = 10;
 const MAX_COMMITS: usize = 500;
 
 /// Top files by change count over the last N days (default 30, configurable via `format = "N"`).
 /// `Entries` is the default (`path: count` rows); `Bars` ranks visually; `TextBlock` emits one
-/// `"path (count)"` per line; `Text` collapses everything into a single-line basename summary
+/// `"path (count)"` per line; `MarkdownTextBlock` outputs the same ranking as a numbered markdown
+/// list; `Text` collapses everything into a single-line basename summary
 /// `"main.rs (42), lib.rs (31), …"`. Pairs with `code_largest_files` for "where's the action vs
 /// where's the mass" framing.
 pub struct GitChurn;
@@ -66,6 +73,9 @@ impl Fetcher for GitChurn {
                 "src/render/mod.rs (18)",
                 "src/fetcher/mod.rs (12)",
             ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "1. `src/main.rs` — 42\n2. `src/lib.rs` — 31\n3. `src/render/mod.rs` — 18\n4. `src/fetcher/mod.rs` — 12",
+            ),
             Shape::Text => samples::text("main.rs (42), lib.rs (31), mod.rs (18)"),
             _ => return None,
         })
@@ -182,6 +192,14 @@ fn render_body(ranked: Vec<(String, u64)>, shape: Shape) -> Body {
                 .map(|(path, count)| format!("{path} ({count})"))
                 .collect(),
         ),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: ranked
+                .into_iter()
+                .enumerate()
+                .map(|(i, (path, count))| format!("{}. `{path}` — {count}", i + 1))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
         Shape::Text => {
             if ranked.is_empty() {
                 text_body("")
@@ -312,6 +330,21 @@ mod tests {
         let body = render_body(Vec::new(), Shape::Text);
         match body {
             Body::Text(d) => assert!(d.value.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn markdown_text_block_emits_numbered_list_with_inline_code() {
+        let body = render_body(
+            vec![("src/foo.rs".into(), 3), ("src/bar.rs".into(), 1)],
+            Shape::MarkdownTextBlock,
+        );
+        match body {
+            Body::MarkdownTextBlock(d) => {
+                assert!(d.value.contains("1. `src/foo.rs` — 3"));
+                assert!(d.value.contains("2. `src/bar.rs` — 1"));
+            }
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -4,21 +4,30 @@ use async_trait::async_trait;
 use gix::revision::walk::Sorting;
 use gix::traverse::commit::simple::CommitTimeOrder;
 
-use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload};
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, TextBlockData,
+};
 use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries, Shape::Text];
+const SHAPES: &[Shape] = &[
+    Shape::Bars,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+];
 const DEFAULT_DAYS: u64 = 30;
 const MAX_ENTRIES: usize = 10;
 
 /// Commit authors over the last N days (default 30, configurable via `format = "N"`). Ranked
 /// by commit count, truncated to the top 10 so a busy repo doesn't blow up the widget. `Bars`
-/// is the default (visual ranking); `Entries` emits `name: count` rows; `Text` collapses to
-/// `"alice (23), bob (11)"` style.
+/// is the default (visual ranking); `Entries` emits `name: count` rows; `TextBlock` lists
+/// `"alice  42"` per line; `MarkdownTextBlock` renders the same ranking as a markdown list;
+/// `Text` collapses to `"alice (23), bob (11)"` style.
 pub struct GitContributors;
 
 #[async_trait]
@@ -30,7 +39,7 @@ impl Fetcher for GitContributors {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Top commit authors over the last N days (default 30, override with `format = \"N\"`), ranked by commit count and capped at ten. Useful for surfacing who's been active recently."
+        "Top commit authors over the last N days (default 30, override with `format = \"N\"`), ranked by commit count and capped at ten. Bars/Entries/TextBlock/MarkdownTextBlock all carry the ranking; Text is the headline summary."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -52,6 +61,12 @@ impl Fetcher for GitContributors {
                 ("charlie", "17"),
                 ("dave", "9"),
             ]),
+            Shape::TextBlock => {
+                samples::text_block(&["alice    42", "bob      28", "charlie  17", "dave      9"])
+            }
+            Shape::MarkdownTextBlock => samples::markdown(
+                "1. **alice** — 42\n2. **bob** — 28\n3. **charlie** — 17\n4. **dave** — 9",
+            ),
             Shape::Text => samples::text("alice (42), bob (28), charlie (17), dave (9)"),
             _ => return None,
         })
@@ -116,6 +131,20 @@ fn render_body(ranked: Vec<(String, u64)>, shape: Shape) -> Body {
                     status: None,
                 })
                 .collect(),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: ranked
+                .into_iter()
+                .map(|(name, count)| format!("{name}  {count}"))
+                .collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: ranked
+                .into_iter()
+                .enumerate()
+                .map(|(i, (name, count))| format!("{}. **{name}** — {count}", i + 1))
+                .collect::<Vec<_>>()
+                .join("\n"),
         }),
         Shape::Text => {
             if ranked.is_empty() {
@@ -190,6 +219,37 @@ mod tests {
         let body = render_body(vec![("alice".into(), 3), ("bob".into(), 1)], Shape::Text);
         match body {
             Body::Text(d) => assert_eq!(d.value, "alice (3), bob (1)"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn text_block_lists_one_row_per_contributor() {
+        let body = render_body(
+            vec![("alice".into(), 3), ("bob".into(), 1)],
+            Shape::TextBlock,
+        );
+        match body {
+            Body::TextBlock(d) => {
+                assert_eq!(d.lines.len(), 2);
+                assert!(d.lines[0].starts_with("alice"));
+                assert!(d.lines[0].ends_with("3"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn markdown_text_block_emits_numbered_ranking() {
+        let body = render_body(
+            vec![("alice".into(), 3), ("bob".into(), 1)],
+            Shape::MarkdownTextBlock,
+        );
+        match body {
+            Body::MarkdownTextBlock(d) => {
+                assert!(d.value.contains("1. **alice** — 3"));
+                assert!(d.value.contains("2. **bob** — 1"));
+            }
             _ => panic!(),
         }
     }

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -62,7 +62,7 @@ impl Fetcher for GitContributors {
                 ("dave", "9"),
             ]),
             Shape::TextBlock => {
-                samples::text_block(&["alice    42", "bob      28", "charlie  17", "dave      9"])
+                samples::text_block(&["alice  42", "bob  28", "charlie  17", "dave  9"])
             }
             Shape::MarkdownTextBlock => samples::markdown(
                 "1. **alice** — 42\n2. **bob** — 28\n3. **charlie** — 17\n4. **dave** — 9",

--- a/src/fetcher/git/stash_count.rs
+++ b/src/fetcher/git/stash_count.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 
-use crate::payload::{Body, EntriesData, Entry, Payload};
+use crate::payload::{BadgeData, Body, EntriesData, Entry, Payload, Status};
 use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::{fail, open_repo, payload, repo_cache_key, text_body};
 
-const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries, Shape::Badge];
 
 /// Number of entries in the stash reflog. A missing `refs/stash` ref or an absent reflog returns
 /// zero — both are common (no stashes yet) and shouldn't surface as an error.
@@ -22,7 +22,7 @@ impl Fetcher for GitStashCount {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Number of entries in the stash reflog, as a quiet reminder of work parked aside. `Text` collapses to empty when there are zero stashes; `Entries` always reports the count."
+        "Number of entries in the stash reflog, as a quiet reminder of work parked aside. `Text` collapses to empty when there are zero stashes; `Entries` always reports the count; `Badge` shows the count as a pill (Ok at zero, Warn otherwise)."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -34,6 +34,7 @@ impl Fetcher for GitStashCount {
         Some(match shape {
             Shape::Text => samples::text("3 stashes"),
             Shape::Entries => samples::entries(&[("stashes", "3")]),
+            Shape::Badge => samples::badge(Status::Warn, "3 stashes"),
             _ => return None,
         })
     }
@@ -67,16 +68,25 @@ fn render_body(count: usize, shape: Shape) -> Body {
                 status: None,
             }],
         }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: if count == 0 { Status::Ok } else { Status::Warn },
+            label: stash_label(count),
+        }),
         _ => {
             if count == 0 {
                 text_body("")
             } else {
-                text_body(format!(
-                    "{count} stash{}",
-                    if count == 1 { "" } else { "es" }
-                ))
+                text_body(stash_label(count))
             }
         }
+    }
+}
+
+fn stash_label(count: usize) -> String {
+    match count {
+        0 => "no stashes".into(),
+        1 => "1 stash".into(),
+        n => format!("{n} stashes"),
     }
 }
 
@@ -107,6 +117,26 @@ mod tests {
         let body = render_body(stash_count(&repo).unwrap(), Shape::Text);
         match body {
             Body::Text(d) => assert!(d.value.is_empty()),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn badge_shape_status_reflects_count() {
+        let body = render_body(0, Shape::Badge);
+        match body {
+            Body::Badge(b) => {
+                assert_eq!(b.status, Status::Ok);
+                assert_eq!(b.label, "no stashes");
+            }
+            _ => panic!(),
+        }
+        let body = render_body(2, Shape::Badge);
+        match body {
+            Body::Badge(b) => {
+                assert_eq!(b.status, Status::Warn);
+                assert_eq!(b.label, "2 stashes");
+            }
             _ => panic!(),
         }
     }

--- a/src/fetcher/github/action_history.rs
+++ b/src/fetcher/github/action_history.rs
@@ -6,7 +6,10 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, NumberSeriesData, Payload, Status, TimelineData, TimelineEvent};
+use crate::payload::{
+    Body, NumberSeriesData, Payload, PointSeries, PointSeriesData, Status, TimelineData,
+    TimelineEvent,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -14,7 +17,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, parse_timestamp, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::NumberSeries, Shape::Timeline];
+const SHAPES: &[Shape] = &[Shape::NumberSeries, Shape::Timeline, Shape::PointSeries];
 const DEFAULT_LIMIT: u32 = 30;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -63,7 +66,7 @@ impl Fetcher for GithubActionHistory {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Recent CI workflow runs as a pass/fail sparkline or a timeline of the last N runs. Use `github_action_status` instead for just the current main-branch state."
+        "Recent CI workflow runs as a pass/fail sparkline (`NumberSeries`), a timeline of the last N runs, or a duration scatter plot of `(run_number, seconds)` for spotting CI slowdowns (`PointSeries`). Use `github_action_status` instead for just the current main-branch state."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -85,6 +88,18 @@ impl Fetcher for GithubActionHistory {
                 (1_775_800_000, "#4234 feat/a", Some("failing")),
                 (1_775_600_000, "#4233 main", Some("passing")),
             ]),
+            Shape::PointSeries => Body::PointSeries(PointSeriesData {
+                series: vec![PointSeries {
+                    name: "ci duration (s)".into(),
+                    points: vec![
+                        (4233.0, 142.0),
+                        (4234.0, 168.0),
+                        (4235.0, 138.0),
+                        (4236.0, 220.0),
+                        (4237.0, 145.0),
+                    ],
+                }],
+            }),
             _ => return None,
         })
     }
@@ -124,6 +139,8 @@ struct WorkflowRun {
     #[serde(default)]
     head_branch: Option<String>,
     #[serde(default)]
+    created_at: String,
+    #[serde(default)]
     updated_at: String,
 }
 
@@ -144,6 +161,16 @@ fn render_body(runs: &[WorkflowRun], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
+        Shape::PointSeries => Body::PointSeries(PointSeriesData {
+            series: vec![PointSeries {
+                name: "ci duration (s)".into(),
+                points: runs
+                    .iter()
+                    .rev()
+                    .filter_map(|r| duration_seconds(r).map(|s| (r.run_number as f64, s)))
+                    .collect(),
+            }],
+        }),
         _ => Body::NumberSeries(NumberSeriesData {
             values: runs
                 .iter()
@@ -158,6 +185,15 @@ fn render_body(runs: &[WorkflowRun], shape: Shape) -> Body {
                 .collect(),
         }),
     }
+}
+
+fn duration_seconds(r: &WorkflowRun) -> Option<f64> {
+    let start = parse_timestamp(&r.created_at);
+    let end = parse_timestamp(&r.updated_at);
+    if start <= 0 || end <= 0 || end < start {
+        return None;
+    }
+    Some((end - start) as f64)
 }
 
 fn status_of(r: &WorkflowRun) -> Status {
@@ -188,4 +224,70 @@ fn repo_for_key(ctx: &FetchContext) -> String {
         .map(String::from)
         .or_else(|| resolve_repo(None).ok().map(|s: RepoSlug| s.as_path()))
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(num: u64, created: &str, updated: &str, conclusion: Option<&str>) -> WorkflowRun {
+        WorkflowRun {
+            run_number: num,
+            status: "completed".into(),
+            conclusion: conclusion.map(String::from),
+            head_branch: Some("main".into()),
+            created_at: created.into(),
+            updated_at: updated.into(),
+        }
+    }
+
+    #[test]
+    fn duration_seconds_returns_delta_when_both_timestamps_parse() {
+        let r = run(
+            10,
+            "2026-04-22T10:00:00Z",
+            "2026-04-22T10:02:30Z",
+            Some("success"),
+        );
+        assert_eq!(duration_seconds(&r), Some(150.0));
+    }
+
+    #[test]
+    fn duration_seconds_returns_none_for_missing_or_inverted_timestamps() {
+        let bad = run(11, "", "2026-04-22T10:02:30Z", None);
+        assert!(duration_seconds(&bad).is_none());
+        let inverted = run(12, "2026-04-22T10:02:30Z", "2026-04-22T10:00:00Z", None);
+        assert!(duration_seconds(&inverted).is_none());
+    }
+
+    #[test]
+    fn point_series_body_filters_out_runs_without_duration() {
+        let runs = vec![
+            run(
+                1,
+                "2026-04-22T10:00:00Z",
+                "2026-04-22T10:01:40Z",
+                Some("success"),
+            ),
+            run(2, "", "", None),
+            run(
+                3,
+                "2026-04-22T10:00:00Z",
+                "2026-04-22T10:03:00Z",
+                Some("success"),
+            ),
+        ];
+        let body = render_body(&runs, Shape::PointSeries);
+        let Body::PointSeries(d) = body else {
+            panic!("expected point series");
+        };
+        assert_eq!(d.series.len(), 1);
+        let pts = &d.series[0].points;
+        assert_eq!(pts.len(), 2);
+        // Newest-first input is reversed → expect oldest first by run_number.
+        assert_eq!(pts[0].0, 3.0);
+        assert_eq!(pts[0].1, 180.0);
+        assert_eq!(pts[1].0, 1.0);
+        assert_eq!(pts[1].1, 100.0);
+    }
 }

--- a/src/fetcher/github/contributions.rs
+++ b/src/fetcher/github/contributions.rs
@@ -7,7 +7,7 @@ use chrono::{Datelike, NaiveDate};
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, HeatmapData, Payload};
+use crate::payload::{Body, HeatmapData, NumberSeriesData, Payload};
 use crate::render::Shape;
 use crate::samples;
 
@@ -15,7 +15,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::graphql;
 use super::common::{cache_key, parse_options, payload};
 
-const SHAPES: &[Shape] = &[Shape::Heatmap];
+const SHAPES: &[Shape] = &[Shape::Heatmap, Shape::NumberSeries];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     name: "login",
@@ -49,7 +49,7 @@ impl Fetcher for GithubContributions {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "The GitHub contribution calendar (kusa) as a year-long heatmap of daily commit counts. Defaults to the authenticated viewer; pass `login` to show another user."
+        "The GitHub contribution calendar (kusa) as a year-long heatmap of daily commit counts. Defaults to the authenticated viewer; pass `login` to show another user. `NumberSeries` collapses the calendar to one value per week for sparkline-style rendering."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -69,6 +69,9 @@ impl Fetcher for GithubContributions {
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         match shape {
             Shape::Heatmap => Some(samples::heatmap_grid(7, 52)),
+            Shape::NumberSeries => Some(Body::NumberSeries(NumberSeriesData {
+                values: vec![3, 4, 7, 5, 11, 9, 13, 8, 6, 15, 12, 18],
+            })),
             _ => None,
         }
     }
@@ -78,7 +81,11 @@ impl Fetcher for GithubContributions {
             None => fetch_viewer().await?,
             Some(login) => fetch_user(login).await?,
         };
-        Ok(payload(Body::Heatmap(to_heatmap(&calendar))))
+        let body = match ctx.shape.unwrap_or(Shape::Heatmap) {
+            Shape::NumberSeries => Body::NumberSeries(to_weekly_series(&calendar)),
+            _ => Body::Heatmap(to_heatmap(&calendar)),
+        };
+        Ok(payload(body))
     }
 }
 
@@ -161,6 +168,23 @@ fn to_heatmap(cal: &Calendar) -> HeatmapData {
     }
 }
 
+fn to_weekly_series(cal: &Calendar) -> NumberSeriesData {
+    NumberSeriesData {
+        values: cal
+            .weeks
+            .iter()
+            .map(|w| {
+                u64::from(
+                    w.contribution_days
+                        .iter()
+                        .map(|d| d.contribution_count)
+                        .sum::<u32>(),
+                )
+            })
+            .collect(),
+    }
+}
+
 fn weekday_index(raw: &str) -> Option<usize> {
     let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d").ok()?;
     // ISO weekday: Mon=0..Sun=6. GitHub's weeks start Sunday, so shift to Sun=0..Sat=6.
@@ -233,5 +257,17 @@ mod tests {
         };
         let h = to_heatmap(&cal);
         assert_eq!(h.cells[0][0], 9);
+    }
+
+    #[test]
+    fn weekly_series_sums_contributions_per_week() {
+        let cal = Calendar {
+            weeks: vec![
+                week(vec![day("2026-04-19", 1), day("2026-04-20", 2)]),
+                week(vec![day("2026-04-26", 3), day("2026-04-27", 4)]),
+            ],
+        };
+        let series = to_weekly_series(&cal);
+        assert_eq!(series.values, vec![3, 7]);
     }
 }

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -101,7 +101,7 @@ impl Fetcher for GithubContributorsMonthly {
                 ("bob  27", Some("https://github.com/bob")),
                 ("charlie  11", Some("https://github.com/charlie")),
             ]),
-            Shape::TextBlock => samples::text_block(&["alice    42", "bob      27", "charlie  11"]),
+            Shape::TextBlock => samples::text_block(&["alice  42", "bob  27", "charlie  11"]),
             Shape::MarkdownTextBlock => {
                 samples::markdown("1. **@alice** — 42\n2. **@bob** — 27\n3. **@charlie** — 11")
             }

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -9,7 +9,8 @@ use serde::Deserialize;
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    Bar, BarsData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload,
+    Bar, BarsData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData,
+    MarkdownTextBlockData, Payload, TextBlockData, TextData,
 };
 use crate::render::Shape;
 use crate::samples;
@@ -18,7 +19,14 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::{http, resolve_token};
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Bars, Shape::LinkedTextBlock, Shape::Entries];
+const SHAPES: &[Shape] = &[
+    Shape::Bars,
+    Shape::LinkedTextBlock,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -67,7 +75,7 @@ impl Fetcher for GithubContributorsMonthly {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Top contributors to a repo over the last N days, ranked by commit count, as bars or a list. Useful for the maintainer view of who has been shipping recently."
+        "Top contributors to a repo over the last N days, ranked by commit count. Bars / Entries / LinkedTextBlock / TextBlock / MarkdownTextBlock all carry the ranking; Text collapses to a `\"@alice +42 / @bob +27 / …\"` headline."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -88,6 +96,16 @@ impl Fetcher for GithubContributorsMonthly {
             Shape::Entries => {
                 samples::entries(&[("alice", "42"), ("bob", "27"), ("charlie", "11")])
             }
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                ("alice  42", Some("https://github.com/alice")),
+                ("bob  27", Some("https://github.com/bob")),
+                ("charlie  11", Some("https://github.com/charlie")),
+            ]),
+            Shape::TextBlock => samples::text_block(&["alice    42", "bob      27", "charlie  11"]),
+            Shape::MarkdownTextBlock => {
+                samples::markdown("1. **@alice** — 42\n2. **@bob** — 27\n3. **@charlie** — 11")
+            }
+            Shape::Text => samples::text("@alice +42 · @bob +27 · @charlie +11"),
             _ => return None,
         })
     }
@@ -206,6 +224,24 @@ fn render_body(rows: &[(String, u64)], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: rows.iter().map(|(n, c)| format!("{n}  {c}")).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: rows
+                .iter()
+                .enumerate()
+                .map(|(i, (n, c))| format!("{}. **@{n}** — {c}", i + 1))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Text => Body::Text(TextData {
+            value: rows
+                .iter()
+                .map(|(n, c)| format!("@{n} +{c}"))
+                .collect::<Vec<_>>()
+                .join(" · "),
+        }),
         _ => Body::Bars(BarsData {
             bars: rows
                 .iter()
@@ -226,4 +262,41 @@ fn repo_for_key(ctx: &FetchContext) -> String {
         .map(String::from)
         .or_else(|| resolve_repo(None).ok().map(|s: RepoSlug| s.as_path()))
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows() -> Vec<(String, u64)> {
+        vec![("alice".into(), 42), ("bob".into(), 27)]
+    }
+
+    #[test]
+    fn text_body_collapses_to_at_handles_with_plus_counts() {
+        let body = render_body(&rows(), Shape::Text);
+        let Body::Text(d) = body else {
+            panic!("expected text")
+        };
+        assert_eq!(d.value, "@alice +42 · @bob +27");
+    }
+
+    #[test]
+    fn markdown_text_block_lists_handles_and_counts() {
+        let body = render_body(&rows(), Shape::MarkdownTextBlock);
+        let Body::MarkdownTextBlock(d) = body else {
+            panic!("expected markdown")
+        };
+        assert!(d.value.contains("1. **@alice** — 42"));
+        assert!(d.value.contains("2. **@bob** — 27"));
+    }
+
+    #[test]
+    fn text_block_has_one_line_per_contributor() {
+        let body = render_body(&rows(), Shape::TextBlock);
+        let Body::TextBlock(d) = body else {
+            panic!("expected text block")
+        };
+        assert_eq!(d.lines.len(), 2);
+    }
 }

--- a/src/fetcher/github/languages.rs
+++ b/src/fetcher/github/languages.rs
@@ -86,9 +86,7 @@ impl Fetcher for GithubLanguages {
         Some(match shape {
             Shape::Bars => samples::bars(&[("Rust", 87_000), ("TOML", 8_000), ("Shell", 5_000)]),
             Shape::Entries => samples::entries(&[("Rust", "87%"), ("TOML", "8%"), ("Shell", "5%")]),
-            Shape::TextBlock => {
-                samples::text_block(&["Rust    87.0%", "TOML     8.0%", "Shell    5.0%"])
-            }
+            Shape::TextBlock => samples::text_block(&["Rust  87.0%", "TOML  8.0%", "Shell  5.0%"]),
             Shape::MarkdownTextBlock => {
                 samples::markdown("- **Rust** — 87.0%\n- **TOML** — 8.0%\n- **Shell** — 5.0%")
             }

--- a/src/fetcher/github/languages.rs
+++ b/src/fetcher/github/languages.rs
@@ -9,7 +9,10 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Bar, BarsData, Body, EntriesData, Entry, Payload};
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, TextBlockData,
+    TextData,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -17,7 +20,13 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Bars, Shape::Entries];
+const SHAPES: &[Shape] = &[
+    Shape::Bars,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -58,7 +67,7 @@ impl Fetcher for GithubLanguages {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Language byte-count breakdown for a repo, sorted by size, as bars or percent rows. Languages beyond `limit` collapse into a single `other` bucket so totals stay honest."
+        "Language byte-count breakdown for a repo, sorted by size. `Bars` / `Entries` / `TextBlock` / `MarkdownTextBlock` carry the full ranking with percent values; `Text` collapses to a `\"Rust 87% · TOML 8% · …\"` headline. Languages beyond `limit` collapse into a single `other` bucket so totals stay honest."
     }
     fn shapes(&self) -> &[Shape] {
         SHAPES
@@ -77,6 +86,13 @@ impl Fetcher for GithubLanguages {
         Some(match shape {
             Shape::Bars => samples::bars(&[("Rust", 87_000), ("TOML", 8_000), ("Shell", 5_000)]),
             Shape::Entries => samples::entries(&[("Rust", "87%"), ("TOML", "8%"), ("Shell", "5%")]),
+            Shape::TextBlock => {
+                samples::text_block(&["Rust    87.0%", "TOML     8.0%", "Shell    5.0%"])
+            }
+            Shape::MarkdownTextBlock => {
+                samples::markdown("- **Rust** — 87.0%\n- **TOML** — 8.0%\n- **Shell** — 5.0%")
+            }
+            Shape::Text => samples::text("Rust 87% · TOML 8% · Shell 5%"),
             _ => return None,
         })
     }
@@ -101,6 +117,15 @@ fn build_body(raw: BTreeMap<String, u64>, shape: Shape, limit: usize) -> Body {
         Shape::Entries => Body::Entries(EntriesData {
             items: to_entries(&sorted),
         }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: text_lines(&sorted),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: markdown_text(&sorted),
+        }),
+        Shape::Text => Body::Text(TextData {
+            value: text_headline(&sorted),
+        }),
         _ => Body::Bars(BarsData {
             bars: sorted
                 .into_iter()
@@ -108,6 +133,40 @@ fn build_body(raw: BTreeMap<String, u64>, shape: Shape, limit: usize) -> Body {
                 .collect(),
         }),
     }
+}
+
+fn text_lines(sorted: &[(String, u64)]) -> Vec<String> {
+    let total: u64 = sorted.iter().map(|(_, v)| v).sum();
+    sorted
+        .iter()
+        .map(|(label, value)| format!("{label}  {}", format_percent(*value, total)))
+        .collect()
+}
+
+fn markdown_text(sorted: &[(String, u64)]) -> String {
+    let total: u64 = sorted.iter().map(|(_, v)| v).sum();
+    sorted
+        .iter()
+        .map(|(label, value)| format!("- **{label}** — {}", format_percent(*value, total)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn text_headline(sorted: &[(String, u64)]) -> String {
+    let total: u64 = sorted.iter().map(|(_, v)| v).sum();
+    sorted
+        .iter()
+        .map(|(label, value)| format!("{label} {}", format_percent_short(*value, total)))
+        .collect::<Vec<_>>()
+        .join(" · ")
+}
+
+fn format_percent_short(value: u64, total: u64) -> String {
+    if total == 0 {
+        return "0%".into();
+    }
+    let pct = (value as f64 / total as f64) * 100.0;
+    format!("{pct:.0}%")
 }
 
 /// Sort by size descending, cap to `limit` entries. If the source has more languages than
@@ -215,6 +274,33 @@ mod tests {
         let entries = to_entries(&sorted);
         assert_eq!(entries[0].value.as_deref(), Some("75.0%"));
         assert_eq!(entries[1].value.as_deref(), Some("25.0%"));
+    }
+
+    #[test]
+    fn text_headline_collapses_to_one_line_with_rounded_percents() {
+        let sorted = vec![
+            ("Rust".into(), 870),
+            ("TOML".into(), 80),
+            ("Shell".into(), 50),
+        ];
+        assert_eq!(text_headline(&sorted), "Rust 87% · TOML 8% · Shell 5%");
+    }
+
+    #[test]
+    fn markdown_text_emits_one_bullet_per_language() {
+        let sorted = vec![("Rust".into(), 750), ("TOML".into(), 250)];
+        let md = markdown_text(&sorted);
+        assert!(md.contains("- **Rust** — 75.0%"));
+        assert!(md.contains("- **TOML** — 25.0%"));
+    }
+
+    #[test]
+    fn build_body_text_emits_text_value() {
+        let body = build_body(raw(&[("Rust", 870), ("TOML", 130)]), Shape::Text, 10);
+        match body {
+            Body::Text(d) => assert!(d.value.contains("Rust") && d.value.contains("87%")),
+            _ => panic!("expected text"),
+        }
     }
 
     #[test]

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -24,6 +24,9 @@ const SHAPES: &[Shape] = &[
     Shape::Badge,
 ];
 const DEFAULT_LIMIT: u32 = 10;
+/// `/notifications` `per_page` ceiling — also the page size used for the `Badge` shape so the
+/// reported count is exact up to 50 and explicitly capped (`"50+"`) past it.
+const BADGE_PAGE: u32 = 50;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -97,14 +100,19 @@ impl Fetcher for GithubNotifications {
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
-        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 50);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        // Badge needs the inbox total, not a list slice — bypass `limit` and request the API
+        // max so 0..=50 is exact. List shapes still honour the user's `limit` for display.
+        let per_page = if shape == Shape::Badge {
+            BADGE_PAGE
+        } else {
+            opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, BADGE_PAGE)
+        };
         let all = opts.all.unwrap_or(false);
-        let path = format!("/notifications?per_page={limit}&all={all}");
+        let path = format!("/notifications?per_page={per_page}&all={all}");
         let items: Vec<Notification> = rest_get(&path).await?;
-        Ok(payload(render_body(
-            &items,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-        )))
+        let capped = items.len() as u32 >= per_page;
+        Ok(payload(render_body(&items, shape, capped)))
     }
 }
 
@@ -128,7 +136,7 @@ struct Repo {
     full_name: String,
 }
 
-fn render_body(items: &[Notification], shape: Shape) -> Body {
+fn render_body(items: &[Notification], shape: Shape, capped: bool) -> Body {
     match shape {
         Shape::Entries => Body::Entries(EntriesData {
             items: items
@@ -163,7 +171,7 @@ fn render_body(items: &[Notification], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
-        Shape::Badge => Body::Badge(notifications_badge(items.len())),
+        Shape::Badge => Body::Badge(notifications_badge(items.len(), capped)),
         _ => Body::TextBlock(TextBlockData {
             lines: items
                 .iter()
@@ -178,13 +186,14 @@ fn render_body(items: &[Notification], shape: Shape) -> Body {
     }
 }
 
-fn notifications_badge(count: usize) -> BadgeData {
+fn notifications_badge(count: usize, capped: bool) -> BadgeData {
     BadgeData {
         status: if count == 0 { Status::Ok } else { Status::Warn },
-        label: match count {
-            0 => "inbox zero".into(),
-            1 => "1 notification".into(),
-            n => format!("{n} notifications"),
+        label: match (count, capped) {
+            (0, _) => "inbox zero".into(),
+            (1, false) => "1 notification".into(),
+            (n, true) => format!("{n}+ notifications"),
+            (n, false) => format!("{n} notifications"),
         },
     }
 }
@@ -230,13 +239,13 @@ mod tests {
 
     #[test]
     fn badge_body_collapses_to_count_pill() {
-        let body = render_body(&[sample(), sample()], Shape::Badge);
+        let body = render_body(&[sample(), sample()], Shape::Badge, false);
         let Body::Badge(b) = body else {
             panic!("expected badge")
         };
         assert_eq!(b.status, Status::Warn);
         assert_eq!(b.label, "2 notifications");
-        let body = render_body(&[], Shape::Badge);
+        let body = render_body(&[], Shape::Badge, false);
         let Body::Badge(b) = body else {
             panic!("expected badge")
         };
@@ -245,8 +254,20 @@ mod tests {
     }
 
     #[test]
+    fn badge_label_marks_capped_count_with_plus() {
+        // Simulate a full BADGE_PAGE response — the page is exhausted, so the true total may be
+        // higher and the label has to admit that with `"50+"`.
+        let items: Vec<Notification> = (0..BADGE_PAGE).map(|_| sample()).collect();
+        let body = render_body(&items, Shape::Badge, true);
+        let Body::Badge(b) = body else {
+            panic!("expected badge")
+        };
+        assert_eq!(b.label, format!("{BADGE_PAGE}+ notifications"));
+    }
+
+    #[test]
     fn text_block_body_composes_repo_reason_title() {
-        let body = render_body(&[sample()], Shape::TextBlock);
+        let body = render_body(&[sample()], Shape::TextBlock, false);
         let Body::TextBlock(l) = body else {
             panic!("expected text_block");
         };

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, TextBlockData,
-    TimelineData, TimelineEvent,
+    BadgeData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, Payload, Status,
+    TextBlockData, TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 use crate::samples;
@@ -21,6 +21,7 @@ const SHAPES: &[Shape] = &[
     Shape::TextBlock,
     Shape::Entries,
     Shape::Timeline,
+    Shape::Badge,
 ];
 const DEFAULT_LIMIT: u32 = 10;
 
@@ -90,6 +91,7 @@ impl Fetcher for GithubNotifications {
                 ),
                 (1_773_800_000, "ratatui", Some("mention: rfc: themes")),
             ]),
+            Shape::Badge => samples::badge(Status::Warn, "2 notifications"),
             _ => return None,
         })
     }
@@ -161,6 +163,7 @@ fn render_body(items: &[Notification], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
+        Shape::Badge => Body::Badge(notifications_badge(items.len())),
         _ => Body::TextBlock(TextBlockData {
             lines: items
                 .iter()
@@ -172,6 +175,17 @@ fn render_body(items: &[Notification], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
+    }
+}
+
+fn notifications_badge(count: usize) -> BadgeData {
+    BadgeData {
+        status: if count == 0 { Status::Ok } else { Status::Warn },
+        label: match count {
+            0 => "inbox zero".into(),
+            1 => "1 notification".into(),
+            n => format!("{n} notifications"),
+        },
     }
 }
 
@@ -212,6 +226,22 @@ mod tests {
     fn short_repo_drops_owner() {
         assert_eq!(short_repo("unhappychoice/splashboard"), "splashboard");
         assert_eq!(short_repo("singleton"), "singleton");
+    }
+
+    #[test]
+    fn badge_body_collapses_to_count_pill() {
+        let body = render_body(&[sample(), sample()], Shape::Badge);
+        let Body::Badge(b) = body else {
+            panic!("expected badge")
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert_eq!(b.label, "2 notifications");
+        let body = render_body(&[], Shape::Badge);
+        let Body::Badge(b) = body else {
+            panic!("expected badge")
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "inbox zero");
     }
 
     #[test]

--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -12,7 +12,8 @@ use sysinfo::{Disks, ProcessesToUpdate, System};
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    Bar, BarsData, Body, EntriesData, Entry, Payload, RatioData, TextBlockData, TextData,
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, Payload, RatioData, Status, TextBlockData,
+    TextData,
 };
 use crate::render::Shape;
 use crate::samples;
@@ -672,7 +673,7 @@ impl RealtimeFetcher for BatteryFetcher {
         "Charge level and state of the primary (or `index`-selected) battery. `Ratio` drives gauges, `Text` formats a summary line whose field is picked by `kind`, and `Entries` rolls up charge / state / time-left / cycles / health. Hosts without a battery render a steady `\"AC\"` placeholder."
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio, Shape::Text, Shape::Entries]
+        &[Shape::Ratio, Shape::Text, Shape::Entries, Shape::Badge]
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         BATTERY_OPTION_SCHEMAS
@@ -688,6 +689,7 @@ impl RealtimeFetcher for BatteryFetcher {
                 ("cycles", "284"),
                 ("health", "97%"),
             ]),
+            Shape::Badge => samples::badge(Status::Ok, "87% · Charging"),
             _ => return None,
         })
     }
@@ -705,6 +707,7 @@ impl RealtimeFetcher for BatteryFetcher {
             (Some(snap), Shape::Entries) => payload(Body::Entries(EntriesData {
                 items: battery_entries(&snap),
             })),
+            (Some(snap), Shape::Badge) => payload(Body::Badge(battery_badge(&snap))),
             (Some(snap), _) => payload(Body::Ratio(RatioData {
                 value: snap.charge,
                 label: Some(format!(
@@ -788,6 +791,19 @@ fn format_battery_text(snap: &BatterySnapshot, kind: BatteryTextKind) -> String 
     }
 }
 
+fn battery_badge(snap: &BatterySnapshot) -> BadgeData {
+    let status = match snap.state {
+        BatteryState::Charging | BatteryState::Full => Status::Ok,
+        _ if snap.charge < 0.20 => Status::Error,
+        _ if snap.charge < 0.50 => Status::Warn,
+        _ => Status::Ok,
+    };
+    BadgeData {
+        status,
+        label: format!("{} · {}", format_percent(snap.charge), snap.state.label()),
+    }
+}
+
 fn battery_entries(snap: &BatterySnapshot) -> Vec<Entry> {
     let mut items = vec![
         entry("charge", &format_percent(snap.charge)),
@@ -816,6 +832,10 @@ fn no_battery_payload(shape: Shape, kind: BatteryTextKind) -> Payload {
         })),
         Shape::Entries => payload(Body::Entries(EntriesData {
             items: vec![entry("power", "AC")],
+        })),
+        Shape::Badge => payload(Body::Badge(BadgeData {
+            status: Status::Ok,
+            label: "AC".into(),
         })),
         _ => payload(Body::Ratio(RatioData {
             value: 1.0,
@@ -1234,12 +1254,25 @@ mod tests {
             Some(Shape::Ratio),
             Some(Shape::Text),
             Some(Shape::Entries),
+            Some(Shape::Badge),
         ] {
             let p = f.compute(&ctx_with_shape(shape));
             // Each branch must produce *some* body; on hosts without a battery we land on the
             // AC stand-in, on laptops we get the real reading. Both are valid.
             assert!(!matches!(p.body, Body::Image(_)));
         }
+    }
+
+    #[test]
+    fn battery_badge_status_reflects_charge_and_state() {
+        let low = snapshot(0.05, BatteryState::Discharging, None);
+        assert_eq!(battery_badge(&low).status, Status::Error);
+        let mid = snapshot(0.30, BatteryState::Discharging, None);
+        assert_eq!(battery_badge(&mid).status, Status::Warn);
+        let high = snapshot(0.95, BatteryState::Discharging, None);
+        assert_eq!(battery_badge(&high).status, Status::Ok);
+        let charging_low = snapshot(0.05, BatteryState::Charging, None);
+        assert_eq!(battery_badge(&charging_low).status, Status::Ok);
     }
 
     #[test]

--- a/src/fetcher/weather.rs
+++ b/src/fetcher/weather.rs
@@ -12,7 +12,10 @@ use reqwest::Client;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, Payload, TextData};
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, NumberSeriesData, Payload, PointSeries,
+    PointSeriesData, Status, TextData,
+};
 use crate::render::Shape;
 
 use super::github::common::cache_key;
@@ -21,6 +24,7 @@ use super::{FetchContext, FetchError, Fetcher, Safety};
 const API_BASE: &str = "https://api.open-meteo.com/v1/forecast";
 const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const HOURLY_HOURS: usize = 24;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -75,10 +79,17 @@ impl Fetcher for WeatherFetcher {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Current-conditions forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` shows condition / temperature / wind / humidity rows; `Text` collapses them into a single line. Metric or imperial units, no API key required."
+        "Forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` / `Text` summarise current conditions; `PointSeries` / `NumberSeries` / `Bars` expose the next 24h of hourly temperature or precipitation; `Badge` flags severe weather codes (thunderstorm = error, freezing / snow / heavy rain = warn). Metric or imperial units, no API key required."
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Entries, Shape::Text]
+        &[
+            Shape::Entries,
+            Shape::Text,
+            Shape::PointSeries,
+            Shape::NumberSeries,
+            Shape::Bars,
+            Shape::Badge,
+        ]
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -92,11 +103,16 @@ impl Fetcher for WeatherFetcher {
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
+        let sample = Sample::default();
         Some(match shape {
-            Shape::Entries => entries(&Sample::default()),
+            Shape::Entries => entries(&sample),
             Shape::Text => Body::Text(TextData {
-                value: Sample::default().as_text(),
+                value: sample.as_text(),
             }),
+            Shape::PointSeries => point_series(&sample.hourly, sample.units),
+            Shape::NumberSeries => number_series(&sample.hourly),
+            Shape::Bars => precipitation_bars(&sample.hourly),
+            Shape::Badge => Body::Badge(weather_badge(sample.code)),
             _ => return None,
         })
     }
@@ -109,6 +125,10 @@ impl Fetcher for WeatherFetcher {
             Shape::Text => Body::Text(TextData {
                 value: report.as_text(),
             }),
+            Shape::PointSeries => point_series(&report.hourly, report.units),
+            Shape::NumberSeries => number_series(&report.hourly),
+            Shape::Bars => precipitation_bars(&report.hourly),
+            Shape::Badge => Body::Badge(weather_badge(report.code)),
             _ => entries(&report),
         };
         Ok(payload(body))
@@ -135,13 +155,36 @@ async fn fetch_report(lat: f64, lon: f64, units: Units) -> Result<Sample, FetchE
         temperature: raw.current.temperature_2m,
         wind_speed: raw.current.wind_speed_10m,
         humidity: raw.current.relative_humidity_2m,
+        hourly: hourly_from(&raw.hourly),
         units,
     })
 }
 
+fn hourly_from(raw: &Hourly) -> Vec<HourPoint> {
+    let temps = raw.temperature_2m.iter().copied();
+    let precs = raw
+        .precipitation
+        .iter()
+        .copied()
+        .chain(std::iter::repeat(0.0));
+    temps
+        .zip(precs)
+        .take(HOURLY_HOURS)
+        .enumerate()
+        .map(|(i, (temp, precip))| HourPoint {
+            offset_hours: i as u32,
+            temperature: temp,
+            precipitation: precip,
+        })
+        .collect()
+}
+
 fn build_url(lat: f64, lon: f64, units: Units) -> String {
     let base = format!(
-        "{API_BASE}?latitude={lat}&longitude={lon}&current=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m"
+        "{API_BASE}?latitude={lat}&longitude={lon}\
+         &current=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m\
+         &hourly=temperature_2m,precipitation\
+         &forecast_days=2"
     );
     match units {
         Units::Metric => format!("{base}&wind_speed_unit=ms"),
@@ -152,6 +195,8 @@ fn build_url(lat: f64, lon: f64, units: Units) -> String {
 #[derive(Debug, Deserialize)]
 struct ApiResponse {
     current: Current,
+    #[serde(default)]
+    hourly: Hourly,
 }
 
 #[derive(Debug, Deserialize)]
@@ -162,21 +207,46 @@ struct Current {
     relative_humidity_2m: u8,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct Hourly {
+    #[serde(default)]
+    temperature_2m: Vec<f64>,
+    #[serde(default)]
+    precipitation: Vec<f64>,
+}
+
 struct Sample {
     code: u16,
     temperature: f64,
     wind_speed: f64,
     humidity: u8,
+    hourly: Vec<HourPoint>,
     units: Units,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HourPoint {
+    offset_hours: u32,
+    temperature: f64,
+    /// Precipitation in mm for metric, inches for imperial.
+    precipitation: f64,
 }
 
 impl Default for Sample {
     fn default() -> Self {
+        let hourly = (0..HOURLY_HOURS as u32)
+            .map(|i| HourPoint {
+                offset_hours: i,
+                temperature: 16.0 + ((i as f64) * 0.4 - (i as f64 / 8.0).sin() * 4.0),
+                precipitation: if (10..=14).contains(&i) { 0.6 } else { 0.0 },
+            })
+            .collect();
         Self {
             code: 3,
             temperature: 18.0,
             wind_speed: 4.0,
             humidity: 67,
+            hourly,
             units: Units::Metric,
         }
     }
@@ -208,6 +278,62 @@ impl Sample {
             self.wind_label(),
             self.humidity_label(),
         )
+    }
+}
+
+fn point_series(hourly: &[HourPoint], units: Units) -> Body {
+    let unit_label = match units {
+        Units::Metric => "°C",
+        Units::Imperial => "°F",
+    };
+    Body::PointSeries(PointSeriesData {
+        series: vec![PointSeries {
+            name: format!("temperature ({unit_label})"),
+            points: hourly
+                .iter()
+                .map(|h| (f64::from(h.offset_hours), h.temperature))
+                .collect(),
+        }],
+    })
+}
+
+fn number_series(hourly: &[HourPoint]) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: hourly
+            .iter()
+            .map(|h| h.temperature.round().clamp(0.0, u64::MAX as f64) as u64)
+            .collect(),
+    })
+}
+
+fn precipitation_bars(hourly: &[HourPoint]) -> Body {
+    Body::Bars(BarsData {
+        bars: hourly
+            .iter()
+            .map(|h| Bar {
+                label: format!("+{}h", h.offset_hours),
+                // Bars are integer-valued; multiply by 10 to keep one decimal of precision
+                // (i.e. units = "tenths of mm" / "tenths of an inch").
+                value: (h.precipitation.max(0.0) * 10.0).round() as u64,
+            })
+            .collect(),
+    })
+}
+
+fn weather_badge(code: u16) -> BadgeData {
+    let (status, label) = match code {
+        95 | 96 | 99 => (Status::Error, "thunderstorm"),
+        56 | 57 | 66 | 67 => (Status::Warn, "freezing"),
+        65 | 75 | 82 | 86 => (Status::Warn, "heavy precip"),
+        61 | 63 | 71 | 73 | 80 | 81 | 85 => (Status::Warn, "precip"),
+        _ => {
+            let (_, desc) = weather_description(code);
+            (Status::Ok, desc)
+        }
+    };
+    BadgeData {
+        status,
+        label: label.into(),
     }
 }
 
@@ -361,6 +487,45 @@ mod tests {
         let raw: toml::Value =
             toml::from_str("latitude = 1.0\nlongitude = 2.0\nbogus = true").unwrap();
         assert!(parse_options::<WeatherOptions>(Some(&raw)).is_err());
+    }
+
+    #[test]
+    fn point_series_carries_one_temperature_series_with_24_points() {
+        let body = point_series(&Sample::default().hourly, Units::Metric);
+        let Body::PointSeries(d) = body else {
+            panic!("expected point series");
+        };
+        assert_eq!(d.series.len(), 1);
+        assert_eq!(d.series[0].points.len(), HOURLY_HOURS);
+        assert!(d.series[0].name.contains("°C"));
+    }
+
+    #[test]
+    fn number_series_rounds_temperatures_to_u64() {
+        let body = number_series(&Sample::default().hourly);
+        let Body::NumberSeries(d) = body else {
+            panic!("expected number series");
+        };
+        assert_eq!(d.values.len(), HOURLY_HOURS);
+    }
+
+    #[test]
+    fn precipitation_bars_are_labelled_with_hour_offsets() {
+        let body = precipitation_bars(&Sample::default().hourly);
+        let Body::Bars(d) = body else {
+            panic!("expected bars");
+        };
+        assert_eq!(d.bars.len(), HOURLY_HOURS);
+        assert_eq!(d.bars[0].label, "+0h");
+        assert_eq!(d.bars[5].label, "+5h");
+    }
+
+    #[test]
+    fn weather_badge_severity_follows_wmo_groups() {
+        assert_eq!(weather_badge(0).status, Status::Ok);
+        assert_eq!(weather_badge(63).status, Status::Warn);
+        assert_eq!(weather_badge(75).status, Status::Warn);
+        assert_eq!(weather_badge(95).status, Status::Error);
     }
 
     /// Live smoke test — hits Open-Meteo. `#[ignore]` keeps CI offline-safe; run with

--- a/src/fetcher/weather.rs
+++ b/src/fetcher/weather.rs
@@ -79,7 +79,7 @@ impl Fetcher for WeatherFetcher {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` / `Text` summarise current conditions; `PointSeries` / `NumberSeries` / `Bars` expose the next 24h of hourly temperature or precipitation; `Badge` flags severe weather codes (thunderstorm = error, freezing / snow / heavy rain = warn). Metric or imperial units, no API key required."
+        "Forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` / `Text` summarise current conditions; `PointSeries` carries the next 24h of hourly temperature (signed °C / °F); `NumberSeries` / `Bars` carry hourly precipitation in tenths of mm/inch; `Badge` flags severe weather codes (thunderstorm = error, freezing / snow / heavy rain = warn). Metric or imperial units, no API key required."
     }
     fn shapes(&self) -> &[Shape] {
         &[
@@ -297,11 +297,15 @@ fn point_series(hourly: &[HourPoint], units: Units) -> Body {
     })
 }
 
+/// Hourly precipitation as `NumberSeries`. Temperature can go negative and would silently
+/// clamp to 0 in `u64`, so the curve lives on `PointSeries` instead. Precipitation is
+/// non-negative by definition; values are tenths of a millimetre (or an inch on imperial)
+/// so one decimal of precision survives the integer round-trip.
 fn number_series(hourly: &[HourPoint]) -> Body {
     Body::NumberSeries(NumberSeriesData {
         values: hourly
             .iter()
-            .map(|h| h.temperature.round().clamp(0.0, u64::MAX as f64) as u64)
+            .map(|h| (h.precipitation.max(0.0) * 10.0).round() as u64)
             .collect(),
     })
 }
@@ -501,12 +505,54 @@ mod tests {
     }
 
     #[test]
-    fn number_series_rounds_temperatures_to_u64() {
-        let body = number_series(&Sample::default().hourly);
+    fn number_series_carries_precipitation_in_tenths() {
+        let hourly = vec![
+            HourPoint {
+                offset_hours: 0,
+                temperature: -3.0, // negative temp must NOT clamp the precip slot to 0
+                precipitation: 0.6,
+            },
+            HourPoint {
+                offset_hours: 1,
+                temperature: -1.0,
+                precipitation: 0.0,
+            },
+            HourPoint {
+                offset_hours: 2,
+                temperature: 1.0,
+                precipitation: 1.25,
+            },
+        ];
+        let body = number_series(&hourly);
         let Body::NumberSeries(d) = body else {
             panic!("expected number series");
         };
-        assert_eq!(d.values.len(), HOURLY_HOURS);
+        // 0.6 mm → 6 tenths, 0.0 → 0, 1.25 → 13 (rounded).
+        assert_eq!(d.values, vec![6, 0, 13]);
+    }
+
+    #[test]
+    fn point_series_temperature_preserves_negative_readings() {
+        // PointSeries is f64 — make sure sub-zero temps survive end-to-end (the bug fixed by
+        // moving temperature off `NumberSeries`, which would have clamped these to 0).
+        let hourly = vec![
+            HourPoint {
+                offset_hours: 0,
+                temperature: -5.0,
+                precipitation: 0.0,
+            },
+            HourPoint {
+                offset_hours: 1,
+                temperature: -2.5,
+                precipitation: 0.0,
+            },
+        ];
+        let body = point_series(&hourly, Units::Metric);
+        let Body::PointSeries(d) = body else {
+            panic!("expected point series");
+        };
+        assert_eq!(d.series[0].points[0].1, -5.0);
+        assert_eq!(d.series[0].points[1].1, -2.5);
     }
 
     #[test]

--- a/src/fetcher/wikipedia/on_this_day.rs
+++ b/src/fetcher/wikipedia/on_this_day.rs
@@ -5,13 +5,16 @@
 //! it can't redirect traffic outside Wikipedia.
 
 use async_trait::async_trait;
-use chrono::{Datelike, Utc};
+use chrono::{Datelike, NaiveDate, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
-use crate::payload::{Body, LinkedLine, LinkedTextBlockData, Payload, TextBlockData, TextData};
+use crate::payload::{
+    Body, LinkedLine, LinkedTextBlockData, Payload, TextBlockData, TextData, TimelineData,
+    TimelineEvent,
+};
 use crate::render::Shape;
 use crate::samples;
 
@@ -21,7 +24,12 @@ const DEFAULT_LIMIT: u32 = 5;
 const MIN_LIMIT: u32 = 1;
 const MAX_LIMIT: u32 = 30;
 
-const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Text];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::Timeline,
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -132,6 +140,18 @@ impl Fetcher for WikipediaOnThisDayFetcher {
                 "1989 — Tim Berners-Lee proposes the World Wide Web",
             ]),
             Shape::Text => samples::text("1969 — Apollo 11 lands on the Moon"),
+            Shape::Timeline => samples::timeline(&[
+                (
+                    -86_400 * 365 * 2, // doesn't matter much; demo only
+                    "1969 — Apollo 11 lands on the Moon",
+                    None,
+                ),
+                (
+                    -86_400 * 365 * 4,
+                    "1492 — Columbus departs Palos de la Frontera",
+                    None,
+                ),
+            ]),
             _ => return None,
         })
     }
@@ -151,15 +171,16 @@ impl Fetcher for WikipediaOnThisDayFetcher {
 
 async fn fetch_events(lang: &str, kind: Kind) -> Result<Vec<EventEntry>, FetchError> {
     let now = Utc::now();
+    let (month, day) = (now.month(), now.day());
     let url = format!(
         "{}/feed/onthisday/{}/{:02}/{:02}",
         rest_api_base(lang),
         kind.endpoint(),
-        now.month(),
-        now.day()
+        month,
+        day
     );
     let response: OnThisDayResponse = get(&url).await?;
-    Ok(response.into_events(kind))
+    Ok(response.into_events(kind, now.year(), month, day))
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -177,7 +198,7 @@ struct OnThisDayResponse {
 }
 
 impl OnThisDayResponse {
-    fn into_events(self, kind: Kind) -> Vec<EventEntry> {
+    fn into_events(self, kind: Kind, today_year: i32, month: u32, day: u32) -> Vec<EventEntry> {
         let raw = match kind {
             Kind::Selected => self.selected,
             Kind::Events => self.events,
@@ -193,7 +214,9 @@ impl OnThisDayResponse {
                 all
             }
         };
-        raw.into_iter().map(EventEntry::from_raw).collect()
+        raw.into_iter()
+            .map(|r| EventEntry::from_raw(r, today_year, month, day))
+            .collect()
     }
 }
 
@@ -211,17 +234,32 @@ struct RawEvent {
 struct EventEntry {
     label: String,
     url: Option<String>,
+    timestamp: i64,
 }
 
 impl EventEntry {
-    fn from_raw(raw: RawEvent) -> Self {
+    fn from_raw(raw: RawEvent, today_year: i32, month: u32, day: u32) -> Self {
         let label = match raw.year {
             Some(year) => format!("{year} — {}", raw.text),
             None => raw.text,
         };
         let url = raw.pages.first().and_then(|p| p.url());
-        Self { label, url }
+        let year = raw.year.unwrap_or(today_year);
+        Self {
+            label,
+            url,
+            timestamp: anniversary_timestamp(year, month, day),
+        }
     }
+}
+
+fn anniversary_timestamp(year: i32, month: u32, day: u32) -> i64 {
+    let date = NaiveDate::from_ymd_opt(year, month, day)
+        .or_else(|| NaiveDate::from_ymd_opt(year, month, 1))
+        .or_else(|| NaiveDate::from_ymd_opt(year, 1, 1));
+    date.and_then(|d| d.and_hms_opt(12, 0, 0))
+        .map(|dt| dt.and_utc().timestamp())
+        .unwrap_or(0)
 }
 
 fn render_body(events: &[EventEntry], shape: Shape, limit: usize) -> Body {
@@ -231,6 +269,18 @@ fn render_body(events: &[EventEntry], shape: Shape, limit: usize) -> Body {
         }),
         Shape::TextBlock => Body::TextBlock(TextBlockData {
             lines: events.iter().take(limit).map(|e| e.label.clone()).collect(),
+        }),
+        Shape::Timeline => Body::Timeline(TimelineData {
+            events: events
+                .iter()
+                .take(limit)
+                .map(|e| TimelineEvent {
+                    timestamp: e.timestamp,
+                    title: e.label.clone(),
+                    detail: None,
+                    status: None,
+                })
+                .collect(),
         }),
         _ => Body::LinkedTextBlock(LinkedTextBlockData {
             items: events
@@ -305,7 +355,12 @@ mod tests {
 
     #[test]
     fn event_entry_prefixes_year_when_present() {
-        let e = EventEntry::from_raw(raw_event(Some(1969), "Apollo 11 lands.", vec![]));
+        let e = EventEntry::from_raw(
+            raw_event(Some(1969), "Apollo 11 lands.", vec![]),
+            2026,
+            4,
+            27,
+        );
         assert_eq!(e.label, "1969 — Apollo 11 lands.");
         assert!(e.url.is_none());
     }
@@ -313,30 +368,60 @@ mod tests {
     #[test]
     fn event_entry_omits_year_dash_when_year_missing() {
         // Holidays don't have a `year` field — label stays as the raw text.
-        let e = EventEntry::from_raw(raw_event(None, "Independence Day", vec![]));
+        let e = EventEntry::from_raw(raw_event(None, "Independence Day", vec![]), 2026, 4, 27);
         assert_eq!(e.label, "Independence Day");
     }
 
     #[test]
     fn event_entry_url_uses_first_page() {
-        let e = EventEntry::from_raw(raw_event(
-            Some(1969),
-            "Apollo 11.",
-            vec![
-                page("Apollo 11", "https://en.wikipedia.org/wiki/Apollo_11"),
-                page("Moon", "https://en.wikipedia.org/wiki/Moon"),
-            ],
-        ));
+        let e = EventEntry::from_raw(
+            raw_event(
+                Some(1969),
+                "Apollo 11.",
+                vec![
+                    page("Apollo 11", "https://en.wikipedia.org/wiki/Apollo_11"),
+                    page("Moon", "https://en.wikipedia.org/wiki/Moon"),
+                ],
+            ),
+            2026,
+            4,
+            27,
+        );
         assert_eq!(
             e.url.as_deref(),
             Some("https://en.wikipedia.org/wiki/Apollo_11")
         );
     }
 
+    #[test]
+    fn event_entry_timestamp_uses_event_year_with_today_month_day() {
+        let e = EventEntry::from_raw(raw_event(Some(1969), "Apollo 11.", vec![]), 2026, 7, 20);
+        let date = NaiveDate::from_ymd_opt(1969, 7, 20)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp();
+        assert_eq!(e.timestamp, date);
+    }
+
+    #[test]
+    fn event_entry_timestamp_falls_back_to_today_year_when_missing() {
+        let e = EventEntry::from_raw(raw_event(None, "Independence Day", vec![]), 2026, 7, 4);
+        let date = NaiveDate::from_ymd_opt(2026, 7, 4)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp();
+        assert_eq!(e.timestamp, date);
+    }
+
     fn entry(label: &str, url: Option<&str>) -> EventEntry {
         EventEntry {
             label: label.into(),
             url: url.map(String::from),
+            timestamp: 0,
         }
     }
 
@@ -417,7 +502,7 @@ mod tests {
             events: vec![raw_event(Some(2), "e", vec![])],
             ..Default::default()
         };
-        let events = resp.into_events(Kind::Selected);
+        let events = resp.into_events(Kind::Selected, 2026, 4, 27);
         assert_eq!(events.len(), 1);
         assert!(events[0].label.contains("s"));
     }
@@ -431,7 +516,7 @@ mod tests {
             deaths: vec![raw_event(Some(4), "d", vec![])],
             holidays: vec![raw_event(None, "h", vec![])],
         };
-        let events = resp.into_events(Kind::All);
+        let events = resp.into_events(Kind::All, 2026, 4, 27);
         assert_eq!(events.len(), 5);
     }
 
@@ -456,12 +541,36 @@ mod tests {
             ]
         }"#;
         let r: OnThisDayResponse = serde_json::from_str(raw).unwrap();
-        let selected = r.into_events(Kind::Selected);
+        let selected = r.into_events(Kind::Selected, 2026, 4, 27);
         assert_eq!(selected[0].label, "1969 — Apollo 11.");
         assert_eq!(
             selected[0].url.as_deref(),
             Some("https://en.wikipedia.org/wiki/Apollo_11")
         );
+    }
+
+    #[test]
+    fn timeline_body_carries_anniversary_timestamps() {
+        let events = vec![
+            EventEntry {
+                label: "1969 — A".into(),
+                url: None,
+                timestamp: 12345,
+            },
+            EventEntry {
+                label: "1066 — B".into(),
+                url: None,
+                timestamp: 67890,
+            },
+        ];
+        let body = render_body(&events, Shape::Timeline, 5);
+        let Body::Timeline(t) = body else {
+            panic!("expected timeline");
+        };
+        assert_eq!(t.events.len(), 2);
+        assert_eq!(t.events[0].timestamp, 12345);
+        assert_eq!(t.events[0].title, "1969 — A");
+        assert_eq!(t.events[1].timestamp, 67890);
     }
 
     /// Live smoke test — hits Wikipedia REST API. `#[ignore]` keeps CI offline-safe.


### PR DESCRIPTION
## Summary

Reviewed every fetcher's `shapes()` against the `Shape` enum and closed the gaps surfaced by three patterns: ranking fetchers missing one of `TextBlock` / `MarkdownTextBlock` / `Text` (per the *multi-row-shapes-carry-the-ranking* rule), status-y fetchers without `Badge`, and structurally rich fetchers without their natural series shape (`PointSeries` had **zero** producers before this PR).

### Per-fetcher changes

- `system_battery`: + `Badge` (low-charge tiers)
- `git_stash_count`: + `Badge` (count pill)
- `github_notifications`: + `Badge` (unread count pill)
- `wikipedia_on_this_day`: + `Timeline` (anniversary timestamps from event year + today's month/day)
- `clock_almanac`: + `Calendar` (today highlighted)
- `clock_countdown`: + `Ratio` (window-based approach progress, default 30d) + `Calendar` (target day + multi-target events on the same month). New `window_days` option.
- `github_contributions`: + `NumberSeries` (weekly sums for sparkline)
- `github_action_history`: + `PointSeries` (`(run_number, duration_sec)`) — first non-ReadStore producer of `PointSeries`.
- `git_contributors`: + `TextBlock` + `MarkdownTextBlock`
- `git_churn`: + `MarkdownTextBlock`
- `code_todos`: + `MarkdownTextBlock`
- `github_languages`: + `Text` + `TextBlock` + `MarkdownTextBlock`
- `github_contributors_monthly`: + `Text` + `TextBlock` + `MarkdownTextBlock`
- `weather`: + `PointSeries` (hourly temp) + `NumberSeries` + `Bars` (hourly precipitation) + `Badge` (severe-weather tiers). API request now pulls a 24h hourly forecast alongside the existing current-conditions block.

### Out of scope

- `weather` `Image` (weather icons): would need a bundled icon-asset pipeline (selection, rasterisation, license review). Filed-as-followup-worthy, not done in this PR.

Refs #41.

## Test plan

- [x] `cargo test` (1006 passed, 9 ignored)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [ ] Smoke-test live shapes via `.splashboard/dashboard.toml` for at least one fetcher per family (weather PointSeries → `chart_line`, github_action_history PointSeries → `chart_scatter`, clock_countdown Ratio → `gauge_line`, clock_almanac Calendar → `grid_calendar`, github_notifications Badge → `status_badge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Calendar and Ratio shape support to clock widgets with configurable time window options
  * Introduced MarkdownTextBlock formatting for code todos and git metrics
  * Added Badge displays for notification counts, battery status, and stash indicators
  * Implemented chart visualizations (point series, number series, bar charts) for GitHub activity and weather data
  * Added Timeline view for historical events
  * Enhanced weather widget with 24-hour hourly forecast data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->