### PR TITLE
fix(docs): render LinkedTextBlock previews as real anchors

### DIFF
--- a/docs-site/src/styles/snapshot.css
+++ b/docs-site/src/styles/snapshot.css
@@ -75,6 +75,16 @@
   vertical-align: top;
 }
 
+/* Linked rows from `list_links` carry the same parent text colour; underline on hover
+   marks them as clickable without overpowering the snapshot. */
+.splash-snapshot .splash-link {
+  color: inherit;
+  text-decoration: none;
+}
+.splash-snapshot .splash-link:hover {
+  text-decoration: underline;
+}
+
 /* Landing full-dashboard preview: behaves like an image — scales to the container's width
    while preserving aspect ratio, no horizontal scroll ever. The dogfood renders at 120 cells
    so at the reference previews' fixed 0.95rem font-size it overflows narrower content

--- a/src/fetcher/github/assigned_issues.rs
+++ b/src/fetcher/github/assigned_issues.rs
@@ -61,6 +61,16 @@ impl Fetcher for GithubAssignedIssues {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "unhappychoice/splashboard#41 meta: widget catalog & roadmap",
+                    Some("https://github.com/unhappychoice/splashboard/issues/41"),
+                ),
+                (
+                    "unhappychoice/splashboard#17 theme system",
+                    Some("https://github.com/unhappychoice/splashboard/issues/17"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "unhappychoice/splashboard#41 meta: widget catalog & roadmap",
                 "unhappychoice/splashboard#17 theme system",

--- a/src/fetcher/github/good_first_issues.rs
+++ b/src/fetcher/github/good_first_issues.rs
@@ -82,6 +82,16 @@ impl Fetcher for GithubGoodFirstIssues {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "ratatui/ratatui#999 improve docs for Paragraph",
+                    Some("https://github.com/ratatui/ratatui/issues/999"),
+                ),
+                (
+                    "tokio-rs/console#123 add quickstart section",
+                    Some("https://github.com/tokio-rs/console/issues/123"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "ratatui/ratatui#999 improve docs for Paragraph",
                 "tokio-rs/console#123 add quickstart section",

--- a/src/fetcher/github/my_prs.rs
+++ b/src/fetcher/github/my_prs.rs
@@ -62,6 +62,16 @@ impl Fetcher for GithubMyPrs {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "unhappychoice/splashboard#54 feat(docs): generate widget catalogue",
+                    Some("https://github.com/unhappychoice/splashboard/pull/54"),
+                ),
+                (
+                    "unhappychoice/splashboard#51 feat(fetcher): split clock options",
+                    Some("https://github.com/unhappychoice/splashboard/pull/51"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "unhappychoice/splashboard#54 feat(docs): generate widget catalogue",
                 "unhappychoice/splashboard#51 feat(fetcher): split clock options",

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -78,6 +78,16 @@ impl Fetcher for GithubNotifications {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "splashboard review_requested: feat: heatmap",
+                    Some("https://github.com/unhappychoice/splashboard/pull/12"),
+                ),
+                (
+                    "ratatui mention: rfc: themes",
+                    Some("https://github.com/ratatui/ratatui/issues/345"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "splashboard review_requested: feat: heatmap",
                 "ratatui mention: rfc: themes",

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -74,6 +74,16 @@ impl Fetcher for GithubRecentReleases {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "v0.3.0  2026-04-10",
+                    Some("https://github.com/unhappychoice/splashboard/releases/tag/v0.3.0"),
+                ),
+                (
+                    "v0.2.1  2026-03-05",
+                    Some("https://github.com/unhappychoice/splashboard/releases/tag/v0.2.1"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&["v0.3.0  2026-04-10", "v0.2.1  2026-03-05"]),
             Shape::Entries => {
                 samples::entries(&[("v0.3.0", "2026-04-10"), ("v0.2.1", "2026-03-05")])

--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -73,6 +73,16 @@ impl Fetcher for GithubRepoIssues {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "#41 meta: widget catalog & roadmap",
+                    Some("https://github.com/unhappychoice/splashboard/issues/41"),
+                ),
+                (
+                    "#17 theme system",
+                    Some("https://github.com/unhappychoice/splashboard/issues/17"),
+                ),
+            ]),
             Shape::TextBlock => {
                 samples::text_block(&["#41 meta: widget catalog & roadmap", "#17 theme system"])
             }

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -73,6 +73,16 @@ impl Fetcher for GithubRepoPrs {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "#54 feat(docs): generate widget catalogue",
+                    Some("https://github.com/unhappychoice/splashboard/pull/54"),
+                ),
+                (
+                    "#51 feat(fetcher): split clock options",
+                    Some("https://github.com/unhappychoice/splashboard/pull/51"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "#54 feat(docs): generate widget catalogue",
                 "#51 feat(fetcher): split clock options",

--- a/src/fetcher/github/review_requests.rs
+++ b/src/fetcher/github/review_requests.rs
@@ -61,6 +61,16 @@ impl Fetcher for GithubReviewRequests {
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "ratatui/ratatui#1234 feat: add pie chart",
+                    Some("https://github.com/ratatui/ratatui/pull/1234"),
+                ),
+                (
+                    "tokio-rs/tokio#5678 fix: race in spawn",
+                    Some("https://github.com/tokio-rs/tokio/pull/5678"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "ratatui/ratatui#1234 feat: add pie chart",
                 "tokio-rs/tokio#5678 fix: race in spawn",

--- a/xtask/src/html_snapshot.rs
+++ b/xtask/src/html_snapshot.rs
@@ -12,23 +12,78 @@ pub fn buffer_to_html(buf: &Buffer) -> String {
     out.push_str("<pre class=\"splash-snapshot\">");
     let area = buf.area();
     for y in 0..area.height {
-        let mut run_style: Option<Style> = None;
-        let mut run_cells: Vec<String> = Vec::new();
-        for x in 0..area.width {
-            let cell = buf[(x, y)].clone();
-            let style = cell_style(&cell);
-            if Some(style) != run_style {
-                flush_run(&mut out, run_style.as_ref(), &run_cells);
-                run_cells.clear();
-                run_style = Some(style);
-            }
-            run_cells.push(cell.symbol().to_string());
-        }
-        flush_run(&mut out, run_style.as_ref(), &run_cells);
+        emit_row(&mut out, buf, y, area.width);
         out.push('\n');
     }
     out.push_str("</pre>");
     out
+}
+
+fn emit_row(out: &mut String, buf: &Buffer, y: u16, width: u16) {
+    let mut run_style: Option<Style> = None;
+    let mut run_cells: Vec<String> = Vec::new();
+    for x in 0..width {
+        let cell = buf[(x, y)].clone();
+        // Cells flagged `skip` are placeholders for the visible region of an OSC 8 hyperlink
+        // — the link's first cell carries the whole sequence; the trailing cells exist only
+        // so terminal cursor math lines up. Drop them in HTML to avoid emitting stray spaces.
+        if cell.skip {
+            continue;
+        }
+        let style = cell_style(&cell);
+        if let Some((url, visible)) = parse_osc8(cell.symbol()) {
+            flush_run(out, run_style.as_ref(), &run_cells);
+            run_cells.clear();
+            run_style = None;
+            emit_link(out, &style, &url, &visible);
+            continue;
+        }
+        if Some(style) != run_style {
+            flush_run(out, run_style.as_ref(), &run_cells);
+            run_cells.clear();
+            run_style = Some(style);
+        }
+        run_cells.push(cell.symbol().to_string());
+    }
+    flush_run(out, run_style.as_ref(), &run_cells);
+}
+
+/// Parse an OSC 8 hyperlink wrapper of the form `ESC ] 8 ; ; <url> ESC \ <visible> ESC ] 8 ; ; ESC \`
+/// into its URL and visible-text components. The terminal renderer (`list_links`) embeds the
+/// whole sequence into a single cell symbol; in HTML we need the parts so we can emit a real
+/// `<a>` tag instead of leaking the escape codes as text.
+fn parse_osc8(symbol: &str) -> Option<(String, String)> {
+    const PREFIX: &str = "\x1b]8;;";
+    const ST: &str = "\x1b\\";
+    const CLOSE: &str = "\x1b]8;;\x1b\\";
+    let s = symbol.strip_prefix(PREFIX)?;
+    let url_end = s.find(ST)?;
+    let url = &s[..url_end];
+    let after_url = &s[url_end + ST.len()..];
+    let close_pos = after_url.rfind(CLOSE)?;
+    let visible = &after_url[..close_pos];
+    Some((url.to_string(), visible.to_string()))
+}
+
+fn emit_link(out: &mut String, style: &Style, url: &str, visible: &str) {
+    let styled = has_visible_style(style);
+    if styled {
+        out.push_str("<span style=\"");
+        out.push_str(&style_css(style));
+        out.push_str("\">");
+    }
+    out.push_str("<a href=\"");
+    out.push_str(&escape_html(url));
+    out.push_str("\" class=\"splash-link\">");
+    for ch in visible.chars() {
+        out.push_str("<span class=\"c\">");
+        out.push_str(&escape_html(&ch.to_string()));
+        out.push_str("</span>");
+    }
+    out.push_str("</a>");
+    if styled {
+        out.push_str("</span>");
+    }
 }
 
 /// Skip `Color::Reset` (ratatui's "no explicit color" sentinel) so default cells produce plain
@@ -163,5 +218,32 @@ mod tests {
         assert!(html.contains("&lt;"));
         assert!(html.contains("&amp;"));
         assert!(html.contains("&gt;"));
+    }
+
+    #[test]
+    fn osc8_hyperlink_becomes_anchor() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 5, 1));
+        buf[(0, 0)].set_symbol("\x1b]8;;https://example.com/\x1b\\Hi\x1b]8;;\x1b\\");
+        buf[(1, 0)].set_skip(true);
+        let html = buffer_to_html(&buf);
+        assert!(
+            html.contains("<a href=\"https://example.com/\""),
+            "expected anchor tag, got: {html}"
+        );
+        assert!(html.contains("<span class=\"c\">H</span>"));
+        assert!(html.contains("<span class=\"c\">i</span>"));
+        assert!(!html.contains("\x1b"));
+        assert!(!html.contains("]8;;"));
+    }
+
+    #[test]
+    fn skip_cells_are_dropped() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+        buf[(0, 0)].set_symbol("a");
+        buf[(1, 0)].set_skip(true);
+        buf[(2, 0)].set_skip(true);
+        buf[(3, 0)].set_symbol("b");
+        let html = buffer_to_html(&buf);
+        assert_eq!(html.matches("<span class=\"c\">").count(), 2);
     }
 }


### PR DESCRIPTION
## Summary

- `xtask/html_snapshot` was embedding the `list_links` OSC 8 hyperlink escape sequence verbatim into a single cell, so the docs site rendered `]8;;https://…\Apr 26 …]8;;\` instead of clickable rows. Now detects the OSC 8 wrapper and emits a real `<a href="…" class="splash-link">` with one `<span class="c">` per visible char, plus honours `cell.skip` so the placeholder cells don't bleed extra spaces.
- Most `github_*` fetchers had no `Shape::LinkedTextBlock` arm in `sample_body`, which silently dropped the `linked_text_block` preview from those reference pages. Filled them in with realistic URLs (`my_prs` / `repo_prs` / `repo_issues` / `good_first_issues` / `review_requests` / `recent_releases` / `notifications` / `assigned_issues`).
- Added a tiny `.splash-link` rule (inherit colour, underline on hover) to `docs-site/src/styles/snapshot.css`.

## Test plan

- [x] `cargo test` (1024 + 12 passing)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask` regenerates docs; spot-checked `rss.md` and `github_my_prs.md` — `linked_text_block` previews now contain `<a href=…>` instead of leaked escape codes.
- [ ] Visual sanity check on the live docs site after Astro picks up the regenerated content + CSS rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for linked text blocks with proper hyperlink rendering across GitHub data sources.
  * Linked elements now display with underlines on hover while maintaining clean default appearance.

* **Tests**
  * Added test coverage for hyperlink rendering and placeholder cell handling in snapshot output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->