### PR TITLE
feat(templates): add project_codebase preset (#164)

### DIFF
--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -57,8 +57,8 @@ your chosen theme — followed by a final confirmation page:
    `home_minimal` / `home_feed`. Shown on new shells and when `cd`-ing
    anywhere outside a git repo root.
 2. **Project dashboard** — one of `project_splash` / `project_github` /
-   `project_minimal`. Shown when `cd`-ing into the top of any git repo that
-   doesn't ship its own `./.splashboard/`.
+   `project_minimal` / `project_codebase`. Shown when `cd`-ing into the top
+   of any git repo that doesn't ship its own `./.splashboard/`.
 3. **Theme** — `default` (the Splash signature ocean palette), or one of
    `tokyo_night`, `catppuccin_mocha`, `dracula`, `nord`, `gruvbox_dark`. The
    preview re-renders your home pick under the highlighted theme so you see
@@ -112,7 +112,7 @@ Flag reference:
 Available templates:
 
 - **home**: `home_splash`, `home_daily`, `home_github`, `home_minimal`, `home_feed`
-- **project**: `project_splash`, `project_github`, `project_minimal`
+- **project**: `project_splash`, `project_github`, `project_minimal`, `project_codebase`
 
 See [Presets](/guides/presets/) for a rendered preview of each,
 and [Themes](/guides/themes/) for the palette details.

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -199,25 +199,27 @@ same whether you're online, behind a firewall, or haven't run
 
 ### `project_codebase` — repo personality at a glance
 
-Dominant-language logo as the hero, repo age underneath, then five body
-panels: a LOC ranking paired with the LOC table, files per top-level
-directory, the 草-style commit heatmap, top contributors paired with
-churn, and the largest files paired with the TODO headline.
+Frame layout with the project title figlet at the centre, surrounded by
+analytics tiles: LOC by language, project age breakdown, comment density
+on the top row; files-by-dir on the left and largest-files on the right
+flanking the title; most-churned files, TODO comment list, and TODO
+hotspots on the bottom row.
 
 <div class="splash-landing" set:html={projectCodebase} />
 
 | role | implementation |
 |---|---|
-| hero | `code_language_logo` → `media_image` (22×9, contain) |
-| subtitle | `git_age` (Text) → `text_plain` |
-| languages | `code_loc` (Bars) → `chart_bar` (horizontal) |
-| LOC | `code_loc` (Entries) → `grid_table` |
-| files | `code_files` (Entries) → `grid_table` |
-| commits | `git_commits_activity` (Heatmap) → `grid_heatmap` |
-| contributors | `git_contributors` (Bars) → `chart_bar` |
-| churn | `git_churn` (Entries) → `grid_table` |
-| largest files | `code_largest_files` (Entries) → `grid_table` |
-| TODOs | `code_todos` (Text) → `text_plain` |
+| title | `git_repo_name` → `text_ascii` (blocks, quadrant) |
+| age | `git_age` (Text, `format = "full"`) → `text_plain` |
+| LOC summary | `code_loc` (Text) → `text_plain` |
+| LOC by language | `code_loc` (Bars) → `list_ranking` |
+| project age | `git_age` (Entries) → `grid_table` |
+| comment density | `code_comments` (Bars, `unit = "loc"`) → `list_ranking` |
+| files by dir | `code_files` (Bars) → `list_ranking` |
+| largest files | `code_largest_files` (Bars) → `list_ranking` |
+| most churned | `git_churn` (Bars) → `list_ranking` |
+| TODO comments | `code_todos` (TextBlock) → `list_plain` |
+| TODO hotspots | `code_todos` (Bars) → `list_ranking` |
 
 Local-only — every widget reads git2 / the working tree, no network or
 auth. Sister to `project_github` (operational forge view) on the

--- a/docs-site/src/content/docs/guides/presets.mdx
+++ b/docs-site/src/content/docs/guides/presets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Presets
-description: Eight curated dashboards you can adopt verbatim — pair one home with one project.
+description: Nine curated dashboards you can adopt verbatim — pair one home with one project.
 ---
 
 import homeSplash from '../../../assets/rendered/home_splash.html?raw';
@@ -11,8 +11,9 @@ import homeFeed from '../../../assets/rendered/home_feed.html?raw';
 import projectSplash from '../../../assets/rendered/project_splash.html?raw';
 import projectGithub from '../../../assets/rendered/project_github.html?raw';
 import projectMinimal from '../../../assets/rendered/project_minimal.html?raw';
+import projectCodebase from '../../../assets/rendered/project_codebase.html?raw';
 
-Eight curated dashboards — five home, three project. Pick one of each as a
+Nine curated dashboards — five home, four project. Pick one of each as a
 starting point and edit freely.
 
 - **Home presets** apply when the shell starts outside a git repo —
@@ -195,3 +196,29 @@ than the default noise.
 Fully offline — every widget reads local git, so the preset renders the
 same whether you're online, behind a firewall, or haven't run
 `gh auth login`.
+
+### `project_codebase` — repo personality at a glance
+
+Dominant-language logo as the hero, repo age underneath, then five body
+panels: a LOC ranking paired with the LOC table, files per top-level
+directory, the 草-style commit heatmap, top contributors paired with
+churn, and the largest files paired with the TODO headline.
+
+<div class="splash-landing" set:html={projectCodebase} />
+
+| role | implementation |
+|---|---|
+| hero | `code_language_logo` → `media_image` (22×9, contain) |
+| subtitle | `git_age` (Text) → `text_plain` |
+| languages | `code_loc` (Bars) → `chart_bar` (horizontal) |
+| LOC | `code_loc` (Entries) → `grid_table` |
+| files | `code_files` (Entries) → `grid_table` |
+| commits | `git_commits_activity` (Heatmap) → `grid_heatmap` |
+| contributors | `git_contributors` (Bars) → `chart_bar` |
+| churn | `git_churn` (Entries) → `grid_table` |
+| largest files | `code_largest_files` (Entries) → `grid_table` |
+| TODOs | `code_todos` (Text) → `text_plain` |
+
+Local-only — every widget reads git2 / the working tree, no network or
+auth. Sister to `project_github` (operational forge view) on the
+"what's the shape of this repo" axis.

--- a/docs-site/src/content/docs/showcases.md
+++ b/docs-site/src/content/docs/showcases.md
@@ -11,7 +11,7 @@ the relevant section below.
 
 _Screenshots pending: `home_splash`, `home_daily`, `home_github`,_
 _`home_minimal`, `home_feed`, `project_splash`, `project_github`,_
-_`project_minimal`._
+_`project_minimal`, `project_codebase`._
 
 ## Themes
 

--- a/src/render/chart_bar.rs
+++ b/src/render/chart_bar.rs
@@ -25,6 +25,8 @@ struct Options {
     pub max_bars: Option<usize>,
     #[serde(default)]
     pub bar_width: Option<u16>,
+    #[serde(default)]
+    pub bar_gap: Option<u16>,
 }
 
 const COLOR_KEYS: &[ColorKey] = &[theme::TEXT];
@@ -57,6 +59,13 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
         required: false,
         default: Some("3 for vertical, 1 for horizontal"),
         description: "Thickness of each bar along the axis perpendicular to its growth. Horizontal bars default to 1 cell so several fit into a compact slot without stacking tall; vertical bars default to 3 so labels under them have room.",
+    },
+    OptionSchema {
+        name: "bar_gap",
+        type_hint: "cells (u16)",
+        required: false,
+        default: Some("1 for vertical, 0 for horizontal"),
+        description: "Gap between adjacent bars. Vertical bars default to 1 cell so labels under each bar stay legible; horizontal bars default to 0 so rows pack tight without blank gutters between them.",
     },
 ];
 
@@ -110,10 +119,12 @@ fn render_bars(
         Direction::Vertical
     };
     let bar_width = specific.bar_width.unwrap_or(if horizontal { 1 } else { 3 });
+    let bar_gap = specific.bar_gap.unwrap_or(if horizontal { 0 } else { 1 });
     frame.render_widget(
         BarChart::default()
             .data(&bars)
             .bar_width(bar_width)
+            .bar_gap(bar_gap)
             .direction(direction)
             .label_style(Style::default().fg(theme.text))
             .value_style(Style::default().fg(theme.text)),

--- a/src/render/grid_table.rs
+++ b/src/render/grid_table.rs
@@ -101,8 +101,15 @@ fn render_rows(
     theme: &Theme,
 ) {
     let column_align = column_alignments(specific.column_align.as_deref());
+    let key_width = data
+        .items
+        .iter()
+        .map(|e| e.key.chars().count())
+        .max()
+        .unwrap_or(0)
+        .min(area.width as usize);
+    let widths = [Constraint::Length(key_width as u16), Constraint::Fill(1)];
     let rows = data.items.iter().map(|e| to_row(e, column_align, theme));
-    let widths = [Constraint::Percentage(40), Constraint::Percentage(60)];
     frame.render_widget(
         Table::new(rows, widths).style(Style::default().fg(theme.text)),
         area,
@@ -150,16 +157,18 @@ fn parse_align(s: Option<&str>) -> Alignment {
 }
 
 fn column_alignments(raw: Option<&[String]>) -> [Alignment; 2] {
-    let get = |i: usize| -> Alignment {
+    let get = |i: usize, default: Alignment| -> Alignment {
         raw.and_then(|a| a.get(i))
             .map(|s| match s.as_str() {
                 "center" => Alignment::Center,
                 "right" => Alignment::Right,
                 _ => Alignment::Left,
             })
-            .unwrap_or(Alignment::Left)
+            .unwrap_or(default)
     };
-    [get(0), get(1)]
+    // Key left-aligned, value right-aligned by default so the value sits flush against
+    // the right edge of the cell (fills the panel width). Override via `column_align`.
+    [get(0, Alignment::Left), get(1, Alignment::Right)]
 }
 
 fn to_row<'a>(item: &'a Entry, aligns: [Alignment; 2], theme: &Theme) -> Row<'a> {

--- a/src/render/list_ranking.rs
+++ b/src/render/list_ranking.rs
@@ -92,12 +92,27 @@ fn render_ranking(
     let style = opts.style.as_deref().unwrap_or("number");
     let prefixes: Vec<String> = (0..rows.len()).map(|i| rank_prefix(i, style)).collect();
     let widths = column_widths(&prefixes, &rows);
+    // Stretch the label column so the value sits flush against the right edge of
+    // the cell instead of leaving dead space, and truncate over-long labels so the
+    // value doesn't get clipped off the right.
+    let target = align_rect(area, widths.total() as u16, opts.align.as_deref());
+    let prefix_part = if widths.prefix > 0 {
+        widths.prefix + 1
+    } else {
+        0
+    };
+    let fixed = prefix_part + COLUMN_GAP.len() + widths.value;
+    let label_width = (target.width as usize).saturating_sub(fixed);
+    let effective = Widths {
+        prefix: widths.prefix,
+        label: label_width,
+        value: widths.value,
+    };
     let lines: Vec<Line> = rows
         .iter()
         .zip(prefixes.iter())
-        .map(|((label, value), prefix)| compose_line(prefix, label, *value, widths, theme))
+        .map(|((label, value), prefix)| compose_line(prefix, label, *value, effective, theme))
         .collect();
-    let target = align_rect(area, widths.total() as u16, opts.align.as_deref());
     frame.render_widget(
         Paragraph::new(lines).style(Style::default().fg(theme.text)),
         target,
@@ -173,10 +188,32 @@ fn compose_line<'a>(
             Style::default().fg(theme.text_dim),
         ));
     }
-    spans.push(Span::raw(pad_right(label, widths.label)));
+    spans.push(Span::raw(fit_label(label, widths.label)));
     spans.push(Span::raw(COLUMN_GAP));
     spans.push(Span::raw(pad_left(&value.to_string(), widths.value)));
     Line::from(spans)
+}
+
+/// Pad with trailing spaces if `label` fits, else truncate from the right (with a single
+/// `…` ellipsis) so the value column stays visible. Empty width returns empty.
+fn fit_label(label: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let n = label.chars().count();
+    if n <= width {
+        let mut out = String::with_capacity(width);
+        out.push_str(label);
+        out.extend(std::iter::repeat_n(' ', width - n));
+        return out;
+    }
+    if width == 1 {
+        return "…".to_string();
+    }
+    let take = width - 1;
+    let mut out: String = label.chars().take(take).collect();
+    out.push('…');
+    out
 }
 
 fn align_rect(area: Rect, content_width: u16, align: Option<&str>) -> Rect {
@@ -204,17 +241,6 @@ fn pad_left(s: &str, width: usize) -> String {
     let mut out = String::with_capacity(width);
     out.extend(std::iter::repeat_n(' ', width - n));
     out.push_str(s);
-    out
-}
-
-fn pad_right(s: &str, width: usize) -> String {
-    let n = s.chars().count();
-    if n >= width {
-        return s.to_string();
-    }
-    let mut out = String::with_capacity(width);
-    out.push_str(s);
-    out.extend(std::iter::repeat_n(' ', width - n));
     out
 }
 

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -76,7 +76,7 @@ pub const TEMPLATES: &[Template] = &[
     Template {
         name: "project_codebase",
         context: TemplateContext::Project,
-        description: "Repo personality dashboard: dominant-language logo, age, LOC ranking + table, file map, commit heatmap, contributors / churn, and largest files / TODOs. Local-only — no network or auth.",
+        description: "Repo analytics dashboard: project-name figlet at the centre flanked by files-by-dir and largest-files rankings, with LOC / age / comment-density tiles above and churn / TODO list / TODO hotspots below. Local-only — no network or auth.",
         body: include_str!("project_codebase.toml"),
     },
 ];

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -73,6 +73,12 @@ pub const TEMPLATES: &[Template] = &[
         description: "Quiet preset: repo name, latest tag, and the last three commits. Fully offline (no GitHub calls) — acknowledges the repo without taking over the screen.",
         body: include_str!("project_minimal.toml"),
     },
+    Template {
+        name: "project_codebase",
+        context: TemplateContext::Project,
+        description: "Repo personality dashboard: dominant-language logo, age, LOC ranking + table, file map, commit heatmap, contributors / churn, and largest files / TODOs. Local-only — no network or auth.",
+        body: include_str!("project_codebase.toml"),
+    },
 ];
 
 /// Lookup by name. Returns `None` for unknown templates so callers can surface a

--- a/src/templates/project_codebase.toml
+++ b/src/templates/project_codebase.toml
@@ -1,0 +1,224 @@
+# project_codebase — code analytics dashboard arranged as a frame around a
+# centred identity block. The project title sits dead-centre with analytics
+# blocks surrounding it on every side: a top row of LOC-by-language,
+# age-breakdown, and comment-density tiles; files-by-dir and largest-files
+# panels flanking the title left and right; then a churn / TODOs strip at
+# the bottom. Top/bottom `fill` paddings push the title block toward the
+# vertical centre so the whole dashboard breathes around it.
+#
+# Sister to `project_github` (operational forge view) on a different value
+# axis — "what is this codebase" rather than "what's open right now". Skips
+# commits-heatmap and contributors panels because `project_github` already
+# covers them; this preset focuses on local code structure analytics that
+# work offline with no auth.
+
+# ── Widgets ──────────────────────────────────────────────────────
+
+# Project name in compact big-text. `style = "blocks"` + `pixel_size = "quadrant"`
+# is the universally-supported dense tier (sextant uses Unicode 13 glyphs that
+# many terminal fonts still miss).
+[[widget]]
+id = "name"
+fetcher = "git_repo_name"
+render = { type = "text_ascii", style = "blocks", pixel_size = "quadrant", color = "panel_title", align = "center" }
+
+# `git_age` Text with `format = "full"` → "2y 3m · since 2024-01-15".
+[[widget]]
+id = "age"
+fetcher = "git_age"
+shape = "text"
+format = "full"
+render = { type = "text_plain", align = "center" }
+
+# `code_loc` Text → "73,202 lines across 6 languages".
+[[widget]]
+id = "loc_total"
+fetcher = "code_loc"
+shape = "text"
+render = { type = "text_plain", align = "center" }
+
+# Top analytics blocks — three tiles capped at 4 rows. Lines of code and
+# comment density are language rankings so they use `list_ranking` (Bars);
+# Project age is a year/month/day breakdown (not a ranking) so it stays
+# `grid_table` (Entries).
+[[widget]]
+id = "loc_by_lang"
+fetcher = "code_loc"
+shape = "bars"
+render = { type = "list_ranking", style = "number" }
+options = { limit = 4 }
+
+[[widget]]
+id = "age_breakdown"
+fetcher = "git_age"
+shape = "entries"
+render = "grid_table"
+
+[[widget]]
+id = "comment_density"
+fetcher = "code_comments"
+shape = "bars"
+render = { type = "list_ranking", style = "number" }
+options = { limit = 4, unit = "loc" }
+
+# Side panels directly flanking the title.
+[[widget]]
+id = "files_by_dir"
+fetcher = "code_files"
+shape = "bars"
+render = { type = "list_ranking", style = "number" }
+
+[[widget]]
+id = "largest_files"
+fetcher = "code_largest_files"
+shape = "bars"
+render = { type = "list_ranking", style = "number" }
+
+# Bottom strip.
+[[widget]]
+id = "churn"
+fetcher = "git_churn"
+shape = "bars"
+render = { type = "list_ranking", style = "number" }
+
+# Actual TODO comment locations (line-by-line listing).
+[[widget]]
+id = "todos"
+fetcher = "code_todos"
+shape = "text_block"
+render = { type = "list_plain", bullet = "·" }
+
+# TODO hotspots — files with the most TODO/FIXME markers, ranked by count.
+[[widget]]
+id = "todo_hotspots"
+fetcher = "code_todos"
+shape = "bars"
+render = { type = "list_ranking", style = "number" }
+
+# ── Layout ───────────────────────────────────────────────────────
+
+[[row]]
+height = { length = 1 }
+
+# Top analytics row — three bordered Entries blocks. Height 5 = 1 border
+# + 4 content rows, matching git_age's fixed 4-entry breakdown. Length(1)
+# spacers on the outer edges keep a 1-cell gutter against the terminal sides.
+[[row]]
+height = { length = 5 }
+gap = 2
+  [[row.child]]
+  width = { length = 1 }
+  [[row.child]]
+  widget = "loc_by_lang"
+  width = { fill = 1 }
+  border = "top"
+  title = "  Lines of code  "
+  title_align = "center"
+  [[row.child]]
+  widget = "age_breakdown"
+  width = { fill = 1 }
+  border = "top"
+  title = "  Project age  "
+  title_align = "center"
+  [[row.child]]
+  widget = "comment_density"
+  width = { fill = 1 }
+  border = "top"
+  title = "  Comment density  "
+  title_align = "center"
+  [[row.child]]
+  width = { length = 1 }
+
+# Top fill — pushes the title block toward the vertical centre.
+[[row]]
+height = { fill = 1 }
+
+# Title row — figlet flanked by `files_by_dir` (left) and `largest_files`
+# (right). 4 rows tall = exact figlet height; the side panels show their
+# top 4 entries alongside. Length(1) outer spacers match the other rows.
+[[row]]
+height = { length = 4 }
+gap = 2
+  [[row.child]]
+  width = { length = 1 }
+  [[row.child]]
+  widget = "files_by_dir"
+  width = { fill = 1 }
+  border = "top"
+  title = "  Files by dir  "
+  title_align = "center"
+  [[row.child]]
+  widget = "name"
+  width = { fill = 2 }
+  [[row.child]]
+  widget = "largest_files"
+  width = { fill = 1 }
+  border = "top"
+  title = "  Largest files  "
+  title_align = "center"
+  [[row.child]]
+  width = { length = 1 }
+
+# Subtitle stack — only the centre column carries text. Same 1:2:1 fills
+# as the title row so the centre column reads as a single continuous
+# title block.
+[[row]]
+height = { length = 1 }
+gap = 2
+  [[row.child]]
+  width = { fill = 1 }
+  [[row.child]]
+  widget = "age"
+  width = { fill = 2 }
+  [[row.child]]
+  width = { fill = 1 }
+
+[[row]]
+height = { length = 1 }
+gap = 2
+  [[row.child]]
+  width = { fill = 1 }
+  [[row.child]]
+  widget = "loc_total"
+  width = { fill = 2 }
+  [[row.child]]
+  width = { fill = 1 }
+
+# Bottom fill — mirrors the top fill so the title sits at the vertical
+# centre.
+[[row]]
+height = { fill = 1 }
+
+# Bottom analytics row — Churn (1/4) | TODOs (2/4 wider, location list
+# needs the room) | TODO hotspots (1/4). Side tiles share the same
+# `list_ranking` style; the middle TODO list uses `list_plain` because
+# it's a `<file>:<line>: <text>` paragraph, not a ranking. Length(1)
+# outer spacers match the rest of the dashboard.
+[[row]]
+height = { length = 8 }
+gap = 2
+  [[row.child]]
+  width = { length = 1 }
+  [[row.child]]
+  widget = "churn"
+  width = { fill = 1 }
+  border = "top"
+  title = "  Most churned  "
+  title_align = "center"
+  [[row.child]]
+  widget = "todos"
+  width = { fill = 2 }
+  border = "top"
+  title = "  TODO comments  "
+  title_align = "center"
+  [[row.child]]
+  widget = "todo_hotspots"
+  width = { fill = 1 }
+  border = "top"
+  title = "  TODO hotspots  "
+  title_align = "center"
+  [[row.child]]
+  width = { length = 1 }
+
+[[row]]
+height = { length = 1 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -50,6 +50,10 @@ const DASHBOARD_SNAPSHOTS: &[(&str, &str)] = &[
     ("src/templates/project_splash.toml", "project_splash.html"),
     ("src/templates/project_github.toml", "project_github.html"),
     ("src/templates/project_minimal.toml", "project_minimal.html"),
+    (
+        "src/templates/project_codebase.toml",
+        "project_codebase.html",
+    ),
 ];
 
 fn main() -> Result<()> {


### PR DESCRIPTION
## Summary

- Adds the `project_codebase` preset — a code-analytics dashboard for the per-project slot, framing the project title figlet with surrounding tiles (LOC by language, project age, comment density on top; files by dir / largest files flanking the title; most-churned, TODO comments list, TODO hotspots on the bottom). All widgets are `Safety::Safe` (local git2 / file scans, no network, no auth).
- Polishes two renderers along the way so the preset's tiles fill their cells properly:
  - `chart_bar` exposes a new `bar_gap` option and defaults horizontal bars to `bar_gap = 0` so rows pack tight (the previous default of 1 left blank rows between bars in narrow horizontal-bar slots).
  - `list_ranking` stretches the label column to the cell width, padding short labels so the value sits flush against the right edge and truncating overlong labels with `…` so the value column never gets clipped.
  - `grid_table` sizes the key column to the widest key, fills the remaining width with the value column, and right-aligns values by default. Long keys (e.g. `first_commit_date`) no longer get truncated and value cells no longer leave dead space on the right.
- Registers the preset in `TEMPLATES` (auto-picked up by the install-time picker in #58) and lists it in the docs-site Presets / Showcases / Getting started guides.

Tracks #164.

## Test plan

- [x] `cargo test` — 1024 lib tests passing, including the four `templates::tests` (parse / fetcher-known / renderer-known / renders-without-panic).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] `cargo run` smoke-render in a real repo (splashboard's own tree) — title + figlet + tiles render correctly with values flush right; long file paths in the side panels truncate with `…` instead of dropping the count.
- [ ] `cargo xtask` regenerates `docs-site/src/assets/rendered/project_codebase.html` with the rest of the preset gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "project_codebase" dashboard preset showcasing repository analytics (repo identity, age, LOC, rankings, TODO hotspots).
  * Snapshot output now includes a rendered preview of the new preset.

* **Improvements**
  * Chart spacing is now configurable for clearer bar charts.
  * Tables and ranking lists better size and truncate labels for improved readability.

* **Documentation**
  * Guides and installer/presets listings updated to include the new template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->