### PR TITLE
feat(fetcher): add deariary_* family for diary entries

### DIFF
--- a/src/fetcher/deariary/client.rs
+++ b/src/fetcher/deariary/client.rs
@@ -69,6 +69,41 @@ pub fn entry_url(date: &str) -> String {
     format!("https://app.deariary.com/entries/{path}")
 }
 
+/// Stable opaque scope string for a token. Used to namespace both the in-process slot cache
+/// keys and the per-fetcher disk `cache_key` so account A's cached entries can't be served
+/// to a widget configured against account B's token. Hashing avoids two distinct concerns
+/// in one go: keeps the raw token out of the cache-key strings (which surface in logs /
+/// file paths under `cache/`) and dodges any collision risk from a literal `|` separator
+/// in the token. We take only the first 16 hex chars of SHA-256 — collisions are vanishingly
+/// unlikely at that width and short keys keep the on-disk cache filenames reasonable.
+/// Callers that don't have a token (resolution failed earlier) pass `""`, yielding a stable
+/// empty-token scope rather than skipping the namespace entirely.
+pub fn token_scope(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(token.as_bytes());
+    let mut s = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        use std::fmt::Write;
+        let _ = write!(s, "{byte:02x}");
+    }
+    s
+}
+
+/// Cache-key `extra` partition string for the deariary family. Resolves the token via the
+/// same precedence as `fetch` (config option > `DEARIARY_TOKEN` env), then prefixes the raw
+/// options blob with the scoped token hash so changing accounts produces distinct disk
+/// cache files even when the token only lives in env (cf. CodeRabbit review on PR #176 —
+/// without this, two users sharing a `$HOME/.splashboard/cache` directory would observe
+/// each other's diary entries). Token-resolution failure folds to the empty scope; the
+/// subsequent fetch surfaces the missing-token error via `error_placeholder`.
+pub fn cache_extra(opts_token: Option<&str>, raw_opts: Option<&toml::Value>) -> String {
+    let resolved = resolve_token(opts_token).unwrap_or_default();
+    let opts_str = raw_opts
+        .and_then(|v| toml::to_string(v).ok())
+        .unwrap_or_default();
+    format!("{}|{}", token_scope(&resolved), opts_str)
+}
+
 pub fn resolve_token(config_token: Option<&str>) -> Result<String, FetchError> {
     let trimmed = config_token
         .map(str::trim)
@@ -175,12 +210,14 @@ fn list_cache() -> &'static StdMutex<HashMap<String, ListSlot>> {
 
 /// Cache key scopes the per-date slot to the token so a process holding multiple tokens
 /// (e.g. one widget per account) doesn't serve account A's entries to account B's widget.
-/// The token is part of the in-process key only — never written to disk or logs.
+/// The token is hashed via [`token_scope`] before becoming part of the key — defends
+/// against `|` colliding two distinct (token, date) pairs into one slot, and keeps the raw
+/// token out of the in-memory key string.
 fn entry_slot(token: &str, date: &str) -> EntrySlot {
     entry_cache()
         .lock()
         .unwrap()
-        .entry(format!("{token}|{date}"))
+        .entry(format!("{}|{date}", token_scope(token)))
         .or_insert_with(|| Arc::new(AsyncMutex::new(None)))
         .clone()
 }
@@ -189,7 +226,7 @@ fn list_slot(token: &str, tag: &str) -> ListSlot {
     list_cache()
         .lock()
         .unwrap()
-        .entry(format!("{token}|{tag}"))
+        .entry(format!("{}|{tag}", token_scope(token)))
         .or_insert_with(|| Arc::new(AsyncMutex::new(None)))
         .clone()
 }
@@ -397,6 +434,62 @@ mod tests {
             entry_url("2026-04-27"),
             "https://app.deariary.com/entries/2026/04/27"
         );
+    }
+
+    #[test]
+    fn token_scope_is_stable_collision_resistant_and_obscures_raw_token() {
+        let a = token_scope("tok-A");
+        let b = token_scope("tok-A");
+        assert_eq!(a, b, "scope must be deterministic for repeat calls");
+        assert_ne!(token_scope("tok-A"), token_scope("tok-B"));
+        // 16 hex chars = 64 bits of entropy. Plenty for distinguishing local accounts.
+        assert_eq!(a.len(), 16);
+        // Token-content-derived but not the token itself — defends `cache/` filenames /
+        // log lines that surface the scope from leaking the bearer.
+        assert!(!a.contains("tok-A"));
+    }
+
+    #[test]
+    fn token_scope_dodges_naive_pipe_separator_collision() {
+        // The slot key was previously `format!("{token}|{date}")`. A token containing `|`
+        // could collide with an entirely different (token, date) pair. Hashed scope removes
+        // the ambiguity — `a|b` and `a` against date `|b` no longer hash to the same bucket.
+        assert_ne!(token_scope("a|b"), token_scope("a"));
+    }
+
+    #[test]
+    fn cache_extra_partitions_disk_cache_per_resolved_token() {
+        // Direct config tokens — different tokens must produce different extras even with
+        // the same options blob, otherwise account A's disk cache leaks to account B.
+        let a = cache_extra(Some("tok-A"), None);
+        let b = cache_extra(Some("tok-B"), None);
+        assert_ne!(
+            a, b,
+            "different config tokens must yield different cache extras",
+        );
+    }
+
+    #[test]
+    fn cache_extra_includes_options_blob_for_per_invocation_keys() {
+        // Same token, different options (e.g. different `tag`) → different extras so
+        // cached entries don't bleed across invocation parameters.
+        let v1: toml::Value = toml::from_str("tag = \"work\"").unwrap();
+        let v2: toml::Value = toml::from_str("tag = \"travel\"").unwrap();
+        let a = cache_extra(Some("tok-A"), Some(&v1));
+        let b = cache_extra(Some("tok-A"), Some(&v2));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_extra_includes_a_token_scope_prefix() {
+        // Structural assertion: extra always begins with the scoped token followed by `|`,
+        // so even when DEARIARY_TOKEN flips out from under us mid-cache-lifetime, the new
+        // run produces a distinct cache key (we don't read stale account-A data into
+        // account-B's slot). Asserting the prefix shape rather than the exact value sidesteps
+        // env races with parallel tests.
+        let extra = cache_extra(Some("tok-A"), None);
+        let scope = token_scope("tok-A");
+        assert!(extra.starts_with(&format!("{scope}|")), "got: {extra:?}");
     }
 
     #[tokio::test]

--- a/src/fetcher/deariary/client.rs
+++ b/src/fetcher/deariary/client.rs
@@ -1,0 +1,410 @@
+//! Shared HTTP client + auth + API DTOs for the `deariary_*` fetcher family. The base host
+//! `api.deariary.com` is hardcoded so config can never redirect the bearer token to a
+//! third-party origin — that's why every fetcher in this family classifies as `Safety::Safe`.
+//!
+//! On top of the raw HTTP helpers there is a thin in-process layer that:
+//! - **deduplicates concurrent calls** for the same `/entries/:date` (or list query) across
+//!   widgets that differ only in shape / display options. Without it, two widgets viewing
+//!   today as Badge + Markdown would trigger two HTTP calls for identical data.
+//! - **caches successful responses** for 60s so back-to-back refreshes inside the burst
+//!   window reuse the body. The splashboard payload cache keeps shape-specific copies for
+//!   longer; this layer is just the burst smoother in front of it.
+//! - **bounds concurrency** via a semaphore (2 in flight). The documented limit is
+//!   120 req/min per key (rolling window, no burst sub-limit) so 10 calls per refresh
+//!   cycle leaves plenty of headroom; the cap is mainly so `on_this_day`'s 8-anchor fan-
+//!   out doesn't spike disk / network for a moment. If a 429 does fire (token shared with
+//!   another client, repeatedly nuked payload cache, etc.), the server's `Retry-After` is
+//!   honoured with a single retry capped at the request timeout.
+//!
+//! 404 has a dedicated success path (`Ok(None)`): for `/entries/:date` it just means "no
+//! entry that day", which `deariary_today` and `deariary_on_this_day` treat as empty content.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use tokio::sync::{Mutex as AsyncMutex, Semaphore};
+
+use crate::fetcher::FetchError;
+
+pub const API_BASE: &str = "https://api.deariary.com/api/v1";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const RESPONSE_TTL: Duration = Duration::from_secs(60);
+// Documented API limit is 120 req/min per key (no per-second sub-limit), so 8 parallel
+// `on_this_day` anchors are well within budget. The cap is here so a fan-out doesn't pile
+// FDs / sockets on the splashboard side, not because the API needs serialisation.
+const MAX_CONCURRENT_REQUESTS: usize = 4;
+// Cap on the `Retry-After` sleep when 429 fires. The server can ask for tens of seconds
+// (the docs example says "Retry after 24 seconds"), but the per-fetch timeout would kill
+// us before then anyway, so we cap at the same 10s window.
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(10);
+pub const MAX_LIST_LIMIT: u32 = 100;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiEntry {
+    pub date: String,
+    pub title: String,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub sources: Vec<String>,
+    #[serde(rename = "generatedAt", default)]
+    pub generated_at: Option<String>,
+    #[serde(rename = "wordCount", default)]
+    pub word_count: Option<u32>,
+}
+
+/// Public deariary web URL for an entry on the given ISO date (`YYYY-MM-DD`). The web app
+/// segments the path as `YYYY/MM/DD`, so we transform the dash-separated form into slashes.
+/// Used by `LinkedTextBlock` shapes across the family so terminals that honour OSC 8
+/// hyperlinks open the entry page directly.
+pub fn entry_url(date: &str) -> String {
+    let path = date.replace('-', "/");
+    format!("https://app.deariary.com/entries/{path}")
+}
+
+pub fn resolve_token(config_token: Option<&str>) -> Result<String, FetchError> {
+    config_token
+        .filter(|v| !v.is_empty())
+        .map(str::to_string)
+        .or_else(|| std::env::var("DEARIARY_TOKEN").ok())
+        .ok_or_else(|| {
+            FetchError::Failed("deariary token missing: set options.token or DEARIARY_TOKEN".into())
+        })
+}
+
+/// Fetches `/entries/:date` with deduplication + 60s cache. Returns `Ok(None)` on 404.
+pub async fn cached_get_entry(token: &str, date: &str) -> Result<Option<ApiEntry>, FetchError> {
+    let slot = entry_slot(date);
+    let mut guard = slot.lock().await;
+    if let Some(cached) = guard.as_ref()
+        && Instant::now() < cached.expires
+    {
+        return Ok(cached.value.clone());
+    }
+    let _permit = acquire_permit().await?;
+    let value = get_optional::<ApiEntry>(token, &format!("/entries/{date}")).await?;
+    *guard = Some(CacheSlot {
+        expires: Instant::now() + RESPONSE_TTL,
+        value: value.clone(),
+    });
+    Ok(value)
+}
+
+/// Fetches `/entries?limit=100&tag=…` with deduplication + 60s cache. Always asks the API
+/// for the maximum page size so widgets that differ only on `limit` share one HTTP call;
+/// callers slice the returned vector locally.
+pub async fn cached_get_entries(
+    token: &str,
+    tag: Option<&str>,
+) -> Result<Vec<ApiEntry>, FetchError> {
+    let slot = list_slot(tag.unwrap_or(""));
+    let mut guard = slot.lock().await;
+    if let Some(cached) = guard.as_ref()
+        && Instant::now() < cached.expires
+    {
+        return Ok(cached.value.clone());
+    }
+    let _permit = acquire_permit().await?;
+    let mut query: Vec<(&str, String)> = vec![("limit", MAX_LIST_LIMIT.to_string())];
+    if let Some(t) = tag.filter(|s| !s.is_empty()) {
+        query.push(("tag", t.to_string()));
+    }
+    let response: EntriesResponse = get_required(token, "/entries", &query).await?;
+    let value = response.into_vec();
+    *guard = Some(CacheSlot {
+        expires: Instant::now() + RESPONSE_TTL,
+        value: value.clone(),
+    });
+    Ok(value)
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+fn semaphore() -> &'static Semaphore {
+    static S: OnceLock<Semaphore> = OnceLock::new();
+    S.get_or_init(|| Semaphore::new(MAX_CONCURRENT_REQUESTS))
+}
+
+async fn acquire_permit() -> Result<tokio::sync::SemaphorePermit<'static>, FetchError> {
+    semaphore()
+        .acquire()
+        .await
+        .map_err(|e| FetchError::Failed(format!("deariary semaphore poisoned: {e}")))
+}
+
+struct CacheSlot<T> {
+    expires: Instant,
+    value: T,
+}
+
+type EntrySlot = Arc<AsyncMutex<Option<CacheSlot<Option<ApiEntry>>>>>;
+type ListSlot = Arc<AsyncMutex<Option<CacheSlot<Vec<ApiEntry>>>>>;
+
+fn entry_cache() -> &'static StdMutex<HashMap<String, EntrySlot>> {
+    static C: OnceLock<StdMutex<HashMap<String, EntrySlot>>> = OnceLock::new();
+    C.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+fn list_cache() -> &'static StdMutex<HashMap<String, ListSlot>> {
+    static C: OnceLock<StdMutex<HashMap<String, ListSlot>>> = OnceLock::new();
+    C.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+fn entry_slot(date: &str) -> EntrySlot {
+    entry_cache()
+        .lock()
+        .unwrap()
+        .entry(date.to_string())
+        .or_insert_with(|| Arc::new(AsyncMutex::new(None)))
+        .clone()
+}
+
+fn list_slot(tag: &str) -> ListSlot {
+    list_cache()
+        .lock()
+        .unwrap()
+        .entry(tag.to_string())
+        .or_insert_with(|| Arc::new(AsyncMutex::new(None)))
+        .clone()
+}
+
+async fn get_optional<T: DeserializeOwned>(
+    token: &str,
+    path: &str,
+) -> Result<Option<T>, FetchError> {
+    let bytes = match send_with_retry(token, path, &[]).await? {
+        FetchOutcome::NotFound => return Ok(None),
+        FetchOutcome::Body(b) => b,
+    };
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| FetchError::Failed(format!("deariary json parse: {e}")))
+}
+
+async fn get_required<T: DeserializeOwned>(
+    token: &str,
+    path: &str,
+    query: &[(&str, String)],
+) -> Result<T, FetchError> {
+    match send_with_retry(token, path, query).await? {
+        FetchOutcome::NotFound => Err(FetchError::Failed(format!("deariary {path}: 404"))),
+        FetchOutcome::Body(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|e| FetchError::Failed(format!("deariary json parse: {e}"))),
+    }
+}
+
+enum FetchOutcome {
+    NotFound,
+    Body(Vec<u8>),
+}
+
+/// One retry on 429: read `Retry-After` (seconds), sleep, then re-issue. Capped at
+/// `RETRY_AFTER_CAP` so a misbehaving header doesn't stall the splash for minutes.
+async fn send_with_retry(
+    token: &str,
+    path: &str,
+    query: &[(&str, String)],
+) -> Result<FetchOutcome, FetchError> {
+    let mut attempt = 0u8;
+    loop {
+        let url = format!("{API_BASE}{path}");
+        let res = http()
+            .get(&url)
+            .bearer_auth(token)
+            .query(query)
+            .send()
+            .await
+            .map_err(|e| FetchError::Failed(format!("deariary request failed: {e}")))?;
+        let status = res.status();
+        if status == StatusCode::NOT_FOUND {
+            return Ok(FetchOutcome::NotFound);
+        }
+        if status == StatusCode::TOO_MANY_REQUESTS && attempt == 0 {
+            let wait = parse_retry_after(res.headers()).min(RETRY_AFTER_CAP);
+            tracing::warn!(
+                limit = header_str(res.headers(), "X-RateLimit-Limit").as_deref(),
+                remaining = header_str(res.headers(), "X-RateLimit-Remaining").as_deref(),
+                reset = header_str(res.headers(), "X-RateLimit-Reset").as_deref(),
+                retry_after_s = wait.as_secs(),
+                path,
+                "deariary 429: backing off before retry",
+            );
+            tokio::time::sleep(wait).await;
+            attempt += 1;
+            continue;
+        }
+        let bytes = res
+            .bytes()
+            .await
+            .map_err(|e| FetchError::Failed(format!("deariary response body: {e}")))?;
+        if !status.is_success() {
+            return Err(FetchError::Failed(error_message(status, &bytes)));
+        }
+        return Ok(FetchOutcome::Body(bytes.to_vec()));
+    }
+}
+
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Duration {
+    headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(1))
+}
+
+fn header_str(headers: &reqwest::header::HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum EntriesResponse {
+    Wrapped { data: Vec<ApiEntry> },
+    Plain(Vec<ApiEntry>),
+}
+
+impl EntriesResponse {
+    fn into_vec(self) -> Vec<ApiEntry> {
+        match self {
+            Self::Wrapped { data } => data,
+            Self::Plain(items) => items,
+        }
+    }
+}
+
+fn error_message(status: StatusCode, body: &[u8]) -> String {
+    #[derive(Deserialize)]
+    struct Problem {
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        detail: Option<String>,
+    }
+    let reported = serde_json::from_slice::<Problem>(body)
+        .ok()
+        .and_then(|p| p.detail.or(p.title));
+    match reported {
+        Some(m) => format!("deariary {status}: {m}"),
+        None => format!("deariary {status}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entries_response_accepts_bare_array() {
+        let raw = r#"[{"date":"2026-04-27","title":"Hello"}]"#;
+        let parsed: EntriesResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.into_vec().len(), 1);
+    }
+
+    #[test]
+    fn entries_response_accepts_wrapped_data() {
+        let raw = r#"{"data":[{"date":"2026-04-27","title":"Hello"}]}"#;
+        let parsed: EntriesResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.into_vec().len(), 1);
+    }
+
+    #[test]
+    fn api_entry_tolerates_missing_optional_fields() {
+        let raw = r#"{"date":"2026-04-27","title":"Hello"}"#;
+        let entry: ApiEntry = serde_json::from_str(raw).unwrap();
+        assert_eq!(entry.date, "2026-04-27");
+        assert!(entry.content.is_none());
+        assert!(entry.tags.is_empty());
+        assert!(entry.word_count.is_none());
+    }
+
+    #[test]
+    fn api_entry_reads_full_payload() {
+        let raw = r##"{
+            "date":"2026-04-27",
+            "title":"My Day",
+            "content":"# Hello\n\nWorld",
+            "tags":["work","travel"],
+            "sources":["github","calendar"],
+            "generatedAt":"2026-04-27T08:00:00Z",
+            "wordCount":482
+        }"##;
+        let entry: ApiEntry = serde_json::from_str(raw).unwrap();
+        assert_eq!(entry.tags, vec!["work", "travel"]);
+        assert_eq!(entry.sources, vec!["github", "calendar"]);
+        assert_eq!(entry.word_count, Some(482));
+        assert_eq!(entry.generated_at.as_deref(), Some("2026-04-27T08:00:00Z"));
+    }
+
+    #[test]
+    fn error_message_picks_problem_detail_over_title() {
+        let body = br#"{"title":"Bad Request","detail":"date out of range"}"#;
+        let msg = error_message(StatusCode::BAD_REQUEST, body);
+        assert!(msg.contains("date out of range"));
+    }
+
+    #[test]
+    fn error_message_falls_back_to_title_when_detail_missing() {
+        let body = br#"{"title":"Forbidden"}"#;
+        let msg = error_message(StatusCode::FORBIDDEN, body);
+        assert!(msg.contains("Forbidden"));
+    }
+
+    #[test]
+    fn error_message_handles_non_problem_body() {
+        let msg = error_message(StatusCode::INTERNAL_SERVER_ERROR, b"internal explosion");
+        assert!(msg.contains("500"));
+    }
+
+    #[test]
+    fn resolve_token_prefers_config_value_over_env() {
+        let token = resolve_token(Some("from-config")).unwrap();
+        assert_eq!(token, "from-config");
+    }
+
+    #[test]
+    fn entry_url_uses_app_subdomain_with_slash_separated_date() {
+        assert_eq!(
+            entry_url("2026-04-27"),
+            "https://app.deariary.com/entries/2026/04/27"
+        );
+    }
+
+    #[tokio::test]
+    async fn entry_slot_returns_same_arc_for_same_date() {
+        let a = entry_slot("2026-04-27");
+        let b = entry_slot("2026-04-27");
+        assert!(Arc::ptr_eq(&a, &b));
+        let c = entry_slot("2026-04-26");
+        assert!(!Arc::ptr_eq(&a, &c));
+    }
+
+    #[tokio::test]
+    async fn list_slot_returns_same_arc_for_same_tag() {
+        let a = list_slot("travel");
+        let b = list_slot("travel");
+        assert!(Arc::ptr_eq(&a, &b));
+        let c = list_slot("");
+        assert!(!Arc::ptr_eq(&a, &c));
+    }
+}

--- a/src/fetcher/deariary/client.rs
+++ b/src/fetcher/deariary/client.rs
@@ -70,18 +70,24 @@ pub fn entry_url(date: &str) -> String {
 }
 
 pub fn resolve_token(config_token: Option<&str>) -> Result<String, FetchError> {
-    config_token
+    let trimmed = config_token
+        .map(str::trim)
         .filter(|v| !v.is_empty())
         .map(str::to_string)
-        .or_else(|| std::env::var("DEARIARY_TOKEN").ok())
-        .ok_or_else(|| {
-            FetchError::Failed("deariary token missing: set options.token or DEARIARY_TOKEN".into())
-        })
+        .or_else(|| {
+            std::env::var("DEARIARY_TOKEN")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
+    trimmed.ok_or_else(|| {
+        FetchError::Failed("deariary token missing: set options.token or DEARIARY_TOKEN".into())
+    })
 }
 
 /// Fetches `/entries/:date` with deduplication + 60s cache. Returns `Ok(None)` on 404.
 pub async fn cached_get_entry(token: &str, date: &str) -> Result<Option<ApiEntry>, FetchError> {
-    let slot = entry_slot(date);
+    let slot = entry_slot(token, date);
     let mut guard = slot.lock().await;
     if let Some(cached) = guard.as_ref()
         && Instant::now() < cached.expires
@@ -104,7 +110,7 @@ pub async fn cached_get_entries(
     token: &str,
     tag: Option<&str>,
 ) -> Result<Vec<ApiEntry>, FetchError> {
-    let slot = list_slot(tag.unwrap_or(""));
+    let slot = list_slot(token, tag.unwrap_or(""));
     let mut guard = slot.lock().await;
     if let Some(cached) = guard.as_ref()
         && Instant::now() < cached.expires
@@ -167,20 +173,23 @@ fn list_cache() -> &'static StdMutex<HashMap<String, ListSlot>> {
     C.get_or_init(|| StdMutex::new(HashMap::new()))
 }
 
-fn entry_slot(date: &str) -> EntrySlot {
+/// Cache key scopes the per-date slot to the token so a process holding multiple tokens
+/// (e.g. one widget per account) doesn't serve account A's entries to account B's widget.
+/// The token is part of the in-process key only — never written to disk or logs.
+fn entry_slot(token: &str, date: &str) -> EntrySlot {
     entry_cache()
         .lock()
         .unwrap()
-        .entry(date.to_string())
+        .entry(format!("{token}|{date}"))
         .or_insert_with(|| Arc::new(AsyncMutex::new(None)))
         .clone()
 }
 
-fn list_slot(tag: &str) -> ListSlot {
+fn list_slot(token: &str, tag: &str) -> ListSlot {
     list_cache()
         .lock()
         .unwrap()
-        .entry(tag.to_string())
+        .entry(format!("{token}|{tag}"))
         .or_insert_with(|| Arc::new(AsyncMutex::new(None)))
         .clone()
 }
@@ -391,20 +400,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn entry_slot_returns_same_arc_for_same_date() {
-        let a = entry_slot("2026-04-27");
-        let b = entry_slot("2026-04-27");
+    async fn entry_slot_returns_same_arc_for_same_token_and_date() {
+        let a = entry_slot("tok-A", "2026-04-27");
+        let b = entry_slot("tok-A", "2026-04-27");
         assert!(Arc::ptr_eq(&a, &b));
-        let c = entry_slot("2026-04-26");
+        let c = entry_slot("tok-A", "2026-04-26");
         assert!(!Arc::ptr_eq(&a, &c));
     }
 
     #[tokio::test]
-    async fn list_slot_returns_same_arc_for_same_tag() {
-        let a = list_slot("travel");
-        let b = list_slot("travel");
+    async fn entry_slot_isolates_per_token() {
+        let a = entry_slot("tok-A", "2026-04-27");
+        let b = entry_slot("tok-B", "2026-04-27");
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "different tokens must not share a cache slot",
+        );
+    }
+
+    #[tokio::test]
+    async fn list_slot_returns_same_arc_for_same_token_and_tag() {
+        let a = list_slot("tok-A", "travel");
+        let b = list_slot("tok-A", "travel");
         assert!(Arc::ptr_eq(&a, &b));
-        let c = list_slot("");
+        let c = list_slot("tok-A", "");
         assert!(!Arc::ptr_eq(&a, &c));
+    }
+
+    #[tokio::test]
+    async fn list_slot_isolates_per_token() {
+        let a = list_slot("tok-A", "travel");
+        let b = list_slot("tok-B", "travel");
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "different tokens must not share a list cache slot",
+        );
+    }
+
+    #[test]
+    fn resolve_token_trims_whitespace() {
+        let token = resolve_token(Some("  abc  ")).unwrap();
+        assert_eq!(token, "abc");
+    }
+
+    #[test]
+    fn resolve_token_rejects_whitespace_only_config_value() {
+        // Whitespace-only config doesn't take precedence; falls through to env (which we
+        // don't set here in the unit test, so this should fail). Asserts the trim-and-empty
+        // check kicks in.
+        let result = resolve_token(Some("   "));
+        // Either falls back to env (if DEARIARY_TOKEN is set in CI) or errors. We just need
+        // the config value not to be returned verbatim.
+        if let Ok(t) = result {
+            assert!(!t.trim().is_empty(), "should not return whitespace-only");
+            assert_ne!(t, "   ");
+        }
     }
 }

--- a/src/fetcher/deariary/client.rs
+++ b/src/fetcher/deariary/client.rs
@@ -90,18 +90,38 @@ pub fn token_scope(token: &str) -> String {
 }
 
 /// Cache-key `extra` partition string for the deariary family. Resolves the token via the
-/// same precedence as `fetch` (config option > `DEARIARY_TOKEN` env), then prefixes the raw
-/// options blob with the scoped token hash so changing accounts produces distinct disk
-/// cache files even when the token only lives in env (cf. CodeRabbit review on PR #176 —
-/// without this, two users sharing a `$HOME/.splashboard/cache` directory would observe
-/// each other's diary entries). Token-resolution failure folds to the empty scope; the
-/// subsequent fetch surfaces the missing-token error via `error_placeholder`.
+/// same precedence as `fetch` (config option > `DEARIARY_TOKEN` env), then prefixes the
+/// (token-stripped) options blob with the scoped token hash so changing accounts produces
+/// distinct disk cache files even when the token only lives in env (cf. CodeRabbit review
+/// on PR #176 — without this, two users sharing a `$HOME/.splashboard/cache` directory
+/// would observe each other's diary entries). Token-resolution failure folds to the empty
+/// scope; the subsequent fetch surfaces the missing-token error via `error_placeholder`.
+///
+/// The `token` field is stripped from the options blob before serialisation so the bearer
+/// doesn't ride along inside the intermediate `extra` string. The hash-prefix already
+/// partitions per token; reproducing the raw token verbatim in the blob would only
+/// re-introduce it as a panic-backtrace / log-tracing leak surface.
 pub fn cache_extra(opts_token: Option<&str>, raw_opts: Option<&toml::Value>) -> String {
     let resolved = resolve_token(opts_token).unwrap_or_default();
     let opts_str = raw_opts
-        .and_then(|v| toml::to_string(v).ok())
+        .map(strip_token_field)
+        .and_then(|v| toml::to_string(&v).ok())
         .unwrap_or_default();
     format!("{}|{}", token_scope(&resolved), opts_str)
+}
+
+/// Returns a clone of `value` with the top-level `token` key removed. Used by
+/// [`cache_extra`] so the bearer never survives into a cache-key intermediate even when
+/// `[widget.options]` carries it inline. Non-table inputs round-trip unchanged.
+fn strip_token_field(value: &toml::Value) -> toml::Value {
+    match value {
+        toml::Value::Table(table) => {
+            let mut copy = table.clone();
+            copy.remove("token");
+            toml::Value::Table(copy)
+        }
+        other => other.clone(),
+    }
 }
 
 pub fn resolve_token(config_token: Option<&str>) -> Result<String, FetchError> {
@@ -478,6 +498,22 @@ mod tests {
         let a = cache_extra(Some("tok-A"), Some(&v1));
         let b = cache_extra(Some("tok-A"), Some(&v2));
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_extra_strips_token_from_options_blob() {
+        // The bearer must never survive into the `extra` intermediate — the hash prefix
+        // already does the per-account partitioning, and reproducing the raw token in the
+        // serialised blob would only re-introduce it as a panic-backtrace / tracing leak.
+        let opts: toml::Value = toml::from_str("token = \"super-secret\"\ntag = \"work\"").unwrap();
+        let extra = cache_extra(Some("super-secret"), Some(&opts));
+        assert!(
+            !extra.contains("super-secret"),
+            "raw token must not appear in extra: {extra:?}"
+        );
+        // The non-token option survives so different `tag` values still produce distinct
+        // cache keys per account.
+        assert!(extra.contains("tag = \"work\""), "got: {extra:?}");
     }
 
     #[test]

--- a/src/fetcher/deariary/client.rs
+++ b/src/fetcher/deariary/client.rs
@@ -9,7 +9,7 @@
 //! - **caches successful responses** for 60s so back-to-back refreshes inside the burst
 //!   window reuse the body. The splashboard payload cache keeps shape-specific copies for
 //!   longer; this layer is just the burst smoother in front of it.
-//! - **bounds concurrency** via a semaphore (2 in flight). The documented limit is
+//! - **bounds concurrency** via a semaphore (4 in flight). The documented limit is
 //!   120 req/min per key (rolling window, no burst sub-limit) so 10 calls per refresh
 //!   cycle leaves plenty of headroom; the cap is mainly so `on_this_day`'s 8-anchor fan-
 //!   out doesn't spike disk / network for a moment. If a 429 does fire (token shared with

--- a/src/fetcher/deariary/mod.rs
+++ b/src/fetcher/deariary/mod.rs
@@ -1,0 +1,26 @@
+//! `deariary_*` fetcher family — surfaces deariary.com's auto-generated diary entries.
+//!
+//! deariary.com aggregates external tools (GitHub, Calendar, Slack, Linear, Todoist, ...) into
+//! a written entry each morning. Every fetcher in this family targets the fixed host
+//! `api.deariary.com`, so the bearer token (`options.token` or `DEARIARY_TOKEN` env) can
+//! never be redirected to an attacker-controlled origin — Safety::Safe.
+//!
+//! Streak / "did I write today" semantics deliberately don't apply: deariary positions itself
+//! as auto-generated so there's nothing for the user to miss.
+
+mod client;
+pub mod on_this_day;
+pub mod recent;
+pub mod today;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        Arc::new(today::DeariaryToday),
+        Arc::new(recent::DeariaryRecent),
+        Arc::new(on_this_day::DeariaryOnThisDay),
+    ]
+}

--- a/src/fetcher/deariary/on_this_day.rs
+++ b/src/fetcher/deariary/on_this_day.rs
@@ -1,0 +1,437 @@
+//! `deariary_on_this_day` — past diary entries on this same calendar day.
+//!
+//! Fetches eight anchors in parallel (1m / 3m / 6m / 1y / 2y / 3y / 4y / 5y ago) and surfaces
+//! whichever returned content. Splash-native take on deariary.com's opt-in Time Jump feature:
+//! the app only shows past entries when the user opens that view; this widget makes it ambient
+//! on every shell startup.
+//!
+//! Safety::Safe: host `api.deariary.com` is hardcoded.
+
+use async_trait::async_trait;
+use chrono::{Local, Months, NaiveDate};
+use serde::Deserialize;
+use tokio::task::JoinSet;
+
+use super::client::{ApiEntry, cached_get_entry, entry_url, resolve_token};
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData,
+    Payload, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+use crate::samples;
+
+/// Anchors are stored newest-first; rendered output preserves that order so users scan from
+/// the most recent past at the top down to the most distant (5 years) at the bottom.
+const ANCHORS: &[(&str, u32)] = &[
+    ("1 month ago", 1),
+    ("3 months ago", 3),
+    ("6 months ago", 6),
+    ("1 year ago", 12),
+    ("2 years ago", 24),
+    ("3 years ago", 36),
+    ("4 years ago", 48),
+    ("5 years ago", 60),
+];
+
+const SHAPES: &[Shape] = &[
+    Shape::TextBlock,
+    Shape::Timeline,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "token",
+    type_hint: "string",
+    required: false,
+    default: None,
+    description: "Deariary API token. Falls back to the `DEARIARY_TOKEN` env var.",
+}];
+
+pub struct DeariaryOnThisDay;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for DeariaryOnThisDay {
+    fn name(&self) -> &str {
+        "deariary_on_this_day"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Past auto-generated deariary.com entries from the same calendar day, fetched in parallel for 1m / 3m / 6m / 1y / 2y / 3y / 4y / 5y ago. Anchors with no entry are silently skipped. `TextBlock` is the default; `Timeline` plots the surviving anchors chronologically; `LinkedTextBlock` is a list of clickable rows; `Text` and `Badge` headline the most distant hit."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::TextBlock => samples::text_block(&[
+                "1 month ago — Reviewing PRs and shipping the heatmap renderer",
+                "1 year ago — A quiet writing day",
+                "3 years ago — First commit on splashboard",
+            ]),
+            Shape::Timeline => samples::timeline(&[
+                (
+                    1_775_000_000,
+                    "Reviewing PRs and shipping the heatmap renderer",
+                    Some("1 month ago"),
+                ),
+                (1_745_000_000, "A quiet writing day", Some("1 year ago")),
+                (
+                    1_682_000_000,
+                    "First commit on splashboard",
+                    Some("3 years ago"),
+                ),
+            ]),
+            Shape::Text => samples::text("📔 3 years ago: First commit on splashboard"),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- **1 month ago** — Reviewing PRs and shipping the heatmap renderer\n- **1 year ago** — A quiet writing day\n- **3 years ago** — First commit on splashboard",
+            ),
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "1 month ago — Reviewing PRs",
+                    Some("https://app.deariary.com/entries/2026/03/27"),
+                ),
+                (
+                    "1 year ago — A quiet writing day",
+                    Some("https://app.deariary.com/entries/2025/04/27"),
+                ),
+                (
+                    "3 years ago — First commit",
+                    Some("https://app.deariary.com/entries/2023/04/27"),
+                ),
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("1 month ago", "Reviewing PRs"),
+                ("1 year ago", "A quiet writing day"),
+                ("3 years ago", "First commit on splashboard"),
+            ]),
+            Shape::Badge => Body::Badge(BadgeData {
+                status: Status::Ok,
+                label: "📔 3 years ago".into(),
+            }),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let today = Local::now().date_naive();
+        let hits = fetch_anchors(&token, today).await?;
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
+        Ok(payload(render_body(&hits, shape, today)))
+    }
+}
+
+/// Spawns one task per anchor and aggregates the results. Per-anchor 404 is "no entry that
+/// day" and is silently skipped; 429 / 5xx propagate as errors only when *every* anchor failed
+/// — otherwise a single rate-limited anchor would mask all the entries that did come back.
+async fn fetch_anchors(
+    token: &str,
+    today: NaiveDate,
+) -> Result<Vec<(usize, ApiEntry)>, FetchError> {
+    let mut set: JoinSet<(usize, Result<Option<ApiEntry>, FetchError>)> = JoinSet::new();
+    let mut spawned = 0usize;
+    for (idx, (_, months)) in ANCHORS.iter().enumerate() {
+        let Some(date) = anchor_date(today, *months) else {
+            continue;
+        };
+        let token = token.to_string();
+        spawned += 1;
+        set.spawn(async move {
+            let date_str = date.to_string();
+            (idx, cached_get_entry(&token, &date_str).await)
+        });
+    }
+    let mut hits: Vec<(usize, ApiEntry)> = Vec::new();
+    let mut last_error: Option<FetchError> = None;
+    let mut error_count = 0usize;
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok((idx, Ok(Some(entry)))) => hits.push((idx, entry)),
+            Ok((_, Ok(None))) => {}
+            Ok((_, Err(err))) => {
+                error_count += 1;
+                last_error = Some(err);
+            }
+            Err(_) => {}
+        }
+    }
+    if hits.is_empty() && error_count == spawned && spawned > 0 {
+        return Err(last_error.expect("at least one error when all anchors failed"));
+    }
+    hits.sort_by_key(|(idx, _)| *idx);
+    Ok(hits)
+}
+
+fn anchor_date(today: NaiveDate, months: u32) -> Option<NaiveDate> {
+    today.checked_sub_months(Months::new(months))
+}
+
+fn render_body(hits: &[(usize, ApiEntry)], shape: Shape, today: NaiveDate) -> Body {
+    match shape {
+        Shape::Text => render_text(hits),
+        Shape::MarkdownTextBlock => render_markdown(hits),
+        Shape::LinkedTextBlock => render_linked(hits),
+        Shape::Entries => render_entries(hits),
+        Shape::Badge => render_badge(hits),
+        Shape::Timeline => render_timeline(hits, today),
+        _ => render_text_block(hits),
+    }
+}
+
+fn render_text(hits: &[(usize, ApiEntry)]) -> Body {
+    let value = hits.last().map_or(String::new(), |(idx, e)| {
+        format!("📔 {}: {}", ANCHORS[*idx].0, e.title)
+    });
+    Body::Text(TextData { value })
+}
+
+fn render_text_block(hits: &[(usize, ApiEntry)]) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: hits
+            .iter()
+            .map(|(idx, e)| format!("{} — {}", ANCHORS[*idx].0, e.title))
+            .collect(),
+    })
+}
+
+fn render_markdown(hits: &[(usize, ApiEntry)]) -> Body {
+    let value = hits
+        .iter()
+        .map(|(idx, e)| format!("- **{}** — {}", ANCHORS[*idx].0, e.title))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+fn render_linked(hits: &[(usize, ApiEntry)]) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: hits
+            .iter()
+            .map(|(idx, e)| LinkedLine {
+                text: format!("{} — {}", ANCHORS[*idx].0, e.title),
+                url: Some(entry_url(&e.date)),
+            })
+            .collect(),
+    })
+}
+
+fn render_entries(hits: &[(usize, ApiEntry)]) -> Body {
+    Body::Entries(EntriesData {
+        items: hits
+            .iter()
+            .map(|(idx, e)| Entry {
+                key: ANCHORS[*idx].0.into(),
+                value: Some(e.title.clone()),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+fn render_badge(hits: &[(usize, ApiEntry)]) -> Body {
+    let (status, label) = match hits.last() {
+        Some((idx, _)) => (Status::Ok, format!("📔 {}", ANCHORS[*idx].0)),
+        None => (Status::Warn, "📔 no past entries".into()),
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+fn render_timeline(hits: &[(usize, ApiEntry)], today: NaiveDate) -> Body {
+    Body::Timeline(TimelineData {
+        events: hits
+            .iter()
+            .filter_map(|(idx, e)| {
+                let (label, months) = ANCHORS[*idx];
+                let date = anchor_date(today, months)?;
+                let timestamp = date.and_hms_opt(12, 0, 0)?.and_utc().timestamp();
+                Some(TimelineEvent {
+                    timestamp,
+                    title: e.title.clone(),
+                    detail: Some(label.into()),
+                    status: None,
+                })
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(date: &str, title: &str) -> ApiEntry {
+        ApiEntry {
+            date: date.into(),
+            title: title.into(),
+            content: None,
+            tags: vec![],
+            sources: vec![],
+            generated_at: None,
+            word_count: None,
+        }
+    }
+
+    fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn anchors_cover_eight_lookback_points() {
+        assert_eq!(ANCHORS.len(), 8);
+    }
+
+    #[test]
+    fn anchor_date_subtracts_months_safely() {
+        let today = ymd(2026, 4, 27);
+        assert_eq!(anchor_date(today, 1), Some(ymd(2026, 3, 27)));
+        assert_eq!(anchor_date(today, 12), Some(ymd(2025, 4, 27)));
+        assert_eq!(anchor_date(today, 60), Some(ymd(2021, 4, 27)));
+    }
+
+    #[test]
+    fn anchor_date_clamps_when_target_day_does_not_exist() {
+        let today = ymd(2026, 3, 31);
+        assert_eq!(anchor_date(today, 1), Some(ymd(2026, 2, 28)));
+    }
+
+    #[test]
+    fn text_block_orders_anchors_newest_first() {
+        let hits = vec![
+            (0, entry("2026-03-27", "Recent")),
+            (3, entry("2025-04-27", "Year ago")),
+        ];
+        let Body::TextBlock(t) = render_body(&hits, Shape::TextBlock, ymd(2026, 4, 27)) else {
+            panic!("expected TextBlock");
+        };
+        assert_eq!(
+            t.lines,
+            vec![
+                "1 month ago — Recent".to_string(),
+                "1 year ago — Year ago".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn linked_text_block_rows_link_to_each_anchor_entry() {
+        let hits = vec![(0, entry("2026-03-27", "Recent"))];
+        let Body::LinkedTextBlock(l) = render_body(&hits, Shape::LinkedTextBlock, ymd(2026, 4, 27))
+        else {
+            panic!("expected LinkedTextBlock");
+        };
+        assert_eq!(l.items.len(), 1);
+        assert_eq!(
+            l.items[0].url.as_deref(),
+            Some("https://app.deariary.com/entries/2026/03/27")
+        );
+        assert!(l.items[0].text.contains("Recent"));
+    }
+
+    #[test]
+    fn text_headlines_with_oldest_hit() {
+        let hits = vec![
+            (0, entry("2026-03-27", "Recent")),
+            (7, entry("2021-04-27", "Five years")),
+        ];
+        let Body::Text(t) = render_body(&hits, Shape::Text, ymd(2026, 4, 27)) else {
+            panic!("expected Text");
+        };
+        assert!(t.value.contains("5 years ago"));
+        assert!(t.value.contains("Five years"));
+    }
+
+    #[test]
+    fn timeline_emits_one_event_per_hit() {
+        let hits = vec![
+            (0, entry("2026-03-27", "Recent")),
+            (3, entry("2025-04-27", "Year ago")),
+        ];
+        let Body::Timeline(t) = render_body(&hits, Shape::Timeline, ymd(2026, 4, 27)) else {
+            panic!("expected Timeline");
+        };
+        assert_eq!(t.events.len(), 2);
+        assert_eq!(t.events[0].title, "Recent");
+        assert_eq!(t.events[0].detail.as_deref(), Some("1 month ago"));
+        assert!(t.events[0].timestamp > t.events[1].timestamp);
+    }
+
+    #[test]
+    fn empty_hits_yields_empty_text_block() {
+        let Body::TextBlock(t) = render_body(&[], Shape::TextBlock, ymd(2026, 4, 27)) else {
+            panic!("expected TextBlock");
+        };
+        assert!(t.lines.is_empty());
+    }
+
+    #[test]
+    fn empty_hits_yields_warn_badge() {
+        let Body::Badge(b) = render_body(&[], Shape::Badge, ymd(2026, 4, 27)) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert!(b.label.contains("no past entries"));
+    }
+
+    #[test]
+    fn entries_keys_with_anchor_label() {
+        let hits = vec![(2, entry("2025-10-27", "Half year"))];
+        let Body::Entries(e) = render_body(&hits, Shape::Entries, ymd(2026, 4, 27)) else {
+            panic!("expected Entries");
+        };
+        assert_eq!(e.items[0].key, "6 months ago");
+        assert_eq!(e.items[0].value.as_deref(), Some("Half year"));
+    }
+
+    #[test]
+    fn markdown_uses_bold_anchor_labels() {
+        let hits = vec![(0, entry("2026-03-27", "Recent"))];
+        let Body::MarkdownTextBlock(m) =
+            render_body(&hits, Shape::MarkdownTextBlock, ymd(2026, 4, 27))
+        else {
+            panic!("expected MarkdownTextBlock");
+        };
+        assert!(m.value.contains("**1 month ago**"));
+    }
+
+    #[test]
+    fn sample_body_provides_value_for_each_supported_shape() {
+        let f = DeariaryOnThisDay;
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "missing sample for {s:?}");
+        }
+        assert!(f.sample_body(Shape::Heatmap).is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("token = \"x\"\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+}

--- a/src/fetcher/deariary/on_this_day.rs
+++ b/src/fetcher/deariary/on_this_day.rs
@@ -12,7 +12,7 @@ use chrono::{Local, Months, NaiveDate};
 use serde::Deserialize;
 use tokio::task::JoinSet;
 
-use super::client::{ApiEntry, cached_get_entry, entry_url, resolve_token};
+use super::client::{ApiEntry, cache_extra, cached_get_entry, entry_url, resolve_token};
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
@@ -81,11 +81,8 @@ impl Fetcher for DeariaryOnThisDay {
         OPTION_SCHEMAS
     }
     fn cache_key(&self, ctx: &FetchContext) -> String {
-        let extra = ctx
-            .options
-            .as_ref()
-            .and_then(|v| toml::to_string(v).ok())
-            .unwrap_or_default();
+        let opts: Options = parse_options(ctx.options.as_ref()).unwrap_or_default();
+        let extra = cache_extra(opts.token.as_deref(), ctx.options.as_ref());
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {

--- a/src/fetcher/deariary/on_this_day.rs
+++ b/src/fetcher/deariary/on_this_day.rs
@@ -179,7 +179,15 @@ async fn fetch_anchors(
                 error_count += 1;
                 last_error = Some(err);
             }
-            Err(_) => {}
+            // Spawned task panicked or was cancelled. Count it like a fetch error so the
+            // "all anchors failed" branch below can surface a real error rather than an
+            // empty-but-Ok result that would silently render as "no entries".
+            Err(join_err) => {
+                error_count += 1;
+                last_error = Some(FetchError::Failed(format!(
+                    "deariary anchor task failed: {join_err}"
+                )));
+            }
         }
     }
     if hits.is_empty() && error_count == spawned && spawned > 0 {

--- a/src/fetcher/deariary/recent.rs
+++ b/src/fetcher/deariary/recent.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use chrono::{Datelike, Local, NaiveDate};
 use serde::Deserialize;
 
-use super::client::{ApiEntry, MAX_LIST_LIMIT, cached_get_entries, entry_url, resolve_token};
+use super::client::{
+    ApiEntry, MAX_LIST_LIMIT, cache_extra, cached_get_entries, entry_url, resolve_token,
+};
 use crate::fetcher::github::common::{cache_key, parse_options, parse_timestamp, payload};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
@@ -90,11 +92,8 @@ impl Fetcher for DeariaryRecent {
         OPTION_SCHEMAS
     }
     fn cache_key(&self, ctx: &FetchContext) -> String {
-        let extra = ctx
-            .options
-            .as_ref()
-            .and_then(|v| toml::to_string(v).ok())
-            .unwrap_or_default();
+        let opts: Options = parse_options(ctx.options.as_ref()).unwrap_or_default();
+        let extra = cache_extra(opts.token.as_deref(), ctx.options.as_ref());
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {

--- a/src/fetcher/deariary/recent.rs
+++ b/src/fetcher/deariary/recent.rs
@@ -1,0 +1,447 @@
+//! `deariary_recent` — most recent auto-generated diary entries.
+//!
+//! Mirrors deariary.com's reverse-chronological list. The same data feeds Timeline (default),
+//! a list-of-titles view (TextBlock / Entries / LinkedTextBlock / MarkdownTextBlock), a
+//! coverage view (Calendar — which days this month received an entry), and Text / Badge
+//! headlines.
+//!
+//! Safety::Safe: host `api.deariary.com` is hardcoded.
+
+use async_trait::async_trait;
+use chrono::{Datelike, Local, NaiveDate};
+use serde::Deserialize;
+
+use super::client::{ApiEntry, cached_get_entries, entry_url, resolve_token};
+use crate::fetcher::github::common::{cache_key, parse_options, parse_timestamp, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, CalendarData, EntriesData, Entry, LinkedLine, LinkedTextBlockData,
+    MarkdownTextBlockData, Payload, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+use crate::samples;
+
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 100;
+const SHAPES: &[Shape] = &[
+    Shape::Timeline,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+    Shape::Calendar,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "token",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Deariary API token. Falls back to the `DEARIARY_TOKEN` env var.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=100)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of entries to render in row-shaped views.",
+    },
+    OptionSchema {
+        name: "tag",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Restrict results to a single tag slug.",
+    },
+];
+
+pub struct DeariaryRecent;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    limit: Option<u32>,
+    #[serde(default)]
+    tag: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for DeariaryRecent {
+    fn name(&self) -> &str {
+        "deariary_recent"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Recent auto-generated deariary.com entries, newest first. `Timeline` (default) carries the chronological ranking; `TextBlock` / `Entries` / `MarkdownTextBlock` / `LinkedTextBlock` carry the same ranking in their respective row formats; `Calendar` highlights this month's entry days; `Text` and `Badge` summarise the headline."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Timeline => samples::timeline(&[
+                (1_777_478_400, "My adventurous day", Some("482w")),
+                (1_777_392_000, "A quiet Sunday", Some("310w")),
+                (1_777_305_600, "Shipped the heatmap renderer", Some("612w")),
+            ]),
+            Shape::Text => samples::text("📔 3 entries · latest: My adventurous day"),
+            Shape::TextBlock => samples::text_block(&[
+                "04/27 · My adventurous day",
+                "04/26 · A quiet Sunday",
+                "04/25 · Shipped the heatmap renderer",
+            ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- **04/27** — My adventurous day\n- **04/26** — A quiet Sunday\n- **04/25** — Shipped the heatmap renderer",
+            ),
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "04/27 · My adventurous day",
+                    Some("https://app.deariary.com/entries/2026/04/27"),
+                ),
+                (
+                    "04/26 · A quiet Sunday",
+                    Some("https://app.deariary.com/entries/2026/04/26"),
+                ),
+                (
+                    "04/25 · Shipped the heatmap renderer",
+                    Some("https://app.deariary.com/entries/2026/04/25"),
+                ),
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("2026-04-27", "My adventurous day"),
+                ("2026-04-26", "A quiet Sunday"),
+                ("2026-04-25", "Shipped the heatmap renderer"),
+            ]),
+            Shape::Badge => Body::Badge(BadgeData {
+                status: Status::Ok,
+                label: "📔 3 recent".into(),
+            }),
+            Shape::Calendar => samples::calendar(2026, 4, Some(27), &[25, 26, 27]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT);
+        let entries = cached_get_entries(&token, opts.tag.as_deref()).await?;
+        let shape = ctx.shape.unwrap_or(Shape::Timeline);
+        let today = Local::now().date_naive();
+        Ok(payload(render_body(&entries, shape, limit as usize, today)))
+    }
+}
+
+fn render_body(entries: &[ApiEntry], shape: Shape, limit: usize, today: NaiveDate) -> Body {
+    let limited: Vec<&ApiEntry> = entries.iter().take(limit).collect();
+    match shape {
+        Shape::Text => render_text(&limited),
+        Shape::TextBlock => render_text_block(&limited),
+        Shape::MarkdownTextBlock => render_markdown(&limited),
+        Shape::LinkedTextBlock => render_linked(&limited),
+        Shape::Entries => render_entries(&limited),
+        Shape::Badge => render_badge(&limited),
+        Shape::Calendar => render_calendar(entries, today),
+        _ => render_timeline(&limited),
+    }
+}
+
+fn render_text(entries: &[&ApiEntry]) -> Body {
+    let value = entries.first().map_or(String::new(), |e| {
+        format!("📔 {} entries · latest: {}", entries.len(), e.title)
+    });
+    Body::Text(TextData { value })
+}
+
+fn render_text_block(entries: &[&ApiEntry]) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: entries.iter().map(|e| line_for(e)).collect(),
+    })
+}
+
+fn render_markdown(entries: &[&ApiEntry]) -> Body {
+    let value = entries
+        .iter()
+        .map(|e| format!("- **{}** — {}", short_date(&e.date), e.title))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+fn render_linked(entries: &[&ApiEntry]) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: entries
+            .iter()
+            .map(|e| LinkedLine {
+                text: line_for(e),
+                url: Some(entry_url(&e.date)),
+            })
+            .collect(),
+    })
+}
+
+fn render_entries(entries: &[&ApiEntry]) -> Body {
+    Body::Entries(EntriesData {
+        items: entries
+            .iter()
+            .map(|e| Entry {
+                key: e.date.clone(),
+                value: Some(e.title.clone()),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+fn render_badge(entries: &[&ApiEntry]) -> Body {
+    Body::Badge(BadgeData {
+        status: if entries.is_empty() {
+            Status::Warn
+        } else {
+            Status::Ok
+        },
+        label: format!("📔 {} recent", entries.len()),
+    })
+}
+
+fn render_timeline(entries: &[&ApiEntry]) -> Body {
+    Body::Timeline(TimelineData {
+        events: entries
+            .iter()
+            .map(|e| TimelineEvent {
+                timestamp: timestamp_for(e),
+                title: e.title.clone(),
+                detail: None,
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+/// This month's grid with the days that received an entry marked as events. Useful for
+/// "did I write today / how many days this month did I write" at a glance.
+fn render_calendar(entries: &[ApiEntry], today: NaiveDate) -> Body {
+    let events = entries
+        .iter()
+        .filter_map(|e| NaiveDate::parse_from_str(&e.date, "%Y-%m-%d").ok())
+        .filter(|d| d.year() == today.year() && d.month() == today.month())
+        .map(|d| d.day() as u8)
+        .collect();
+    Body::Calendar(CalendarData {
+        year: today.year(),
+        month: today.month() as u8,
+        day: Some(today.day() as u8),
+        events,
+    })
+}
+
+fn line_for(e: &ApiEntry) -> String {
+    format!("{} · {}", short_date(&e.date), e.title)
+}
+
+fn short_date(raw: &str) -> String {
+    NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .map(|d| d.format("%m/%d").to_string())
+        .unwrap_or_else(|_| raw.to_string())
+}
+
+fn timestamp_for(e: &ApiEntry) -> i64 {
+    e.generated_at
+        .as_deref()
+        .map(parse_timestamp)
+        .filter(|ts| *ts > 0)
+        .or_else(|| {
+            NaiveDate::parse_from_str(&e.date, "%Y-%m-%d")
+                .ok()
+                .and_then(|d| d.and_hms_opt(12, 0, 0))
+                .map(|dt| dt.and_utc().timestamp())
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(date: &str, title: &str) -> ApiEntry {
+        ApiEntry {
+            date: date.into(),
+            title: title.into(),
+            content: None,
+            tags: vec![],
+            sources: vec![],
+            generated_at: None,
+            word_count: None,
+        }
+    }
+
+    fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    fn fixture() -> Vec<ApiEntry> {
+        vec![
+            entry("2026-04-27", "My Day"),
+            entry("2026-04-26", "Sunday"),
+            entry("2026-04-25", "Heatmap"),
+        ]
+    }
+
+    #[test]
+    fn timeline_uses_date_when_generated_at_missing() {
+        let entries = fixture();
+        let Body::Timeline(t) = render_body(&entries, Shape::Timeline, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Timeline");
+        };
+        assert_eq!(t.events.len(), 3);
+        assert!(t.events.iter().all(|e| e.timestamp > 0));
+        assert_eq!(t.events[0].title, "My Day");
+    }
+
+    #[test]
+    fn timeline_prefers_generated_at_when_present() {
+        let mut entries = fixture();
+        entries[0].generated_at = Some("2026-04-27T08:00:00Z".into());
+        let Body::Timeline(t) = render_body(&entries, Shape::Timeline, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Timeline");
+        };
+        assert_eq!(
+            t.events[0].timestamp,
+            parse_timestamp("2026-04-27T08:00:00Z")
+        );
+    }
+
+    #[test]
+    fn text_includes_count_and_latest_title() {
+        let entries = fixture();
+        let Body::Text(t) = render_body(&entries, Shape::Text, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Text");
+        };
+        assert!(t.value.contains("3 entries"));
+        assert!(t.value.contains("My Day"));
+    }
+
+    #[test]
+    fn text_block_formats_short_date_and_title() {
+        let entries = fixture();
+        let Body::TextBlock(t) = render_body(&entries, Shape::TextBlock, 10, ymd(2026, 4, 27))
+        else {
+            panic!("expected TextBlock");
+        };
+        assert_eq!(t.lines[0], "04/27 · My Day");
+    }
+
+    #[test]
+    fn linked_text_block_links_each_row_to_its_entry_page() {
+        let entries = fixture();
+        let Body::LinkedTextBlock(l) =
+            render_body(&entries, Shape::LinkedTextBlock, 10, ymd(2026, 4, 27))
+        else {
+            panic!("expected LinkedTextBlock");
+        };
+        assert_eq!(l.items.len(), 3);
+        assert_eq!(
+            l.items[0].url.as_deref(),
+            Some("https://app.deariary.com/entries/2026/04/27")
+        );
+    }
+
+    #[test]
+    fn markdown_uses_bold_dates() {
+        let entries = fixture();
+        let Body::MarkdownTextBlock(m) =
+            render_body(&entries, Shape::MarkdownTextBlock, 10, ymd(2026, 4, 27))
+        else {
+            panic!("expected MarkdownTextBlock");
+        };
+        assert!(m.value.contains("**04/27**"));
+    }
+
+    #[test]
+    fn entries_keys_with_iso_date() {
+        let entries = fixture();
+        let Body::Entries(e) = render_body(&entries, Shape::Entries, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Entries");
+        };
+        assert_eq!(e.items[0].key, "2026-04-27");
+        assert_eq!(e.items[0].value.as_deref(), Some("My Day"));
+    }
+
+    #[test]
+    fn calendar_marks_entries_for_current_month_only() {
+        let mut entries = fixture();
+        entries.push(entry("2026-03-15", "Old"));
+        let Body::Calendar(c) = render_body(&entries, Shape::Calendar, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Calendar");
+        };
+        assert_eq!(c.year, 2026);
+        assert_eq!(c.month, 4);
+        assert_eq!(c.events, vec![27, 26, 25]);
+    }
+
+    #[test]
+    fn limit_caps_returned_rows() {
+        let entries = fixture();
+        let Body::TextBlock(t) = render_body(&entries, Shape::TextBlock, 2, ymd(2026, 4, 27))
+        else {
+            panic!("expected TextBlock");
+        };
+        assert_eq!(t.lines.len(), 2);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_body_and_warn_badge() {
+        let Body::Timeline(t) = render_body(&[], Shape::Timeline, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Timeline");
+        };
+        assert!(t.events.is_empty());
+
+        let Body::Badge(b) = render_body(&[], Shape::Badge, 10, ymd(2026, 4, 27)) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+    }
+
+    #[test]
+    fn sample_body_provides_value_for_each_supported_shape() {
+        let f = DeariaryRecent;
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "missing sample for {s:?}");
+        }
+        assert!(f.sample_body(Shape::Image).is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("limit = 5\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn short_date_falls_back_to_raw_when_unparseable() {
+        assert_eq!(short_date("not-a-date"), "not-a-date");
+    }
+}

--- a/src/fetcher/deariary/recent.rs
+++ b/src/fetcher/deariary/recent.rs
@@ -156,18 +156,21 @@ impl Fetcher for DeariaryRecent {
 fn render_body(entries: &[ApiEntry], shape: Shape, limit: usize, today: NaiveDate) -> Body {
     let limited: Vec<&ApiEntry> = entries.iter().take(limit).collect();
     match shape {
-        Shape::Text => render_text(&limited),
+        // Headline shapes (Text/Badge) report the real total, not the truncated count —
+        // a `limit = 5` widget with 23 cached entries should still say "📔 23 recent",
+        // not "📔 5 recent". The user-set `limit` only governs how many ROWS render.
+        Shape::Text => render_text(entries),
+        Shape::Badge => render_badge(entries),
         Shape::TextBlock => render_text_block(&limited),
         Shape::MarkdownTextBlock => render_markdown(&limited),
         Shape::LinkedTextBlock => render_linked(&limited),
         Shape::Entries => render_entries(&limited),
-        Shape::Badge => render_badge(&limited),
         Shape::Calendar => render_calendar(entries, today),
         _ => render_timeline(&limited),
     }
 }
 
-fn render_text(entries: &[&ApiEntry]) -> Body {
+fn render_text(entries: &[ApiEntry]) -> Body {
     let value = entries.first().map_or(String::new(), |e| {
         format!("📔 {} entries · latest: {}", entries.len(), e.title)
     });
@@ -214,7 +217,7 @@ fn render_entries(entries: &[&ApiEntry]) -> Body {
     })
 }
 
-fn render_badge(entries: &[&ApiEntry]) -> Body {
+fn render_badge(entries: &[ApiEntry]) -> Body {
     Body::Badge(BadgeData {
         status: if entries.is_empty() {
             Status::Warn
@@ -408,6 +411,43 @@ mod tests {
             panic!("expected TextBlock");
         };
         assert_eq!(t.lines.len(), 2);
+    }
+
+    #[test]
+    fn text_headline_reports_total_count_not_limit() {
+        // limit governs how many rows the *list* renderers show. A 23-entry cache shown
+        // through a Text headline should still say "23 entries", not the truncated count.
+        let entries = vec![
+            entry("2026-04-27", "A"),
+            entry("2026-04-26", "B"),
+            entry("2026-04-25", "C"),
+            entry("2026-04-24", "D"),
+            entry("2026-04-23", "E"),
+        ];
+        let Body::Text(t) = render_body(&entries, Shape::Text, 2, ymd(2026, 4, 27)) else {
+            panic!("expected Text");
+        };
+        assert!(
+            t.value.contains("5 entries"),
+            "headline must use real total: {}",
+            t.value
+        );
+    }
+
+    #[test]
+    fn badge_headline_reports_total_count_not_limit() {
+        let entries = vec![
+            entry("2026-04-27", "A"),
+            entry("2026-04-26", "B"),
+            entry("2026-04-25", "C"),
+        ];
+        let Body::Badge(b) = render_body(&entries, Shape::Badge, 1, ymd(2026, 4, 27)) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(
+            b.label, "📔 3 recent",
+            "badge must reflect total entries, not the row limit"
+        );
     }
 
     #[test]

--- a/src/fetcher/deariary/recent.rs
+++ b/src/fetcher/deariary/recent.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use chrono::{Datelike, Local, NaiveDate};
 use serde::Deserialize;
 
-use super::client::{ApiEntry, cached_get_entries, entry_url, resolve_token};
+use super::client::{ApiEntry, MAX_LIST_LIMIT, cached_get_entries, entry_url, resolve_token};
 use crate::fetcher::github::common::{cache_key, parse_options, parse_timestamp, payload};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
@@ -24,7 +24,6 @@ use crate::samples;
 
 const DEFAULT_LIMIT: u32 = 10;
 const MIN_LIMIT: u32 = 1;
-const MAX_LIMIT: u32 = 100;
 const SHAPES: &[Shape] = &[
     Shape::Timeline,
     Shape::Text,
@@ -147,7 +146,7 @@ impl Fetcher for DeariaryRecent {
         let limit = opts
             .limit
             .unwrap_or(DEFAULT_LIMIT)
-            .clamp(MIN_LIMIT, MAX_LIMIT);
+            .clamp(MIN_LIMIT, MAX_LIST_LIMIT);
         let entries = cached_get_entries(&token, opts.tag.as_deref()).await?;
         let shape = ctx.shape.unwrap_or(Shape::Timeline);
         let today = Local::now().date_naive();

--- a/src/fetcher/deariary/today.rs
+++ b/src/fetcher/deariary/today.rs
@@ -1,0 +1,340 @@
+//! `deariary_today` — the most recent auto-generated diary entry.
+//!
+//! deariary.com aggregates external tools (GitHub, Calendar, Slack, Linear, ...) into a
+//! written entry each morning, covering roughly the previous 24 hours. This fetcher targets
+//! whichever entry is freshest right now: usually today's, falling back to yesterday's when
+//! today's hasn't been generated yet (e.g. early morning splash). Requires the deariary
+//! Advanced plan and a Bearer token via `options.token` or `DEARIARY_TOKEN` env.
+//!
+//! Safety::Safe: host `api.deariary.com` is hardcoded.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::client::{ApiEntry, cached_get_entries, cached_get_entry, entry_url, resolve_token};
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData,
+    Payload, Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+const SHAPES: &[Shape] = &[
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "token",
+    type_hint: "string",
+    required: false,
+    default: None,
+    description: "Deariary API token (Bearer). Falls back to the `DEARIARY_TOKEN` env var.",
+}];
+
+pub struct DeariaryToday;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for DeariaryToday {
+    fn name(&self) -> &str {
+        "deariary_today"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "The most recent auto-generated deariary.com entry — typically today's, falling back to yesterday's when today's hasn't generated yet. Aggregated from external tools (GitHub, Calendar, Slack, Linear, ...); requires the Advanced plan. `TextBlock` shows the body, `MarkdownTextBlock` preserves formatting for `text_markdown`, `LinkedTextBlock` is a one-line clickable headline that opens the entry on deariary.com, `Entries` summarises title / date / tags / sources, `Text` is a one-line headline, `Badge` is a status pill."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Text => samples::text("📔 My adventurous day"),
+            Shape::TextBlock => samples::text_block(&[
+                "Caught the morning train to the office and shipped the heatmap renderer.",
+                "Reviewed two pull requests with the team and wrote release notes.",
+                "Wrapped up with a calm dinner and a long walk along the river.",
+            ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "## My adventurous day\n\nCaught the morning train to the office and shipped the heatmap renderer.\n\n- 🐱 GitHub: 3 commits, 2 PRs reviewed\n- 📅 Calendar: 1:1 with manager",
+            ),
+            Shape::LinkedTextBlock => samples::linked_text_block(&[(
+                "📔 My adventurous day",
+                Some("https://app.deariary.com/entries/2026/04/27"),
+            )]),
+            Shape::Entries => samples::entries(&[
+                ("title", "My adventurous day"),
+                ("date", "2026-04-27"),
+                ("tags", "work, travel"),
+                ("sources", "github, calendar"),
+            ]),
+            Shape::Badge => Body::Badge(BadgeData {
+                status: Status::Ok,
+                label: "📔 today".into(),
+            }),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let entry = latest_entry(&token).await?;
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
+        Ok(payload(render_body(entry.as_ref(), shape)))
+    }
+}
+
+/// Pulls the freshest entry: list call (cached, shared with `deariary_recent`) gives the
+/// newest date, then a per-date lookup (cached, shared with `deariary_on_this_day`) returns
+/// the body with `content` populated — `/entries` list responses may strip content for size.
+async fn latest_entry(token: &str) -> Result<Option<ApiEntry>, FetchError> {
+    let entries = cached_get_entries(token, None).await?;
+    let Some(latest) = entries.first() else {
+        return Ok(None);
+    };
+    cached_get_entry(token, &latest.date).await
+}
+
+fn render_body(entry: Option<&ApiEntry>, shape: Shape) -> Body {
+    match entry {
+        None => empty_body(shape),
+        Some(e) => match shape {
+            Shape::Text => render_text(e),
+            Shape::MarkdownTextBlock => render_markdown(e),
+            Shape::LinkedTextBlock => render_linked(e),
+            Shape::Entries => render_entries(e),
+            Shape::Badge => render_badge(e),
+            _ => render_text_block(e),
+        },
+    }
+}
+
+fn render_text(e: &ApiEntry) -> Body {
+    Body::Text(TextData {
+        value: format!("📔 {}", e.title),
+    })
+}
+
+fn render_text_block(e: &ApiEntry) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: content_lines(e),
+    })
+}
+
+fn render_markdown(e: &ApiEntry) -> Body {
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: e.content.clone().unwrap_or_default(),
+    })
+}
+
+/// Single-row clickable headline opening the entry on deariary.com. Multi-line content is
+/// the job of `TextBlock` / `MarkdownTextBlock`; here the user just wants one line they can
+/// click to keep reading.
+fn render_linked(e: &ApiEntry) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: vec![LinkedLine {
+            text: format!("📔 {}", e.title),
+            url: Some(entry_url(&e.date)),
+        }],
+    })
+}
+
+fn render_entries(e: &ApiEntry) -> Body {
+    let items = [
+        ("title", Some(e.title.clone())),
+        ("date", Some(e.date.clone())),
+        ("tags", (!e.tags.is_empty()).then(|| e.tags.join(", "))),
+        (
+            "sources",
+            (!e.sources.is_empty()).then(|| e.sources.join(", ")),
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(key, value)| {
+        value.map(|v| Entry {
+            key: key.into(),
+            value: Some(v),
+            status: None,
+        })
+    })
+    .collect();
+    Body::Entries(EntriesData { items })
+}
+
+fn render_badge(_e: &ApiEntry) -> Body {
+    Body::Badge(BadgeData {
+        status: Status::Ok,
+        label: "📔 today".into(),
+    })
+}
+
+fn content_lines(e: &ApiEntry) -> Vec<String> {
+    e.content
+        .as_deref()
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn empty_body(shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: String::new(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: String::new(),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData { items: vec![] }),
+        Shape::Entries => Body::Entries(EntriesData { items: vec![] }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: "📔 no entry yet".into(),
+        }),
+        _ => Body::TextBlock(TextBlockData { lines: vec![] }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry() -> ApiEntry {
+        ApiEntry {
+            date: "2026-04-27".into(),
+            title: "My Day".into(),
+            content: Some("# Hello\n\nWorld".into()),
+            tags: vec!["work".into(), "travel".into()],
+            sources: vec!["github".into(), "calendar".into()],
+            generated_at: Some("2026-04-27T08:00:00Z".into()),
+            word_count: Some(482),
+        }
+    }
+
+    #[test]
+    fn text_body_uses_title_only() {
+        let Body::Text(t) = render_body(Some(&entry()), Shape::Text) else {
+            panic!("expected Text");
+        };
+        assert!(t.value.contains("My Day"));
+        assert!(!t.value.contains("482"));
+    }
+
+    #[test]
+    fn text_block_splits_content_into_lines() {
+        let Body::TextBlock(t) = render_body(Some(&entry()), Shape::TextBlock) else {
+            panic!("expected TextBlock");
+        };
+        assert_eq!(t.lines, vec!["# Hello", "", "World"]);
+    }
+
+    #[test]
+    fn linked_text_block_emits_one_clickable_headline() {
+        let Body::LinkedTextBlock(l) = render_body(Some(&entry()), Shape::LinkedTextBlock) else {
+            panic!("expected LinkedTextBlock");
+        };
+        assert_eq!(l.items.len(), 1);
+        assert!(l.items[0].text.contains("My Day"));
+        assert_eq!(
+            l.items[0].url.as_deref(),
+            Some("https://app.deariary.com/entries/2026/04/27")
+        );
+    }
+
+    #[test]
+    fn markdown_block_passes_content_through_verbatim() {
+        let Body::MarkdownTextBlock(m) = render_body(Some(&entry()), Shape::MarkdownTextBlock)
+        else {
+            panic!("expected MarkdownTextBlock");
+        };
+        assert_eq!(m.value, "# Hello\n\nWorld");
+    }
+
+    #[test]
+    fn entries_includes_only_present_metadata_keys() {
+        let mut bare = entry();
+        bare.tags.clear();
+        bare.sources.clear();
+        let Body::Entries(e) = render_body(Some(&bare), Shape::Entries) else {
+            panic!("expected Entries");
+        };
+        let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(keys, vec!["title", "date"]);
+    }
+
+    #[test]
+    fn entries_joins_tags_and_sources_when_present() {
+        let Body::Entries(e) = render_body(Some(&entry()), Shape::Entries) else {
+            panic!("expected Entries");
+        };
+        let tags = e.items.iter().find(|i| i.key == "tags").unwrap();
+        assert_eq!(tags.value.as_deref(), Some("work, travel"));
+    }
+
+    #[test]
+    fn badge_label_is_constant_when_entry_present() {
+        let Body::Badge(b) = render_body(Some(&entry()), Shape::Badge) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "📔 today");
+    }
+
+    #[test]
+    fn missing_entry_emits_empty_text_block() {
+        let Body::TextBlock(t) = render_body(None, Shape::TextBlock) else {
+            panic!("expected TextBlock");
+        };
+        assert!(t.lines.is_empty());
+    }
+
+    #[test]
+    fn missing_entry_emits_warn_badge() {
+        let Body::Badge(b) = render_body(None, Shape::Badge) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert!(b.label.contains("no entry"));
+    }
+
+    #[test]
+    fn sample_body_provides_value_for_each_supported_shape() {
+        let f = DeariaryToday;
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "missing sample for {s:?}");
+        }
+        assert!(f.sample_body(Shape::Heatmap).is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("token = \"abc\"\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+}

--- a/src/fetcher/deariary/today.rs
+++ b/src/fetcher/deariary/today.rs
@@ -9,6 +9,7 @@
 //! Safety::Safe: host `api.deariary.com` is hardcoded.
 
 use async_trait::async_trait;
+use chrono::{Local, NaiveDate};
 use serde::Deserialize;
 
 use super::client::{ApiEntry, cached_get_entries, cached_get_entry, entry_url, resolve_token};
@@ -106,7 +107,8 @@ impl Fetcher for DeariaryToday {
         let token = resolve_token(opts.token.as_deref())?;
         let entry = latest_entry(&token).await?;
         let shape = ctx.shape.unwrap_or(Shape::TextBlock);
-        Ok(payload(render_body(entry.as_ref(), shape)))
+        let today = Local::now().date_naive();
+        Ok(payload(render_body(entry.as_ref(), shape, today)))
     }
 }
 
@@ -121,7 +123,7 @@ async fn latest_entry(token: &str) -> Result<Option<ApiEntry>, FetchError> {
     cached_get_entry(token, &latest.date).await
 }
 
-fn render_body(entry: Option<&ApiEntry>, shape: Shape) -> Body {
+fn render_body(entry: Option<&ApiEntry>, shape: Shape, today: NaiveDate) -> Body {
     match entry {
         None => empty_body(shape),
         Some(e) => match shape {
@@ -129,7 +131,7 @@ fn render_body(entry: Option<&ApiEntry>, shape: Shape) -> Body {
             Shape::MarkdownTextBlock => render_markdown(e),
             Shape::LinkedTextBlock => render_linked(e),
             Shape::Entries => render_entries(e),
-            Shape::Badge => render_badge(e),
+            Shape::Badge => render_badge(e, today),
             _ => render_text_block(e),
         },
     }
@@ -187,11 +189,24 @@ fn render_entries(e: &ApiEntry) -> Body {
     Body::Entries(EntriesData { items })
 }
 
-fn render_badge(_e: &ApiEntry) -> Body {
+fn render_badge(e: &ApiEntry, today: NaiveDate) -> Body {
     Body::Badge(BadgeData {
         status: Status::Ok,
-        label: "📔 today".into(),
+        label: format!("📔 {}", relative_day(&e.date, today)),
     })
+}
+
+/// `today` / `yesterday` / falls back to the raw ISO date for older entries — keeps the badge
+/// label honest when today's hasn't generated yet and the fetcher returns yesterday's instead.
+fn relative_day(raw: &str, today: NaiveDate) -> String {
+    let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") else {
+        return raw.to_string();
+    };
+    match (today - date).num_days() {
+        0 => "today".into(),
+        1 => "yesterday".into(),
+        _ => raw.to_string(),
+    }
 }
 
 fn content_lines(e: &ApiEntry) -> Vec<String> {
@@ -237,9 +252,13 @@ mod tests {
         }
     }
 
+    fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
     #[test]
     fn text_body_uses_title_only() {
-        let Body::Text(t) = render_body(Some(&entry()), Shape::Text) else {
+        let Body::Text(t) = render_body(Some(&entry()), Shape::Text, ymd(2026, 4, 27)) else {
             panic!("expected Text");
         };
         assert!(t.value.contains("My Day"));
@@ -248,7 +267,8 @@ mod tests {
 
     #[test]
     fn text_block_splits_content_into_lines() {
-        let Body::TextBlock(t) = render_body(Some(&entry()), Shape::TextBlock) else {
+        let Body::TextBlock(t) = render_body(Some(&entry()), Shape::TextBlock, ymd(2026, 4, 27))
+        else {
             panic!("expected TextBlock");
         };
         assert_eq!(t.lines, vec!["# Hello", "", "World"]);
@@ -256,7 +276,9 @@ mod tests {
 
     #[test]
     fn linked_text_block_emits_one_clickable_headline() {
-        let Body::LinkedTextBlock(l) = render_body(Some(&entry()), Shape::LinkedTextBlock) else {
+        let Body::LinkedTextBlock(l) =
+            render_body(Some(&entry()), Shape::LinkedTextBlock, ymd(2026, 4, 27))
+        else {
             panic!("expected LinkedTextBlock");
         };
         assert_eq!(l.items.len(), 1);
@@ -269,7 +291,8 @@ mod tests {
 
     #[test]
     fn markdown_block_passes_content_through_verbatim() {
-        let Body::MarkdownTextBlock(m) = render_body(Some(&entry()), Shape::MarkdownTextBlock)
+        let Body::MarkdownTextBlock(m) =
+            render_body(Some(&entry()), Shape::MarkdownTextBlock, ymd(2026, 4, 27))
         else {
             panic!("expected MarkdownTextBlock");
         };
@@ -281,7 +304,7 @@ mod tests {
         let mut bare = entry();
         bare.tags.clear();
         bare.sources.clear();
-        let Body::Entries(e) = render_body(Some(&bare), Shape::Entries) else {
+        let Body::Entries(e) = render_body(Some(&bare), Shape::Entries, ymd(2026, 4, 27)) else {
             panic!("expected Entries");
         };
         let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
@@ -290,7 +313,7 @@ mod tests {
 
     #[test]
     fn entries_joins_tags_and_sources_when_present() {
-        let Body::Entries(e) = render_body(Some(&entry()), Shape::Entries) else {
+        let Body::Entries(e) = render_body(Some(&entry()), Shape::Entries, ymd(2026, 4, 27)) else {
             panic!("expected Entries");
         };
         let tags = e.items.iter().find(|i| i.key == "tags").unwrap();
@@ -298,8 +321,8 @@ mod tests {
     }
 
     #[test]
-    fn badge_label_is_constant_when_entry_present() {
-        let Body::Badge(b) = render_body(Some(&entry()), Shape::Badge) else {
+    fn badge_label_says_today_when_entry_date_matches_today() {
+        let Body::Badge(b) = render_body(Some(&entry()), Shape::Badge, ymd(2026, 4, 27)) else {
             panic!("expected Badge");
         };
         assert_eq!(b.status, Status::Ok);
@@ -307,8 +330,24 @@ mod tests {
     }
 
     #[test]
+    fn badge_label_says_yesterday_when_today_has_not_generated_yet() {
+        let Body::Badge(b) = render_body(Some(&entry()), Shape::Badge, ymd(2026, 4, 28)) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.label, "📔 yesterday");
+    }
+
+    #[test]
+    fn badge_label_falls_back_to_iso_date_for_older_entries() {
+        let Body::Badge(b) = render_body(Some(&entry()), Shape::Badge, ymd(2026, 5, 1)) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.label, "📔 2026-04-27");
+    }
+
+    #[test]
     fn missing_entry_emits_empty_text_block() {
-        let Body::TextBlock(t) = render_body(None, Shape::TextBlock) else {
+        let Body::TextBlock(t) = render_body(None, Shape::TextBlock, ymd(2026, 4, 27)) else {
             panic!("expected TextBlock");
         };
         assert!(t.lines.is_empty());
@@ -316,7 +355,7 @@ mod tests {
 
     #[test]
     fn missing_entry_emits_warn_badge() {
-        let Body::Badge(b) = render_body(None, Shape::Badge) else {
+        let Body::Badge(b) = render_body(None, Shape::Badge, ymd(2026, 4, 27)) else {
             panic!("expected Badge");
         };
         assert_eq!(b.status, Status::Warn);

--- a/src/fetcher/deariary/today.rs
+++ b/src/fetcher/deariary/today.rs
@@ -104,22 +104,39 @@ impl Fetcher for DeariaryToday {
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let token = resolve_token(opts.token.as_deref())?;
-        let entry = latest_entry(&token).await?;
-        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
         let today = Local::now().date_naive();
+        let entry = latest_entry(&token, today).await?;
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
         Ok(payload(render_body(entry.as_ref(), shape, today)))
     }
 }
 
-/// Pulls the freshest entry: list call (cached, shared with `deariary_recent`) gives the
-/// newest date, then a per-date lookup (cached, shared with `deariary_on_this_day`) returns
-/// the body with `content` populated — `/entries` list responses may strip content for size.
-async fn latest_entry(token: &str) -> Result<Option<ApiEntry>, FetchError> {
+/// Pulls the freshest entry, but only when it's recent enough to be honest about. The
+/// fetcher's description promises "typically today's, falling back to yesterday's when
+/// today's hasn't generated yet" — surfacing a 5-day-old entry as "today" would be a
+/// silent lie. If the newest available entry isn't from today or yesterday, return
+/// `Ok(None)` and let the empty-state placeholder render instead.
+///
+/// The list call is cached and shared with `deariary_recent`; the per-date lookup is
+/// cached and shared with `deariary_on_this_day` — `/entries` list responses may strip
+/// content for size, so we re-fetch the full body via the date endpoint.
+async fn latest_entry(token: &str, today: NaiveDate) -> Result<Option<ApiEntry>, FetchError> {
     let entries = cached_get_entries(token, None).await?;
     let Some(latest) = entries.first() else {
         return Ok(None);
     };
+    if !is_today_or_yesterday(&latest.date, today) {
+        return Ok(None);
+    }
     cached_get_entry(token, &latest.date).await
+}
+
+fn is_today_or_yesterday(raw: &str, today: NaiveDate) -> bool {
+    let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") else {
+        return false;
+    };
+    let days_back = (today - date).num_days();
+    (0..=1).contains(&days_back)
 }
 
 fn render_body(entry: Option<&ApiEntry>, shape: Shape, today: NaiveDate) -> Body {
@@ -342,6 +359,25 @@ mod tests {
             panic!("expected Badge");
         };
         assert_eq!(b.label, "📔 2026-04-27");
+    }
+
+    #[test]
+    fn freshness_gate_accepts_today_and_yesterday_only() {
+        // The fetcher's contract is "typically today's, falling back to yesterday's" — a
+        // 5-day-old entry must NOT be served as "today" or even "yesterday". Bound the
+        // gate to a 0/1-day delta and let `Ok(None)` fall through to the empty-state
+        // placeholder for older surrogates.
+        let today = ymd(2026, 4, 27);
+        assert!(is_today_or_yesterday("2026-04-27", today));
+        assert!(is_today_or_yesterday("2026-04-26", today));
+        assert!(!is_today_or_yesterday("2026-04-25", today));
+        assert!(!is_today_or_yesterday("2026-04-22", today));
+        // Future-dated entries (clock skew, time-zone weirdness on the API side) shouldn't
+        // be silently surfaced either — guard against them too.
+        assert!(!is_today_or_yesterday("2026-04-28", today));
+        // Unparseable dates fall through to false; the surrogate placeholder beats
+        // surfacing an entry the fetcher can't reason about.
+        assert!(!is_today_or_yesterday("not-a-date", today));
     }
 
     #[test]

--- a/src/fetcher/deariary/today.rs
+++ b/src/fetcher/deariary/today.rs
@@ -12,7 +12,9 @@ use async_trait::async_trait;
 use chrono::{Local, NaiveDate};
 use serde::Deserialize;
 
-use super::client::{ApiEntry, cached_get_entries, cached_get_entry, entry_url, resolve_token};
+use super::client::{
+    ApiEntry, cache_extra, cached_get_entries, cached_get_entry, entry_url, resolve_token,
+};
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
@@ -67,11 +69,8 @@ impl Fetcher for DeariaryToday {
         OPTION_SCHEMAS
     }
     fn cache_key(&self, ctx: &FetchContext) -> String {
-        let extra = ctx
-            .options
-            .as_ref()
-            .and_then(|v| toml::to_string(v).ok())
-            .unwrap_or_default();
+        let opts: Options = parse_options(ctx.options.as_ref()).unwrap_or_default();
+        let extra = cache_extra(opts.token.as_deref(), ctx.options.as_ref());
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -8,10 +8,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::options::OptionSchema;
-use crate::payload::{
-    BadgeData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData,
-    Payload, RatioData, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
-};
+use crate::payload::{Body, ErrorData, ErrorKind, Payload, Status};
 use crate::render::Shape;
 use crate::samples;
 
@@ -151,119 +148,68 @@ pub struct ShapeMismatch {
     pub requested: Shape,
 }
 
-/// Build a placeholder body of the given shape from a list of message lines. Each shape
-/// gets a body its primary renderer will accept, so a 429 / timeout / trust message reaches
-/// the user inline rather than being swallowed by the shape-mismatch path. Shape-only
-/// renderers that can't carry free-form text (NumberSeries / PointSeries / Heatmap / Image
-/// / Bars / Calendar) fall through to `TextBlock`; in those cases `render_payload` shows the
-/// usual "renderer X cannot display TextBlock" warning, which is the right answer for
-/// shapes whose primary renderers genuinely have no slot for a message.
-pub fn placeholder_body(shape: Shape, lines: &[&str]) -> Body {
-    match shape {
-        Shape::Text => Body::Text(TextData {
-            value: lines.join(" — "),
-        }),
-        Shape::TextBlock => Body::TextBlock(TextBlockData {
-            lines: lines.iter().map(|s| (*s).to_string()).collect(),
-        }),
-        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
-            value: lines.join("\n\n"),
-        }),
-        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
-            items: lines
-                .iter()
-                .map(|s| LinkedLine {
-                    text: (*s).to_string(),
-                    url: None,
-                })
-                .collect(),
-        }),
-        Shape::Entries => Body::Entries(EntriesData {
-            items: lines
-                .iter()
-                .map(|s| Entry {
-                    key: (*s).to_string(),
-                    value: None,
-                    status: None,
-                })
-                .collect(),
-        }),
-        Shape::Badge => Body::Badge(BadgeData {
-            status: Status::Error,
-            label: lines.first().map(|s| (*s).to_string()).unwrap_or_default(),
-        }),
-        Shape::Ratio => Body::Ratio(RatioData {
-            value: 0.0,
-            label: lines.first().map(|s| (*s).to_string()),
-            denominator: None,
-        }),
-        Shape::Timeline => Body::Timeline(TimelineData {
-            events: lines
-                .iter()
-                .map(|s| TimelineEvent {
-                    timestamp: 0,
-                    title: (*s).to_string(),
-                    detail: None,
-                    status: Some(Status::Error),
-                })
-                .collect(),
-        }),
-        _ => Body::TextBlock(TextBlockData {
-            lines: lines.iter().map(|s| (*s).to_string()).collect(),
+/// Compose an error placeholder payload. Used by every constructor in this module that
+/// produces a placeholder when a real fetch can't run (`error_placeholder` /
+/// `timeout_placeholder` / `unknown_fetcher_placeholder` / `shape_mismatch_placeholder`),
+/// plus [`crate::trust::requires_trust_placeholder`]. `Body::Error` carries the structured
+/// kind / message / detail straight through to `render_payload`, which renders it inline
+/// regardless of the configured renderer — bypassing the shape × renderer dispatch so the
+/// message reaches the user even for shape-only chart / grid renderers.
+fn error_payload(kind: ErrorKind, message: String, detail: Option<&str>) -> Payload {
+    Payload {
+        icon: None,
+        status: Some(Status::Error),
+        format: None,
+        body: Body::Error(ErrorData {
+            kind,
+            message,
+            detail: detail.map(str::to_string),
         }),
     }
 }
 
-/// Structure mirrors [`crate::trust::requires_trust_placeholder`] — a two-line hint so the user
-/// can tell what's wrong without opening logs. The body matches the renderer's expected shape so
-/// the message renders inline rather than triggering a second-order shape-mismatch error.
+/// Two-line placeholder shown when the fetcher/renderer pair can't produce data the renderer
+/// will accept. First line names the offending fetcher and the shape it was asked to emit;
+/// the second line tells the user where to fix it.
 pub fn shape_mismatch_placeholder(err: &ShapeMismatch) -> Payload {
-    let line1 = format!("⚠ {} can't emit {}", err.fetcher, err.requested.as_str());
-    let lines = [line1.as_str(), "check `render` in config"];
-    Payload {
-        icon: None,
-        status: None,
-        format: None,
-        body: placeholder_body(err.requested, &lines),
-    }
+    error_payload(
+        ErrorKind::ShapeMismatch,
+        format!("⚠ {} can't emit {}", err.fetcher, err.requested.as_str()),
+        Some("check `render` in config"),
+    )
 }
 
 /// Payload rendered in place of a widget whose configured fetcher name isn't registered. Mirrors
 /// the renderer side of the contract (`render_payload` draws `unknown renderer: <name>` for the
 /// same situation): the typical trigger is an installed binary older than the config it's reading,
 /// so the second line points at upgrading rather than the log file.
-pub fn unknown_fetcher_placeholder(shape: Shape, name: &str) -> Payload {
-    let line1 = format!("⚠ unknown fetcher: {name}");
-    Payload {
-        icon: None,
-        status: None,
-        format: None,
-        body: placeholder_body(shape, &[line1.as_str(), "upgrade splashboard?"]),
-    }
+pub fn unknown_fetcher_placeholder(name: &str) -> Payload {
+    error_payload(
+        ErrorKind::UnknownFetcher,
+        format!("⚠ unknown fetcher: {name}"),
+        Some("upgrade splashboard?"),
+    )
 }
 
 /// Payload rendered in place of a widget whose fetch returned `Err`. One-line `⚠ <msg>`, with a
 /// follow-up pointer to the log file so the user can track structured details (error chain,
 /// cache key, fetcher name) without forcing a second line into the splash for every error.
-pub fn error_placeholder(shape: Shape, msg: &str) -> Payload {
-    let line1 = format!("⚠ {msg}");
-    Payload {
-        icon: None,
-        status: None,
-        format: None,
-        body: placeholder_body(shape, &[line1.as_str(), "see $HOME/.splashboard/logs"]),
-    }
+pub fn error_placeholder(msg: &str) -> Payload {
+    error_payload(
+        ErrorKind::Fetch,
+        format!("⚠ {msg}"),
+        Some("see $HOME/.splashboard/logs"),
+    )
 }
 
 /// Payload rendered in place of a widget whose fetch exceeded the runtime deadline. Kept
 /// separate from [`error_placeholder`] so users can tell "slow" from "broken" at a glance.
-pub fn timeout_placeholder(shape: Shape) -> Payload {
-    Payload {
-        icon: None,
-        status: None,
-        format: None,
-        body: placeholder_body(shape, &["⏱ timed out", "see $HOME/.splashboard/logs"]),
-    }
+pub fn timeout_placeholder() -> Payload {
+    error_payload(
+        ErrorKind::Timeout,
+        "⏱ timed out".into(),
+        Some("see $HOME/.splashboard/logs"),
+    )
 }
 
 pub fn default_cache_key(name: &str, ctx: &FetchContext) -> String {
@@ -627,111 +573,69 @@ mod tests {
 
     #[test]
     fn unknown_fetcher_placeholder_mentions_name_and_upgrade_hint() {
-        let p = unknown_fetcher_placeholder(Shape::TextBlock, "system_battery");
-        match p.body {
-            Body::TextBlock(t) => {
-                assert!(
-                    t.lines[0].contains("system_battery"),
-                    "lines: {:?}",
-                    t.lines
-                );
-                assert!(t.lines[0].starts_with("⚠"), "lines: {:?}", t.lines);
-                assert!(
-                    t.lines.iter().any(|l| l.contains("upgrade")),
-                    "expected upgrade hint: {:?}",
-                    t.lines
-                );
-            }
-            other => panic!("expected TextBlock body, got {other:?}"),
-        }
+        let p = unknown_fetcher_placeholder("system_battery");
+        let Body::Error(err) = &p.body else {
+            panic!("expected Body::Error, got {:?}", p.body);
+        };
+        assert_eq!(err.kind, ErrorKind::UnknownFetcher);
+        assert!(err.message.contains("system_battery"));
+        assert!(err.message.starts_with("⚠"));
+        assert!(err.detail.as_deref().is_some_and(|d| d.contains("upgrade")));
+        assert_eq!(p.status, Some(Status::Error));
     }
 
     #[test]
-    fn placeholder_body_adapts_to_shape() {
-        // TextBlock — straight passthrough.
-        let body = placeholder_body(Shape::TextBlock, &["hello", "world"]);
-        let Body::TextBlock(t) = body else {
-            panic!("expected text block");
+    fn shape_mismatch_placeholder_carries_offending_pair_in_message() {
+        let err = ShapeMismatch {
+            fetcher: "static_text".into(),
+            requested: Shape::Bars,
         };
-        assert_eq!(t.lines, vec!["hello".to_string(), "world".to_string()]);
-
-        // LinkedTextBlock — text without URL so list_links can render the message.
-        let body = placeholder_body(Shape::LinkedTextBlock, &["hello", "world"]);
-        let Body::LinkedTextBlock(b) = body else {
-            panic!("expected linked text block");
+        let p = shape_mismatch_placeholder(&err);
+        let Body::Error(e) = &p.body else {
+            panic!("expected Body::Error, got {:?}", p.body);
         };
-        assert_eq!(b.items.len(), 2);
-        assert!(b.items.iter().all(|i| i.url.is_none()));
-
-        // Text — joined into one string so single-line renderers (`text_plain`) get a hint.
-        let body = placeholder_body(Shape::Text, &["hello", "world"]);
-        let Body::Text(t) = body else {
-            panic!("expected text");
-        };
-        assert!(t.value.contains("hello") && t.value.contains("world"));
-
-        // Entries — each line becomes a key with no value, so grid_table renders rows.
-        let body = placeholder_body(Shape::Entries, &["hello"]);
-        let Body::Entries(e) = body else {
-            panic!("expected entries");
-        };
-        assert_eq!(e.items[0].key, "hello");
-        assert!(e.items[0].value.is_none());
-
-        // Badge — placeholder reaches `status_badge` as a Status::Error pill so 429 / trust
-        // messages stay visible without falling through to the mismatch error path.
-        let body = placeholder_body(Shape::Badge, &["⚠ deariary 429", "see logs"]);
-        let Body::Badge(b) = body else {
-            panic!("expected Badge for placeholder");
-        };
-        assert_eq!(b.status, Status::Error);
-        assert_eq!(b.label, "⚠ deariary 429");
-
-        // Ratio — gauge renderers carry the message via the label slot; value clamped to 0.
-        let body = placeholder_body(Shape::Ratio, &["⚠ rate limited", "see logs"]);
-        let Body::Ratio(r) = body else {
-            panic!("expected Ratio for placeholder");
-        };
-        assert_eq!(r.value, 0.0);
-        assert_eq!(r.label.as_deref(), Some("⚠ rate limited"));
-
-        // Timeline — list_timeline reads `title`, so each line becomes one event tagged
-        // with Status::Error; timestamp is 0 (the renderer falls back to "—").
-        let body = placeholder_body(Shape::Timeline, &["⚠ rate limited", "see logs"]);
-        let Body::Timeline(t) = body else {
-            panic!("expected Timeline for placeholder");
-        };
-        assert_eq!(t.events.len(), 2);
-        assert_eq!(t.events[0].title, "⚠ rate limited");
-        assert_eq!(t.events[0].status, Some(Status::Error));
-
-        // Shape-only renderers (chart, grid, image) genuinely have no slot for free-form
-        // text, so they keep falling through to TextBlock and `render_payload` shows the
-        // explicit "renderer X cannot display TextBlock" mismatch warning per the contract.
-        for shape in [
-            Shape::Bars,
-            Shape::NumberSeries,
-            Shape::PointSeries,
-            Shape::Image,
-            Shape::Heatmap,
-            Shape::Calendar,
-        ] {
-            let body = placeholder_body(shape, &["⚠ rate limited", "see logs"]);
-            let Body::TextBlock(t) = body else {
-                panic!("expected TextBlock fallback for {shape:?}");
-            };
-            assert_eq!(t.lines, vec!["⚠ rate limited", "see logs"]);
-        }
-    }
-
-    #[test]
-    fn requires_trust_placeholder_via_fetcher_module_emits_link_shape() {
-        // Cross-module sanity: trust gate routes through `placeholder_body`, so a
-        // `LinkedTextBlock`-expecting renderer must see a `LinkedTextBlock` body.
-        let body = placeholder_body(
-            Shape::LinkedTextBlock,
-            &["🔒 requires trust", "run `splashboard trust`"],
+        assert_eq!(e.kind, ErrorKind::ShapeMismatch);
+        assert!(e.message.contains("static_text"));
+        assert!(e.message.contains("bars"));
+        assert!(
+            e.detail.as_deref().is_some_and(|d| d.contains("`render`")),
+            "detail should point at the render config: {:?}",
+            e.detail,
         );
-        assert!(matches!(body, Body::LinkedTextBlock(_)));
+    }
+
+    #[test]
+    fn error_placeholder_prefixes_warn_glyph_and_points_at_logs() {
+        let p = error_placeholder("deariary 429: rate limited");
+        let Body::Error(err) = &p.body else {
+            panic!("expected Body::Error, got {:?}", p.body);
+        };
+        assert_eq!(err.kind, ErrorKind::Fetch);
+        assert!(err.message.starts_with("⚠"));
+        assert!(err.message.contains("rate limited"));
+        assert!(err.detail.as_deref().is_some_and(|d| d.contains("logs")));
+    }
+
+    #[test]
+    fn timeout_placeholder_uses_clock_glyph_and_points_at_logs() {
+        let p = timeout_placeholder();
+        let Body::Error(err) = &p.body else {
+            panic!("expected Body::Error, got {:?}", p.body);
+        };
+        assert_eq!(err.kind, ErrorKind::Timeout);
+        assert!(err.message.starts_with("⏱"));
+        assert!(err.detail.as_deref().is_some_and(|d| d.contains("logs")));
+    }
+
+    #[test]
+    fn error_payloads_serialize_round_trip_through_serde() {
+        // Body::Error rides the same serde tag/content envelope as the other Body variants,
+        // so cached Err entries deserialize back into the same structured payload after a
+        // process restart.
+        let original = error_placeholder("deariary 429");
+        let json = serde_json::to_string(&original).unwrap();
+        let back: Payload = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, back);
+        assert!(matches!(back.body, Body::Error(_)));
     }
 }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, Payload,
-    TextBlockData, TextData,
+    BadgeData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData,
+    Payload, RatioData, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 use crate::samples;
@@ -151,12 +151,13 @@ pub struct ShapeMismatch {
     pub requested: Shape,
 }
 
-/// Build a placeholder body of the given shape from a list of message lines. Text-bearing
-/// shapes get a natural-shape body so their renderers display the message inline. Other
-/// shapes (Badge, Timeline, Bars, Ratio, NumberSeries, PointSeries, Image, Heatmap,
-/// Calendar) fall through to `TextBlock` — `render_payload` detects the shape mismatch and
-/// routes the body's text through `render_error`, so users see "⚠ deariary 429" rather than
-/// an empty chart or a generic "cannot display" warning.
+/// Build a placeholder body of the given shape from a list of message lines. Each shape
+/// gets a body its primary renderer will accept, so a 429 / timeout / trust message reaches
+/// the user inline rather than being swallowed by the shape-mismatch path. Shape-only
+/// renderers that can't carry free-form text (NumberSeries / PointSeries / Heatmap / Image
+/// / Bars / Calendar) fall through to `TextBlock`; in those cases `render_payload` shows the
+/// usual "renderer X cannot display TextBlock" warning, which is the right answer for
+/// shapes whose primary renderers genuinely have no slot for a message.
 pub fn placeholder_body(shape: Shape, lines: &[&str]) -> Body {
     match shape {
         Shape::Text => Body::Text(TextData {
@@ -184,6 +185,26 @@ pub fn placeholder_body(shape: Shape, lines: &[&str]) -> Body {
                     key: (*s).to_string(),
                     value: None,
                     status: None,
+                })
+                .collect(),
+        }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: Status::Error,
+            label: lines.first().map(|s| (*s).to_string()).unwrap_or_default(),
+        }),
+        Shape::Ratio => Body::Ratio(RatioData {
+            value: 0.0,
+            label: lines.first().map(|s| (*s).to_string()),
+            denominator: None,
+        }),
+        Shape::Timeline => Body::Timeline(TimelineData {
+            events: lines
+                .iter()
+                .map(|s| TimelineEvent {
+                    timestamp: 0,
+                    title: (*s).to_string(),
+                    detail: None,
+                    status: Some(Status::Error),
                 })
                 .collect(),
         }),
@@ -657,14 +678,38 @@ mod tests {
         assert_eq!(e.items[0].key, "hello");
         assert!(e.items[0].value.is_none());
 
-        // Non-text-bearing shapes fall through to TextBlock; render_payload's mismatch path
-        // surfaces the body's text via render_error so the user sees the error message
-        // instead of an empty chart or generic warning.
+        // Badge — placeholder reaches `status_badge` as a Status::Error pill so 429 / trust
+        // messages stay visible without falling through to the mismatch error path.
+        let body = placeholder_body(Shape::Badge, &["⚠ deariary 429", "see logs"]);
+        let Body::Badge(b) = body else {
+            panic!("expected Badge for placeholder");
+        };
+        assert_eq!(b.status, Status::Error);
+        assert_eq!(b.label, "⚠ deariary 429");
+
+        // Ratio — gauge renderers carry the message via the label slot; value clamped to 0.
+        let body = placeholder_body(Shape::Ratio, &["⚠ rate limited", "see logs"]);
+        let Body::Ratio(r) = body else {
+            panic!("expected Ratio for placeholder");
+        };
+        assert_eq!(r.value, 0.0);
+        assert_eq!(r.label.as_deref(), Some("⚠ rate limited"));
+
+        // Timeline — list_timeline reads `title`, so each line becomes one event tagged
+        // with Status::Error; timestamp is 0 (the renderer falls back to "—").
+        let body = placeholder_body(Shape::Timeline, &["⚠ rate limited", "see logs"]);
+        let Body::Timeline(t) = body else {
+            panic!("expected Timeline for placeholder");
+        };
+        assert_eq!(t.events.len(), 2);
+        assert_eq!(t.events[0].title, "⚠ rate limited");
+        assert_eq!(t.events[0].status, Some(Status::Error));
+
+        // Shape-only renderers (chart, grid, image) genuinely have no slot for free-form
+        // text, so they keep falling through to TextBlock and `render_payload` shows the
+        // explicit "renderer X cannot display TextBlock" mismatch warning per the contract.
         for shape in [
-            Shape::Badge,
-            Shape::Timeline,
             Shape::Bars,
-            Shape::Ratio,
             Shape::NumberSeries,
             Shape::PointSeries,
             Shape::Image,
@@ -673,7 +718,7 @@ mod tests {
         ] {
             let body = placeholder_body(shape, &["⚠ rate limited", "see logs"]);
             let Body::TextBlock(t) = body else {
-                panic!("expected TextBlock for {shape:?}");
+                panic!("expected TextBlock fallback for {shape:?}");
             };
             assert_eq!(t.lines, vec!["⚠ rate limited", "see logs"]);
         }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -18,6 +18,7 @@ use crate::samples;
 pub mod calendar;
 pub mod clock;
 pub mod code;
+pub mod deariary;
 pub mod git;
 pub mod github;
 pub mod hackernews;
@@ -150,11 +151,12 @@ pub struct ShapeMismatch {
     pub requested: Shape,
 }
 
-/// Build a placeholder body of the given shape from a list of message lines. Every text-shaped
-/// renderer can carry a 2-line hint, so trust / error / timeout / unknown-fetcher placeholders
-/// stay legible regardless of which renderer is configured. Non-text shapes fall back to
-/// `TextBlock` — the renderer will still reject it, but at least the message text shows up
-/// inside the resulting shape-mismatch warning rather than vanishing.
+/// Build a placeholder body of the given shape from a list of message lines. Text-bearing
+/// shapes get a natural-shape body so their renderers display the message inline. Other
+/// shapes (Badge, Timeline, Bars, Ratio, NumberSeries, PointSeries, Image, Heatmap,
+/// Calendar) fall through to `TextBlock` — `render_payload` detects the shape mismatch and
+/// routes the body's text through `render_error`, so users see "⚠ deariary 429" rather than
+/// an empty chart or a generic "cannot display" warning.
 pub fn placeholder_body(shape: Shape, lines: &[&str]) -> Body {
     match shape {
         Shape::Text => Body::Text(TextData {
@@ -337,6 +339,9 @@ impl Registry {
         r.register(Arc::new(rss::RssFetcher));
         r.register(Arc::new(weather::WeatherFetcher));
         for f in calendar::fetchers() {
+            r.register(f);
+        }
+        for f in deariary::fetchers() {
             r.register(f);
         }
         for f in hackernews::fetchers() {
@@ -652,10 +657,26 @@ mod tests {
         assert_eq!(e.items[0].key, "hello");
         assert!(e.items[0].value.is_none());
 
-        // Non-text shape — falls back to TextBlock; the renderer will still warn but the
-        // message text is preserved rather than vanishing.
-        let body = placeholder_body(Shape::Ratio, &["x"]);
-        assert!(matches!(body, Body::TextBlock(_)));
+        // Non-text-bearing shapes fall through to TextBlock; render_payload's mismatch path
+        // surfaces the body's text via render_error so the user sees the error message
+        // instead of an empty chart or generic warning.
+        for shape in [
+            Shape::Badge,
+            Shape::Timeline,
+            Shape::Bars,
+            Shape::Ratio,
+            Shape::NumberSeries,
+            Shape::PointSeries,
+            Shape::Image,
+            Shape::Heatmap,
+            Shape::Calendar,
+        ] {
+            let body = placeholder_body(shape, &["⚠ rate limited", "see logs"]);
+            let Body::TextBlock(t) = body else {
+                panic!("expected TextBlock for {shape:?}");
+            };
+            assert_eq!(t.lines, vec!["⚠ rate limited", "see logs"]);
+        }
     }
 
     #[test]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -65,6 +65,47 @@ pub enum Body {
     /// history. Timestamps are raw unix seconds so the renderer computes the `"3h ago"` label
     /// at draw time — keeping cached payloads from going stale.
     Timeline(TimelineData),
+    /// Structured error payload — what the user sees instead of a real fetch result when the
+    /// widget can't produce one (fetch failed / timed out, fetcher unknown, fetcher can't emit
+    /// the renderer's required shape, network widget under untrusted config). Bypasses the
+    /// shape × renderer dispatch entirely: `render_payload` short-circuits on `Body::Error` and
+    /// draws the message inline regardless of the configured renderer, since asking
+    /// `chart_bar` to render an error message via `Bars` would either silently drop it or
+    /// trigger a misleading "cannot display" warning. Real fetchers never emit this — only the
+    /// placeholder constructors in `crate::fetcher` and `crate::trust`.
+    Error(ErrorData),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ErrorData {
+    pub kind: ErrorKind,
+    /// First line of the error pill. Convention: lead with the affected source ("⚠ deariary",
+    /// "🔒 requires trust") so users can scan a multi-widget splash for which one needs
+    /// attention without reading the full sentence.
+    pub message: String,
+    /// Optional second line. Typically a follow-up hint ("see logs", "check `render` in
+    /// config"). `None` if the kind is self-explanatory or the area is too narrow for two
+    /// lines anyway.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorKind {
+    /// Fetcher returned `Err` (HTTP failure, parse error, missing token, …).
+    Fetch,
+    /// Fetcher exceeded the runtime deadline.
+    Timeout,
+    /// Configured fetcher name is not in the registry — usually a config newer than the
+    /// installed binary.
+    UnknownFetcher,
+    /// Fetcher can't emit the shape its renderer requires; user needs to change `render` or
+    /// `fetcher` in config.
+    ShapeMismatch,
+    /// `Network`-class widget in an untrusted local config; user runs `splashboard trust` to
+    /// unlock.
+    RequiresTrust,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -530,4 +530,69 @@ mod tests {
         assert!(!json.contains("icon"));
         assert!(!json.contains("status"));
     }
+
+    #[test]
+    fn error_round_trips_with_full_field_set() {
+        // Locks the on-disk wire format for `Body::Error`. Cached `CacheEntryKind::Err`
+        // entries serialize this and must deserialize back identically after a process
+        // restart, otherwise the cache layer drops the placeholder mid-flight.
+        let p = bare(Body::Error(ErrorData {
+            kind: ErrorKind::Fetch,
+            message: "⚠ deariary 429".into(),
+            detail: Some("see logs".into()),
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn error_round_trips_without_detail() {
+        // Detail is `Option<String>` — round-trip must preserve `None` rather than
+        // collapsing it to an empty string, because the renderer treats the two distinctly
+        // (no detail = single-line layout vs detail = two-line message + hint).
+        let p = bare(Body::Error(ErrorData {
+            kind: ErrorKind::Timeout,
+            message: "⏱ timed out".into(),
+            detail: None,
+        }));
+        assert_eq!(p, round_trip(&p));
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(
+            !json.contains("detail"),
+            "skip_serializing_if must drop None detail: {json}"
+        );
+    }
+
+    #[test]
+    fn error_serializes_with_expected_shape_tag_and_snake_case_kind() {
+        // Pins the canonical wire format so changes to the serde derives surface here
+        // rather than as silent breakage in cached payloads.
+        let p = bare(Body::Error(ErrorData {
+            kind: ErrorKind::ShapeMismatch,
+            message: "⚠ static_text can't emit bars".into(),
+            detail: Some("check `render` in config".into()),
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["shape"], "error");
+        assert_eq!(v["data"]["kind"], "shape_mismatch");
+        assert_eq!(v["data"]["message"], "⚠ static_text can't emit bars");
+        assert_eq!(v["data"]["detail"], "check `render` in config");
+    }
+
+    #[test]
+    fn error_kind_covers_every_known_variant() {
+        // Exhaustive snake_case round-trip per ErrorKind so a new variant landing without
+        // a corresponding renaming convention trips this test.
+        for (kind, expected) in [
+            (ErrorKind::Fetch, "fetch"),
+            (ErrorKind::Timeout, "timeout"),
+            (ErrorKind::UnknownFetcher, "unknown_fetcher"),
+            (ErrorKind::ShapeMismatch, "shape_mismatch"),
+            (ErrorKind::RequiresTrust, "requires_trust"),
+        ] {
+            let s = serde_json::to_string(&kind).unwrap();
+            assert_eq!(s, format!("\"{expected}\""), "kind: {kind:?}");
+            let back: ErrorKind = serde_json::from_str(&s).unwrap();
+            assert_eq!(back, kind);
+        }
+    }
 }

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -123,15 +123,32 @@ thread_local! {
 }
 
 /// Run `f` with OSC 8 hyperlink wrapping disabled. Idempotent and re-entrant: nested calls
-/// stack the suppression and restore the prior value on exit.
+/// stack the suppression and restore the prior value on exit. Panic-safe: an RAII guard
+/// restores the prior value via `Drop`, so a panic inside `f` doesn't leak the suppressed
+/// state into subsequent unrelated draws on the same thread.
 pub fn without_osc8<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
-    let prior = OSC8_SUPPRESSED.with(|cell| cell.replace(true));
-    let result = f();
-    OSC8_SUPPRESSED.with(|cell| cell.set(prior));
-    result
+    let _guard = SuppressionGuard::engage();
+    f()
+}
+
+struct SuppressionGuard {
+    prior: bool,
+}
+
+impl SuppressionGuard {
+    fn engage() -> Self {
+        let prior = OSC8_SUPPRESSED.with(|cell| cell.replace(true));
+        Self { prior }
+    }
+}
+
+impl Drop for SuppressionGuard {
+    fn drop(&mut self) {
+        OSC8_SUPPRESSED.with(|cell| cell.set(self.prior));
+    }
 }
 
 fn osc8_suppressed() -> bool {
@@ -349,5 +366,36 @@ mod tests {
             assert!(row.contains(ch), "missing {ch}: {row:?}");
         }
         assert!(row.contains("world"));
+    }
+
+    #[test]
+    fn without_osc8_restores_state_after_panic() {
+        assert!(!osc8_suppressed());
+        let result = std::panic::catch_unwind(|| {
+            without_osc8(|| {
+                assert!(osc8_suppressed());
+                panic!("simulated renderer panic");
+            })
+        });
+        assert!(result.is_err(), "the inner panic should propagate");
+        assert!(
+            !osc8_suppressed(),
+            "RAII guard must reset suppression even when f panics",
+        );
+    }
+
+    #[test]
+    fn without_osc8_nested_calls_restore_outer_state() {
+        without_osc8(|| {
+            assert!(osc8_suppressed());
+            without_osc8(|| {
+                assert!(osc8_suppressed());
+            });
+            assert!(
+                osc8_suppressed(),
+                "nested guard exit must not flip the outer suppression off",
+            );
+        });
+        assert!(!osc8_suppressed());
     }
 }

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -8,6 +8,15 @@
 //! atomic in the byte stream (no `MoveTo` interruption), and dodges `Buffer::diff`'s width
 //! calculation, which would otherwise count the printable characters inside the escape sequence
 //! as visible columns and incorrectly skip the cells immediately after the link.
+//!
+//! The `skip = true` trick only buys real-terminal correctness: `TestBackend` doesn't
+//! simulate the terminal's char-rendering of the OSC 8 visible portion, so the skipped cells
+//! stay at their default empty state in its buffer. The runtime's off-screen scrollback
+//! capture (`render_full_into_buffer`) targets `TestBackend` and would inherit that broken
+//! state — we wrap that draw in [`without_osc8`] so the renderer emits plain text for the
+//! capture, while the on-screen `CrosstermBackend` pass keeps the OSC 8 wrap.
+
+use std::cell::Cell as StdCell;
 
 use ratatui::{Frame, buffer::Buffer, layout::Rect, style::Style};
 
@@ -95,9 +104,38 @@ fn write_row(buf: &mut Buffer, x: u16, y: u16, max_width: u16, line: &LinkedLine
     if drawn == 0 {
         return;
     }
+    if osc8_suppressed() {
+        return;
+    }
     if let Some(url) = line.url.as_deref() {
         wrap_link(buf, x, y, end_x, url, style);
     }
+}
+
+thread_local! {
+    /// Suppresses the OSC 8 wrap inside the closure passed to [`without_osc8`]. The runtime's
+    /// off-screen capture path (`render_full_into_buffer`) targets `TestBackend`, which holds
+    /// raw cell symbols verbatim and doesn't interpret escape sequences — putting the OSC 8
+    /// wrap there would only pollute the buffer that later gets sliced into the inline
+    /// scrollback. The on-screen `CrosstermBackend` pass runs without this flag so user-facing
+    /// frames keep the clickable hyperlinks.
+    static OSC8_SUPPRESSED: StdCell<bool> = const { StdCell::new(false) };
+}
+
+/// Run `f` with OSC 8 hyperlink wrapping disabled. Idempotent and re-entrant: nested calls
+/// stack the suppression and restore the prior value on exit.
+pub fn without_osc8<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let prior = OSC8_SUPPRESSED.with(|cell| cell.replace(true));
+    let result = f();
+    OSC8_SUPPRESSED.with(|cell| cell.set(prior));
+    result
+}
+
+fn osc8_suppressed() -> bool {
+    OSC8_SUPPRESSED.with(StdCell::get)
 }
 
 fn wrap_link(buf: &mut Buffer, x: u16, y: u16, end_x: u16, url: &str, style: Style) {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -35,7 +35,7 @@ mod gauge_thermometer;
 mod grid_calendar;
 mod grid_heatmap;
 mod grid_table;
-mod list_links;
+pub mod list_links;
 mod list_plain;
 mod list_ranking;
 mod list_timeline;
@@ -443,15 +443,30 @@ pub fn render_payload(
         return;
     };
     if !renderer.accepts().contains(&shape) {
-        render_error(
-            frame,
-            area,
-            &format!("renderer {name} cannot display {shape:?}"),
-            theme,
-        );
+        // Mismatch usually means the user's config picked an incompatible renderer, but it
+        // also fires when an error / timeout / trust placeholder lands here as a TextBlock
+        // body en route to a non-text renderer (status_badge, chart_*, grid_*, …). In that
+        // case we'd rather surface the placeholder's own message than the generic
+        // "cannot display" warning, since the placeholder text *is* the actionable signal.
+        let msg = body_as_text(&payload.body)
+            .unwrap_or_else(|| format!("renderer {name} cannot display {shape:?}"));
+        render_error(frame, area, &msg, theme);
         return;
     }
     renderer.render(frame, area, &payload.body, &options, theme, registry);
+}
+
+/// Extracts the placeholder text from a `TextBlock` body. Returns `None` for everything
+/// else so misconfigured user payloads (a fetcher whose actual `Text` / `Markdown` body
+/// landed at the wrong renderer) still trip the explicit "cannot display" warning rather
+/// than being silently rendered as plain text. `placeholder_body` always falls through to
+/// `TextBlock` for non-text shapes, so error / trust / timeout messages on chart and grid
+/// renderers reach this function with the right body type to be surfaced.
+fn body_as_text(body: &Body) -> Option<String> {
+    match body {
+        Body::TextBlock(d) => Some(d.lines.join("\n")),
+        _ => None,
+    }
 }
 
 /// `true` when the body has no meaningful data to render. Callers (most usefully

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -443,30 +443,15 @@ pub fn render_payload(
         return;
     };
     if !renderer.accepts().contains(&shape) {
-        // Mismatch usually means the user's config picked an incompatible renderer, but it
-        // also fires when an error / timeout / trust placeholder lands here as a TextBlock
-        // body en route to a non-text renderer (status_badge, chart_*, grid_*, …). In that
-        // case we'd rather surface the placeholder's own message than the generic
-        // "cannot display" warning, since the placeholder text *is* the actionable signal.
-        let msg = body_as_text(&payload.body)
-            .unwrap_or_else(|| format!("renderer {name} cannot display {shape:?}"));
-        render_error(frame, area, &msg, theme);
+        render_error(
+            frame,
+            area,
+            &format!("renderer {name} cannot display {shape:?}"),
+            theme,
+        );
         return;
     }
     renderer.render(frame, area, &payload.body, &options, theme, registry);
-}
-
-/// Extracts the placeholder text from a `TextBlock` body. Returns `None` for everything
-/// else so misconfigured user payloads (a fetcher whose actual `Text` / `Markdown` body
-/// landed at the wrong renderer) still trip the explicit "cannot display" warning rather
-/// than being silently rendered as plain text. `placeholder_body` always falls through to
-/// `TextBlock` for non-text shapes, so error / trust / timeout messages on chart and grid
-/// renderers reach this function with the right body type to be surfaced.
-fn body_as_text(body: &Body) -> Option<String> {
-    match body {
-        Body::TextBlock(d) => Some(d.lines.join("\n")),
-        _ => None,
-    }
 }
 
 /// `true` when the body has no meaningful data to render. Callers (most usefully

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -68,6 +68,10 @@ pub enum Shape {
     Heatmap,
     Badge,
     Timeline,
+    /// Pseudo-shape carried by [`Body::Error`] so `shape_of` stays total. Never appears in a
+    /// fetcher's `shapes()` list or a renderer's `accepts()` list — `render_payload`
+    /// short-circuits Body::Error before any dispatch.
+    Error,
 }
 
 pub fn shape_of(body: &Body) -> Shape {
@@ -86,6 +90,7 @@ pub fn shape_of(body: &Body) -> Shape {
         Body::Heatmap(_) => Shape::Heatmap,
         Body::Badge(_) => Shape::Badge,
         Body::Timeline(_) => Shape::Timeline,
+        Body::Error(_) => Shape::Error,
     }
 }
 
@@ -108,6 +113,7 @@ impl Shape {
             Self::Heatmap => "heatmap",
             Self::Badge => "badge",
             Self::Timeline => "timeline",
+            Self::Error => "error",
         }
     }
 }
@@ -407,6 +413,10 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
         Shape::Heatmap => "grid_heatmap",
         Shape::Badge => "status_badge",
         Shape::Timeline => "list_timeline",
+        // Body::Error short-circuits in `render_payload` before this is called, but include
+        // a stable string so the function stays total. `text_plain` is the closest fallback
+        // if an Error body somehow leaked past the short-circuit.
+        Shape::Error => "text_plain",
     }
 }
 
@@ -426,6 +436,16 @@ pub fn render_payload(
     registry: &Registry,
     theme: &Theme,
 ) {
+    // Error bodies bypass the shape × renderer dispatch entirely. Asking the configured
+    // renderer (e.g. `chart_bar`, `grid_calendar`) to display a structured fetch / trust /
+    // timeout error would either silently drop the message or trigger a misleading
+    // "cannot display" warning. Render the error message inline regardless of the spec —
+    // the AGENTS.md contract about explicit shape-mismatch warnings still applies to
+    // genuine misconfigured payloads, which never carry a `Body::Error`.
+    if let Body::Error(err) = &payload.body {
+        render_error_body(frame, area, err, theme);
+        return;
+    }
     if is_empty_body(&payload.body) {
         render_empty_state(frame, area, theme);
         return;
@@ -454,6 +474,23 @@ pub fn render_payload(
     renderer.render(frame, area, &payload.body, &options, theme, registry);
 }
 
+fn render_error_body(
+    frame: &mut Frame,
+    area: Rect,
+    err: &crate::payload::ErrorData,
+    theme: &Theme,
+) {
+    // `render_error` already centers + dims the text and respects narrow areas. Joining the
+    // two-line variant with a newline lets it lay out as message-on-top, detail-below when
+    // the area has at least two rows; narrower areas collapse to the first line via the
+    // helper's own clamp.
+    let text = match &err.detail {
+        Some(d) => format!("{}\n{}", err.message, d),
+        None => err.message.clone(),
+    };
+    render_error(frame, area, &text, theme);
+}
+
 /// `true` when the body has no meaningful data to render. Callers (most usefully
 /// [`render_payload`]) use this to substitute an empty-state placeholder rather than letting a
 /// specific renderer silently draw nothing.
@@ -475,7 +512,9 @@ pub fn is_empty_body(body: &Body) -> bool {
         Body::Image(d) => d.path.is_empty(),
         Body::Heatmap(d) => d.cells.is_empty() || d.cells.iter().all(|r| r.is_empty()),
         Body::Timeline(d) => d.events.is_empty(),
-        Body::Badge(_) | Body::Calendar(_) | Body::Ratio(_) => false,
+        // `Error` always carries a message — we want the user to see it, never collapse it to
+        // the "nothing here yet" placeholder.
+        Body::Badge(_) | Body::Calendar(_) | Body::Ratio(_) | Body::Error(_) => false,
     }
 }
 
@@ -711,6 +750,40 @@ mod tests {
         assert!(
             joined.contains("nothing here yet"),
             "missing caption: {joined:?}"
+        );
+    }
+
+    #[test]
+    fn error_body_renders_inline_regardless_of_configured_renderer() {
+        // Regression: a fetcher error (e.g. 429) feeding a chart_bar slot used to fall
+        // through to the "renderer chart_bar cannot display TextBlock" warning, hiding the
+        // actionable message in logs only. Body::Error short-circuits before the shape ×
+        // renderer dispatch, so the message reaches the user even on shape-only renderers.
+        use crate::payload::{Body, ErrorData, ErrorKind, Payload};
+        use crate::render::test_utils::{line_text, render_to_buffer_with_spec};
+        let p = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Error(ErrorData {
+                kind: ErrorKind::Fetch,
+                message: "⚠ deariary 429".into(),
+                detail: Some("see logs".into()),
+            }),
+        };
+        let registry = Registry::with_builtins();
+        // chart_bar accepts only Bars — under the old contract this would render the generic
+        // "cannot display" warning and lose the placeholder text.
+        let spec = RenderSpec::Short("chart_bar".into());
+        let buf = render_to_buffer_with_spec(&p, Some(&spec), &registry, 40, 4);
+        let joined: String = (0..4).map(|y| line_text(&buf, y)).collect();
+        assert!(
+            joined.contains("deariary 429"),
+            "actionable error message must reach the user: {joined:?}"
+        );
+        assert!(
+            !joined.contains("cannot display"),
+            "Body::Error should bypass the shape × renderer mismatch path: {joined:?}"
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -269,14 +269,12 @@ pub async fn run(
         &shapes,
     ));
     for w in &gated {
-        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
-        payloads.insert(w.id.clone(), trust::requires_trust_placeholder(shape));
+        payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
     }
     for w in &unknown {
-        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
         payloads.insert(
             w.id.clone(),
-            fetcher::unknown_fetcher_placeholder(shape, &w.fetcher),
+            fetcher::unknown_fetcher_placeholder(&w.fetcher),
         );
     }
     for (w, err) in &shape_invalid {
@@ -531,14 +529,12 @@ fn refresh_payloads(
         payloads.insert(id, payload);
     }
     for w in buckets.gated {
-        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
-        payloads.insert(w.id.clone(), trust::requires_trust_placeholder(shape));
+        payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
     }
     for w in buckets.unknown {
-        let shape = shapes.get(&w.id).copied().unwrap_or(Shape::TextBlock);
         payloads.insert(
             w.id.clone(),
-            fetcher::unknown_fetcher_placeholder(shape, &w.fetcher),
+            fetcher::unknown_fetcher_placeholder(&w.fetcher),
         );
     }
     for (w, err) in buckets.shape_invalid {
@@ -635,10 +631,7 @@ async fn fetch_all(
                         cache_key,
                         ERROR_CACHE_TTL_SECS,
                         CacheEntryKind::Err,
-                        fetcher::error_placeholder(
-                            ctx.shape.unwrap_or(Shape::TextBlock),
-                            &e.to_string(),
-                        ),
+                        fetcher::error_placeholder(&e.to_string()),
                     )
                 }
                 Err(_) => {
@@ -654,7 +647,7 @@ async fn fetch_all(
                         cache_key,
                         ERROR_CACHE_TTL_SECS,
                         CacheEntryKind::Timeout,
-                        fetcher::timeout_placeholder(ctx.shape.unwrap_or(Shape::TextBlock)),
+                        fetcher::timeout_placeholder(),
                     )
                 }
             }
@@ -1506,12 +1499,15 @@ mod tests {
 
         let payload = fresh.get("x").expect("error must surface as a payload");
         match &payload.body {
-            Body::TextBlock(t) => assert!(
-                t.lines.iter().any(|l| l.contains("boom")),
-                "error message must appear in the placeholder: {:?}",
-                t.lines
-            ),
-            other => panic!("expected TextBlock error placeholder, got {other:?}"),
+            Body::Error(err) => {
+                assert_eq!(err.kind, crate::payload::ErrorKind::Fetch);
+                assert!(
+                    err.message.contains("boom"),
+                    "error message must appear in the placeholder: {:?}",
+                    err.message
+                );
+            }
+            other => panic!("expected Body::Error error placeholder, got {other:?}"),
         }
 
         let key = registry
@@ -1570,12 +1566,15 @@ mod tests {
 
         let payload = fresh.get("x").expect("timeout must surface as a payload");
         match &payload.body {
-            Body::TextBlock(t) => assert!(
-                t.lines.iter().any(|l| l.contains("timed out")),
-                "timeout message must appear: {:?}",
-                t.lines
-            ),
-            other => panic!("expected TextBlock timeout placeholder, got {other:?}"),
+            Body::Error(err) => {
+                assert_eq!(err.kind, crate::payload::ErrorKind::Timeout);
+                assert!(
+                    err.message.contains("timed out"),
+                    "timeout message must appear: {:?}",
+                    err.message
+                );
+            }
+            other => panic!("expected Body::Error timeout placeholder, got {other:?}"),
         }
 
         let key = registry
@@ -1724,12 +1723,15 @@ mod tests {
         let _ = refresh_payloads(&None, &registry, &buckets, &HashMap::new(), &mut payloads);
         let payload = payloads.get("typo").expect("unknown fetcher must surface");
         match &payload.body {
-            Body::TextBlock(t) => assert!(
-                t.lines.iter().any(|l| l.contains("no_such_fetcher")),
-                "placeholder must mention the unknown fetcher name: {:?}",
-                t.lines
-            ),
-            other => panic!("expected TextBlock placeholder, got {other:?}"),
+            Body::Error(err) => {
+                assert_eq!(err.kind, crate::payload::ErrorKind::UnknownFetcher);
+                assert!(
+                    err.message.contains("no_such_fetcher"),
+                    "placeholder must mention the unknown fetcher name: {:?}",
+                    err.message
+                );
+            }
+            other => panic!("expected Body::Error placeholder, got {other:?}"),
         }
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -871,12 +871,20 @@ fn render_full_into_buffer(
     let mut inner = Terminal::new(backend).expect("TestBackend::new is infallible");
     inner
         .draw(|frame| {
-            let area = frame.area();
-            paint_viewport_bg(frame, area, theme);
-            let content = shrink(area, padding);
-            layout::draw(
-                frame, content, root, payloads, specs, registry, theme, loading,
-            );
+            // `TestBackend` stores cell symbols verbatim and never interprets escape
+            // sequences, so the OSC 8 wrap that `list_links` adds for clickable hyperlinks
+            // would only pollute this off-screen buffer (the diff drops the wrapped row's
+            // skip cells, leaving them empty in the captured scrollback). Suppress the wrap
+            // for this draw — the user-facing on-screen frame still goes through
+            // `CrosstermBackend` without suppression and keeps the clickable links.
+            render::list_links::without_osc8(|| {
+                let area = frame.area();
+                paint_viewport_bg(frame, area, theme);
+                let content = shrink(area, padding);
+                layout::draw(
+                    frame, content, root, payloads, specs, registry, theme, loading,
+                );
+            });
         })
         .expect("TestBackend draw is infallible");
     inner.backend().buffer().clone()

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -47,6 +47,8 @@ pub fn canonical_sample(shape: Shape) -> Option<Body> {
             (1_699_990_000, "opened #41", None),
             (1_699_900_000, "reverted #40", None),
         ]),
+        // `Error` is a placeholder body, not a fetcher-emitted shape — no sample needed.
+        Shape::Error => return None,
     })
 }
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -153,15 +153,16 @@ pub fn partition_by_trust(
         })
 }
 
-pub fn requires_trust_placeholder(shape: crate::render::Shape) -> Payload {
+pub fn requires_trust_placeholder() -> Payload {
     Payload {
         icon: None,
-        status: None,
+        status: Some(crate::payload::Status::Error),
         format: None,
-        body: crate::fetcher::placeholder_body(
-            shape,
-            &["🔒 requires trust", "run `splashboard trust`"],
-        ),
+        body: crate::payload::Body::Error(crate::payload::ErrorData {
+            kind: crate::payload::ErrorKind::RequiresTrust,
+            message: "🔒 requires trust".into(),
+            detail: Some("run `splashboard trust`".into()),
+        }),
     }
 }
 
@@ -421,30 +422,23 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_has_lock_icon_in_first_line() {
-        let p = requires_trust_placeholder(crate::render::Shape::TextBlock);
+    fn placeholder_carries_lock_icon_and_trust_command() {
+        let p = requires_trust_placeholder();
         match p.body {
-            crate::payload::Body::TextBlock(t) => {
-                assert!(t.lines[0].contains("🔒"));
-                assert!(t.lines[1].contains("splashboard trust"));
+            crate::payload::Body::Error(err) => {
+                assert_eq!(err.kind, crate::payload::ErrorKind::RequiresTrust);
+                assert!(err.message.contains("🔒"));
+                assert!(
+                    err.detail
+                        .as_deref()
+                        .is_some_and(|d| d.contains("splashboard trust"))
+                );
             }
-            _ => panic!("expected text_block body"),
+            other => panic!("expected Body::Error, got {other:?}"),
         }
-    }
-
-    /// `list_links`-equipped widgets (the canonical home_feed / hackernews_top pair) need a
-    /// `LinkedTextBlock`-shaped placeholder; otherwise the trust gate's TextBlock body trips
-    /// the renderer's shape check and the user sees "renderer list_links cannot display
-    /// TextBlock" instead of the actual "🔒 requires trust" message.
-    #[test]
-    fn placeholder_emits_linked_text_block_for_link_renderer() {
-        let p = requires_trust_placeholder(crate::render::Shape::LinkedTextBlock);
-        match p.body {
-            crate::payload::Body::LinkedTextBlock(d) => {
-                assert!(d.items[0].text.contains("🔒"));
-                assert!(d.items.iter().all(|i| i.url.is_none()));
-            }
-            _ => panic!("expected linked_text_block body"),
-        }
+        // Status::Error is the orthogonal "this widget is in error state" signal carried on
+        // the Payload header — useful for outside listeners (cache-entry tagging, future
+        // status sidebars). Body::Error already implies it; we set both for redundancy.
+        assert_eq!(p.status, Some(crate::payload::Status::Error));
     }
 }


### PR DESCRIPTION
## Summary

- Adds three `deariary_*` fetchers (Safe, cached, host-pinned to `api.deariary.com`) backed by a shared HTTP client that dedups concurrent calls, caches responses for 60s, caps in-flight requests at 4, and honors `Retry-After` once on 429.
- `deariary_today` — most recent entry (today's, falling back to yesterday's when today's hasn't generated yet). 6 shapes.
- `deariary_recent` — newest-first list with `limit` (1..=100) + `tag` options. 8 shapes including a `Calendar` that highlights this month's entry days.
- `deariary_on_this_day` — same calendar day anchors at 1m / 3m / 6m / 1y / 2y / 3y / 4y / 5y ago fetched in parallel; missing anchors silently skipped. 7 shapes.
- `LinkedTextBlock` rows produce OSC 8 hyperlinks pointing at `https://app.deariary.com/entries/YYYY/MM/DD`.
- Side fix: `list_links` gains a `without_osc8` thread-local guard, applied in `runtime::render_full_into_buffer` so off-screen `TestBackend` captures don't bake OSC 8 escape sequences into the snapshot buffer (real-terminal output is unchanged).

Ticks the `deariary_*` checkbox in #68.

## `deariary_today`

The most recent auto-generated deariary.com entry — typically today's, falling back to yesterday's when today's hasn't generated yet. Aggregated from external tools (GitHub, Calendar, Slack, Linear, ...); requires the Advanced plan.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `text_block`, `text`, `markdown_text_block`, `linked_text_block`, `entries`, `badge` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `token` | string | no | — | Deariary API token (Bearer). Falls back to the `DEARIARY_TOKEN` env var. |

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| `text_block` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave), [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain) |
| `text` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot), [`animated_figlet_morph`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_figlet_morph), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap), [`animated_typewriter`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_typewriter), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain) |
| `markdown_text_block` | [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown) |
| `linked_text_block` | [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links) |
| `entries` | [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table), animated wrappers |
| `badge` | [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge), animated wrappers |

## `deariary_recent`

Recent auto-generated deariary.com entries, newest first. `Timeline` (default) carries the chronological ranking; `TextBlock` / `Entries` / `MarkdownTextBlock` / `LinkedTextBlock` carry the same ranking in their respective row formats; `Calendar` highlights this month's entry days; `Text` and `Badge` summarise the headline.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `timeline`, `text`, `text_block`, `markdown_text_block`, `linked_text_block`, `entries`, `badge`, `calendar` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `token` | string | no | — | Deariary API token. Falls back to the `DEARIARY_TOKEN` env var. |
| `limit` | integer (1..=100) | no | 10 | Maximum number of entries to render in row-shaped views. |
| `tag` | string | no | — | Restrict results to a single tag slug. |

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| `timeline` | [`list_timeline`](https://splashboard.unhappychoice.com/reference/renderers/list/list_timeline), animated wrappers |
| `text` | [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii), [`animated_typewriter`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_typewriter), animated wrappers |
| `text_block` | [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain), animated wrappers |
| `markdown_text_block` | [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown) |
| `linked_text_block` | [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links) |
| `entries` | [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table), animated wrappers |
| `badge` | [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge), animated wrappers |
| `calendar` | [`grid_calendar`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_calendar), animated wrappers |

## `deariary_on_this_day`

Past auto-generated deariary.com entries from the same calendar day, fetched in parallel for 1m / 3m / 6m / 1y / 2y / 3y / 4y / 5y ago. Anchors with no entry are silently skipped.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `text_block`, `timeline`, `text`, `markdown_text_block`, `linked_text_block`, `entries`, `badge` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `token` | string | no | — | Deariary API token. Falls back to the `DEARIARY_TOKEN` env var. |

### Compatible renderers

Same shape × renderer matrix as `deariary_today`, plus `timeline` → `list_timeline`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1056 + 12 passed, 9 ignored)
- [x] User smoke-test: 17-widget dashboard exercising every shape × renderer combination renders without panic; OSC 8 hyperlinks clickable in the real terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deariary integration: three fetchers (today, recent, on-this-day) exposing multiple output shapes (text, markdown, timeline, calendar, linked entries).
  * Structured error payload/shape so failures render as clear inline error messages.

* **Improvements**
  * Token handling, per-account caching, deduplicated in-flight requests, and polite retry behavior for more reliable fetching.
  * Off-screen hyperlink suppression to prevent escape-sequence noise in captures while keeping on-screen links.

* **Tests**
  * Expanded unit tests for parsing, rendering, caching, error cases, and edge conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->