### PR TITLE
feat(secrets): load tokens from $HOME/.splashboard/secrets.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,10 +111,17 @@ All splashboard state lives under **`$HOME/.splashboard/`** (no XDG paths, same 
 ```
 $HOME/.splashboard/
 ├── config.toml        # global config
+├── secrets.toml       # tokens / env vars exported at startup (git-ignored by install)
 ├── trust.toml         # trust store (path + sha256 entries)
 ├── cache/             # per-widget cache (key.json + key.lock)
 └── store/             # ReadStore files — $HOME/.splashboard/store/<id>.<ext>
 ```
+
+`secrets.toml` is a flat top-level TOML map (`GH_TOKEN = "ghp_..."`). Keys get exported
+as process env at startup, but only when the shell env doesn't already define them — shell
+wins. `SPLASHBOARD_*`, `PATH`, `HOME`, `SHELL`, and a small denylist of ambient/owned keys
+are filtered out (see `secrets.rs`). `splashboard install` drops `secrets.toml` into
+`$HOME/.splashboard/.gitignore` so dotfiles-in-git users don't commit tokens by accident.
 
 Overridable via `SPLASHBOARD_HOME` env var (for tests, CI, relocatable installs).
 

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -140,6 +140,7 @@ pub fn run(opts: InstallOptions) -> io::Result<()> {
     }
 
     ensure_parent_dirs(&destinations)?;
+    ensure_secrets_gitignore(&home_dir)?;
     let mut write_report = write_dashboards(&destinations, home, project)?;
     let settings_report = write_settings(
         &destinations.settings,
@@ -275,6 +276,29 @@ impl Destinations {
             project_dashboard: dir.join("project.dashboard.toml"),
         }
     }
+}
+
+/// Drops `secrets.toml` into `$HOME/.splashboard/.gitignore` so dotfiles-in-git users who
+/// commit the rest of `.splashboard/` don't leak their tokens by accident. Idempotent:
+/// appends the line only when missing, leaves the rest of the file alone.
+fn ensure_secrets_gitignore(home_dir: &Path) -> io::Result<()> {
+    let path = home_dir.join(".gitignore");
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    if existing
+        .lines()
+        .any(|l| l.trim() == "secrets.toml" || l.trim() == "/secrets.toml")
+    {
+        return Ok(());
+    }
+    let mut next = existing;
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    if next.is_empty() {
+        next.push_str("# Written by `splashboard install` — keeps tokens out of dotfiles repos.\n");
+    }
+    next.push_str("secrets.toml\n");
+    std::fs::write(&path, next)
 }
 
 fn ensure_parent_dirs(dest: &Destinations) -> io::Result<()> {
@@ -737,6 +761,34 @@ mod tests {
             std::fs::read_to_string(&backup).unwrap(),
             "# hand-edited settings\n"
         );
+    }
+
+    #[test]
+    fn ensure_secrets_gitignore_creates_when_missing() {
+        let dir = tempdir().unwrap();
+        ensure_secrets_gitignore(dir.path()).unwrap();
+        let body = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(body.contains("secrets.toml"));
+    }
+
+    #[test]
+    fn ensure_secrets_gitignore_appends_to_existing() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "node_modules\n").unwrap();
+        ensure_secrets_gitignore(dir.path()).unwrap();
+        let body = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(body.contains("node_modules"));
+        assert!(body.contains("secrets.toml"));
+    }
+
+    #[test]
+    fn ensure_secrets_gitignore_is_idempotent() {
+        let dir = tempdir().unwrap();
+        ensure_secrets_gitignore(dir.path()).unwrap();
+        let first = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        ensure_secrets_gitignore(dir.path()).unwrap();
+        let second = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert_eq!(first, second);
     }
 
     /// Running `install` twice with identical flags should be a no-op — no backup

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod payload;
 pub mod render;
 pub mod runtime;
 pub mod samples;
+pub mod secrets;
 pub mod shell;
 pub mod templates;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use splashboard::logging;
 use splashboard::paths;
 use splashboard::render::Registry as RenderRegistry;
 use splashboard::runtime;
+use splashboard::secrets::SecretsConfig;
 use splashboard::shell::{self, Shell};
 use splashboard::trust::{TrustStore, load_dashboard_and_hash};
 
@@ -128,6 +129,7 @@ enum CatalogTarget {
 async fn main() -> io::Result<()> {
     let cli = Cli::parse();
     logging::init();
+    apply_secrets();
     match cli.command {
         Some(Command::Init { shell }) => {
             print!("{}", shell::init_snippet(shell));
@@ -232,6 +234,31 @@ fn load_full_config(source: &DashboardSource) -> io::Result<(Config, Option<(Pat
         DashboardSource::Project => (load_project_dashboard_or_baked()?, None),
     };
     Ok((Config::from_parts(settings, dashboard), ident))
+}
+
+/// Loads `$HOME/.splashboard/secrets.toml` and exports each entry as a process env var, but
+/// only when the env doesn't already define it. Runs once at startup so every fetcher
+/// (`GH_TOKEN`, `TODOIST_TOKEN`, etc.) sees the same view regardless of who reads first.
+/// Failures (parse error, unreadable file) log and continue — a stale token shouldn't break
+/// the splash, and the user's shell env is still authoritative.
+fn apply_secrets() {
+    let Some(path) = paths::secrets_path() else {
+        return;
+    };
+    match SecretsConfig::load_or_default(&path) {
+        Ok(secrets) => {
+            secrets.apply_to_env(
+                |k| std::env::var(k).ok(),
+                // SAFETY: called once from `main` before any user code reads env. The Tokio
+                // worker threads exist but are idle — none of our fetchers / runtime tasks
+                // have been spawned yet, so no thread is racing on `getenv`/`setenv`.
+                |k, v| unsafe { std::env::set_var(k, v) },
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load secrets.toml; continuing without it");
+        }
+    }
 }
 
 fn load_settings() -> io::Result<SettingsConfig> {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -24,6 +24,13 @@ pub fn settings_path() -> Option<PathBuf> {
     splashboard_home().map(|d| d.join("settings.toml"))
 }
 
+/// Sensitive env vars (`GH_TOKEN`, `TODOIST_TOKEN`, etc.). Kept separate from `settings.toml`
+/// so dotfiles-in-git users can git-ignore this one file without losing the rest of their
+/// splashboard config.
+pub fn secrets_path() -> Option<PathBuf> {
+    splashboard_home().map(|d| d.join("secrets.toml"))
+}
+
 /// Default dashboard when no per-dir dashboard applies and the CWD isn't a project root.
 pub fn home_dashboard_path() -> Option<PathBuf> {
     splashboard_home().map(|d| d.join("home.dashboard.toml"))
@@ -80,6 +87,7 @@ mod tests {
         }
         assert_eq!(splashboard_home(), Some(path.clone()));
         assert_eq!(settings_path(), Some(path.join("settings.toml")));
+        assert_eq!(secrets_path(), Some(path.join("secrets.toml")));
         assert_eq!(
             home_dashboard_path(),
             Some(path.join("home.dashboard.toml"))

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,143 @@
+//! Loader for `$HOME/.splashboard/secrets.toml` — a flat top-level TOML map of
+//! `KEY = "value"` pairs that get exported as process env at startup. Lives in its own
+//! file (not `settings.toml`) so dotfiles-in-git users can git-ignore exactly the file
+//! that holds tokens without losing their settings.
+//!
+//! Shell env wins: a key already present in the environment is left alone, so a
+//! `GH_TOKEN=... splashboard ...` style override still works.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// Keys we refuse to import from `secrets.toml`. Two reasons:
+///
+/// - `SPLASHBOARD_*` controls splashboard's own behavior (HOME, log filter, trust escape
+///   hatch). Letting a config file flip those creates a confusing layered setup.
+/// - `PATH` / `HOME` / `SHELL` etc. are ambient process state owned by the shell. A typo
+///   here could redirect `git2`/`gix` to a different binary or break HOME discovery.
+const DENYLIST: &[&str] = &[
+    "PATH",
+    "HOME",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "PWD",
+    "OLDPWD",
+    "IFS",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+];
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(transparent)]
+pub struct SecretsConfig {
+    entries: BTreeMap<String, String>,
+}
+
+impl SecretsConfig {
+    pub fn parse(toml_str: &str) -> Result<Self, String> {
+        toml::from_str(toml_str).map_err(|e| e.to_string())
+    }
+
+    /// Loads the file if present, returns an empty config if missing, errors on parse
+    /// failure. Same shape as `SettingsConfig::load_or_default`.
+    pub fn load_or_default(path: &Path) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Self::parse(&s).map_err(|e| format!("{}: {e}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("{}: {e}", path.display())),
+        }
+    }
+
+    /// Iterate the entries that survived denylist + `SPLASHBOARD_*` filtering. Skips
+    /// silently rather than erroring so a stray entry doesn't tank the whole splash.
+    pub fn importable(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.entries
+            .iter()
+            .filter(|(k, _)| is_importable(k))
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    /// Apply each entry to the process env, but only if the env doesn't already have a
+    /// value for that key. Shell env always wins. Returns the keys actually set.
+    pub fn apply_to_env<F, G>(&self, get: F, mut set: G) -> Vec<String>
+    where
+        F: Fn(&str) -> Option<String>,
+        G: FnMut(&str, &str),
+    {
+        self.importable()
+            .filter(|(k, _)| get(k).is_none())
+            .map(|(k, v)| {
+                set(k, v);
+                k.to_string()
+            })
+            .collect()
+    }
+}
+
+fn is_importable(key: &str) -> bool {
+    !key.starts_with("SPLASHBOARD_") && !DENYLIST.contains(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_flat_toml() {
+        let s = SecretsConfig::parse("GH_TOKEN = \"ghp_x\"\nTODOIST_TOKEN = \"t_y\"\n").unwrap();
+        let mut got: Vec<_> = s.importable().collect();
+        got.sort();
+        assert_eq!(got, vec![("GH_TOKEN", "ghp_x"), ("TODOIST_TOKEN", "t_y")]);
+    }
+
+    #[test]
+    fn missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = SecretsConfig::load_or_default(&dir.path().join("secrets.toml")).unwrap();
+        assert_eq!(s.importable().count(), 0);
+    }
+
+    #[test]
+    fn parse_failure_surfaces() {
+        let err = SecretsConfig::parse("not = valid = toml").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn denylist_blocks_dangerous_keys() {
+        let s = SecretsConfig::parse("PATH = \"/tmp\"\nGH_TOKEN = \"x\"\n").unwrap();
+        let keys: Vec<_> = s.importable().map(|(k, _)| k).collect();
+        assert_eq!(keys, vec!["GH_TOKEN"]);
+    }
+
+    #[test]
+    fn splashboard_prefix_is_ignored() {
+        let s = SecretsConfig::parse(
+            "SPLASHBOARD_HOME = \"/x\"\nSPLASHBOARD_TRUST_ALL = \"1\"\nGH_TOKEN = \"x\"\n",
+        )
+        .unwrap();
+        let keys: Vec<_> = s.importable().map(|(k, _)| k).collect();
+        assert_eq!(keys, vec!["GH_TOKEN"]);
+    }
+
+    #[test]
+    fn shell_env_wins_over_secrets() {
+        let s = SecretsConfig::parse("GH_TOKEN = \"from_secrets\"\nNEW_KEY = \"new\"\n").unwrap();
+        let env: BTreeMap<&str, &str> = [("GH_TOKEN", "from_shell")].into();
+        let mut written: BTreeMap<String, String> = BTreeMap::new();
+        let applied = s.apply_to_env(
+            |k| env.get(k).map(|v| v.to_string()),
+            |k, v| {
+                written.insert(k.to_string(), v.to_string());
+            },
+        );
+        assert_eq!(applied, vec!["NEW_KEY"]);
+        assert_eq!(written.get("NEW_KEY").map(|s| s.as_str()), Some("new"));
+        assert!(!written.contains_key("GH_TOKEN"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `SecretsConfig` loader for `$HOME/.splashboard/secrets.toml` — a flat top-level TOML map (`GH_TOKEN = "ghp_..."`) whose entries get exported as process env at startup. Shell env wins, so existing `GH_TOKEN=... splashboard ...` overrides keep working.
- A small denylist filters `SPLASHBOARD_*`, `PATH`, `HOME`, `SHELL`, `LD_PRELOAD` and friends so a stray entry can't redirect ambient process state or splashboard's own behaviour.
- `splashboard install` drops `secrets.toml` into a sibling `.gitignore` (idempotent) so dotfiles-in-git users don't commit tokens by accident.

## Why a separate file?

Keeping tokens out of `settings.toml` lets dotfiles-in-git users `.gitignore` exactly one file without losing the rest of their splashboard config. Parse failures log a warning rather than tanking the splash — the user's shell env is still authoritative.

## Usage

```toml
# $HOME/.splashboard/secrets.toml
GH_TOKEN = "ghp_xxxxxxxxxxxx"
TODOIST_TOKEN = "..."
GITHUB_USER = "unhappychoice"
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib --bins` (1033 + 12 tests, all green)
- [x] New unit tests cover: flat-TOML parsing, missing file → empty, parse-failure surfacing, denylist behaviour, `SPLASHBOARD_*` filtering, shell-env-wins semantics, gitignore idempotency / append / create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)