### PR TITLE
docs(secrets): document $HOME/.splashboard/secrets.toml in user guides

### DIFF
--- a/docs-site/src/content/docs/guides/configuration.md
+++ b/docs-site/src/content/docs/guides/configuration.md
@@ -28,6 +28,7 @@ tests or relocatable installs.
 ```
 $HOME/.splashboard/
 ├── settings.toml              # [general], [theme]
+├── secrets.toml               # tokens / env vars exported at startup
 ├── home.dashboard.toml        # ambient splash
 ├── project.dashboard.toml     # repo-root splash when the repo ships no config
 ├── trust.toml                 # trust store (auto-managed)
@@ -104,6 +105,42 @@ panel_title = "#ff0088"
 
 Full theme token list and the `"reset"` escape hatch for light terminals:
 see [Themes](/guides/themes/).
+
+## `secrets.toml`
+
+Tokens and other env vars that fetchers need (`GH_TOKEN`, `GITHUB_TOKEN`,
+`TODOIST_TOKEN`, …) can live in a flat top-level TOML map at
+`$HOME/.splashboard/secrets.toml`. splashboard reads it once at startup and
+exports each entry as a process env var, so any fetcher that looks up the
+matching env name picks it up without touching your shell rc.
+
+```toml
+# $HOME/.splashboard/secrets.toml
+GH_TOKEN      = "ghp_..."
+TODOIST_TOKEN = "..."
+```
+
+Rules:
+
+- **Shell env always wins.** A key already defined in the environment is
+  left alone, so an ad-hoc `GH_TOKEN=... splashboard ...` override still
+  works.
+- **Filtered keys.** `SPLASHBOARD_*` (splashboard's own knobs) and ambient
+  process state owned by the shell — `PATH`, `HOME`, `SHELL`, `USER`,
+  `LOGNAME`, `PWD`, `OLDPWD`, `IFS`, `LD_PRELOAD`, `LD_LIBRARY_PATH`,
+  `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH` — are silently ignored, so a
+  stray entry can't redirect ambient state.
+- **Best-effort.** A missing file is fine; a parse error logs a warning and
+  the splash still renders.
+- **Git-ignored by `splashboard install`.** The installer drops
+  `secrets.toml` into a sibling `$HOME/.splashboard/.gitignore` (idempotent),
+  so dotfiles-in-git users who commit the rest of `.splashboard/` don't leak
+  their tokens by accident.
+
+Lives in its own file (not `settings.toml`) so dotfiles-in-git users can
+git-ignore exactly the file that holds tokens without losing the rest of
+their splashboard config. See the
+[cookbook](/guides/cookbook/#github-credentials) for example wiring.
 
 ## Dashboard files
 

--- a/docs-site/src/content/docs/guides/cookbook.md
+++ b/docs-site/src/content/docs/guides/cookbook.md
@@ -11,15 +11,31 @@ Small recipes that stitch together the pieces from the other guides.
 query. splashboard reads `GH_TOKEN` first, then falls back to
 `GITHUB_TOKEN`.
 
-```bash
-# In ~/.zshrc / ~/.bashrc — export before the splashboard init snippet.
-export GH_TOKEN="ghp_..."
+The recommended place is `$HOME/.splashboard/secrets.toml` — a flat TOML
+map of `KEY = "value"` pairs that splashboard exports as process env at
+startup. No shell rc edit, no leakage into other tools.
+
+```toml
+# $HOME/.splashboard/secrets.toml
+GH_TOKEN      = "ghp_..."
+TODOIST_TOKEN = "..."          # any fetcher that reads an env var works the same way
 ```
 
-If you already have the `gh` CLI configured and don't want the token in
-an rc file, a typical setup is:
+`splashboard install` git-ignores this file under
+`$HOME/.splashboard/.gitignore` so dotfiles-in-git users don't commit it
+by accident. Shell env always wins, so an ad-hoc
+`GH_TOKEN=... splashboard ...` override still works. See the
+[`secrets.toml` reference](/guides/configuration/#secretstoml) for the
+denylist and full rules.
+
+If you'd rather keep the token in your shell rc — e.g. because other
+tools also read it — that still works. Export before the splashboard init
+snippet:
 
 ```bash
+# ~/.zshrc / ~/.bashrc
+export GH_TOKEN="ghp_..."
+# or, if you have the `gh` CLI configured:
 export GH_TOKEN="$(gh auth token 2>/dev/null)"
 ```
 

--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -189,9 +189,16 @@ the [trust model guide](/guides/trust/) for the consent flow —
 `splashboard trust` is usually what you want.
 
 **A GitHub widget renders an error.** `github_*` fetchers need a token with
-read access. Export `GH_TOKEN` (or `GITHUB_TOKEN`) before starting the shell.
-See the [cookbook](/guides/cookbook/#github-credentials) for the
-recommended place to put it.
+read access. The simplest fix is to drop a line into
+`$HOME/.splashboard/secrets.toml`:
+
+```toml
+GH_TOKEN = "ghp_..."
+```
+
+splashboard exports it at startup, so no shell rc edit is required. See
+the [cookbook](/guides/cookbook/#github-credentials) for alternatives
+(shell rc, `gh auth token`, `GITHUB_TOKEN` fallback).
 
 **I want to see fresh data, not cached.** Run `splashboard --wait` once. The
 cached-first model normally paints instantly from the last refresh; `--wait`


### PR DESCRIPTION
## Summary

The secrets loader shipped in #177 had no user-facing docs. This PR fills
that gap in the three hand-authored guides:

- **`configuration.md`** — adds `secrets.toml` to the `$HOME/.splashboard/`
  file tree and a dedicated section covering: flat TOML format, shell-env
  precedence, the filtered keys (`SPLASHBOARD_*` + `PATH`/`HOME`/`SHELL`/…
  denylist), best-effort error handling, and the install-time
  `.gitignore` line.
- **`cookbook.md`** — rewrites *GitHub credentials* to lead with
  `secrets.toml`; keeps the shell-rc and `gh auth token` paths as
  alternatives. Calls out that any token-based fetcher (`TODOIST_TOKEN`,
  …) works the same way.
- **`getting-started.md`** — switches the `GH_TOKEN` troubleshooting
  bullet to the `secrets.toml` snippet, and points at the cookbook for
  alternatives.

`AGENTS.md` was already updated in #177; the auto-generated fetcher
reference pages are untouched.

## Test plan

- [x] `npm run build` (docs-site) — 195 pages, no errors.
- [ ] Spot-check the rendered guides locally with `astro dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)