### PR TITLE
fix(xtask): step past OSC 8 link cells in HTML snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6029,6 +6029,7 @@ dependencies = [
  "ratatui",
  "splashboard",
  "toml 1.1.2+spec-1.1.0",
+ "unicode-width",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,3 +15,4 @@ clap = { version = "4", features = ["derive"] }
 ratatui = { version = "0.30", features = ["widget-calendar"] }
 toml = "1.1"
 anyhow = "1"
+unicode-width = "0.2"

--- a/xtask/src/html_snapshot.rs
+++ b/xtask/src/html_snapshot.rs
@@ -6,6 +6,7 @@
 
 use ratatui::buffer::Buffer;
 use ratatui::style::{Color, Modifier, Style};
+use unicode_width::UnicodeWidthStr;
 
 pub fn buffer_to_html(buf: &Buffer) -> String {
     let mut out = String::new();
@@ -22,12 +23,14 @@ pub fn buffer_to_html(buf: &Buffer) -> String {
 fn emit_row(out: &mut String, buf: &Buffer, y: u16, width: u16) {
     let mut run_style: Option<Style> = None;
     let mut run_cells: Vec<String> = Vec::new();
-    for x in 0..width {
+    let mut x = 0u16;
+    while x < width {
         let cell = buf[(x, y)].clone();
         // Cells flagged `skip` are placeholders for the visible region of an OSC 8 hyperlink
         // — the link's first cell carries the whole sequence; the trailing cells exist only
         // so terminal cursor math lines up. Drop them in HTML to avoid emitting stray spaces.
         if cell.skip {
+            x += 1;
             continue;
         }
         let style = cell_style(&cell);
@@ -36,6 +39,13 @@ fn emit_row(out: &mut String, buf: &Buffer, y: u16, width: u16) {
             run_cells.clear();
             run_style = None;
             emit_link(out, &style, &url, &visible);
+            // The TestBackend stores the OSC 8 sequence in the first cell only; the trailing
+            // cells the renderer flagged with `skip` aren't preserved across the diff/flush
+            // (the backend's per-cell store has no `skip` field), so they keep whatever the
+            // prior frame left there. Step past them ourselves using the visible text's
+            // display width so we don't double-emit the underlying spaces / glyphs.
+            let cells_consumed = UnicodeWidthStr::width(visible.as_str()).max(1) as u16;
+            x = x.saturating_add(cells_consumed);
             continue;
         }
         if Some(style) != run_style {
@@ -44,6 +54,7 @@ fn emit_row(out: &mut String, buf: &Buffer, y: u16, width: u16) {
             run_style = Some(style);
         }
         run_cells.push(cell.symbol().to_string());
+        x += 1;
     }
     flush_run(out, run_style.as_ref(), &run_cells);
 }
@@ -234,6 +245,21 @@ mod tests {
         assert!(html.contains("<span class=\"c\">i</span>"));
         assert!(!html.contains("\x1b"));
         assert!(!html.contains("]8;;"));
+    }
+
+    #[test]
+    fn osc8_link_consumes_underlying_cells_even_when_skip_is_lost() {
+        // The TestBackend doesn't carry the renderer's `skip` flag across the diff/flush, so
+        // the cells trailing an OSC 8 link land back in the buffer as plain spaces. Without
+        // the visible-width step in `emit_row`, those would emit as extra cell spans on top
+        // of the link's own char spans — a 5-char link in a 10-wide row would produce 5 + 4
+        // = 9 spans inside the link area, blowing past the row width.
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+        buf[(0, 0)].set_symbol("\x1b]8;;https://example.com/\x1b\\hello\x1b]8;;\x1b\\");
+        // No skip flags — emulating what the TestBackend hands back after the diff/flush.
+        let html = buffer_to_html(&buf);
+        // 5 link chars + 5 trailing cells = 10 cell spans, matching the buffer width.
+        assert_eq!(html.matches("<span class=\"c\">").count(), 10);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `list_links` packs the OSC 8 sequence into the first cell and flags the trailing cells with `skip = true`. The `TestBackend` used by `cargo xtask`'s dashboard snapshot doesn't carry `skip` across diff/flush, so those cells landed back in the buffer as plain spaces.
- `emit_row` then emitted the link's visible chars **plus** all the underlying spaces, blowing rows in `home_feed` / `home_github` / `project_github` past the 120-cell canvas (up to ~200 cells). The CSS in `.splash-landing .splash-snapshot` (`font-size: min(0.9rem, calc(100cqi / 82))`) assumes ~120 cells, so the previews overflowed to the right on the docs site.
- Step `x` past the visible text's display width (`UnicodeWidthStr::width`) after emitting an OSC 8 link so the underlying cells aren't double-counted.

Added a regression test that mirrors the TestBackend behaviour (OSC 8 in cell 0, no skip flags) and asserts the row stays at the buffer width.

## Test plan

- [x] `cargo test` (1117 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo xtask` regenerates `docs-site/src/assets/rendered/*.html` — every row now has at most 120 `<span class="c">` per line (was up to 202 in the affected presets)
- [x] `astro dev` preset gallery — visually verify presets fit container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML snapshot generation to prevent cell double-emission and ensure accurate text width calculations.

* **Chores**
  * Added Unicode width support to development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->