### PR TITLE
Improve render test coverage for text and animated renderers

### DIFF
--- a/src/render/animated_boot.rs
+++ b/src/render/animated_boot.rs
@@ -241,7 +241,14 @@ fn process_start() -> Instant {
 mod tests {
     use super::*;
     use crate::payload::{Payload, TextData};
-    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+    use crate::render::{
+        RenderSpec,
+        test_utils::{line_text, render_to_buffer_with_spec},
+    };
+
+    fn joined_text(buf: &ratatui::buffer::Buffer) -> String {
+        (0..buf.area.height).map(|y| line_text(buf, y)).collect()
+    }
 
     #[test]
     fn boot_lines_falls_back_to_default_when_none() {
@@ -275,6 +282,87 @@ mod tests {
         assert!(parsed.boot_lines.is_none());
         assert!(inner.duration_ms.is_none());
         assert_eq!(inner.style.as_deref(), Some("figlet"));
+    }
+
+    #[test]
+    fn empty_boot_lines_hands_off_to_default_inner_renderer() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "hello".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_boot".into(),
+            options: RenderOptions::default().with_extra("boot_lines", Vec::<String>::new()),
+        };
+        let registry = super::super::Registry::with_builtins();
+        let buf = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 20, 3);
+        assert!(joined_text(&buf).contains("hello"));
+    }
+
+    #[test]
+    fn unknown_inner_renderer_surfaces_inline_error() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "hello".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_boot".into(),
+            options: RenderOptions::default().with_extra("inner", "missing_renderer"),
+        };
+        let registry = super::super::Registry::with_builtins();
+        let buf = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 80, 3);
+        assert!(joined_text(&buf).contains("unknown inner renderer: missing_renderer"));
+    }
+
+    #[test]
+    fn incompatible_inner_renderer_surfaces_shape_error() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: "hello".into(),
+            }),
+        };
+        let spec = RenderSpec::Full {
+            type_name: "animated_boot".into(),
+            options: RenderOptions::default().with_extra("inner", "grid_table"),
+        };
+        let registry = super::super::Registry::with_builtins();
+        let buf = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 80, 3);
+        assert!(joined_text(&buf).contains("inner grid_table cannot display Text"));
+    }
+
+    #[test]
+    fn natural_height_falls_back_to_one_for_unknown_inner_renderer() {
+        let renderer = AnimatedBootRenderer;
+        let registry = super::super::Registry::with_builtins();
+        let body = Body::Text(TextData {
+            value: "hello\nworld".into(),
+        });
+        let opts = RenderOptions::default().with_extra("inner", "missing_renderer");
+        assert_eq!(renderer.natural_height(&body, &opts, 20, &registry), 1);
+    }
+
+    #[test]
+    fn natural_height_delegates_to_shape_default_renderer() {
+        let renderer = AnimatedBootRenderer;
+        let registry = super::super::Registry::with_builtins();
+        let body = Body::Text(TextData {
+            value: "hello\nworld".into(),
+        });
+        assert_eq!(
+            renderer.natural_height(&body, &RenderOptions::default(), 20, &registry),
+            2
+        );
     }
 
     #[test]

--- a/src/render/animated_typewriter.rs
+++ b/src/render/animated_typewriter.rs
@@ -110,8 +110,51 @@ fn process_start() -> Instant {
 
 #[cfg(test)]
 mod tests {
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
+
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    use super::*;
+    use crate::payload::{ErrorData, ErrorKind, Payload};
+    use crate::render::{
+        RenderSpec,
+        test_utils::{line_text, render_to_buffer_with_spec},
+    };
+
     fn reveal(text: &str, budget: usize) -> String {
         text.chars().take(budget).collect()
+    }
+
+    fn text_payload(value: &str) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: value.to_string(),
+            }),
+        }
+    }
+
+    fn render_direct(body: &Body, opts: &RenderOptions, width: u16, height: u16) -> Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::default();
+        let registry = Registry::with_builtins();
+        let renderer = AnimatedTypewriterRenderer;
+        terminal
+            .draw(|f| renderer.render(f, f.area(), body, opts, &theme, &registry))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn wait_until_revealed(total: usize) {
+        let deadline = Instant::now() + Duration::from_millis(250);
+        while chars_revealed(total) < total && Instant::now() < deadline {
+            sleep(Duration::from_millis(5));
+        }
+        assert_eq!(chars_revealed(total), total);
     }
 
     #[test]
@@ -124,5 +167,64 @@ mod tests {
     #[test]
     fn empty_budget_yields_empty_string() {
         assert_eq!(reveal("x", 0), "");
+    }
+
+    #[test]
+    fn parse_align_supports_center_right_and_fallback() {
+        assert_eq!(parse_align(Some("center")), Alignment::Center);
+        assert_eq!(parse_align(Some("right")), Alignment::Right);
+        assert_eq!(parse_align(Some("bogus")), Alignment::Left);
+        assert_eq!(parse_align(None), Alignment::Left);
+    }
+
+    #[test]
+    fn chars_revealed_clamps_to_total() {
+        assert_eq!(chars_revealed(0), 0);
+        wait_until_revealed(1);
+        assert_eq!(chars_revealed(1), 1);
+    }
+
+    #[test]
+    fn centered_render_reveals_text_once_budget_catches_up() {
+        wait_until_revealed(2);
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Full {
+            type_name: "animated_typewriter".into(),
+            options: RenderOptions {
+                align: Some("center".into()),
+                ..RenderOptions::default()
+            },
+        };
+        let buf = render_to_buffer_with_spec(&text_payload("OK"), Some(&spec), &registry, 6, 1);
+        assert_eq!(line_text(&buf, 0), "  OK  ");
+    }
+
+    #[test]
+    fn renderer_ignores_non_text_bodies() {
+        let body = Body::Error(ErrorData {
+            kind: ErrorKind::Fetch,
+            message: "boom".into(),
+            detail: None,
+        });
+        let buf = render_direct(&body, &RenderOptions::default(), 8, 1);
+        assert_eq!(line_text(&buf, 0), "        ");
+    }
+
+    #[test]
+    fn renderer_exposes_docs_metadata() {
+        let renderer = AnimatedTypewriterRenderer;
+        let schemas = renderer.option_schemas();
+        let colors = renderer.color_keys();
+
+        assert_eq!(renderer.name(), "animated_typewriter");
+        assert!(renderer.animates());
+        assert!(renderer.description().contains("40 chars/sec"));
+        assert_eq!(renderer.accepts(), &[Shape::Text]);
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0].name, "align");
+        assert_eq!(schemas[0].type_hint, "\"left\" | \"center\" | \"right\"");
+        assert_eq!(schemas[0].default, Some("\"left\""));
+        assert_eq!(colors.len(), 1);
+        assert_eq!(colors[0].name, "text");
     }
 }

--- a/src/render/animated_wave.rs
+++ b/src/render/animated_wave.rs
@@ -208,7 +208,49 @@ fn process_start() -> Instant {
 mod tests {
     use super::*;
     use crate::payload::{Payload, TextData};
-    use crate::render::{RenderSpec, test_utils::render_to_buffer_with_spec};
+    use crate::render::{
+        RenderSpec,
+        test_utils::{line_text, render_to_buffer_with_spec},
+    };
+    use ratatui::{
+        Terminal, backend::TestBackend, buffer::Buffer, style::Color, widgets::Paragraph,
+    };
+
+    fn text_payload(value: &str) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData {
+                value: value.into(),
+            }),
+        }
+    }
+
+    fn fg_at(buf: &Buffer, row: u16, needle: char) -> Color {
+        let area = buf.area;
+        for x in 0..area.width {
+            let cell = buf.cell((x, row)).unwrap();
+            if cell.symbol().contains(needle) {
+                return cell.style().fg.unwrap_or(Color::Reset);
+            }
+        }
+        panic!("char {needle:?} not found on row {row}");
+    }
+
+    fn render_wave_frame(elapsed_ms: u32, total_ms: u32, width: u16) -> Buffer {
+        let backend = TestBackend::new(width, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::default();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                frame.render_widget(Paragraph::new("ABCDEFGH"), area);
+                apply_wave(frame, area, elapsed_ms, total_ms, &theme);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
 
     #[test]
     fn inner_options_strips_wrapper_fields() {
@@ -226,15 +268,84 @@ mod tests {
     }
 
     #[test]
-    fn renders_without_panic() {
-        let payload = Payload {
-            icon: None,
-            status: None,
-            format: None,
-            body: Body::Text(TextData {
-                value: "wave".into(),
-            }),
+    fn renderer_exposes_docs_metadata() {
+        let renderer = AnimatedWaveRenderer;
+        let schemas = renderer.option_schemas();
+        let colors = renderer.color_keys();
+
+        assert_eq!(renderer.name(), "animated_wave");
+        assert!(renderer.animates());
+        assert!(renderer.description().contains("wave of signal"));
+        assert_eq!(renderer.accepts(), ALL_SHAPES);
+        assert_eq!(schemas.len(), 2);
+        assert_eq!(schemas[0].name, "inner");
+        assert_eq!(schemas[1].name, "duration_ms");
+        assert_eq!(colors.len(), 2);
+        assert_eq!(colors[0].name, "panel_title");
+        assert_eq!(colors[1].name, "text");
+    }
+
+    #[test]
+    fn unknown_inner_renderer_renders_inline_error() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Full {
+            type_name: "animated_wave".into(),
+            options: RenderOptions::default().with_extra("inner", "missing"),
         };
+        let buf = render_to_buffer_with_spec(&text_payload("wave"), Some(&spec), &registry, 50, 1);
+        assert!(line_text(&buf, 0).contains("unknown inner renderer: missing"));
+    }
+
+    #[test]
+    fn shape_mismatch_inner_renderer_renders_inline_error() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Full {
+            type_name: "animated_wave".into(),
+            options: RenderOptions::default().with_extra("inner", "grid_table"),
+        };
+        let buf = render_to_buffer_with_spec(&text_payload("wave"), Some(&spec), &registry, 50, 1);
+        assert!(line_text(&buf, 0).contains("cannot display Text"));
+    }
+
+    #[test]
+    fn natural_height_uses_shape_default_and_unknown_falls_back_to_one() {
+        let registry = Registry::with_builtins();
+        let renderer = AnimatedWaveRenderer;
+        let body = text_payload("wave\ncrest").body;
+        let opts = RenderOptions::default();
+        let expected = registry
+            .get(default_renderer_for(Shape::Text))
+            .unwrap()
+            .natural_height(&body, &inner_options(&opts), 20, &registry);
+
+        assert_eq!(
+            renderer.natural_height(&body, &opts, 20, &registry),
+            expected
+        );
+        assert_eq!(
+            renderer.natural_height(
+                &body,
+                &RenderOptions::default().with_extra("inner", "missing"),
+                20,
+                &registry,
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn wave_masks_future_columns_and_highlights_the_crest() {
+        let theme = Theme::default();
+        let buf = render_wave_frame(250, 1000, 8);
+
+        assert_eq!(line_text(&buf, 0), "ABCDEF  ");
+        assert_eq!(fg_at(&buf, 0, 'A'), theme.panel_title);
+        assert_eq!(fg_at(&buf, 0, 'F'), Color::Reset);
+    }
+
+    #[test]
+    fn renders_without_panic() {
+        let payload = text_payload("wave");
         let spec = RenderSpec::Full {
             type_name: "animated_wave".into(),
             options: RenderOptions {

--- a/src/render/text_plain.rs
+++ b/src/render/text_plain.rs
@@ -87,7 +87,7 @@ fn parse_align(s: Option<&str>) -> Alignment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{Payload, TextData};
+    use crate::payload::{ErrorData, ErrorKind, Payload, TextData};
     use crate::render::test_utils::{line_text, render_to_buffer};
 
     fn text_payload(value: &str) -> Payload {
@@ -131,5 +131,41 @@ mod tests {
             r.natural_height(&text_payload("").body, &opts, 30, &registry),
             1
         );
+    }
+
+    #[test]
+    fn natural_height_non_text_falls_back_to_one() {
+        let r = TextPlainRenderer;
+        let registry = Registry::with_builtins();
+        let opts = RenderOptions::default();
+        let body = Body::Error(ErrorData {
+            kind: ErrorKind::Fetch,
+            message: "boom".to_string(),
+            detail: None,
+        });
+        assert_eq!(r.natural_height(&body, &opts, 30, &registry), 1);
+    }
+
+    #[test]
+    fn parse_align_supports_center_right_and_fallback() {
+        assert_eq!(parse_align(Some("center")), Alignment::Center);
+        assert_eq!(parse_align(Some("right")), Alignment::Right);
+        assert_eq!(parse_align(Some("bogus")), Alignment::Left);
+        assert_eq!(parse_align(None), Alignment::Left);
+    }
+
+    #[test]
+    fn renderer_exposes_docs_metadata() {
+        let r = TextPlainRenderer;
+        let schemas = r.option_schemas();
+        let colors = r.color_keys();
+
+        assert!(r.description().contains("Single-line body text"));
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0].name, "align");
+        assert_eq!(schemas[0].type_hint, "\"left\" | \"center\" | \"right\"");
+        assert_eq!(schemas[0].default, Some("\"left\""));
+        assert_eq!(colors.len(), 1);
+        assert_eq!(colors[0].name, "text");
     }
 }


### PR DESCRIPTION
## Summary
- add missing branch and metadata validation coverage for `render/text_plain.rs`
- add regression coverage for `render/animated_boot.rs`
- add focused regression tests for `render/animated_typewriter.rs` and `render/animated_wave.rs`

## Why
These renderer modules had weak coverage around branch-specific behavior and wrapper paths. This change locks those cases down with focused tests.

## Impact
- reduces regression risk in text and animated renderers
- keeps renderer metadata and wrapper behavior covered

## Test plan
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the animated boot renderer, including override behavior and error handling scenarios.
  * Added comprehensive tests for the animated typewriter renderer, covering alignment parsing, reveal timing, and rendering validation.
  * Enhanced test suite for the animated wave renderer with metadata verification and masking behavior validation.
  * Increased test coverage for the plain text renderer, including alignment parsing and metadata exposure checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->