### PR TITLE
chore(gnhf): save overnight loop prompts and launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /.splashboard/
+/.gnhf/runs/
+

--- a/.gnhf/README.md
+++ b/.gnhf/README.md
@@ -14,35 +14,39 @@ moves a metric in one direction.
 ├── prompts/
 │   ├── coverage-loop.md   # tests-only loop: line coverage only goes up
 │   └── perf-loop.md       # perf-only loop: cold-start latency only goes down
-├── run.sh                 # launches both loops in parallel worktrees
+├── run.sh                 # launches one loop (foreground) on a gnhf/ branch
 └── runs/                  # gnhf runtime state (git-ignored)
 ```
 
 ## Usage
 
-Start fresh on `main` with a clean tree:
+Start fresh on `main` with a clean tree, then pick a loop:
 
 ```sh
 git checkout main && git pull --ff-only
-./.gnhf/run.sh
+
+./.gnhf/run.sh coverage   # tests-only loop
+./.gnhf/run.sh perf       # perf-only loop
 ```
 
-Two `gnhf` processes detach into the background, each in its own git worktree
-under `../splashboard-gnhf-worktrees/`. Logs land in `/tmp/gnhf-*.log`.
-
-In the morning:
+`run.sh` runs in the foreground so you can watch the live gnhf TUI and
+Ctrl+C when you're done. Override the token cap with `GNHF_MAX_TOKENS`:
 
 ```sh
-ls ../splashboard-gnhf-worktrees/
-tail /tmp/gnhf-coverage.log /tmp/gnhf-perf.log
+GNHF_MAX_TOKENS=10000000 ./.gnhf/run.sh coverage
 ```
 
-Review the commit stack on each worktree's `gnhf/...` branch, cherry-pick the
-good ones onto a feature branch, open PRs, merge with `--merge`.
+When the loop ends (token cap, runtime cap, or Ctrl+C), the commits live on
+the `gnhf/...` branch gnhf created. Cherry-pick the good ones onto a feature
+branch, open a PR, merge with `--merge`.
+
+Only one loop at a time per checkout — `gnhf` writes to a single `gnhf/`
+branch in this repo. Run separate loops in separate clones if you want them
+in parallel.
 
 ## Adding a new loop
 
 1. Drop a new `<name>-loop.md` into `prompts/`. Write a continuous objective
    with a measurable metric and an "exit non-zero if metric did not move"
    gate, so failed iterations roll back automatically.
-2. Add a launch line to `run.sh`.
+2. `./.gnhf/run.sh <name>` picks it up automatically.

--- a/.gnhf/README.md
+++ b/.gnhf/README.md
@@ -1,0 +1,48 @@
+# .gnhf/
+
+Overnight [gnhf](https://github.com/kunchenguid/gnhf) loop prompts and launcher.
+
+`gnhf` keeps an agent running while you sleep — each iteration makes one
+small, committed change toward an objective. These prompts define
+**continuous-improvement objectives** (no terminal state): every iteration
+moves a metric in one direction.
+
+## Layout
+
+```
+.gnhf/
+├── prompts/
+│   ├── coverage-loop.md   # tests-only loop: line coverage only goes up
+│   └── perf-loop.md       # perf-only loop: cold-start latency only goes down
+├── run.sh                 # launches both loops in parallel worktrees
+└── runs/                  # gnhf runtime state (git-ignored)
+```
+
+## Usage
+
+Start fresh on `main` with a clean tree:
+
+```sh
+git checkout main && git pull --ff-only
+./.gnhf/run.sh
+```
+
+Two `gnhf` processes detach into the background, each in its own git worktree
+under `../splashboard-gnhf-worktrees/`. Logs land in `/tmp/gnhf-*.log`.
+
+In the morning:
+
+```sh
+ls ../splashboard-gnhf-worktrees/
+tail /tmp/gnhf-coverage.log /tmp/gnhf-perf.log
+```
+
+Review the commit stack on each worktree's `gnhf/...` branch, cherry-pick the
+good ones onto a feature branch, open PRs, merge with `--merge`.
+
+## Adding a new loop
+
+1. Drop a new `<name>-loop.md` into `prompts/`. Write a continuous objective
+   with a measurable metric and an "exit non-zero if metric did not move"
+   gate, so failed iterations roll back automatically.
+2. Add a launch line to `run.sh`.

--- a/.gnhf/prompts/coverage-loop.md
+++ b/.gnhf/prompts/coverage-loop.md
@@ -1,0 +1,54 @@
+You are working on splashboard. Read AGENTS.md and CLAUDE.md before doing anything.
+
+Continuous objective (no end state):
+Push splashboard's line + branch coverage upward, forever, one commit at a time.
+Every iteration measures current coverage, finds the highest-leverage uncovered
+region, adds tests, and commits. The number only goes up.
+
+Procedure for THIS iteration:
+1. Measure baseline:
+     cargo install cargo-llvm-cov --locked   # if missing
+     cargo llvm-cov --workspace --summary-only
+   Record the overall line%.
+
+2. Read notes.md if it exists. Skip targets already attempted in prior iterations.
+
+3. Pick ONE target by priority:
+   a. File with < 60% line coverage that has real logic.
+   b. Function with high cyclomatic complexity and 0 test hits.
+   c. Error/fallback branch never exercised (Err(_), None =>, _ =>, unwrap_or, ok()?).
+   d. Realtime/cached fetcher path with no test.
+   e. Renderer's render() for a Shape variant not covered via render/test_utils.rs.
+   Skip generated code, main.rs arg parsing, trivial code.
+
+4. Add tests, NOT new production code:
+   - #[cfg(test)] mod tests next to the code.
+   - Renderer tests use src/render/test_utils.rs.
+   - Tests touching SPLASHBOARD_HOME or process env MUST take paths::TEST_ENV_LOCK.
+   - Assert on observable output (rendered cells, returned Body, error variants).
+   - If genuinely untestable as written, pick a different target. Do NOT refactor
+     production code in a coverage iteration.
+
+5. Re-measure. Overall line% MUST be strictly higher than step 1. If not, exit
+   non-zero so gnhf rolls back.
+
+6. Quality gate (all must pass, else exit non-zero):
+   - cargo test
+   - cargo clippy --all-targets -- -D warnings
+   - cargo fmt --all -- --check
+
+7. Commit:
+   - Conventional: test(scope): cover <area>
+   - Body includes: before% -> after% (+Xpp), which file/function, why it was the pick.
+   - Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   - Append one line to notes.md: "<commit-sha-short> covered <file>::<fn> (X.X% -> Y.Y%)"
+
+Hard rules:
+- Tests-only commit. No production code changes (renaming a private item to make
+  it testable is OK, keep diff minimal).
+- No new top-level deps. cargo-llvm-cov is dev-only.
+- No #[ignore], no --no-verify, no skipping flaky tests.
+- Do NOT reintroduce closed designs (#5 plugin protocol, #20 command widget,
+  XDG paths, screensaver mode).
+
+Coverage only goes up.

--- a/.gnhf/prompts/perf-loop.md
+++ b/.gnhf/prompts/perf-loop.md
@@ -1,0 +1,57 @@
+You are working on splashboard. Read AGENTS.md and CLAUDE.md before doing anything.
+
+Continuous objective (no end state):
+Drive cold-start render latency downward, forever, one commit at a time. The
+killer feature is fast cached first-paint on shell startup and cd. Every
+millisecond shaved is felt on every prompt. The number only goes down.
+
+Procedure for THIS iteration:
+1. Measure baseline. Release build, warm pagecache, hyperfine 20 runs, take median:
+     cargo build --release
+     ./target/release/splashboard render --once >/dev/null 2>&1 || true
+     hyperfine --warmup 3 --runs 20 './target/release/splashboard render --once'
+   Record median + stddev.
+
+2. Read notes.md if it exists. Skip targets already attempted.
+
+3. Pick ONE target by priority:
+   a. Sync I/O on the cold path that can become lazy/cached/skipped on first paint
+      (cache-miss falls through to background refresh — that pattern exists, extend it).
+   b. serde deserialize of a large blob that can be bounded/streamed/cached parsed.
+   c. Panic-on-startup safety check that can be relaxed to a warning.
+   d. RealtimeFetcher::compute that is NOT actually < 1ms — fix or demote to cached.
+   e. Renderer doing avoidable work for empty bodies (empty-state short-circuit
+      lives in render::render_payload — make sure nobody bypasses it).
+   f. Crate features / build profile tweaks that reduce binary size or startup
+      symbol resolution without behavior change.
+   Skip anything that changes user-visible output. Skip correctness-for-speed trades.
+
+4. Implement. Small, surgical diff. Preserve Shape × Fetcher × Renderer separation.
+   No new top-level deps unless removing a heavier one in the same commit.
+   No unsafe to chase microseconds.
+
+5. Re-measure with the same hyperfine command. New median MUST be lower than
+   step 1 by MORE than hyperfine's stddev. If not, the change is noise — exit
+   non-zero so gnhf rolls back.
+
+6. Quality gate (all must pass, else exit non-zero):
+   - cargo test
+   - cargo clippy --all-targets -- -D warnings
+   - cargo fmt --all -- --check
+   - Visual smoke: ./target/release/splashboard render --once still produces the
+     expected splash for the default config.
+
+7. Commit:
+   - Conventional: perf(scope): <what was sped up>
+   - Body includes: before ms ± stddev -> after ms ± stddev (delta + %), what was
+     slow, why, what changed, machine info (uname -a; rustc --version).
+   - Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   - Append one line to notes.md: "<commit-sha-short> sped up <area> (Xms -> Yms)"
+
+Hard rules:
+- Output of render --once must be byte-identical for the default config (or
+  visually identical if timestamps/randomness — document any intentional diff).
+- No reintroducing closed designs (#5, #20, XDG paths, screensaver mode).
+- "Looks faster" doesn't count. If you can't measure a real improvement, exit non-zero.
+
+Latency only goes down.

--- a/.gnhf/run.sh
+++ b/.gnhf/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Launch overnight gnhf loops in parallel worktrees.
+# See .gnhf/README.md for the full workflow.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROMPTS="$ROOT/.gnhf/prompts"
+TOKEN_CAP="${GNHF_MAX_TOKENS:-5000000}"
+
+if ! command -v gnhf >/dev/null 2>&1; then
+  echo "gnhf not found. install: npm install -g gnhf" >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$ROOT" status --porcelain)" ]; then
+  echo "working tree not clean — gnhf --worktree requires a clean tree" >&2
+  exit 1
+fi
+
+cd "$ROOT"
+
+cat "$PROMPTS/coverage-loop.md" | gnhf --worktree --max-tokens "$TOKEN_CAP" \
+  > /tmp/gnhf-coverage.log 2>&1 &
+COVERAGE_PID=$!
+
+cat "$PROMPTS/perf-loop.md" | gnhf --worktree --max-tokens "$TOKEN_CAP" \
+  > /tmp/gnhf-perf.log 2>&1 &
+PERF_PID=$!
+
+disown "$COVERAGE_PID" "$PERF_PID" 2>/dev/null || true
+
+cat <<MSG
+launched two gnhf loops:
+  coverage-loop  pid=$COVERAGE_PID  log=/tmp/gnhf-coverage.log
+  perf-loop      pid=$PERF_PID      log=/tmp/gnhf-perf.log
+
+token cap per loop: $TOKEN_CAP (override with GNHF_MAX_TOKENS=...)
+worktrees will appear under: $(cd .. && pwd)/splashboard-gnhf-worktrees/
+
+morning checklist:
+  ls ../splashboard-gnhf-worktrees/
+  tail /tmp/gnhf-coverage.log /tmp/gnhf-perf.log
+MSG

--- a/.gnhf/run.sh
+++ b/.gnhf/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Launch overnight gnhf loops in parallel worktrees.
+# Launch a gnhf loop. Pick which one with the first argument.
 # See .gnhf/README.md for the full workflow.
 
 set -euo pipefail
@@ -8,37 +8,42 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROMPTS="$ROOT/.gnhf/prompts"
 TOKEN_CAP="${GNHF_MAX_TOKENS:-5000000}"
 
+usage() {
+  {
+    echo "usage: $0 <loop-name>"
+    echo
+    echo "available loops:"
+    for p in "$PROMPTS"/*-loop.md; do
+      [ -f "$p" ] || continue
+      name="$(basename "$p" -loop.md)"
+      echo "  $name"
+    done
+    echo
+    echo "token cap: \$GNHF_MAX_TOKENS (default $TOKEN_CAP)"
+  } >&2
+  exit 2
+}
+
+[ $# -eq 1 ] || usage
+
+NAME="$1"
+PROMPT="$PROMPTS/$NAME-loop.md"
+
+if [ ! -f "$PROMPT" ]; then
+  echo "no such loop: $NAME ($PROMPT not found)" >&2
+  usage
+fi
+
 if ! command -v gnhf >/dev/null 2>&1; then
   echo "gnhf not found. install: npm install -g gnhf" >&2
   exit 1
 fi
 
 if [ -n "$(git -C "$ROOT" status --porcelain)" ]; then
-  echo "working tree not clean — gnhf --worktree requires a clean tree" >&2
+  echo "working tree not clean — commit or stash before launching gnhf" >&2
   exit 1
 fi
 
 cd "$ROOT"
 
-cat "$PROMPTS/coverage-loop.md" | gnhf --worktree --max-tokens "$TOKEN_CAP" \
-  > /tmp/gnhf-coverage.log 2>&1 &
-COVERAGE_PID=$!
-
-cat "$PROMPTS/perf-loop.md" | gnhf --worktree --max-tokens "$TOKEN_CAP" \
-  > /tmp/gnhf-perf.log 2>&1 &
-PERF_PID=$!
-
-disown "$COVERAGE_PID" "$PERF_PID" 2>/dev/null || true
-
-cat <<MSG
-launched two gnhf loops:
-  coverage-loop  pid=$COVERAGE_PID  log=/tmp/gnhf-coverage.log
-  perf-loop      pid=$PERF_PID      log=/tmp/gnhf-perf.log
-
-token cap per loop: $TOKEN_CAP (override with GNHF_MAX_TOKENS=...)
-worktrees will appear under: $(cd .. && pwd)/splashboard-gnhf-worktrees/
-
-morning checklist:
-  ls ../splashboard-gnhf-worktrees/
-  tail /tmp/gnhf-coverage.log /tmp/gnhf-perf.log
-MSG
+exec gnhf --max-tokens "$TOKEN_CAP" < "$PROMPT"


### PR DESCRIPTION
## Summary

Persist two continuous-improvement objectives for [gnhf](https://github.com/kunchenguid/gnhf) overnight loops, plus a launcher that runs them in parallel worktrees.

- `.gnhf/prompts/coverage-loop.md` — tests-only iterations; line coverage only goes up.
- `.gnhf/prompts/perf-loop.md` — perf-only iterations; cold-start latency only goes down.
- `.gnhf/run.sh` — launches both loops detached, each in its own `git worktree`, with a shared `GNHF_MAX_TOKENS` cap.
- `.gnhf/README.md` — usage notes.
- `.gitignore` — exclude `/.gnhf/runs/` (gnhf runtime state).

Each prompt requires the iteration to exit non-zero when its metric does not move, so failed runs roll back automatically.

## Test plan

- [x] `./.gnhf/run.sh` errors out cleanly when `gnhf` is not installed or the tree is dirty.
- [ ] Smoke a single overnight session and confirm two worktrees appear under `../splashboard-gnhf-worktrees/` with commits on `gnhf/...` branches.
- [ ] Confirm `/tmp/gnhf-coverage.log` and `/tmp/gnhf-perf.log` capture per-iteration output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for overnight continuous-improvement automation workflows.

* **Chores**
  * Introduced configuration for automated coverage-improvement and performance-optimization loops.
  * Added startup script to run improvement workflows with logging and worktree management.
  * Updated `.gitignore` to exclude runtime artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->