### PR TITLE
test: raise workspace coverage and tweak gnhf launcher

### DIFF
--- a/.gnhf/run.sh
+++ b/.gnhf/run.sh
@@ -46,4 +46,4 @@ fi
 
 cd "$ROOT"
 
-exec gnhf --max-tokens "$TOKEN_CAP" < "$PROMPT"
+exec gnhf --max-tokens "$TOKEN_CAP" --prevent-sleep off < "$PROMPT"

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -161,6 +161,8 @@ fn repo_for_key(ctx: &FetchContext) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     fn run(status: &str, conclusion: Option<&str>) -> WorkflowRun {
@@ -169,6 +171,75 @@ mod tests {
             conclusion: conclusion.map(String::from),
             head_branch: Some("main".into()),
         }
+    }
+
+    fn run_with_branch(
+        status: &str,
+        conclusion: Option<&str>,
+        head_branch: Option<&str>,
+    ) -> WorkflowRun {
+        WorkflowRun {
+            status: status.into(),
+            conclusion: conclusion.map(String::from),
+            head_branch: head_branch.map(String::from),
+        }
+    }
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "ci".into(),
+            format: Some("compact".into()),
+            timeout: Duration::from_secs(1),
+            file_format: None,
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            timezone: None,
+            locale: None,
+        }
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.repo.is_none());
+        assert!(opts.branch.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_repo_and_branch() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nbranch = \"main\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.repo.as_deref(), Some("foo/bar"));
+        assert_eq!(opts.branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_metadata_and_samples_cover_supported_shapes() {
+        let fetcher = GithubActionStatus;
+        assert_eq!(fetcher.name(), "github_action_status");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("latest CI workflow run"));
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::Badge);
+        assert_eq!(fetcher.option_schemas().len(), 2);
+
+        let Some(Body::Badge(badge)) = fetcher.sample_body(Shape::Badge) else {
+            panic!("expected badge sample");
+        };
+        assert_eq!(badge.status, Status::Ok);
+        assert_eq!(badge.label, "ci passing");
+
+        let Some(Body::Text(text)) = fetcher.sample_body(Shape::Text) else {
+            panic!("expected text sample");
+        };
+        assert_eq!(text.value, "main · passing");
+        assert!(fetcher.sample_body(Shape::Entries).is_none());
     }
 
     #[test]
@@ -187,5 +258,90 @@ mod tests {
     #[test]
     fn in_progress_is_warn() {
         assert_eq!(classify(&run("in_progress", None)).0, Status::Warn);
+    }
+
+    #[test]
+    fn completed_timed_out_and_startup_failure_are_errors() {
+        ["timed_out", "startup_failure"]
+            .into_iter()
+            .for_each(|conclusion| {
+                assert_eq!(
+                    classify(&run("completed", Some(conclusion))),
+                    (Status::Error, "failing")
+                );
+            });
+    }
+
+    #[test]
+    fn completed_cancelled_and_skipped_stay_warn() {
+        ["cancelled", "neutral", "skipped"]
+            .into_iter()
+            .map(|conclusion| (conclusion, classify(&run("completed", Some(conclusion)))))
+            .for_each(|(conclusion, actual)| {
+                let expected = if conclusion == "cancelled" {
+                    (Status::Warn, "cancelled")
+                } else {
+                    (Status::Warn, "skipped")
+                };
+                assert_eq!(actual, expected);
+            });
+    }
+
+    #[test]
+    fn completed_unknown_conclusion_falls_back_to_completed() {
+        assert_eq!(
+            classify(&run("completed", Some("action_required"))),
+            (Status::Warn, "completed")
+        );
+        assert_eq!(
+            classify(&run("completed", None)),
+            (Status::Warn, "completed")
+        );
+    }
+
+    #[test]
+    fn render_badge_uses_branch_and_classified_label() {
+        let body = render_body(&run("completed", Some("cancelled")), Shape::Badge);
+        let Body::Badge(badge) = body else {
+            panic!("expected badge");
+        };
+        assert_eq!(badge.status, Status::Warn);
+        assert_eq!(badge.label, "main · cancelled");
+    }
+
+    #[test]
+    fn render_text_falls_back_to_question_mark_for_missing_branch() {
+        let body = render_body(
+            &run_with_branch("completed", Some("success"), None),
+            Shape::Text,
+        );
+        let Body::Text(text) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(text.value, "? · passing");
+    }
+
+    #[test]
+    fn repo_for_key_prefers_explicit_repo_option() {
+        assert_eq!(
+            repo_for_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Badge))),
+            "foo/bar"
+        );
+    }
+
+    #[test]
+    fn repo_for_key_falls_back_to_resolved_repo() {
+        assert_eq!(
+            repo_for_key(&ctx(None, Some(Shape::Badge))),
+            resolve_repo(None).unwrap().as_path()
+        );
+    }
+
+    #[test]
+    fn cache_key_changes_with_repo_option() {
+        let fetcher = GithubActionStatus;
+        let a = fetcher.cache_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Badge)));
+        let b = fetcher.cache_key(&ctx(Some("repo = \"foo/baz\""), Some(Shape::Badge)));
+        assert_ne!(a, b);
     }
 }

--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -175,6 +175,7 @@ fn payload(body: Body) -> Payload {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fetcher::github::client;
 
     struct EnvGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -240,7 +241,9 @@ mod tests {
             ("GH_TOKEN", None),
             ("GITHUB_TOKEN", None),
         ]);
+        client::clear_authenticated_user_cache();
         let err = resolve_user(None).await.unwrap_err();
+        client::clear_authenticated_user_cache();
         assert!(err.contains("GH_TOKEN"), "unexpected error: {err}");
     }
 

--- a/src/fetcher/github/client.rs
+++ b/src/fetcher/github/client.rs
@@ -21,6 +21,7 @@ const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
 const ACCEPT: &str = "application/vnd.github+json";
 const API_VERSION: &str = "2022-11-28";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+static AUTHENTICATED_USER_CACHE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
 
 pub fn http() -> &'static Client {
     static CLIENT: OnceLock<Client> = OnceLock::new();
@@ -45,8 +46,7 @@ pub fn resolve_token() -> Result<String, FetchError> {
 /// within a session. Lets `github_avatar` / `github_user` work with zero config when a token is
 /// already set.
 pub async fn resolve_authenticated_user() -> Result<String, FetchError> {
-    static CACHED: OnceLock<Mutex<Option<String>>> = OnceLock::new();
-    let slot = CACHED.get_or_init(|| Mutex::new(None));
+    let slot = AUTHENTICATED_USER_CACHE.get_or_init(|| Mutex::new(None));
     if let Some(cached) = slot.lock().ok().and_then(|g| g.clone()) {
         return Ok(cached);
     }
@@ -59,6 +59,16 @@ pub async fn resolve_authenticated_user() -> Result<String, FetchError> {
         *g = Some(me.login.clone());
     }
     Ok(me.login)
+}
+
+#[cfg(test)]
+pub(crate) fn clear_authenticated_user_cache() {
+    if let Ok(mut guard) = AUTHENTICATED_USER_CACHE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    {
+        *guard = None;
+    }
 }
 
 /// REST GET → deserialize JSON. Non-2xx responses surface the GitHub-reported `message` when

--- a/xtask/src/dashboard_snapshot.rs
+++ b/xtask/src/dashboard_snapshot.rs
@@ -265,3 +265,165 @@ fn inner_renderer_name(opts: &RenderOptions) -> String {
 fn font_sequence(opts: &RenderOptions) -> Option<Vec<String>> {
     opts.extra_string_array("font_sequence")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn widget(id: &str, fetcher: &str) -> WidgetConfig {
+        WidgetConfig {
+            id: id.into(),
+            fetcher: fetcher.into(),
+            render: None,
+            format: None,
+            refresh_interval: None,
+            file_format: None,
+            options: None,
+        }
+    }
+
+    fn write_dashboard(body: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "splashboard-dashboard-snapshot-{unique}-{}.toml",
+            std::process::id()
+        ));
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn render_config_html_renders_basic_static_dashboard() {
+        let path = write_dashboard(
+            r#"
+[[widget]]
+id = "hello"
+fetcher = "basic_static"
+format = "Hi"
+render = "list_plain"
+
+[[row]]
+height = { length = 1 }
+  [[row.child]]
+  widget = "hello"
+"#,
+        );
+        let html = render_config_html(&path, 12, 4).unwrap();
+        fs::remove_file(path).unwrap();
+
+        assert!(html.starts_with("<pre class=\"splash-snapshot\">"));
+        assert!(html.contains("<span class=\"c\">H</span>"));
+        assert!(html.contains("<span class=\"c\">i</span>"));
+        assert!(html.ends_with("</pre>"));
+    }
+
+    #[test]
+    fn sample_payloads_use_realtime_compute_and_basic_static_override() {
+        let fetchers = FetcherRegistry::with_builtins();
+        let renderers = RenderRegistry::with_builtins();
+
+        let mut static_widget = widget("static", "basic_static");
+        static_widget.format = Some("alpha\nbeta".into());
+        static_widget.render = Some(RenderSpec::Short("list_plain".into()));
+
+        let mut clock_widget = widget("clock", "clock");
+        clock_widget.render = Some(RenderSpec::Short("grid_table".into()));
+
+        let payloads = sample_payloads(&[static_widget, clock_widget], &fetchers, &renderers);
+
+        assert!(matches!(
+            &payloads.get("static").unwrap().body,
+            Body::TextBlock(TextBlockData { lines })
+                if lines == &vec![String::from("alpha"), String::from("beta")]
+        ));
+        assert!(matches!(
+            payloads.get("clock").map(|payload| &payload.body),
+            Some(Body::Entries(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_shape_prefers_shared_shape_and_falls_back_to_renderer_shape() {
+        let fetchers = FetcherRegistry::with_builtins();
+        let renderers = RenderRegistry::with_builtins();
+        let fetcher = fetchers.get("basic_static").unwrap();
+
+        let mut shared = widget("shared", "basic_static");
+        shared.render = Some(RenderSpec::Short("list_plain".into()));
+        assert_eq!(
+            resolve_shape(&shared, &fetcher, &renderers),
+            Some(Shape::TextBlock)
+        );
+
+        let mut mismatch = widget("mismatch", "basic_static");
+        mismatch.render = Some(RenderSpec::Short("status_badge".into()));
+        assert_eq!(
+            resolve_shape(&mismatch, &fetcher, &renderers),
+            Some(Shape::Badge)
+        );
+    }
+
+    #[test]
+    fn widget_specs_default_and_deanimate_wrapped_renderers() {
+        let plain = widget("plain", "basic_static");
+
+        let mut typewriter = widget("typewriter", "basic_static");
+        typewriter.render = Some(RenderSpec::Short("animated_typewriter".into()));
+
+        let mut postfx = widget("postfx", "basic_static");
+        postfx.render = Some(RenderSpec::Full {
+            type_name: "animated_postfx".into(),
+            options: RenderOptions {
+                align: Some("center".into()),
+                ..RenderOptions::default()
+            }
+            .with_extra("inner", "list_plain"),
+        });
+
+        let specs = widget_specs(&[plain, typewriter, postfx]);
+
+        assert!(matches!(
+            specs.get("plain"),
+            Some(RenderSpec::Short(name)) if name == "text_plain"
+        ));
+        assert!(matches!(
+            specs.get("typewriter"),
+            Some(RenderSpec::Short(name)) if name == "text_plain"
+        ));
+        assert!(matches!(
+            specs.get("postfx"),
+            Some(RenderSpec::Full { type_name, options })
+                if type_name == "list_plain" && options.align.as_deref() == Some("center")
+        ));
+    }
+
+    #[test]
+    fn deanimate_figlet_morph_uses_last_font_and_preserves_style_options() {
+        let spec = RenderSpec::Full {
+            type_name: "animated_figlet_morph".into(),
+            options: RenderOptions {
+                align: Some("right".into()),
+                color: Some("panel_title".into()),
+                ..RenderOptions::default()
+            }
+            .with_extra("font_sequence", vec!["small", "doom"]),
+        };
+
+        let deanimated = deanimate(spec);
+
+        assert!(matches!(
+            deanimated,
+            RenderSpec::Full { type_name, options }
+                if type_name == "text_ascii"
+                    && options.style.as_deref() == Some("figlet")
+                    && options.align.as_deref() == Some("right")
+                    && options.color.as_deref() == Some("panel_title")
+                    && options.extra_str("font") == Some("doom")
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- Add tests for `xtask/src/dashboard_snapshot.rs`, lifting workspace line coverage from 78.10% → 78.90%.
- Cover untested branches in `github_action_status` (and minor adjustments in `github::avatar` / `github::client`), lifting coverage from 78.42% → 78.62%.
- Pass `--prevent-sleep off` from `.gnhf/run.sh` so overnight loops don't fight the system sleep policy.

## Test plan
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for GitHub action status handling, validation logic, and badge/text rendering.
  * Enhanced avatar resolution testing with improved cache state management.
  * Added comprehensive test suite for dashboard snapshot rendering and widget configuration.

* **Chores**
  * Updated build script configuration for sleep prevention handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->