### PR TITLE
perf: gnhf overnight wins (cold-start latency, English commit prompts)

### DIFF
--- a/.gnhf/prompts/coverage-loop.md
+++ b/.gnhf/prompts/coverage-loop.md
@@ -38,6 +38,7 @@ Procedure for THIS iteration:
    - cargo fmt --all -- --check
 
 7. Commit:
+   - The structured `summary` field and the commit body MUST be written in English. No Japanese, no other languages.
    - Conventional: test(scope): cover <area>
    - Body includes: before% -> after% (+Xpp), which file/function, why it was the pick.
    - Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

--- a/.gnhf/prompts/perf-loop.md
+++ b/.gnhf/prompts/perf-loop.md
@@ -42,6 +42,7 @@ Procedure for THIS iteration:
      expected splash for the default config.
 
 7. Commit:
+   - The structured `summary` field and the commit body MUST be written in English. No Japanese, no other languages.
    - Conventional: perf(scope): <what was sped up>
    - Body includes: before ms ± stddev -> after ms ± stddev (delta + %), what was
      slow, why, what changed, machine info (uname -a; rustc --version).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ members = [".", "xtask"]
 default-members = ["."]
 resolver = "2"
 
+[profile.release]
+codegen-units = 1
+lto = "thin"
+strip = "symbols"
+
 [package]
 name = "splashboard"
 version = "1.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::io::{self, BufRead, IsTerminal, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
 
@@ -125,11 +126,8 @@ enum CatalogTarget {
     Renderer { name: Option<String> },
 }
 
-#[tokio::main(flavor = "multi_thread")]
-async fn main() -> io::Result<()> {
+fn main() -> io::Result<()> {
     let cli = Cli::parse();
-    logging::init();
-    apply_secrets();
     match cli.command {
         Some(Command::Init { shell }) => {
             print!("{}", shell::init_snippet(shell));
@@ -153,25 +151,42 @@ async fn main() -> io::Result<()> {
             wait: wait.then_some(true),
             ..Default::default()
         }),
-        Some(Command::FetchOnly { kind, path }) => {
-            daemon::run_fetch_only(kind, path.as_deref()).await
-        }
+        Some(Command::FetchOnly { kind, path }) => run_async({
+            logging::init();
+            apply_secrets();
+            daemon::run_fetch_only(kind, path.as_deref())
+        }),
         Some(Command::Trust { path }) => run_trust(path),
         Some(Command::Revoke { path }) => run_revoke(path),
         Some(Command::ListTrusted) => run_list_trusted(),
         Some(Command::Catalog { target }) => run_catalog(target),
         Some(Command::License { own }) => run_license(own),
         None => {
+            if !should_render() {
+                return Ok(());
+            }
+            logging::init();
+            apply_secrets();
             // Swallow render errors at the shell-facing boundary so a broken splash never breaks
             // the user's prompt. Internal paths (FetchOnly above) still propagate errors.
             let _ = if cli.on_cd {
-                render_for_cd(cli.wait).await
+                run_async(render_for_cd(cli.wait))
             } else {
-                render_splash(cli.wait).await
+                run_async(render_splash(cli.wait))
             };
             Ok(())
         }
     }
+}
+
+fn run_async<F>(future: F) -> io::Result<()>
+where
+    F: Future<Output = io::Result<()>>,
+{
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(future)
 }
 
 async fn render_splash(wait: bool) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- `perf(cli)`: switch to sync dispatch and lazy Tokio init — cold `render --once` median **5.396ms → 1.351ms**.
- `perf(build)`: tighten release profile (`codegen-units = 1`, thin LTO, strip symbols) — cold median **1.503ms → 1.341ms** (-10.8%).
- `chore(gnhf)`: require the loop prompts to write `summary` / commit body in English (codex was emitting Japanese summaries that got wrapped into the `gnhf #N:` commits).

The two perf commits were originally produced by gnhf's overnight loops; they are reworded here from `gnhf #N: <jp>` into Conventional Commits with no diff change.

## Test plan
- [x] `cargo build --release` succeeds with the new profile.
- [ ] `cargo test` green
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] Smoke: `./target/release/splashboard render --once` still produces the expected splash for the default config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)