### PR TITLE
test: improve coverage for github + hackernews fetchers

### DIFF
--- a/src/fetcher/github/good_first_issues.rs
+++ b/src/fetcher/github/good_first_issues.rs
@@ -148,3 +148,203 @@ fn repo_for_key(ctx: &FetchContext) -> String {
         .map(String::from)
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::time::Duration;
+
+    use super::*;
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        restore: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let lock = crate::paths::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let restore = pairs
+                .iter()
+                .map(|(key, value)| {
+                    let previous = std::env::var(key).ok();
+                    match value {
+                        Some(value) => unsafe { std::env::set_var(key, value) },
+                        None => unsafe { std::env::remove_var(key) },
+                    }
+                    (*key, previous)
+                })
+                .collect();
+            Self {
+                _lock: lock,
+                restore,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            self.restore.iter().for_each(|(key, value)| match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            });
+        }
+    }
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "good-first".into(),
+            format: Some("compact".into()),
+            timeout: Duration::from_secs(1),
+            file_format: None,
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            timezone: None,
+            locale: None,
+        }
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.repo.is_none());
+        assert!(opts.limit.is_none());
+        assert!(opts.label.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_repo_limit_and_label() {
+        let raw: toml::Value =
+            toml::from_str("repo = \"foo/bar\"\nlimit = 7\nlabel = \"help wanted\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.repo.as_deref(), Some("foo/bar"));
+        assert_eq!(opts.limit, Some(7));
+        assert_eq!(opts.label.as_deref(), Some("help wanted"));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_metadata_and_samples_cover_supported_shapes() {
+        let fetcher = GithubGoodFirstIssues;
+        assert_eq!(fetcher.name(), "github_good_first_issues");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("good-first-issue"));
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.option_schemas().len(), 3);
+        assert_eq!(fetcher.option_schemas()[0].name, "repo");
+        assert_eq!(fetcher.option_schemas()[1].name, "limit");
+        assert_eq!(fetcher.option_schemas()[2].name, "label");
+
+        let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
+        else {
+            panic!("expected linked text block sample");
+        };
+        assert_eq!(
+            linked.items[0].text,
+            "ratatui/ratatui#999 improve docs for Paragraph"
+        );
+        assert_eq!(
+            linked.items[1].url.as_deref(),
+            Some("https://github.com/tokio-rs/console/issues/123")
+        );
+
+        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
+            panic!("expected text block sample");
+        };
+        assert_eq!(text.lines[1], "tokio-rs/console#123 add quickstart section");
+
+        let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
+            panic!("expected entries sample");
+        };
+        assert_eq!(entries.items[0].key, "ratatui #999");
+        assert_eq!(
+            entries.items[1].value.as_deref(),
+            Some("add quickstart section")
+        );
+
+        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
+            panic!("expected timeline sample");
+        };
+        assert_eq!(timeline.events[0].title, "ratatui/ratatui#999");
+        assert_eq!(
+            timeline.events[1].detail.as_deref(),
+            Some("add quickstart section")
+        );
+        assert!(fetcher.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn cache_key_changes_with_repo_option() {
+        let fetcher = GithubGoodFirstIssues;
+        let a = fetcher.cache_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries)));
+        let b = fetcher.cache_key(&ctx(Some("repo = \"foo/baz\""), Some(Shape::Entries)));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repo_for_key_prefers_explicit_repo_option() {
+        assert_eq!(
+            repo_for_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries))),
+            "foo/bar"
+        );
+    }
+
+    #[test]
+    fn repo_for_key_defaults_to_empty_string() {
+        assert_eq!(repo_for_key(&ctx(None, Some(Shape::Entries))), "");
+    }
+
+    #[test]
+    fn fetch_rejects_invalid_repo_before_auth_lookup() {
+        let fetcher = GithubGoodFirstIssues;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("repo = \"not-a-slug\"\nlimit = 99\nlabel = \"help wanted\""),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("invalid repo option")));
+    }
+
+    #[test]
+    fn fetch_global_search_surfaces_missing_token_without_network_response() {
+        let _guard = EnvGuard::set(&[("GH_TOKEN", None), ("GITHUB_TOKEN", None)]);
+        let fetcher = GithubGoodFirstIssues;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("limit = 99\nlabel = \"good first issue\""),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(
+            matches!(err, FetchError::Failed(msg) if msg.contains("GH_TOKEN / GITHUB_TOKEN not set"))
+        );
+    }
+
+    #[test]
+    fn fetch_repo_search_surfaces_missing_token_without_network_response() {
+        let _guard = EnvGuard::set(&[("GH_TOKEN", None), ("GITHUB_TOKEN", None)]);
+        let fetcher = GithubGoodFirstIssues;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("repo = \"foo/bar\"\nlimit = 99\nlabel = \"help wanted\""),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(
+            matches!(err, FetchError::Failed(msg) if msg.contains("GH_TOKEN / GITHUB_TOKEN not set"))
+        );
+    }
+}

--- a/src/fetcher/github/items.rs
+++ b/src/fetcher/github/items.rs
@@ -119,6 +119,17 @@ fn entries_key(i: &IssueItem, include_repo: bool) -> String {
 mod tests {
     use super::*;
 
+    fn issue_item() -> IssueItem {
+        IssueItem {
+            title: "Fix cached splash mismatch".into(),
+            number: 42,
+            repository_url: "https://api.github.com/repos/unhappychoice/splashboard".into(),
+            updated_at: "2026-04-22T10:15:30Z".into(),
+            html_url: "https://github.com/unhappychoice/splashboard/issues/42".into(),
+            state: "open".into(),
+        }
+    }
+
     #[test]
     fn repo_from_url_extracts_slug() {
         let s = repo_from_url("https://api.github.com/repos/foo/bar").unwrap();
@@ -129,5 +140,65 @@ mod tests {
     #[test]
     fn repo_from_url_rejects_non_api_host() {
         assert!(repo_from_url("https://github.com/foo/bar").is_none());
+    }
+
+    #[test]
+    fn render_entries_include_repo_name_and_title() {
+        let Body::Entries(data) = render_items(&[issue_item()], Shape::Entries, true) else {
+            panic!("expected entries");
+        };
+        assert_eq!(data.items.len(), 1);
+        assert_eq!(data.items[0].key, "splashboard #42");
+        assert_eq!(
+            data.items[0].value.as_deref(),
+            Some("Fix cached splash mismatch")
+        );
+        assert!(data.items[0].status.is_none());
+    }
+
+    #[test]
+    fn render_linked_text_block_uses_short_label_and_optional_url() {
+        let mut item = issue_item();
+        item.html_url.clear();
+
+        let Body::LinkedTextBlock(data) = render_items(&[item], Shape::LinkedTextBlock, false)
+        else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(data.items.len(), 1);
+        assert_eq!(data.items[0].text, "#42 Fix cached splash mismatch");
+        assert!(data.items[0].url.is_none());
+    }
+
+    #[test]
+    fn render_timeline_uses_repo_fallback_and_parsed_timestamp() {
+        let mut item = issue_item();
+        item.repository_url = "https://api.github.com/not-a-repo".into();
+
+        let Body::Timeline(data) = render_items(&[item], Shape::Timeline, true) else {
+            panic!("expected timeline");
+        };
+        assert_eq!(data.events.len(), 1);
+        assert_eq!(data.events[0].timestamp, 1_776_852_930);
+        assert_eq!(data.events[0].title, "?#42");
+        assert_eq!(
+            data.events[0].detail.as_deref(),
+            Some("Fix cached splash mismatch")
+        );
+        assert!(data.events[0].status.is_none());
+    }
+
+    #[test]
+    fn render_text_block_is_the_fallback_shape() {
+        let Body::TextBlock(data) = render_items(&[issue_item()], Shape::TextBlock, false) else {
+            panic!("expected text block");
+        };
+        assert_eq!(data.lines, vec!["#42 Fix cached splash mismatch"]);
+    }
+
+    #[test]
+    fn search_result_defaults_missing_items_to_empty() {
+        let result: SearchResult = serde_json::from_str("{}").unwrap();
+        assert!(result.items.is_empty());
     }
 }

--- a/src/fetcher/github/recent_releases.rs
+++ b/src/fetcher/github/recent_releases.rs
@@ -203,3 +203,165 @@ fn repo_for_key(ctx: &FetchContext) -> String {
         .or_else(|| resolve_repo(None).ok().map(|s: RepoSlug| s.as_path()))
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "releases".into(),
+            format: Some("compact".into()),
+            timeout: Duration::from_secs(1),
+            file_format: None,
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            timezone: None,
+            locale: None,
+        }
+    }
+
+    fn releases() -> Vec<Release> {
+        vec![
+            Release {
+                tag_name: "v1.2.3".into(),
+                name: Some("latest".into()),
+                published_at: Some("2026-04-10T12:34:56Z".into()),
+                html_url: "https://github.com/foo/bar/releases/tag/v1.2.3".into(),
+            },
+            Release {
+                tag_name: "v1.2.2".into(),
+                name: None,
+                published_at: None,
+                html_url: String::new(),
+            },
+        ]
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.repo.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_repo_and_limit() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nlimit = 7").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.repo.as_deref(), Some("foo/bar"));
+        assert_eq!(opts.limit, Some(7));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_metadata_and_samples_cover_supported_shapes() {
+        let fetcher = GithubRecentReleases;
+        assert_eq!(fetcher.name(), "github_recent_releases");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("Latest published releases"));
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.option_schemas().len(), 2);
+        assert_eq!(fetcher.option_schemas()[0].name, "repo");
+        assert_eq!(fetcher.option_schemas()[1].name, "limit");
+
+        let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
+        else {
+            panic!("expected linked text block sample");
+        };
+        assert_eq!(linked.items.len(), 2);
+        assert_eq!(linked.items[0].text, "v0.3.0  2026-04-10");
+
+        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
+            panic!("expected text block sample");
+        };
+        assert_eq!(text.lines[1], "v0.2.1  2026-03-05");
+
+        let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
+            panic!("expected entries sample");
+        };
+        assert_eq!(entries.items[0].key, "v0.3.0");
+
+        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
+            panic!("expected timeline sample");
+        };
+        assert_eq!(timeline.events[0].detail.as_deref(), Some("latest"));
+        assert!(fetcher.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn entries_body_uses_tag_name_and_iso_date() {
+        let body = render_body(&releases(), Shape::Entries);
+        let Body::Entries(entries) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(entries.items[0].key, "v1.2.3");
+        assert_eq!(entries.items[0].value.as_deref(), Some("2026-04-10"));
+        assert_eq!(entries.items[1].value.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn linked_text_block_uses_release_date_and_optional_link() {
+        let body = render_body(&releases(), Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(linked) = body else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(linked.items[0].text, "v1.2.3  2026-04-10");
+        assert_eq!(
+            linked.items[0].url.as_deref(),
+            Some("https://github.com/foo/bar/releases/tag/v1.2.3")
+        );
+        assert_eq!(linked.items[1].text, "v1.2.2  ");
+        assert!(linked.items[1].url.is_none());
+    }
+
+    #[test]
+    fn timeline_body_preserves_optional_name_and_missing_timestamp() {
+        let body = render_body(&releases(), Shape::Timeline);
+        let Body::Timeline(timeline) = body else {
+            panic!("expected timeline");
+        };
+        assert_eq!(
+            timeline.events[0].timestamp,
+            parse_timestamp("2026-04-10T12:34:56Z")
+        );
+        assert_eq!(timeline.events[0].detail.as_deref(), Some("latest"));
+        assert_eq!(timeline.events[1].timestamp, 0);
+        assert!(timeline.events[1].detail.is_none());
+    }
+
+    #[test]
+    fn text_block_body_falls_back_to_plain_lines() {
+        let body = render_body(&releases(), Shape::TextBlock);
+        let Body::TextBlock(text) = body else {
+            panic!("expected text block");
+        };
+        assert_eq!(
+            text.lines,
+            vec!["v1.2.3  2026-04-10".to_string(), "v1.2.2  ".to_string()]
+        );
+    }
+
+    #[test]
+    fn cache_key_changes_with_repo_option() {
+        let fetcher = GithubRecentReleases;
+        let a = fetcher.cache_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries)));
+        let b = fetcher.cache_key(&ctx(Some("repo = \"foo/baz\""), Some(Shape::Entries)));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repo_for_key_prefers_explicit_repo_option() {
+        assert_eq!(
+            repo_for_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries))),
+            "foo/bar"
+        );
+    }
+}

--- a/src/fetcher/hackernews/client.rs
+++ b/src/fetcher/hackernews/client.rs
@@ -42,3 +42,86 @@ pub async fn get<T: DeserializeOwned>(url: &str) -> Result<T, FetchError> {
         .await
         .map_err(|e| FetchError::Failed(format!("hn json parse: {e}")))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct TestPayload {
+        title: String,
+    }
+
+    #[test]
+    fn get_deserializes_success_body() {
+        let (url, server) = serve_once("200 OK", r#"{"title":"Launch HN"}"#);
+        let payload: TestPayload = run_async(get(&url)).unwrap();
+        server.join().unwrap();
+        assert_eq!(payload.title, "Launch HN");
+    }
+
+    #[test]
+    fn get_surfaces_non_success_status() {
+        let (url, server) = serve_once("503 Service Unavailable", "");
+        let err = run_async(get::<TestPayload>(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg == "hn 503 Service Unavailable"
+        ));
+    }
+
+    #[test]
+    fn get_surfaces_json_parse_errors() {
+        let (url, server) = serve_once("200 OK", "not-json");
+        let err = run_async(get::<TestPayload>(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("hn json parse")
+        ));
+    }
+
+    #[test]
+    fn get_surfaces_request_failures() {
+        let err = run_async(get::<TestPayload>("not-a-url")).unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("hn request failed")
+        ));
+    }
+
+    fn serve_once(status: &str, body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+}


### PR DESCRIPTION
## Summary
- Add focused tests for the shared GitHub issue/PR item renderer helper (`src/fetcher/github/items.rs`)
- Cover `src/fetcher/github/recent_releases.rs` with offline tests
- Add offline tests for `github_good_first_issues`
- Fully cover the shared Hacker News HTTP client with offline tests

Workspace line coverage: 81.15% → 81.96%.

## Test plan
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for GitHub integration features including good first issues, items rendering, and recent releases.
  * Added comprehensive test suite for API client functionality with multiple error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->