### PR TITLE
test(github): cover repo_issues and repo_prs fetchers offline

### DIFF
--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -140,3 +140,209 @@ fn repo_for_key(ctx: &FetchContext) -> String {
         .or_else(|| resolve_repo(None).ok().map(|s: RepoSlug| s.as_path()))
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::time::Duration;
+
+    use super::*;
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        restore: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let lock = crate::paths::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let restore = pairs
+                .iter()
+                .map(|(key, value)| {
+                    let previous = std::env::var(key).ok();
+                    match value {
+                        Some(value) => unsafe { std::env::set_var(key, value) },
+                        None => unsafe { std::env::remove_var(key) },
+                    }
+                    (*key, previous)
+                })
+                .collect();
+            Self {
+                _lock: lock,
+                restore,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            self.restore.iter().for_each(|(key, value)| match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            });
+        }
+    }
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "repo-issues".into(),
+            format: Some("compact".into()),
+            timeout: Duration::from_secs(1),
+            file_format: None,
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            timezone: None,
+            locale: None,
+        }
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.repo.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_repo_and_limit() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nlimit = 7").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.repo.as_deref(), Some("foo/bar"));
+        assert_eq!(opts.limit, Some(7));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_metadata_and_samples_cover_supported_shapes() {
+        let fetcher = GithubRepoIssues;
+        assert_eq!(fetcher.name(), "github_repo_issues");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("pull requests filtered out"));
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.option_schemas().len(), 2);
+        assert_eq!(fetcher.option_schemas()[0].name, "repo");
+        assert_eq!(fetcher.option_schemas()[1].name, "limit");
+
+        let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
+        else {
+            panic!("expected linked text block sample");
+        };
+        assert_eq!(linked.items[0].text, "#41 meta: widget catalog & roadmap");
+        assert_eq!(
+            linked.items[1].url.as_deref(),
+            Some("https://github.com/unhappychoice/splashboard/issues/17")
+        );
+
+        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
+            panic!("expected text block sample");
+        };
+        assert_eq!(text.lines[1], "#17 theme system");
+
+        let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
+            panic!("expected entries sample");
+        };
+        assert_eq!(entries.items[0].key, "#41");
+        assert_eq!(entries.items[1].value.as_deref(), Some("theme system"));
+
+        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
+            panic!("expected timeline sample");
+        };
+        assert_eq!(timeline.events[0].title, "#41");
+        assert_eq!(timeline.events[1].detail.as_deref(), Some("theme system"));
+        assert!(fetcher.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn repo_issue_items_filter_out_pull_requests_before_rendering() {
+        let raw = r#"[
+            {
+                "title": "Keep real issues",
+                "number": 41,
+                "updated_at": "2026-04-22T10:15:30Z",
+                "html_url": "https://github.com/foo/bar/issues/41",
+                "state": "open"
+            },
+            {
+                "title": "Drop pull requests",
+                "number": 42,
+                "updated_at": "2026-04-22T11:15:30Z",
+                "html_url": "https://github.com/foo/bar/pull/42",
+                "state": "open",
+                "pull_request": {}
+            }
+        ]"#;
+        let items: Vec<RepoIssueItem> = serde_json::from_str(raw).unwrap();
+        let issues: Vec<IssueItem> = items
+            .into_iter()
+            .filter(|item| item.pull_request.is_none())
+            .map(|item| item.inner)
+            .collect();
+
+        let Body::TextBlock(text) = render_items(&issues, Shape::TextBlock, false) else {
+            panic!("expected text block");
+        };
+        assert_eq!(text.lines, vec!["#41 Keep real issues"]);
+    }
+
+    #[test]
+    fn cache_key_changes_with_repo_option() {
+        let fetcher = GithubRepoIssues;
+        let a = fetcher.cache_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries)));
+        let b = fetcher.cache_key(&ctx(Some("repo = \"foo/baz\""), Some(Shape::Entries)));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repo_for_key_prefers_explicit_repo_option() {
+        assert_eq!(
+            repo_for_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries))),
+            "foo/bar"
+        );
+    }
+
+    #[test]
+    fn repo_for_key_falls_back_to_cwd_remote_when_available() {
+        let expected = resolve_repo(None).unwrap().as_path();
+        assert_eq!(repo_for_key(&ctx(None, Some(Shape::Entries))), expected);
+    }
+
+    #[test]
+    fn fetch_rejects_invalid_repo_before_auth_lookup() {
+        let fetcher = GithubRepoIssues;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("repo = \"not-a-slug\"\nlimit = 99"),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("invalid repo option")));
+    }
+
+    #[test]
+    fn fetch_surfaces_missing_token_without_network_response() {
+        let _guard = EnvGuard::set(&[("GH_TOKEN", None), ("GITHUB_TOKEN", None)]);
+        let fetcher = GithubRepoIssues;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("repo = \"foo/bar\"\nlimit = 99"),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(
+            matches!(err, FetchError::Failed(msg) if msg.contains("GH_TOKEN / GITHUB_TOKEN not set"))
+        );
+    }
+}

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -128,3 +128,186 @@ fn repo_for_key(ctx: &FetchContext) -> String {
         .or_else(|| resolve_repo(None).ok().map(|s: RepoSlug| s.as_path()))
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::time::Duration;
+
+    use super::*;
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        restore: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let lock = crate::paths::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let restore = pairs
+                .iter()
+                .map(|(key, value)| {
+                    let previous = std::env::var(key).ok();
+                    match value {
+                        Some(value) => unsafe { std::env::set_var(key, value) },
+                        None => unsafe { std::env::remove_var(key) },
+                    }
+                    (*key, previous)
+                })
+                .collect();
+            Self {
+                _lock: lock,
+                restore,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            self.restore.iter().for_each(|(key, value)| match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            });
+        }
+    }
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "repo-prs".into(),
+            format: Some("compact".into()),
+            timeout: Duration::from_secs(1),
+            file_format: None,
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            timezone: None,
+            locale: None,
+        }
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.repo.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_repo_and_limit() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nlimit = 7").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.repo.as_deref(), Some("foo/bar"));
+        assert_eq!(opts.limit, Some(7));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("repo = \"foo/bar\"\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_metadata_and_samples_cover_supported_shapes() {
+        let fetcher = GithubRepoPrs;
+        assert_eq!(fetcher.name(), "github_repo_prs");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("target repo"));
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.option_schemas().len(), 2);
+        assert_eq!(fetcher.option_schemas()[0].name, "repo");
+        assert_eq!(fetcher.option_schemas()[1].name, "limit");
+
+        let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
+        else {
+            panic!("expected linked text block sample");
+        };
+        assert_eq!(
+            linked.items[0].text,
+            "#54 feat(docs): generate widget catalogue"
+        );
+        assert_eq!(
+            linked.items[1].url.as_deref(),
+            Some("https://github.com/unhappychoice/splashboard/pull/51")
+        );
+
+        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
+            panic!("expected text block sample");
+        };
+        assert_eq!(text.lines[1], "#51 feat(fetcher): split clock options");
+
+        let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
+            panic!("expected entries sample");
+        };
+        assert_eq!(entries.items[0].key, "#54");
+        assert_eq!(
+            entries.items[1].value.as_deref(),
+            Some("feat(fetcher): split clock options")
+        );
+
+        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
+            panic!("expected timeline sample");
+        };
+        assert_eq!(timeline.events[0].title, "#54");
+        assert_eq!(
+            timeline.events[1].detail.as_deref(),
+            Some("feat(fetcher): split clock options")
+        );
+        assert!(fetcher.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn cache_key_changes_with_repo_option() {
+        let fetcher = GithubRepoPrs;
+        let a = fetcher.cache_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries)));
+        let b = fetcher.cache_key(&ctx(Some("repo = \"foo/baz\""), Some(Shape::Entries)));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repo_for_key_prefers_explicit_repo_option() {
+        assert_eq!(
+            repo_for_key(&ctx(Some("repo = \"foo/bar\""), Some(Shape::Entries))),
+            "foo/bar"
+        );
+    }
+
+    #[test]
+    fn repo_for_key_falls_back_to_cwd_remote_when_available() {
+        let expected = resolve_repo(None).unwrap().as_path();
+        assert_eq!(repo_for_key(&ctx(None, Some(Shape::Entries))), expected);
+    }
+
+    #[test]
+    fn fetch_rejects_invalid_repo_before_auth_lookup() {
+        let fetcher = GithubRepoPrs;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("repo = \"not-a-slug\"\nlimit = 99"),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("invalid repo option")));
+    }
+
+    #[test]
+    fn fetch_surfaces_missing_token_without_network_response() {
+        let _guard = EnvGuard::set(&[("GH_TOKEN", None), ("GITHUB_TOKEN", None)]);
+        let fetcher = GithubRepoPrs;
+        let err = run_async(fetcher.fetch(&ctx(
+            Some("repo = \"foo/bar\"\nlimit = 99"),
+            Some(Shape::Entries),
+        )))
+        .unwrap_err();
+        assert!(
+            matches!(err, FetchError::Failed(msg) if msg.contains("GH_TOKEN / GITHUB_TOKEN not set"))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds offline unit tests for `src/fetcher/github/repo_issues.rs`, raising that file's line coverage from 23.73% → 95.89%.
- Adds offline unit tests for `src/fetcher/github/repo_prs.rs`.
- Net workspace line coverage: 81.80% → 82.21%.

Continues the GitHub-fetcher coverage push tracked alongside #186.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)