### PR TITLE
feat(config): add auto_home / auto_on_cd toggles to opt out of auto-display

### DIFF
--- a/docs-site/src/content/docs/guides/configuration.md
+++ b/docs-site/src/content/docs/guides/configuration.md
@@ -93,6 +93,11 @@ height = 24
 # `{ x = 2, y = 1 }` (split horizontal / vertical).
 padding = { x = 2, y = 1 }
 
+# Auto-display toggles — both default true. Set independently to mute one
+# trigger without unwiring the shell rc. See the cookbook for use cases.
+auto_home  = true   # render the home dashboard at shell startup
+auto_on_cd = true   # repaint when entering a project directory
+
 [theme]
 # Base palette — one of "default", "tokyo_night", "nord", "dracula",
 # "gruvbox_dark", "catppuccin_mocha". See the themes guide.

--- a/docs-site/src/content/docs/guides/cookbook.md
+++ b/docs-site/src/content/docs/guides/cookbook.md
@@ -130,6 +130,42 @@ To mute just the current shell:
 export SPLASHBOARD_SILENT=1
 ```
 
+### Disable the auto-display selectively
+
+Two `[general]` toggles in `settings.toml` carve up the auto-display
+behaviour without killing it entirely:
+
+```toml
+[general]
+# Skip the home dashboard at shell startup. The cd-hook still paints the
+# project splash when you enter a project directory.
+auto_home = false
+
+# Skip every cd-hook repaint. Shell startup still renders.
+auto_on_cd = false
+```
+
+Both default to `true`. Set both to `false` and `splashboard` only renders
+when you invoke it explicitly.
+
+### Remove the install line entirely
+
+For the simplest opt-out, delete the marker block that
+`splashboard install` wrote into your shell rc:
+
+```text
+# >>> splashboard >>>
+# Added by `splashboard install`. Safe to remove.
+eval "$(splashboard init zsh)"
+# <<< splashboard <<<
+```
+
+Drop those lines from `~/.zshrc` / `~/.bashrc` / `~/.config/fish/config.fish`
+and no startup or cd-hook fires. The `splashboard` binary still works on
+demand; only the auto-display is gone.
+
+### Slower paint, fresher data
+
 To trade snappiness for freshness (block the initial paint until every
 widget has fetched):
 

--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -180,8 +180,12 @@ rendering when any of these is true:
 - `TERM=dumb`.
 - Any of `CI`, `SPLASHBOARD_SILENT`, or `NO_SPLASHBOARD` is set.
 - The terminal is smaller than 40×16.
+- Source resolves to the home dashboard and `[general] auto_home = false`,
+  or the trigger is the cd-hook and `[general] auto_on_cd = false`.
 
-Unset the variable or widen the terminal and try again.
+Unset the variable or widen the terminal and try again. To opt out
+deliberately — only at the home context, only on `cd`, or entirely — see
+the [cookbook](/guides/cookbook/#opting-out).
 
 **A widget renders `🔒 requires trust`.** The widget is classified as
 `Network` and the local dashboard it came from has not been trusted yet. See

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub struct DashboardConfig {
     pub rows: Vec<RowConfig>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct General {
     #[serde(default)]
     pub wait_for_fresh: bool,
@@ -72,6 +72,33 @@ pub struct General {
     /// rendering identical strings.
     #[serde(default)]
     pub locale: Option<String>,
+    /// Render the home dashboard automatically on shell startup. Default `true`.
+    /// Set to `false` to keep `splashboard` quiet when CWD doesn't resolve to a project,
+    /// while still letting the cd-hook paint the project splash on entry.
+    #[serde(default = "default_true")]
+    pub auto_home: bool,
+    /// Run the cd-hook (`splashboard --on-cd`) when entering a project directory. Default
+    /// `true`. Set to `false` to disable per-`cd` repaints without unwiring the shell rc.
+    #[serde(default = "default_true")]
+    pub auto_on_cd: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            wait_for_fresh: false,
+            height: None,
+            padding: None,
+            timezone: None,
+            locale: None,
+            auto_home: true,
+            auto_on_cd: true,
+        }
+    }
 }
 
 /// Uniform or split padding. Short form `padding = 1` applies the same value to all sides;
@@ -659,6 +686,36 @@ preset = "nord"
         assert!(s.general.wait_for_fresh);
         assert_eq!(s.general.height, Some(24));
         assert_eq!(s.theme.preset.as_deref(), Some("nord"));
+    }
+
+    #[test]
+    fn auto_display_toggles_default_to_true() {
+        let s = SettingsConfig::default_baked();
+        assert!(s.general.auto_home);
+        assert!(s.general.auto_on_cd);
+    }
+
+    #[test]
+    fn auto_display_toggles_parse_when_false() {
+        let toml = r#"
+[general]
+auto_home = false
+auto_on_cd = false
+"#;
+        let s = SettingsConfig::parse(toml).unwrap();
+        assert!(!s.general.auto_home);
+        assert!(!s.general.auto_on_cd);
+    }
+
+    #[test]
+    fn auto_display_toggles_partial_override_keeps_other_default() {
+        let toml = r#"
+[general]
+auto_home = false
+"#;
+        let s = SettingsConfig::parse(toml).unwrap();
+        assert!(!s.general.auto_home);
+        assert!(s.general.auto_on_cd);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,9 @@ async fn render_splash(wait: bool) -> io::Result<()> {
     }
     let source = config::resolve_dashboard_source();
     let (config, ident) = load_full_config(&source)?;
+    if matches!(source, DashboardSource::Home) && !config.general.auto_home {
+        return Ok(());
+    }
     let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
     runtime::run(&config, &source, ident_ref, wait).await
 }
@@ -207,6 +210,9 @@ async fn render_for_cd(wait: bool) -> io::Result<()> {
         return Ok(());
     };
     let (config, ident) = load_full_config(&source)?;
+    if !config.general.auto_on_cd {
+        return Ok(());
+    }
     let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
     runtime::run(&config, &source, ident_ref, wait).await
 }


### PR DESCRIPTION
## Summary

- Adds `[general] auto_home` and `[general] auto_on_cd` booleans to `settings.toml`, both defaulting to `true`. `auto_home = false` keeps the shell-startup splash quiet when CWD doesn't resolve to a project; `auto_on_cd = false` skips every `--on-cd` repaint. Set both to `false` and `splashboard` only renders on explicit invocation — no need to unwire the shell rc.
- Cookbook now documents both the new toggles and the simplest workaround: delete the marker block that `splashboard install` wrote into `~/.zshrc` / `~/.bashrc` / `config.fish`.
- Configuration guide gains the two keys in the `[general]` example; troubleshooting in the getting-started guide cross-links the cookbook.

Implementation:
- `General::default()` is now hand-written (the new fields default to `true`, which `derive(Default)` can't express).
- `render_splash` exits silently when source is `Home` and `auto_home = false`; `render_for_cd` exits silently when `auto_on_cd = false`.
- 3 new config tests cover defaults, both-false, and partial override.

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Smoke: with `auto_home = false`, run `splashboard` from `$HOME` — silent
- [ ] Smoke: with `auto_on_cd = false`, run `splashboard --on-cd` from a project root — silent
- [ ] Smoke: defaults unchanged for users without the new keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `auto_home` and `auto_on_cd` configuration toggles to provide granular control over automatic dashboard rendering at startup and when changing directories. Both default to enabled to maintain backward compatibility with existing workflows.

* **Documentation**
  * Updated configuration, cookbook, and troubleshooting guides with documentation of the new toggles and instructions for disabling automatic rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->