### PR TITLE
fix(render): let animated wrappers pass inner-renderer fields through

### DIFF
--- a/src/render/animated_boot.rs
+++ b/src/render/animated_boot.rs
@@ -15,8 +15,10 @@ use crate::theme::{self, ColorKey, Theme};
 
 use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
 
+/// Lenient on unknown fields: see `animated_postfx::Options` for the rationale (the
+/// `raw` blob also carries inner-renderer keys; a strict parse would silently drop
+/// `inner`).
 #[derive(Debug, Clone, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 struct Options {
     #[serde(default)]
     pub inner: Option<String>,

--- a/src/render/animated_postfx.rs
+++ b/src/render/animated_postfx.rs
@@ -14,8 +14,11 @@ use crate::theme::Theme;
 
 use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
 
+/// Wrapper Options intentionally lenient on unknown fields: the same `raw` blob carries
+/// inner-renderer keys (e.g. `font` / `pixel_size` for text_ascii), which a strict parse
+/// would reject and silently fall back to defaults, dropping `inner` and turning a figlet
+/// hero into plain text.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 pub(super) struct Options {
     #[serde(default)]
     pub inner: Option<String>,
@@ -370,6 +373,22 @@ mod tests {
             joined.contains("unknown inner"),
             "expected inline error, got {joined:?}"
         );
+    }
+
+    #[test]
+    fn postfx_options_survive_inner_only_extras() {
+        // Regression: project_splash spec inlines `font = "ansi_shadow"` (a text_ascii field)
+        // alongside `inner` and `effect`. With deny_unknown_fields and no catch-all, the
+        // postfx Options parse failed silently, falling back to inner=None — which then
+        // resolved to text_plain instead of the intended text_ascii figlet, producing a
+        // single-line "splashboard" instead of the figlet hero.
+        let opts = RenderOptions::default()
+            .with_extra("inner", "text_ascii")
+            .with_extra("effect", "particle_burst")
+            .with_extra("font", "ansi_shadow");
+        let parsed: Options = opts.parse_specific();
+        assert_eq!(parsed.inner.as_deref(), Some("text_ascii"));
+        assert_eq!(parsed.effect.as_deref(), Some("particle_burst"));
     }
 
     #[test]

--- a/src/render/animated_scanlines.rs
+++ b/src/render/animated_scanlines.rs
@@ -14,8 +14,8 @@ use crate::theme::{self, ColorKey, Theme};
 
 use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
 
+/// Lenient on unknown fields: see `animated_postfx::Options` for the rationale.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 struct Options {
     #[serde(default)]
     pub inner: Option<String>,

--- a/src/render/animated_splitflap.rs
+++ b/src/render/animated_splitflap.rs
@@ -14,8 +14,8 @@ use crate::theme::{self, ColorKey, Theme};
 
 use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
 
+/// Lenient on unknown fields: see `animated_postfx::Options` for the rationale.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 struct Options {
     #[serde(default)]
     pub inner: Option<String>,

--- a/src/render/animated_wave.rs
+++ b/src/render/animated_wave.rs
@@ -14,8 +14,8 @@ use crate::theme::{self, ColorKey, Theme};
 
 use super::{Registry, RenderOptions, Renderer, Shape, default_renderer_for, shape_of};
 
+/// Lenient on unknown fields: see `animated_postfx::Options` for the rationale.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
 struct Options {
     #[serde(default)]
     pub inner: Option<String>,


### PR DESCRIPTION
## Summary

Fixes the `home_splash` / `project_splash` hero figlet rendering as a single line of plain text instead of an ANSI-shadow figlet (looked essentially blank).

Root cause: the wrapper Options for `animated_postfx`, `animated_boot`, `animated_scanlines`, `animated_splitflap`, and `animated_wave` had `#[serde(deny_unknown_fields)]`. Render specs route through one shared `raw` blob that carries both wrapper fields (`inner`, `effect`) and inner-renderer fields (`font`, `pixel_size`, ...). Strict-mode rejected the inner-renderer keys; `RenderOptions::parse_specific` swallows the error via `unwrap_or_default()`, so `inner` silently dropped to `None`. The wrapper then resolved its inner to `default_renderer_for(shape)` (`text_plain` for `Shape::Text`) instead of the spec's `text_ascii`, killing the figlet.

Concretely the broken templates:

```toml
render = { type = "animated_postfx", inner = "text_ascii", effect = "particle_burst", duration_ms = 1500, style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
```

The `font` key tripped strict mode and the hero rendered as `splashboard` plain text.

Fix: drop `deny_unknown_fields` on the affected wrapper Options and document why. Inner renderers keep their own strict mode so structural typos still surface where the field actually lives. Adds a regression test (`postfx_options_survive_inner_only_extras`) covering the inner + effect + inner-extras path.

## Affected templates

- `home_splash` (hero + subtitle widgets, both via `animated_postfx`)
- `project_splash` (hero, via `animated_postfx`)

Other wrappers with `inner` (`boot`, `scanlines`, `splitflap`, `wave`) had the same latent bug; fixed for consistency before another template hits it.

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New regression test fails before the fix, passes after
- [ ] Smoke: install `project_splash` and confirm the figlet hero renders as ANSI-shadow ASCII art instead of plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Render effects across multiple modules now gracefully handle configuration fields they don't recognize, preventing parsing failures.
  * Prevents loss of valid configuration settings when additional unknown fields are present.

* **Tests**
  * Added regression test validating configuration integrity during parsing with extra renderer options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->