### PR TITLE
feat(linear): add linear_issues, linear_notifications, linear_cycle fetchers

### DIFF
--- a/src/fetcher/linear/client.rs
+++ b/src/fetcher/linear/client.rs
@@ -1,0 +1,288 @@
+//! Shared GraphQL client + auth + cache-key helpers for the `linear_*` fetcher family. The
+//! base host `api.linear.app` is hardcoded so config can never redirect the personal API key
+//! to a third-party origin — that's why every fetcher in this family classifies as
+//! `Safety::Safe`.
+//!
+//! Linear authenticates personal API keys (`lin_api_*`) by sending the raw key in the
+//! `Authorization` header — without a `Bearer` prefix. OAuth tokens use `Bearer`; we don't
+//! ship an OAuth flow because splashboard's startup window has no place to host a callback.
+//!
+//! On top of the raw HTTP call there's:
+//! - a 4-permit semaphore so a future multi-widget splash doesn't fan out beyond Linear's
+//!   complexity-based rate limit;
+//! - one `Retry-After`-honoured retry on 429, capped at the request timeout so a misbehaving
+//!   header can't stall the splash.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tokio::sync::Semaphore;
+
+use crate::fetcher::FetchError;
+
+pub const API_URL: &str = "https://api.linear.app/graphql";
+pub const APP_BASE: &str = "https://linear.app";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_CONCURRENT_REQUESTS: usize = 4;
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(15);
+
+pub fn resolve_token(config_token: Option<&str>) -> Result<String, FetchError> {
+    config_token
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var("LINEAR_TOKEN")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .ok_or_else(|| {
+            FetchError::Failed("linear token missing: set options.token or LINEAR_TOKEN".into())
+        })
+}
+
+/// Stable opaque scope string for a token. Mirrors the deariary helper: 16 hex chars of
+/// SHA-256, used to namespace disk cache keys so account A's cached payloads can't be served
+/// to account B's widget.
+pub fn token_scope(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    let mut s = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        use std::fmt::Write;
+        let _ = write!(s, "{byte:02x}");
+    }
+    s
+}
+
+/// Cache-key `extra` partition for the linear family. Resolves the token via the same
+/// precedence as `fetch` (config option > `LINEAR_TOKEN` env), then prefixes the
+/// (token-stripped) options blob with the scoped token hash so two users sharing a
+/// `$HOME/.splashboard/cache` directory can't observe each other's payloads.
+pub fn cache_extra(opts_token: Option<&str>, raw_opts: Option<&toml::Value>) -> String {
+    let resolved = resolve_token(opts_token).unwrap_or_default();
+    let opts_str = raw_opts
+        .map(strip_token_field)
+        .and_then(|v| toml::to_string(&v).ok())
+        .unwrap_or_default();
+    format!("{}|{}", token_scope(&resolved), opts_str)
+}
+
+fn strip_token_field(value: &toml::Value) -> toml::Value {
+    match value {
+        toml::Value::Table(table) => {
+            let mut copy = table.clone();
+            copy.remove("token");
+            toml::Value::Table(copy)
+        }
+        other => other.clone(),
+    }
+}
+
+pub fn issue_url(workspace: &str, identifier: &str) -> String {
+    format!("{APP_BASE}/{workspace}/issue/{identifier}")
+}
+
+pub fn cycle_url(workspace: &str, team_key: &str, cycle_number: i64) -> String {
+    format!("{APP_BASE}/{workspace}/team/{team_key}/cycle/{cycle_number}")
+}
+
+/// Issue a GraphQL query and deserialize `data` into `T`. Returns [`FetchError::Failed`] on
+/// network / HTTP / parse / GraphQL errors.
+pub async fn graphql_query<T: DeserializeOwned>(
+    token: &str,
+    query: &str,
+    variables: Value,
+) -> Result<T, FetchError> {
+    let _permit = acquire_permit().await?;
+    let body = json!({ "query": query, "variables": variables });
+    let bytes = send_with_retry(token, &body).await?;
+    let envelope: GraphqlResponse<T> = serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("linear json parse: {e}")))?;
+    if let Some(errors) = envelope.errors.filter(|e| !e.is_empty()) {
+        let msg = errors
+            .into_iter()
+            .map(|e| e.message)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(FetchError::Failed(format!("linear graphql: {msg}")));
+    }
+    envelope
+        .data
+        .ok_or_else(|| FetchError::Failed("linear graphql: empty data".into()))
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlResponse<T> {
+    #[serde(default = "Option::default")]
+    data: Option<T>,
+    #[serde(default)]
+    errors: Option<Vec<GraphqlError>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
+}
+
+async fn send_with_retry(token: &str, body: &Value) -> Result<Vec<u8>, FetchError> {
+    let mut attempt = 0u8;
+    loop {
+        let res = http()
+            .post(API_URL)
+            .header("Authorization", token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| FetchError::Failed(format!("linear request failed: {e}")))?;
+        let status = res.status();
+        if status == StatusCode::TOO_MANY_REQUESTS && attempt == 0 {
+            let wait = parse_retry_after(res.headers()).min(RETRY_AFTER_CAP);
+            tracing::warn!(retry_after_s = wait.as_secs(), "linear 429: backing off");
+            tokio::time::sleep(wait).await;
+            attempt += 1;
+            continue;
+        }
+        let bytes = res
+            .bytes()
+            .await
+            .map_err(|e| FetchError::Failed(format!("linear response body: {e}")))?;
+        if !status.is_success() {
+            return Err(FetchError::Failed(error_message(status, &bytes)));
+        }
+        return Ok(bytes.to_vec());
+    }
+}
+
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Duration {
+    headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(1))
+}
+
+fn error_message(status: StatusCode, body: &[u8]) -> String {
+    if let Ok(envelope) = serde_json::from_slice::<GraphqlResponse<Value>>(body)
+        && let Some(errors) = envelope.errors.filter(|e| !e.is_empty())
+    {
+        let msg = errors
+            .into_iter()
+            .map(|e| e.message)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return format!("linear {status}: {msg}");
+    }
+    format!("linear {status}")
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+fn semaphore() -> &'static Semaphore {
+    static S: OnceLock<Semaphore> = OnceLock::new();
+    S.get_or_init(|| Semaphore::new(MAX_CONCURRENT_REQUESTS))
+}
+
+async fn acquire_permit() -> Result<tokio::sync::SemaphorePermit<'static>, FetchError> {
+    semaphore()
+        .acquire()
+        .await
+        .map_err(|e| FetchError::Failed(format!("linear semaphore poisoned: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_token_prefers_config_value() {
+        let token = resolve_token(Some("from-config")).unwrap();
+        assert_eq!(token, "from-config");
+    }
+
+    #[test]
+    fn resolve_token_trims_whitespace() {
+        let token = resolve_token(Some("  abc  ")).unwrap();
+        assert_eq!(token, "abc");
+    }
+
+    #[test]
+    fn resolve_token_rejects_empty_config_value() {
+        let result = resolve_token(Some("   "));
+        if let Ok(t) = result {
+            assert!(!t.trim().is_empty());
+        }
+    }
+
+    #[test]
+    fn token_scope_is_deterministic_and_obscures_token() {
+        let a = token_scope("lin_api_x");
+        let b = token_scope("lin_api_x");
+        assert_eq!(a, b);
+        assert_ne!(token_scope("lin_api_x"), token_scope("lin_api_y"));
+        assert_eq!(a.len(), 16);
+        assert!(!a.contains("lin_api_x"));
+    }
+
+    #[test]
+    fn cache_extra_partitions_per_token() {
+        let a = cache_extra(Some("tok-A"), None);
+        let b = cache_extra(Some("tok-B"), None);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_extra_strips_token_from_options_blob() {
+        let opts: toml::Value =
+            toml::from_str("token = \"super-secret\"\nfilter_team = \"ENG\"").unwrap();
+        let extra = cache_extra(Some("super-secret"), Some(&opts));
+        assert!(!extra.contains("super-secret"), "got: {extra:?}");
+        assert!(extra.contains("filter_team = \"ENG\""), "got: {extra:?}");
+    }
+
+    #[test]
+    fn issue_url_uses_workspace_and_identifier() {
+        assert_eq!(
+            issue_url("acme", "ENG-123"),
+            "https://linear.app/acme/issue/ENG-123"
+        );
+    }
+
+    #[test]
+    fn cycle_url_uses_team_key_and_cycle_number() {
+        assert_eq!(
+            cycle_url("acme", "ENG", 24),
+            "https://linear.app/acme/team/ENG/cycle/24"
+        );
+    }
+
+    #[test]
+    fn error_message_extracts_graphql_messages() {
+        let body = br#"{"errors":[{"message":"Authentication required"}]}"#;
+        let msg = error_message(StatusCode::UNAUTHORIZED, body);
+        assert!(msg.contains("Authentication required"));
+    }
+
+    #[test]
+    fn error_message_falls_back_to_status_when_no_graphql_payload() {
+        let msg = error_message(StatusCode::BAD_GATEWAY, b"upstream gone");
+        assert!(msg.contains("502"));
+    }
+}

--- a/src/fetcher/linear/cycle.rs
+++ b/src/fetcher/linear/cycle.rs
@@ -1,0 +1,717 @@
+//! `linear_cycle` — current sprint progress for a Linear team.
+//!
+//! Safety::Safe: every request targets `api.linear.app` (fixed in [`super::client`]).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Datelike, NaiveDate, Utc};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, NumberSeriesData, Payload, RatioData, Status,
+    TextBlockData, TextData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{cycle_url, graphql_query, resolve_token};
+
+const SHAPES: &[Shape] = &[
+    Shape::Ratio,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::Entries,
+    Shape::NumberSeries,
+    Shape::Bars,
+    Shape::Calendar,
+    Shape::Badge,
+];
+
+const QUERY: &str = r#"
+query Cycle($filter: CycleFilter) {
+  viewer { organization { urlKey } }
+  cycles(filter: $filter, first: 1) {
+    nodes {
+      number
+      name
+      startsAt
+      endsAt
+      progress
+      completedIssueCountHistory
+      issueCountHistory
+      team { key name }
+      issues(first: 200) {
+        nodes {
+          identifier
+          title
+          state { name type }
+          dueDate
+          url
+        }
+      }
+    }
+  }
+}
+"#;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "token",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Linear personal API key (`lin_api_*`). Falls back to `LINEAR_TOKEN` env.",
+    },
+    OptionSchema {
+        name: "workspace",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Workspace slug for `LinkedTextBlock` URLs. Defaults to viewer's organization urlKey.",
+    },
+    OptionSchema {
+        name: "team",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Team key (e.g. `\"ENG\"`). When omitted, the first active cycle the viewer can see is used.",
+    },
+    OptionSchema {
+        name: "cycle",
+        type_hint: "\"current\" | \"next\" | \"previous\" | integer",
+        required: false,
+        default: Some("\"current\""),
+        description: "Cycle to surface.",
+    },
+];
+
+pub struct LinearCycle;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    workspace: Option<String>,
+    #[serde(default)]
+    team: Option<String>,
+    #[serde(default)]
+    cycle: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    viewer: ApiViewer,
+    cycles: ApiConnection<ApiCycle>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiViewer {
+    organization: ApiOrganization,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiOrganization {
+    #[serde(rename = "urlKey")]
+    url_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiConnection<T> {
+    nodes: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiCycle {
+    number: i64,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(rename = "startsAt")]
+    starts_at: String,
+    #[serde(rename = "endsAt")]
+    ends_at: String,
+    #[serde(default)]
+    progress: Option<f64>,
+    #[serde(rename = "completedIssueCountHistory", default)]
+    completed_history: Vec<f64>,
+    #[serde(rename = "issueCountHistory", default)]
+    total_history: Vec<f64>,
+    #[serde(default)]
+    team: Option<ApiTeam>,
+    #[serde(default)]
+    issues: Option<ApiConnection<ApiIssue>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiTeam {
+    key: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiIssue {
+    identifier: String,
+    title: String,
+    state: ApiState,
+    #[serde(rename = "dueDate", default)]
+    due_date: Option<String>,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiState {
+    name: String,
+    #[serde(rename = "type")]
+    state_type: String,
+}
+
+#[derive(Debug)]
+struct CycleView {
+    number: i64,
+    name: String,
+    starts_at: NaiveDate,
+    ends_at: NaiveDate,
+    progress: f64,
+    completed_count: u64,
+    total_count: u64,
+    completed_history: Vec<u64>,
+    team_key: String,
+    team_name: String,
+    workspace: String,
+    issues: Vec<IssueView>,
+}
+
+#[derive(Debug)]
+struct IssueView {
+    identifier: String,
+    title: String,
+    state_name: String,
+    state_type: String,
+    due_date: Option<NaiveDate>,
+    url: String,
+}
+
+#[async_trait]
+impl Fetcher for LinearCycle {
+    fn name(&self) -> &str {
+        "linear_cycle"
+    }
+
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+
+    fn description(&self) -> &'static str {
+        "Linear cycle (sprint) progress — completed/total issues, days remaining, burndown sparkline. `Ratio` is the headline (completion fraction); `NumberSeries` carries the daily completed-count history; `Bars` breaks down issue states; `Calendar` highlights cycle days + issue due dates; `Badge` summarises on-track vs at-risk vs behind."
+    }
+
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+
+    fn default_shape(&self) -> Shape {
+        Shape::Ratio
+    }
+
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        super::cache_key("linear_cycle", ctx)
+    }
+
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Ratio => Body::Ratio(RatioData {
+                value: 0.42,
+                label: Some("Cycle 24".into()),
+                denominator: Some(40),
+            }),
+            Shape::Text => samples::text("Cycle 24 — 17/40 · 5d left"),
+            Shape::TextBlock => samples::text_block(&[
+                "Cycle 24",
+                "started 2026-04-22",
+                "ends 2026-05-06",
+                "completed 17/40",
+                "5 days left",
+            ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "**Cycle 24**\n\n- started **2026-04-22**\n- ends **2026-05-06**\n- completed **17/40**\n- **5** days left",
+            ),
+            Shape::LinkedTextBlock => samples::linked_text_block(&[(
+                "Cycle 24 — 17/40 · 5d left",
+                Some("https://linear.app/acme/team/ENG/cycle/24"),
+            )]),
+            Shape::Entries => samples::entries(&[
+                ("Cycle", "24"),
+                ("Started", "2026-04-22"),
+                ("Ends", "2026-05-06"),
+                ("Completed", "17 / 40"),
+                ("Days left", "5"),
+            ]),
+            Shape::NumberSeries => samples::number_series(&[0, 1, 3, 5, 7, 10, 12, 15, 17]),
+            Shape::Bars => samples::bars(&[
+                ("Completed", 17),
+                ("In Progress", 8),
+                ("Todo", 12),
+                ("Canceled", 3),
+            ]),
+            Shape::Calendar => samples::calendar(2026, 4, Some(29), &[22, 23, 24, 28, 29, 30]),
+            Shape::Badge => samples::badge(Status::Warn, "Cycle 24 at risk"),
+            _ => return None,
+        })
+    }
+
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref())?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let filter = build_filter(&opts);
+        let response: ApiResponse =
+            graphql_query(&token, QUERY, json!({ "filter": filter })).await?;
+        let cycle =
+            response.cycles.nodes.into_iter().next().ok_or_else(|| {
+                FetchError::Failed("linear cycle: no cycle matched filter".into())
+            })?;
+        let workspace = opts
+            .workspace
+            .filter(|s| !s.is_empty())
+            .unwrap_or(response.viewer.organization.url_key);
+        let view = to_view(cycle, workspace)?;
+        let shape = ctx.shape.unwrap_or(Shape::Ratio);
+        Ok(payload(render_body(&view, shape)))
+    }
+}
+
+pub fn fetcher() -> Arc<dyn Fetcher> {
+    Arc::new(LinearCycle)
+}
+
+fn parse_options(raw: Option<&toml::Value>) -> Result<Options, FetchError> {
+    raw.map(|v| {
+        v.clone()
+            .try_into::<Options>()
+            .map_err(|e| FetchError::Failed(format!("invalid options: {e}")))
+    })
+    .unwrap_or_else(|| Ok(Options::default()))
+}
+
+fn build_filter(opts: &Options) -> Value {
+    let cycle = opts
+        .cycle
+        .as_deref()
+        .unwrap_or("current")
+        .trim()
+        .to_lowercase();
+    let mut map = serde_json::Map::new();
+    if let Some(team) = opts.team.as_deref().filter(|s| !s.is_empty()) {
+        map.insert("team".into(), json!({ "key": { "eq": team } }));
+    }
+    match cycle.as_str() {
+        "next" => {
+            map.insert("isNext".into(), json!({ "eq": true }));
+        }
+        "previous" | "prev" => {
+            map.insert("isPrevious".into(), json!({ "eq": true }));
+        }
+        s => match s.parse::<i64>() {
+            Ok(n) => {
+                map.insert("number".into(), json!({ "eq": n }));
+            }
+            Err(_) => {
+                map.insert("isActive".into(), json!({ "eq": true }));
+            }
+        },
+    }
+    Value::Object(map)
+}
+
+fn to_view(api: ApiCycle, workspace: String) -> Result<CycleView, FetchError> {
+    let starts_at = parse_date(&api.starts_at)?;
+    let ends_at = parse_date(&api.ends_at)?;
+    let team = api
+        .team
+        .ok_or_else(|| FetchError::Failed("linear cycle: missing team".into()))?;
+    let issues: Vec<IssueView> = api
+        .issues
+        .map(|c| c.nodes.into_iter().map(to_issue_view).collect())
+        .unwrap_or_default();
+    let total_count = api
+        .total_history
+        .last()
+        .copied()
+        .map(|x| x.round().max(0.0) as u64)
+        .unwrap_or_else(|| issues.len() as u64);
+    let completed_count = api
+        .completed_history
+        .last()
+        .copied()
+        .map(|x| x.round().max(0.0) as u64)
+        .unwrap_or_else(|| {
+            issues
+                .iter()
+                .filter(|i| i.state_type == "completed")
+                .count() as u64
+        });
+    let progress = api.progress.unwrap_or_else(|| {
+        if total_count == 0 {
+            0.0
+        } else {
+            completed_count as f64 / total_count as f64
+        }
+    });
+    Ok(CycleView {
+        number: api.number,
+        name: api
+            .name
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| format!("Cycle {}", api.number)),
+        starts_at,
+        ends_at,
+        progress: progress.clamp(0.0, 1.0),
+        completed_count,
+        total_count,
+        completed_history: api
+            .completed_history
+            .into_iter()
+            .map(|x| x.round().max(0.0) as u64)
+            .collect(),
+        team_key: team.key,
+        team_name: team.name,
+        workspace,
+        issues,
+    })
+}
+
+fn to_issue_view(api: ApiIssue) -> IssueView {
+    IssueView {
+        identifier: api.identifier,
+        title: api.title,
+        state_name: api.state.name,
+        state_type: api.state.state_type,
+        due_date: api
+            .due_date
+            .as_deref()
+            .and_then(|d| NaiveDate::parse_from_str(d, "%Y-%m-%d").ok()),
+        url: api.url,
+    }
+}
+
+fn parse_date(raw: &str) -> Result<NaiveDate, FetchError> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc).date_naive())
+        .or_else(|_| NaiveDate::parse_from_str(raw, "%Y-%m-%d"))
+        .map_err(|e| FetchError::Failed(format!("linear cycle date parse: {e}")))
+}
+
+fn days_left(view: &CycleView, today: NaiveDate) -> i64 {
+    (view.ends_at - today).num_days().max(0)
+}
+
+fn render_body(view: &CycleView, shape: Shape) -> Body {
+    let today = Utc::now().date_naive();
+    let left = days_left(view, today);
+    match shape {
+        Shape::Ratio => Body::Ratio(RatioData {
+            value: view.progress,
+            label: Some(view.name.clone()),
+            denominator: Some(view.total_count),
+        }),
+        Shape::Text => Body::Text(TextData {
+            value: format!(
+                "{} — {}/{} · {}d left",
+                view.name, view.completed_count, view.total_count, left
+            ),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: vec![
+                view.name.clone(),
+                format!("started {}", view.starts_at),
+                format!("ends {}", view.ends_at),
+                format!("completed {}/{}", view.completed_count, view.total_count),
+                format!("{} days left", left),
+            ],
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: format!(
+                "**{}**\n\n- started **{}**\n- ends **{}**\n- completed **{}/{}**\n- **{}** days left",
+                view.name,
+                view.starts_at,
+                view.ends_at,
+                view.completed_count,
+                view.total_count,
+                left,
+            ),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: vec![LinkedLine {
+                text: format!(
+                    "{} — {}/{} · {}d left",
+                    view.name, view.completed_count, view.total_count, left
+                ),
+                url: Some(cycle_url(&view.workspace, &view.team_key, view.number)),
+            }],
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                Entry {
+                    key: "Cycle".into(),
+                    value: Some(view.number.to_string()),
+                    status: None,
+                },
+                Entry {
+                    key: "Team".into(),
+                    value: Some(view.team_name.clone()),
+                    status: None,
+                },
+                Entry {
+                    key: "Started".into(),
+                    value: Some(view.starts_at.to_string()),
+                    status: None,
+                },
+                Entry {
+                    key: "Ends".into(),
+                    value: Some(view.ends_at.to_string()),
+                    status: None,
+                },
+                Entry {
+                    key: "Completed".into(),
+                    value: Some(format!("{} / {}", view.completed_count, view.total_count)),
+                    status: Some(progress_status(view, today)),
+                },
+                Entry {
+                    key: "Days left".into(),
+                    value: Some(left.to_string()),
+                    status: None,
+                },
+            ],
+        }),
+        Shape::NumberSeries => Body::NumberSeries(NumberSeriesData {
+            values: view.completed_history.clone(),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: state_breakdown(view),
+        }),
+        Shape::Calendar => calendar_body(view, today),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: progress_status(view, today),
+            label: format!("{} {}", view.name, badge_label(view, today)),
+        }),
+        _ => Body::Text(TextData {
+            value: view.name.clone(),
+        }),
+    }
+}
+
+fn state_breakdown(view: &CycleView) -> Vec<Bar> {
+    let mut counts: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    for issue in &view.issues {
+        *counts.entry(issue.state_name.clone()).or_insert(0) += 1;
+    }
+    let mut bars: Vec<Bar> = counts
+        .into_iter()
+        .map(|(label, value)| Bar { label, value })
+        .collect();
+    bars.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.label.cmp(&b.label)));
+    bars
+}
+
+fn calendar_body(view: &CycleView, today: NaiveDate) -> Body {
+    let anchor = if today < view.starts_at {
+        view.starts_at
+    } else if today > view.ends_at {
+        view.ends_at
+    } else {
+        today
+    };
+    let mut events: Vec<u8> = (0..)
+        .map(|i| view.starts_at + chrono::Duration::days(i))
+        .take_while(|d| *d <= view.ends_at)
+        .filter(|d| d.year() == anchor.year() && d.month() == anchor.month())
+        .map(|d| d.day() as u8)
+        .collect();
+    for issue in &view.issues {
+        if let Some(d) = issue.due_date
+            && d.year() == anchor.year()
+            && d.month() == anchor.month()
+            && !events.contains(&(d.day() as u8))
+        {
+            events.push(d.day() as u8);
+        }
+    }
+    events.sort();
+    Body::Calendar(CalendarData {
+        year: anchor.year(),
+        month: anchor.month() as u8,
+        day: Some(today.day() as u8),
+        events,
+    })
+}
+
+fn progress_status(view: &CycleView, today: NaiveDate) -> Status {
+    if view.progress >= 1.0 {
+        return Status::Ok;
+    }
+    let total_days = (view.ends_at - view.starts_at).num_days().max(1) as f64;
+    let elapsed = (today - view.starts_at)
+        .num_days()
+        .clamp(0, total_days as i64) as f64;
+    let elapsed_ratio = elapsed / total_days;
+    let gap = elapsed_ratio - view.progress;
+    if gap > 0.20 {
+        Status::Error
+    } else if gap > 0.05 {
+        Status::Warn
+    } else {
+        Status::Ok
+    }
+}
+
+fn badge_label(view: &CycleView, today: NaiveDate) -> &'static str {
+    if view.progress >= 1.0 {
+        "done"
+    } else {
+        match progress_status(view, today) {
+            Status::Ok => "on track",
+            Status::Warn => "at risk",
+            Status::Error => "behind",
+        }
+    }
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(raw: &str) -> Options {
+        let value: toml::Value = toml::from_str(raw).unwrap();
+        parse_options(Some(&value)).unwrap()
+    }
+
+    #[test]
+    fn build_filter_defaults_to_active_cycle() {
+        let f = build_filter(&Options::default());
+        assert_eq!(f["isActive"]["eq"], json!(true));
+    }
+
+    #[test]
+    fn build_filter_with_team_includes_team_clause() {
+        let f = build_filter(&options("team = \"ENG\""));
+        assert_eq!(f["team"]["key"]["eq"], json!("ENG"));
+        assert_eq!(f["isActive"]["eq"], json!(true));
+    }
+
+    #[test]
+    fn build_filter_next_uses_is_next() {
+        let f = build_filter(&options("cycle = \"next\""));
+        assert_eq!(f["isNext"]["eq"], json!(true));
+        assert!(f.get("isActive").is_none());
+    }
+
+    #[test]
+    fn build_filter_specific_number_uses_number_eq() {
+        let f = build_filter(&options("cycle = \"24\""));
+        assert_eq!(f["number"]["eq"], json!(24));
+    }
+
+    #[test]
+    fn render_ratio_carries_progress_and_denominator() {
+        let view = view_for_test(0.5, 5, 10);
+        let body = render_body(&view, Shape::Ratio);
+        let Body::Ratio(r) = body else {
+            panic!("expected ratio");
+        };
+        assert!((r.value - 0.5).abs() < 1e-9);
+        assert_eq!(r.denominator, Some(10));
+    }
+
+    #[test]
+    fn progress_status_done_when_progress_full() {
+        let view = view_for_test(1.0, 10, 10);
+        let today = view.starts_at + chrono::Duration::days(3);
+        assert_eq!(progress_status(&view, today), Status::Ok);
+    }
+
+    #[test]
+    fn progress_status_behind_when_elapsed_far_ahead_of_progress() {
+        let view = view_for_test(0.10, 1, 10);
+        // 70% elapsed, 10% complete → 60% gap → behind.
+        let today = view.starts_at + chrono::Duration::days(7);
+        assert_eq!(progress_status(&view, today), Status::Error);
+    }
+
+    #[test]
+    fn progress_status_at_risk_when_slightly_behind() {
+        let view = view_for_test(0.40, 4, 10);
+        // 14-day cycle: 7 days in = 50% elapsed; with 40% complete the gap is 10% → at risk.
+        let today = view.starts_at + chrono::Duration::days(7);
+        assert_eq!(progress_status(&view, today), Status::Warn);
+    }
+
+    #[test]
+    fn render_text_includes_name_and_progress_counts() {
+        let view = view_for_test(0.4, 4, 10);
+        let body = render_body(&view, Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("Cycle 24"));
+        assert!(t.value.contains("4/10"));
+    }
+
+    #[test]
+    fn render_linked_block_uses_cycle_url() {
+        let view = view_for_test(0.4, 4, 10);
+        let body = render_body(&view, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked");
+        };
+        let url = b.items[0].url.as_deref().unwrap();
+        assert!(url.contains("/team/ENG/cycle/24"), "got: {url}");
+    }
+
+    #[test]
+    fn render_number_series_uses_completed_history() {
+        let mut view = view_for_test(0.4, 4, 10);
+        view.completed_history = vec![0, 1, 3, 4];
+        let body = render_body(&view, Shape::NumberSeries);
+        let Body::NumberSeries(n) = body else {
+            panic!("expected number_series");
+        };
+        assert_eq!(n.values, vec![0, 1, 3, 4]);
+    }
+
+    fn view_for_test(progress: f64, completed: u64, total: u64) -> CycleView {
+        CycleView {
+            number: 24,
+            name: "Cycle 24".into(),
+            starts_at: NaiveDate::from_ymd_opt(2026, 4, 22).unwrap(),
+            ends_at: NaiveDate::from_ymd_opt(2026, 5, 6).unwrap(),
+            progress,
+            completed_count: completed,
+            total_count: total,
+            completed_history: vec![],
+            team_key: "ENG".into(),
+            team_name: "Engineering".into(),
+            workspace: "acme".into(),
+            issues: vec![],
+        }
+    }
+}

--- a/src/fetcher/linear/cycle.rs
+++ b/src/fetcher/linear/cycle.rs
@@ -714,4 +714,147 @@ mod tests {
             issues: vec![],
         }
     }
+
+    fn issue_for_test(id: &str, state: &str, due: Option<NaiveDate>) -> IssueView {
+        IssueView {
+            identifier: id.into(),
+            title: format!("Title {id}"),
+            state_name: state.into(),
+            state_type: state.to_lowercase(),
+            due_date: due,
+            url: format!("https://linear.app/acme/issue/{id}"),
+        }
+    }
+
+    #[test]
+    fn build_filter_previous_uses_is_previous() {
+        let f = build_filter(&options("cycle = \"previous\""));
+        assert_eq!(f["isPrevious"]["eq"], json!(true));
+        assert!(f.get("isActive").is_none());
+    }
+
+    #[test]
+    fn build_filter_unrecognised_keyword_falls_back_to_active() {
+        let f = build_filter(&options("cycle = \"garbage\""));
+        assert_eq!(f["isActive"]["eq"], json!(true));
+    }
+
+    #[test]
+    fn render_text_block_lists_dates_and_days_left() {
+        let view = view_for_test(0.4, 4, 10);
+        let body = render_body(&view, Shape::TextBlock);
+        let Body::TextBlock(b) = body else {
+            panic!("expected text_block");
+        };
+        let joined = b.lines.join("\n");
+        assert!(joined.contains(&view.starts_at.to_string()));
+        assert!(joined.contains(&view.ends_at.to_string()));
+        assert!(joined.contains("4/10"));
+    }
+
+    #[test]
+    fn render_markdown_uses_bold_for_name_and_dates() {
+        let view = view_for_test(0.4, 4, 10);
+        let body = render_body(&view, Shape::MarkdownTextBlock);
+        let Body::MarkdownTextBlock(b) = body else {
+            panic!("expected markdown");
+        };
+        assert!(b.value.contains("**Cycle 24**"));
+        assert!(b.value.contains("**4/10**"));
+    }
+
+    #[test]
+    fn render_entries_returns_six_canonical_rows() {
+        let view = view_for_test(0.4, 4, 10);
+        let body = render_body(&view, Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec!["Cycle", "Team", "Started", "Ends", "Completed", "Days left"]
+        );
+    }
+
+    #[test]
+    fn render_bars_groups_issues_by_state_name() {
+        let mut view = view_for_test(0.4, 2, 4);
+        view.issues = vec![
+            issue_for_test("ENG-1", "Started", None),
+            issue_for_test("ENG-2", "Todo", None),
+            issue_for_test("ENG-3", "Todo", None),
+            issue_for_test("ENG-4", "Completed", None),
+        ];
+        let body = render_body(&view, Shape::Bars);
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        let todo = b.bars.iter().find(|x| x.label == "Todo").unwrap();
+        assert_eq!(todo.value, 2);
+    }
+
+    #[test]
+    fn calendar_includes_cycle_days_within_anchor_month() {
+        let view = view_for_test(0.4, 4, 10);
+        let body = render_body(&view, Shape::Calendar);
+        let Body::Calendar(c) = body else {
+            panic!("expected calendar");
+        };
+        // The cycle spans 4-22 → 5-6 (14 days). The anchor is whatever month `today` is in,
+        // clamped into the cycle range — for tests we just check the events are non-empty
+        // and lie within the cycle's date range.
+        assert!(!c.events.is_empty());
+        for day in &c.events {
+            assert!((1..=31).contains(day));
+        }
+    }
+
+    #[test]
+    fn calendar_anchor_clamps_to_cycle_end_when_today_is_after() {
+        let mut view = view_for_test(1.0, 10, 10);
+        view.starts_at = NaiveDate::from_ymd_opt(2020, 1, 5).unwrap();
+        view.ends_at = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
+        // `today` (the current process date) is far after Jan 2020; the anchor should clamp
+        // to the cycle end → January 2020, with all 11 cycle days populated.
+        let body = render_body(&view, Shape::Calendar);
+        let Body::Calendar(c) = body else {
+            panic!("expected calendar");
+        };
+        assert_eq!(c.year, 2020);
+        assert_eq!(c.month, 1);
+        for day in 5u8..=15 {
+            assert!(c.events.contains(&day), "missing day {day}");
+        }
+    }
+
+    #[test]
+    fn render_badge_label_reflects_progress_status() {
+        let mut view = view_for_test(0.10, 1, 10);
+        view.starts_at = NaiveDate::from_ymd_opt(2026, 4, 22).unwrap();
+        view.ends_at = NaiveDate::from_ymd_opt(2026, 5, 6).unwrap();
+        let body = render_body(&view, Shape::Badge);
+        let Body::Badge(b) = body else {
+            panic!("expected badge");
+        };
+        // We can't pin the today-relative label deterministically, but the static result of
+        // calling badge_label / progress_status with today=ends_at gives "behind" for this
+        // view (10% done, 100% elapsed → gap 0.90).
+        let label = badge_label(&view, view.ends_at);
+        assert!(["behind", "at risk", "on track", "done"].contains(&label));
+        assert!(b.label.contains("Cycle 24"));
+    }
+
+    #[test]
+    fn badge_label_done_when_progress_full() {
+        let view = view_for_test(1.0, 10, 10);
+        assert_eq!(badge_label(&view, view.starts_at), "done");
+    }
+
+    #[test]
+    fn days_left_clamps_to_zero_when_cycle_has_ended() {
+        let view = view_for_test(1.0, 10, 10);
+        let after = view.ends_at + chrono::Duration::days(7);
+        assert_eq!(days_left(&view, after), 0);
+    }
 }

--- a/src/fetcher/linear/issues.rs
+++ b/src/fetcher/linear/issues.rs
@@ -1,0 +1,810 @@
+//! `linear_issues` — Linear issues snapshot with structured filters.
+//!
+//! Safety::Safe: every request targets `api.linear.app` (fixed in [`super::client`]).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{Datelike, NaiveDate};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, Payload, Status, TextBlockData, TextData,
+    TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+use crate::samples;
+use crate::time as t;
+
+use super::client::{graphql_query, resolve_token};
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Calendar,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const DEFAULT_LIMIT: usize = 10;
+const MAX_LIMIT: usize = 100;
+
+const QUERY: &str = r#"
+query Issues($filter: IssueFilter, $first: Int) {
+  issues(filter: $filter, first: $first, orderBy: updatedAt) {
+    nodes {
+      identifier
+      title
+      priority
+      priorityLabel
+      state { name type }
+      assignee { displayName email }
+      team { key name }
+      project { name }
+      labels { nodes { name } }
+      dueDate
+      url
+      updatedAt
+    }
+  }
+}
+"#;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "token",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Linear personal API key (`lin_api_*`). Falls back to `LINEAR_TOKEN` env.",
+    },
+    OptionSchema {
+        name: "filter_status",
+        type_hint: "\"open\" | \"unstarted\" | \"started\" | \"completed\" | \"canceled\" | \"triage\" | \"backlog\"",
+        required: false,
+        default: Some("\"open\""),
+        description: "Workflow state filter. `open` excludes completed and canceled.",
+    },
+    OptionSchema {
+        name: "filter_assignee",
+        type_hint: "\"me\" | \"unassigned\" | email | \"any\"",
+        required: false,
+        default: Some("\"me\""),
+        description: "Assignee scope.",
+    },
+    OptionSchema {
+        name: "filter_team",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Team key (e.g. `\"ENG\"`).",
+    },
+    OptionSchema {
+        name: "filter_project",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Project name match.",
+    },
+    OptionSchema {
+        name: "filter_priority",
+        type_hint: "\"urgent\" | \"high\" | \"medium\" | \"low\" | \"none\"",
+        required: false,
+        default: None,
+        description: "Priority filter.",
+    },
+    OptionSchema {
+        name: "filter_due",
+        type_hint: "\"overdue\" | \"today\" | \"this_week\" | \"no_due\" | \"any\"",
+        required: false,
+        default: Some("\"any\""),
+        description: "Due-date window.",
+    },
+    OptionSchema {
+        name: "filter_label",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Label name match.",
+    },
+    OptionSchema {
+        name: "group_by",
+        type_hint: "\"priority\" | \"status\" | \"team\" | \"assignee\" | \"project\"",
+        required: false,
+        default: Some("\"priority\""),
+        description: "Bars grouping. Ignored by other shapes.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=100)",
+        required: false,
+        default: Some("10"),
+        description: "Max rows for list-shaped renderers.",
+    },
+];
+
+pub struct LinearIssues;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    filter_status: Option<String>,
+    #[serde(default)]
+    filter_assignee: Option<String>,
+    #[serde(default)]
+    filter_team: Option<String>,
+    #[serde(default)]
+    filter_project: Option<String>,
+    #[serde(default)]
+    filter_priority: Option<String>,
+    #[serde(default)]
+    filter_due: Option<String>,
+    #[serde(default)]
+    filter_label: Option<String>,
+    #[serde(default)]
+    group_by: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    issues: ApiConnection<ApiIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiConnection<T> {
+    nodes: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiIssue {
+    identifier: String,
+    title: String,
+    priority: f32,
+    #[serde(rename = "priorityLabel")]
+    priority_label: Option<String>,
+    state: ApiState,
+    #[serde(default)]
+    assignee: Option<ApiUser>,
+    #[serde(default)]
+    team: Option<ApiTeam>,
+    #[serde(default)]
+    project: Option<ApiProject>,
+    #[serde(default)]
+    labels: Option<ApiConnection<ApiLabel>>,
+    #[serde(rename = "dueDate", default)]
+    due_date: Option<String>,
+    url: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiState {
+    name: String,
+    #[serde(rename = "type")]
+    state_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiUser {
+    #[serde(rename = "displayName", default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiTeam {
+    key: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiProject {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiLabel {
+    name: String,
+}
+
+#[derive(Debug)]
+struct IssueView {
+    identifier: String,
+    title: String,
+    priority: u8,
+    priority_label: String,
+    state_name: String,
+    state_type: String,
+    assignee: Option<String>,
+    team_name: Option<String>,
+    project: Option<String>,
+    labels: Vec<String>,
+    due_date: Option<NaiveDate>,
+    url: String,
+    updated_at: i64,
+}
+
+#[async_trait]
+impl Fetcher for LinearIssues {
+    fn name(&self) -> &str {
+        "linear_issues"
+    }
+
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+
+    fn description(&self) -> &'static str {
+        "Linear issues snapshot with filter-first options (status, assignee, team, project, priority, due window, label). `Bars` groups by `group_by` (default priority). `Calendar` highlights due dates; list shapes link each row to the Linear issue."
+    }
+
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+
+    fn default_shape(&self) -> Shape {
+        Shape::LinkedTextBlock
+    }
+
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        super::cache_key("linear_issues", ctx)
+    }
+
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "ENG-123 Fix login flow [In Progress] · today · P1",
+                    Some("https://linear.app/acme/issue/ENG-123"),
+                ),
+                (
+                    "ENG-118 Polish dashboard layout [Todo] · P3",
+                    Some("https://linear.app/acme/issue/ENG-118"),
+                ),
+            ]),
+            Shape::Text => samples::text("7 issues"),
+            Shape::TextBlock => samples::text_block(&[
+                "ENG-123 Fix login flow [In Progress] · today · P1",
+                "ENG-118 Polish dashboard layout [Todo] · P3",
+            ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- **ENG-123** Fix login flow *[In Progress]* · today · P1\n- **ENG-118** Polish dashboard layout *[Todo]* · P3",
+            ),
+            Shape::Entries => samples::entries(&[
+                ("ENG-123", "Fix login flow"),
+                ("ENG-118", "Polish dashboard layout"),
+            ]),
+            Shape::Bars => samples::bars(&[("Urgent", 1), ("High", 3), ("Medium", 2), ("Low", 1)]),
+            Shape::Calendar => samples::calendar(2026, 4, Some(29), &[2, 14, 22]),
+            Shape::Badge => samples::badge(Status::Warn, "linear 7"),
+            Shape::Timeline => samples::timeline(&[
+                (
+                    1_745_896_800,
+                    "ENG-123 Fix login flow",
+                    Some("In Progress · P1"),
+                ),
+                (
+                    1_745_810_400,
+                    "ENG-118 Polish dashboard layout",
+                    Some("Todo · P3"),
+                ),
+            ]),
+            _ => return None,
+        })
+    }
+
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref())?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let now = t::now_in(ctx.timezone.as_deref());
+        let today = now.date_naive();
+        let filter = build_filter(&opts, today);
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+        let response: ApiResponse = graphql_query(
+            &token,
+            QUERY,
+            json!({ "filter": filter, "first": limit as i64 }),
+        )
+        .await?;
+        let mut views: Vec<IssueView> = response.issues.nodes.into_iter().map(to_view).collect();
+        views.sort_by(cmp_views);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        Ok(payload(render_body(&views, shape, &opts, limit)))
+    }
+}
+
+pub fn fetcher() -> Arc<dyn Fetcher> {
+    Arc::new(LinearIssues)
+}
+
+fn parse_options(raw: Option<&toml::Value>) -> Result<Options, FetchError> {
+    raw.map(|v| {
+        v.clone()
+            .try_into::<Options>()
+            .map_err(|e| FetchError::Failed(format!("invalid options: {e}")))
+    })
+    .unwrap_or_else(|| Ok(Options::default()))
+}
+
+fn build_filter(opts: &Options, today: NaiveDate) -> Value {
+    let mut clauses: Vec<(&str, Value)> = Vec::new();
+    if let Some(v) = state_filter(opts.filter_status.as_deref()) {
+        clauses.push(("state", v));
+    }
+    if let Some(v) = assignee_filter(opts.filter_assignee.as_deref()) {
+        clauses.push(("assignee", v));
+    }
+    if let Some(team) = opts.filter_team.as_deref().filter(|s| !s.is_empty()) {
+        clauses.push(("team", json!({ "key": { "eq": team } })));
+    }
+    if let Some(project) = opts.filter_project.as_deref().filter(|s| !s.is_empty()) {
+        clauses.push(("project", json!({ "name": { "eq": project } })));
+    }
+    if let Some(p) = priority_filter(opts.filter_priority.as_deref()) {
+        clauses.push(("priority", p));
+    }
+    if let Some(v) = due_filter(opts.filter_due.as_deref(), today) {
+        clauses.push(("dueDate", v));
+    }
+    if let Some(label) = opts.filter_label.as_deref().filter(|s| !s.is_empty()) {
+        clauses.push(("labels", json!({ "name": { "eq": label } })));
+    }
+    let mut map = serde_json::Map::with_capacity(clauses.len());
+    for (k, v) in clauses {
+        map.insert(k.into(), v);
+    }
+    Value::Object(map)
+}
+
+fn state_filter(raw: Option<&str>) -> Option<Value> {
+    let kind = raw.unwrap_or("open").trim().to_lowercase();
+    match kind.as_str() {
+        "any" => None,
+        "open" => Some(json!({ "type": { "nin": ["completed", "canceled"] } })),
+        "unstarted" | "started" | "completed" | "canceled" | "triage" | "backlog" => {
+            Some(json!({ "type": { "eq": kind } }))
+        }
+        _ => Some(json!({ "name": { "eq": raw.unwrap_or_default() } })),
+    }
+}
+
+fn assignee_filter(raw: Option<&str>) -> Option<Value> {
+    match raw.unwrap_or("me").trim().to_lowercase().as_str() {
+        "me" => Some(json!({ "isMe": { "eq": true } })),
+        "unassigned" => Some(json!({ "null": true })),
+        "any" => None,
+        other => Some(json!({ "email": { "eq": other } })),
+    }
+}
+
+fn priority_filter(raw: Option<&str>) -> Option<Value> {
+    let v = raw?.trim().to_lowercase();
+    match v.as_str() {
+        "none" => Some(json!({ "eq": 0 })),
+        "urgent" => Some(json!({ "eq": 1 })),
+        "high" => Some(json!({ "eq": 2 })),
+        "medium" => Some(json!({ "eq": 3 })),
+        "low" => Some(json!({ "eq": 4 })),
+        _ => v.parse::<u8>().ok().map(|n| json!({ "eq": n })),
+    }
+}
+
+fn due_filter(raw: Option<&str>, today: NaiveDate) -> Option<Value> {
+    let kind = raw.unwrap_or("any").trim().to_lowercase();
+    let iso = today.format("%Y-%m-%d").to_string();
+    let week = (today + chrono::Duration::days(7))
+        .format("%Y-%m-%d")
+        .to_string();
+    match kind.as_str() {
+        "any" => None,
+        "no_due" => Some(json!({ "null": true })),
+        "overdue" => Some(json!({ "lt": iso })),
+        "today" => Some(json!({ "eq": iso })),
+        "this_week" => Some(json!({ "gte": iso, "lte": week })),
+        _ => None,
+    }
+}
+
+fn to_view(api: ApiIssue) -> IssueView {
+    IssueView {
+        identifier: api.identifier,
+        title: api.title,
+        priority: priority_to_u8(api.priority),
+        priority_label: api.priority_label.unwrap_or_else(|| "—".into()),
+        state_name: api.state.name,
+        state_type: api.state.state_type,
+        assignee: api.assignee.and_then(|a| a.display_name.or(a.email)),
+        team_name: api.team.map(|t| t.name),
+        project: api.project.map(|p| p.name),
+        labels: api
+            .labels
+            .map(|c| c.nodes.into_iter().map(|l| l.name).collect())
+            .unwrap_or_default(),
+        due_date: api
+            .due_date
+            .as_deref()
+            .and_then(|d| NaiveDate::parse_from_str(d, "%Y-%m-%d").ok()),
+        url: api.url,
+        updated_at: parse_timestamp(&api.updated_at),
+    }
+}
+
+fn priority_to_u8(p: f32) -> u8 {
+    let n = p.round() as i32;
+    n.clamp(0, 4) as u8
+}
+
+fn parse_timestamp(raw: &str) -> i64 {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0)
+}
+
+fn cmp_views(a: &IssueView, b: &IssueView) -> std::cmp::Ordering {
+    priority_rank(a.priority)
+        .cmp(&priority_rank(b.priority))
+        .then_with(|| due_rank(a.due_date).cmp(&due_rank(b.due_date)))
+        .then_with(|| b.updated_at.cmp(&a.updated_at))
+}
+
+/// 0 (Urgent) ranks above 1..4; "no priority" (0 from API) ranks last.
+fn priority_rank(p: u8) -> u8 {
+    match p {
+        0 => 5,
+        n => n,
+    }
+}
+
+fn due_rank(d: Option<NaiveDate>) -> i64 {
+    d.map(|x| x.num_days_from_ce() as i64).unwrap_or(i64::MAX)
+}
+
+fn render_body(views: &[IssueView], shape: Shape, opts: &Options, limit: usize) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: format!("{} issues", views.len()),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: views.iter().take(limit).map(line_for).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: views
+                .iter()
+                .take(limit)
+                .map(markdown_line_for)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: views
+                .iter()
+                .take(limit)
+                .map(|v| LinkedLine {
+                    text: line_for(v),
+                    url: Some(v.url.clone()),
+                })
+                .collect(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: views
+                .iter()
+                .take(limit)
+                .map(|v| Entry {
+                    key: v.identifier.clone(),
+                    value: Some(v.title.clone()),
+                    status: state_to_status(&v.state_type),
+                })
+                .collect(),
+        }),
+        Shape::Bars => bars_body(views, opts.group_by.as_deref()),
+        Shape::Calendar => calendar_body(views),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: badge_status(views.len()),
+            label: format!("linear {}", views.len()),
+        }),
+        Shape::Timeline => Body::Timeline(TimelineData {
+            events: views
+                .iter()
+                .take(limit)
+                .map(|v| TimelineEvent {
+                    timestamp: v.updated_at,
+                    title: format!("{} {}", v.identifier, v.title),
+                    detail: Some(format!("{} · P{}", v.state_name, v.priority)),
+                    status: state_to_status(&v.state_type),
+                })
+                .collect(),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: views.iter().take(limit).map(line_for).collect(),
+        }),
+    }
+}
+
+fn line_for(v: &IssueView) -> String {
+    let due = v
+        .due_date
+        .map(|d| format!(" · due {:02}-{:02}", d.month(), d.day()))
+        .unwrap_or_default();
+    format!(
+        "{} {} [{}]{} · P{}",
+        v.identifier, v.title, v.state_name, due, v.priority
+    )
+}
+
+fn markdown_line_for(v: &IssueView) -> String {
+    let due = v
+        .due_date
+        .map(|d| format!(" · due {:02}-{:02}", d.month(), d.day()))
+        .unwrap_or_default();
+    format!(
+        "- **{}** {} *[{}]*{} · P{}",
+        v.identifier, v.title, v.state_name, due, v.priority
+    )
+}
+
+fn state_to_status(state_type: &str) -> Option<Status> {
+    match state_type {
+        "completed" => Some(Status::Ok),
+        "started" => Some(Status::Warn),
+        "canceled" => Some(Status::Error),
+        _ => None,
+    }
+}
+
+fn badge_status(total: usize) -> Status {
+    match total {
+        0 => Status::Ok,
+        1..=3 => Status::Ok,
+        4..=9 => Status::Warn,
+        _ => Status::Error,
+    }
+}
+
+fn bars_body(views: &[IssueView], group_by: Option<&str>) -> Body {
+    let key = group_by.unwrap_or("priority").trim().to_lowercase();
+    let extract: Box<dyn Fn(&IssueView) -> String> = match key.as_str() {
+        "status" => Box::new(|v| v.state_name.clone()),
+        "team" => Box::new(|v| v.team_name.clone().unwrap_or_else(|| "—".into())),
+        "assignee" => Box::new(|v| v.assignee.clone().unwrap_or_else(|| "Unassigned".into())),
+        "project" => Box::new(|v| v.project.clone().unwrap_or_else(|| "—".into())),
+        _ => Box::new(|v| v.priority_label.clone()),
+    };
+    Body::Bars(BarsData {
+        bars: tally(views, extract.as_ref()),
+    })
+}
+
+fn tally(views: &[IssueView], extract: &dyn Fn(&IssueView) -> String) -> Vec<Bar> {
+    let mut counts: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    for v in views {
+        *counts.entry(extract(v)).or_insert(0) += 1;
+    }
+    let mut bars: Vec<Bar> = counts
+        .into_iter()
+        .map(|(label, value)| Bar { label, value })
+        .collect();
+    bars.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.label.cmp(&b.label)));
+    bars
+}
+
+fn calendar_body(views: &[IssueView]) -> Body {
+    let now = t::now_in(None);
+    let today = now.date_naive();
+    let events: Vec<u8> = views
+        .iter()
+        .filter_map(|v| v.due_date)
+        .filter(|d| d.year() == today.year() && d.month() == today.month())
+        .map(|d| d.day() as u8)
+        .collect();
+    Body::Calendar(CalendarData {
+        year: today.year(),
+        month: today.month() as u8,
+        day: Some(today.day() as u8),
+        events,
+    })
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(raw: &str) -> Options {
+        let value: toml::Value = toml::from_str(raw).unwrap();
+        parse_options(Some(&value)).unwrap()
+    }
+
+    #[test]
+    fn state_filter_open_excludes_completed_and_canceled() {
+        let v = state_filter(Some("open")).unwrap();
+        assert_eq!(
+            v["type"]["nin"],
+            json!(["completed", "canceled"]),
+            "got: {v}"
+        );
+    }
+
+    #[test]
+    fn state_filter_named_state_uses_eq() {
+        let v = state_filter(Some("started")).unwrap();
+        assert_eq!(v["type"]["eq"], json!("started"));
+    }
+
+    #[test]
+    fn state_filter_any_means_no_filter() {
+        assert!(state_filter(Some("any")).is_none());
+    }
+
+    #[test]
+    fn assignee_filter_me_uses_isme() {
+        let v = assignee_filter(Some("me")).unwrap();
+        assert_eq!(v["isMe"]["eq"], json!(true));
+    }
+
+    #[test]
+    fn assignee_filter_unassigned_uses_null() {
+        let v = assignee_filter(Some("unassigned")).unwrap();
+        assert_eq!(v["null"], json!(true));
+    }
+
+    #[test]
+    fn assignee_filter_email_uses_eq() {
+        let v = assignee_filter(Some("a@b.com")).unwrap();
+        assert_eq!(v["email"]["eq"], json!("a@b.com"));
+    }
+
+    #[test]
+    fn priority_filter_named_to_numeric() {
+        assert_eq!(priority_filter(Some("urgent")).unwrap()["eq"], json!(1));
+        assert_eq!(priority_filter(Some("low")).unwrap()["eq"], json!(4));
+        assert_eq!(priority_filter(Some("none")).unwrap()["eq"], json!(0));
+    }
+
+    #[test]
+    fn due_filter_overdue_uses_lt_today() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let v = due_filter(Some("overdue"), today).unwrap();
+        assert_eq!(v["lt"], json!("2026-04-29"));
+    }
+
+    #[test]
+    fn due_filter_this_week_spans_seven_days() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let v = due_filter(Some("this_week"), today).unwrap();
+        assert_eq!(v["gte"], json!("2026-04-29"));
+        assert_eq!(v["lte"], json!("2026-05-06"));
+    }
+
+    #[test]
+    fn build_filter_combines_clauses() {
+        let opts = options(
+            "filter_status = \"started\"\nfilter_team = \"ENG\"\nfilter_priority = \"high\"\n",
+        );
+        let f = build_filter(&opts, NaiveDate::from_ymd_opt(2026, 4, 29).unwrap());
+        assert_eq!(f["state"]["type"]["eq"], json!("started"));
+        assert_eq!(f["team"]["key"]["eq"], json!("ENG"));
+        assert_eq!(f["priority"]["eq"], json!(2));
+        // Default `filter_assignee` of "me" still applied.
+        assert_eq!(f["assignee"]["isMe"]["eq"], json!(true));
+    }
+
+    #[test]
+    fn cmp_views_promotes_urgent_above_high() {
+        let urgent = view_for_test("ENG-1", 1, None, 0);
+        let high = view_for_test("ENG-2", 2, None, 0);
+        let mut list = [high, urgent];
+        list.sort_by(cmp_views);
+        assert_eq!(list[0].identifier, "ENG-1");
+    }
+
+    #[test]
+    fn cmp_views_demotes_no_priority_below_low() {
+        let none = view_for_test("ENG-1", 0, None, 0);
+        let low = view_for_test("ENG-2", 4, None, 0);
+        let mut list = [none, low];
+        list.sort_by(cmp_views);
+        assert_eq!(list[0].identifier, "ENG-2");
+    }
+
+    #[test]
+    fn render_text_emits_count() {
+        let views = vec![view_for_test("ENG-1", 1, None, 0)];
+        let body = render_body(&views, Shape::Text, &Options::default(), 10);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("1"));
+    }
+
+    #[test]
+    fn render_linked_text_block_includes_url() {
+        let views = vec![view_for_test("ENG-1", 1, None, 0)];
+        let body = render_body(&views, Shape::LinkedTextBlock, &Options::default(), 10);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked");
+        };
+        assert!(b.items[0].url.as_deref().unwrap().contains("ENG-1"));
+    }
+
+    #[test]
+    fn render_bars_groups_by_priority_label_by_default() {
+        let views = vec![
+            view_for_test("ENG-1", 1, None, 0),
+            view_for_test("ENG-2", 1, None, 0),
+            view_for_test("ENG-3", 2, None, 0),
+        ];
+        let body = render_body(&views, Shape::Bars, &Options::default(), 10);
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        let urgent = b.bars.iter().find(|x| x.label == "Urgent").unwrap();
+        assert_eq!(urgent.value, 2);
+    }
+
+    #[test]
+    fn render_badge_status_scales_with_count() {
+        let one = view_for_test("E-1", 1, None, 0);
+        let body = render_body(&[one], Shape::Badge, &Options::default(), 10);
+        let Body::Badge(b) = body else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        let many: Vec<IssueView> = (0..15).map(|i| view_for_test("E", 1, None, i)).collect();
+        let body = render_body(&many, Shape::Badge, &Options::default(), 10);
+        let Body::Badge(b) = body else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Error);
+    }
+
+    fn view_for_test(id: &str, priority: u8, due: Option<NaiveDate>, ts: i64) -> IssueView {
+        IssueView {
+            identifier: id.into(),
+            title: "title".into(),
+            priority,
+            priority_label: match priority {
+                1 => "Urgent".into(),
+                2 => "High".into(),
+                3 => "Medium".into(),
+                4 => "Low".into(),
+                _ => "No priority".into(),
+            },
+            state_name: "Todo".into(),
+            state_type: "unstarted".into(),
+            assignee: None,
+            team_name: None,
+            project: None,
+            labels: vec![],
+            due_date: due,
+            url: format!("https://linear.app/acme/issue/{id}"),
+            updated_at: ts,
+        }
+    }
+}

--- a/src/fetcher/linear/issues.rs
+++ b/src/fetcher/linear/issues.rs
@@ -807,4 +807,116 @@ mod tests {
             updated_at: ts,
         }
     }
+
+    #[test]
+    fn render_text_block_caps_at_limit() {
+        let views: Vec<IssueView> = (0..15)
+            .map(|i| view_for_test(&format!("ENG-{i}"), 1, None, 0))
+            .collect();
+        let body = render_body(&views, Shape::TextBlock, &Options::default(), 5);
+        let Body::TextBlock(b) = body else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 5);
+    }
+
+    #[test]
+    fn render_markdown_emboldens_identifier() {
+        let views = vec![view_for_test("ENG-7", 2, None, 0)];
+        let body = render_body(&views, Shape::MarkdownTextBlock, &Options::default(), 10);
+        let Body::MarkdownTextBlock(b) = body else {
+            panic!("expected markdown");
+        };
+        assert!(b.value.contains("**ENG-7**"), "got: {}", b.value);
+        assert!(b.value.contains("*[Todo]*"), "got: {}", b.value);
+    }
+
+    #[test]
+    fn render_entries_maps_state_type_to_status() {
+        let mut started = view_for_test("ENG-1", 2, None, 0);
+        started.state_type = "started".into();
+        let mut completed = view_for_test("ENG-2", 2, None, 0);
+        completed.state_type = "completed".into();
+        let mut canceled = view_for_test("ENG-3", 2, None, 0);
+        canceled.state_type = "canceled".into();
+        let body = render_body(
+            &[started, completed, canceled],
+            Shape::Entries,
+            &Options::default(),
+            10,
+        );
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].status, Some(Status::Warn));
+        assert_eq!(e.items[1].status, Some(Status::Ok));
+        assert_eq!(e.items[2].status, Some(Status::Error));
+    }
+
+    #[test]
+    fn render_calendar_filters_due_dates_to_current_month() {
+        let now = t::now_in(None).date_naive();
+        let in_month = NaiveDate::from_ymd_opt(now.year(), now.month(), 5).unwrap();
+        let last_year = NaiveDate::from_ymd_opt(now.year() - 1, now.month(), 9).unwrap();
+        let views = vec![
+            view_for_test("ENG-1", 1, Some(in_month), 0),
+            view_for_test("ENG-2", 2, Some(last_year), 0),
+            view_for_test("ENG-3", 3, None, 0),
+        ];
+        let body = render_body(&views, Shape::Calendar, &Options::default(), 10);
+        let Body::Calendar(c) = body else {
+            panic!("expected calendar");
+        };
+        assert_eq!(c.year, now.year());
+        assert!(c.events.contains(&5));
+        assert!(!c.events.contains(&9));
+    }
+
+    #[test]
+    fn render_timeline_carries_state_status_and_priority_detail() {
+        let mut started = view_for_test("ENG-1", 1, None, 1_700_000_000);
+        started.state_type = "started".into();
+        started.state_name = "In Progress".into();
+        let body = render_body(&[started], Shape::Timeline, &Options::default(), 10);
+        let Body::Timeline(t) = body else {
+            panic!("expected timeline");
+        };
+        assert_eq!(t.events[0].status, Some(Status::Warn));
+        assert_eq!(t.events[0].timestamp, 1_700_000_000);
+        let detail = t.events[0].detail.as_deref().unwrap();
+        assert!(detail.contains("In Progress"), "got: {detail}");
+        assert!(detail.contains("P1"), "got: {detail}");
+    }
+
+    #[test]
+    fn bars_group_by_status_uses_state_name() {
+        let mut a = view_for_test("ENG-1", 1, None, 0);
+        a.state_name = "In Progress".into();
+        let mut b = view_for_test("ENG-2", 1, None, 0);
+        b.state_name = "Todo".into();
+        let mut c = view_for_test("ENG-3", 1, None, 0);
+        c.state_name = "Todo".into();
+        let opts = Options {
+            group_by: Some("status".into()),
+            ..Default::default()
+        };
+        let body = render_body(&[a, b, c], Shape::Bars, &opts, 10);
+        let Body::Bars(bars) = body else {
+            panic!("expected bars");
+        };
+        let todo = bars.bars.iter().find(|x| x.label == "Todo").unwrap();
+        assert_eq!(todo.value, 2);
+    }
+
+    #[test]
+    fn cmp_views_breaks_ties_with_due_date_then_recency() {
+        let dec1 = NaiveDate::from_ymd_opt(2026, 12, 1).unwrap();
+        let dec5 = NaiveDate::from_ymd_opt(2026, 12, 5).unwrap();
+        let earlier = view_for_test("ENG-A", 2, Some(dec5), 100);
+        let later = view_for_test("ENG-B", 2, Some(dec1), 50);
+        let mut list = [earlier, later];
+        list.sort_by(cmp_views);
+        // Same priority → earlier due date wins.
+        assert_eq!(list[0].identifier, "ENG-B");
+    }
 }

--- a/src/fetcher/linear/mod.rs
+++ b/src/fetcher/linear/mod.rs
@@ -1,0 +1,88 @@
+//! `linear_*` fetcher family — Linear issues, notifications, current-cycle progress.
+//!
+//! Every fetcher in this family targets the fixed host `api.linear.app` (see `client::API_URL`),
+//! so the personal API key (`options.token` or `LINEAR_TOKEN` env) can never be redirected to
+//! an attacker-controlled origin — Safety::Safe.
+//!
+//! OAuth flow is intentionally not supported: splashboard's startup window has no place to host
+//! a callback. Personal API keys (`lin_api_*`) are sent as-is in the `Authorization` header by
+//! [`client::graphql_query`].
+
+mod client;
+pub mod cycle;
+pub mod issues;
+pub mod notifications;
+
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+
+use crate::fetcher::{FetchContext, Fetcher};
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        issues::fetcher(),
+        notifications::fetcher(),
+        cycle::fetcher(),
+    ]
+}
+
+/// Cache key for any `linear_*` fetcher. Mixes shape, format, options blob, and a token-scope
+/// prefix so two accounts sharing a `$HOME/.splashboard/cache` directory can't observe each
+/// other's payloads.
+pub(crate) fn cache_key(name: &str, ctx: &FetchContext) -> String {
+    let shape = ctx.shape.map(|s| s.as_str()).unwrap_or("");
+    let format = ctx.format.as_deref().unwrap_or("");
+    let opts_token = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("token"))
+        .and_then(|v| v.as_str());
+    let extra = client::cache_extra(opts_token, ctx.options.as_ref());
+    let raw = format!("{name}|{shape}|{format}|{extra}");
+    let digest = Sha256::digest(raw.as_bytes());
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{name}-{hex}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::Shape;
+
+    fn ctx_with(opts: Option<toml::Value>) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            options: opts,
+            shape: Some(Shape::LinkedTextBlock),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cache_key_is_prefixed_with_fetcher_name() {
+        let k = cache_key("linear_issues", &ctx_with(None));
+        assert!(k.starts_with("linear_issues-"));
+    }
+
+    #[test]
+    fn cache_key_partitions_per_token() {
+        let opts_a: toml::Value = toml::from_str("token = \"tok-A\"").unwrap();
+        let opts_b: toml::Value = toml::from_str("token = \"tok-B\"").unwrap();
+        let a = cache_key("linear_issues", &ctx_with(Some(opts_a)));
+        let b = cache_key("linear_issues", &ctx_with(Some(opts_b)));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_partitions_per_shape() {
+        let mut a = ctx_with(None);
+        let mut b = ctx_with(None);
+        a.shape = Some(Shape::LinkedTextBlock);
+        b.shape = Some(Shape::Bars);
+        assert_ne!(
+            cache_key("linear_issues", &a),
+            cache_key("linear_issues", &b)
+        );
+    }
+}

--- a/src/fetcher/linear/notifications.rs
+++ b/src/fetcher/linear/notifications.rs
@@ -772,4 +772,118 @@ mod tests {
         let line = line_for(&v);
         assert!(line.contains("Please review"), "got: {line}");
     }
+
+    #[test]
+    fn pretty_type_maps_pr_review_distinct_from_pr() {
+        assert_eq!(pretty_type("pullRequestReviewRequested"), "PR review");
+        assert_eq!(pretty_type("pullRequestComment"), "PR");
+        assert_eq!(pretty_type("pullRequestMerged"), "PR");
+    }
+
+    #[test]
+    fn pretty_type_humanises_unknown_camel_case() {
+        assert_eq!(pretty_type("issueDoneSomething"), "issue done something");
+    }
+
+    #[test]
+    fn line_for_omits_actor_segment_when_actor_missing() {
+        let mut v = view_for_test("issueMention", true, Some("ENG-1"));
+        v.actor = None;
+        let line = line_for(&v);
+        assert!(
+            !line.contains("@"),
+            "actor segment should be elided: {line}"
+        );
+        assert!(line.contains("ENG-1"));
+    }
+
+    #[test]
+    fn render_text_block_caps_at_limit() {
+        let views: Vec<NotifView> = (0..15)
+            .map(|i| view_for_test("issueMention", true, Some(&format!("E-{i}"))))
+            .collect();
+        let body = render_body(&views, Shape::TextBlock, 5);
+        let Body::TextBlock(b) = body else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 5);
+    }
+
+    #[test]
+    fn render_entries_marks_unread_with_warn_status() {
+        let unread = view_for_test("issueMention", true, Some("ENG-1"));
+        let read = view_for_test("issueMention", false, Some("ENG-2"));
+        let body = render_body(&[unread, read], Shape::Entries, 10);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].status, Some(Status::Warn));
+        assert_eq!(e.items[1].status, None);
+    }
+
+    #[test]
+    fn render_timeline_event_carries_created_ts_and_unread_status() {
+        let v = view_for_test("issueMention", true, Some("ENG-1"));
+        let body = render_body(&[v], Shape::Timeline, 10);
+        let Body::Timeline(t) = body else {
+            panic!("expected timeline");
+        };
+        assert_eq!(t.events[0].timestamp, 1_745_896_800);
+        assert_eq!(t.events[0].status, Some(Status::Warn));
+    }
+
+    #[test]
+    fn badge_warn_when_unread_in_warn_band() {
+        let views: Vec<NotifView> = (0..5)
+            .map(|i| view_for_test("issueMention", true, Some(&format!("E-{i}"))))
+            .collect();
+        let body = render_body(&views, Shape::Badge, 10);
+        let Body::Badge(b) = body else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+    }
+
+    #[test]
+    fn to_view_prefers_pull_request_over_project_when_both_absent_for_issue() {
+        let api = ApiNotification {
+            notif_type: "pullRequestReviewRequested".into(),
+            read_at: None,
+            created_at: "2026-04-29T00:00:00Z".into(),
+            actor: None,
+            issue: None,
+            project: None,
+            comment: None,
+            pull_request: Some(ApiPullRequest {
+                number: 42,
+                title: "Fix login flow".into(),
+                url: "https://github.com/acme/widgets/pull/42".into(),
+            }),
+        };
+        let v = to_view(api);
+        assert_eq!(v.issue_identifier.as_deref(), Some("acme/widgets#42"));
+        assert_eq!(v.issue_title.as_deref(), Some("Fix login flow"));
+        assert!(v.is_unread);
+    }
+
+    #[test]
+    fn to_view_uses_project_when_no_issue_or_pull_request() {
+        let api = ApiNotification {
+            notif_type: "projectUpdateCreated".into(),
+            read_at: Some("2026-04-29T00:00:00Z".into()),
+            created_at: "2026-04-28T00:00:00Z".into(),
+            actor: None,
+            issue: None,
+            project: Some(ApiProject {
+                name: "Q2 Roadmap".into(),
+                url: "https://linear.app/acme/project/q2-roadmap".into(),
+            }),
+            comment: None,
+            pull_request: None,
+        };
+        let v = to_view(api);
+        assert_eq!(v.issue_identifier, None);
+        assert_eq!(v.issue_title.as_deref(), Some("Q2 Roadmap"));
+        assert!(!v.is_unread);
+    }
 }

--- a/src/fetcher/linear/notifications.rs
+++ b/src/fetcher/linear/notifications.rs
@@ -1,0 +1,775 @@
+//! `linear_notifications` — Linear inbox snapshot with structured filters.
+//!
+//! Safety::Safe: every request targets `api.linear.app` (fixed in [`super::client`]).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData,
+    MarkdownTextBlockData, Payload, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{graphql_query, resolve_token};
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const DEFAULT_LIMIT: usize = 10;
+const MAX_LIMIT: usize = 100;
+const FETCH_LIMIT: i64 = 50;
+
+// Linear's `NotificationFilter` does not expose `readAt`, so the read-state filter is applied
+// client-side (see [`matches_read`]). We pull a wider page (`FETCH_LIMIT = 50`) and slice
+// after filtering; that gives `filter_read = "unread"` (the default daily-driver lens) enough
+// headroom to surface the top N unread items even when the inbox is mostly read traffic.
+//
+// `actor` lives on each concrete subtype rather than the `Notification` interface, so we pull
+// it under each fragment we render. Subtypes we don't fragment on (`OauthClientApproval...`)
+// surface as type-only rows without an actor — better than crashing the query. `comment.body`
+// is the fallback content for PR / review notifications where Linear's GitHub integration
+// emits an `IssueNotification` whose `actor` is the GitHub user (no Linear `User` row, so
+// `displayName` is null) — at least the comment body still gives the row some context.
+const QUERY: &str = r#"
+query Notifications($first: Int) {
+  notifications(first: $first) {
+    nodes {
+      id
+      type
+      readAt
+      createdAt
+      ... on IssueNotification {
+        actor { displayName email }
+        issue { identifier title url team { key } }
+        comment { body }
+      }
+      ... on ProjectNotification {
+        actor { displayName email }
+        project { name url }
+      }
+      ... on PullRequestNotification {
+        actor { displayName email }
+        pullRequest { number title url }
+      }
+    }
+  }
+}
+"#;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "token",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Linear personal API key (`lin_api_*`). Falls back to `LINEAR_TOKEN` env.",
+    },
+    OptionSchema {
+        name: "filter_read",
+        type_hint: "\"unread\" | \"read\" | \"all\"",
+        required: false,
+        default: Some("\"unread\""),
+        description: "Read-state filter.",
+    },
+    OptionSchema {
+        name: "filter_type",
+        type_hint: "\"mention\" | \"assigned\" | \"comment\" | \"status_changed\" | \"project_update\" | \"any\"",
+        required: false,
+        default: Some("\"any\""),
+        description: "Notification type filter (matched on the API `type` string).",
+    },
+    OptionSchema {
+        name: "filter_team",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Team key (e.g. `\"ENG\"`) — keeps only issue notifications from the team.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=100)",
+        required: false,
+        default: Some("10"),
+        description: "Max rows for list-shaped renderers.",
+    },
+];
+
+pub struct LinearNotifications;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    filter_read: Option<String>,
+    #[serde(default)]
+    filter_type: Option<String>,
+    #[serde(default)]
+    filter_team: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    notifications: ApiConnection<ApiNotification>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiConnection<T> {
+    nodes: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiNotification {
+    #[serde(rename = "type")]
+    notif_type: String,
+    #[serde(rename = "readAt", default)]
+    read_at: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(default)]
+    actor: Option<ApiUser>,
+    #[serde(default)]
+    issue: Option<ApiIssue>,
+    #[serde(default)]
+    project: Option<ApiProject>,
+    #[serde(default)]
+    comment: Option<ApiComment>,
+    #[serde(rename = "pullRequest", default)]
+    pull_request: Option<ApiPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiPullRequest {
+    number: i64,
+    title: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiProject {
+    name: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiComment {
+    #[serde(default)]
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiUser {
+    #[serde(rename = "displayName", default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiIssue {
+    identifier: String,
+    title: String,
+    url: String,
+    #[serde(default)]
+    team: Option<ApiTeam>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiTeam {
+    key: String,
+}
+
+#[derive(Debug)]
+struct NotifView {
+    notif_type: String,
+    type_label: String,
+    actor: Option<String>,
+    issue_identifier: Option<String>,
+    issue_title: Option<String>,
+    issue_url: Option<String>,
+    team_key: Option<String>,
+    /// Comment body when the notification carries one (notifications about comments,
+    /// PR activity, etc.). Stripped to the first non-empty line so multi-paragraph
+    /// review comments don't blow up the row height.
+    snippet: Option<String>,
+    created_ts: i64,
+    is_unread: bool,
+}
+
+#[async_trait]
+impl Fetcher for LinearNotifications {
+    fn name(&self) -> &str {
+        "linear_notifications"
+    }
+
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+
+    fn description(&self) -> &'static str {
+        "Linear inbox snapshot — mentions, assignments, comments, status changes — with structured filters for read state, type, and team. List shapes link each row to the originating issue."
+    }
+
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+
+    fn default_shape(&self) -> Shape {
+        Shape::LinkedTextBlock
+    }
+
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        super::cache_key("linear_notifications", ctx)
+    }
+
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "ENG-123 @sarah mentioned you · 2h ago",
+                    Some("https://linear.app/acme/issue/ENG-123"),
+                ),
+                (
+                    "ENG-118 assigned by @max · yesterday",
+                    Some("https://linear.app/acme/issue/ENG-118"),
+                ),
+            ]),
+            Shape::Text => samples::text("3 unread"),
+            Shape::TextBlock => samples::text_block(&[
+                "ENG-123 @sarah mentioned you · 2h ago",
+                "ENG-118 assigned by @max · yesterday",
+            ]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- **ENG-123** *mention* by @sarah · 2h ago\n- **ENG-118** *assigned* by @max · yesterday",
+            ),
+            Shape::Entries => samples::entries(&[
+                ("ENG-123", "@sarah mentioned you"),
+                ("ENG-118", "assigned by @max"),
+            ]),
+            Shape::Bars => samples::bars(&[("Mention", 2), ("Assigned", 1)]),
+            Shape::Badge => samples::badge(Status::Warn, "linear inbox 3"),
+            Shape::Timeline => samples::timeline(&[
+                (
+                    1_745_896_800,
+                    "ENG-123 mention by @sarah",
+                    Some("Fix login flow"),
+                ),
+                (
+                    1_745_810_400,
+                    "ENG-118 assigned by @max",
+                    Some("Polish dashboard"),
+                ),
+            ]),
+            _ => return None,
+        })
+    }
+
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref())?;
+        let token = resolve_token(opts.token.as_deref())?;
+        let response: ApiResponse =
+            graphql_query(&token, QUERY, json!({ "first": FETCH_LIMIT })).await?;
+        let mut views: Vec<NotifView> = response
+            .notifications
+            .nodes
+            .into_iter()
+            .map(to_view)
+            .filter(|v| matches_read(v, opts.filter_read.as_deref()))
+            .filter(|v| matches_type(v, opts.filter_type.as_deref()))
+            .filter(|v| matches_team(v, opts.filter_team.as_deref()))
+            .collect();
+        views.sort_by(|a, b| b.created_ts.cmp(&a.created_ts));
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        Ok(payload(render_body(&views, shape, limit)))
+    }
+}
+
+pub fn fetcher() -> Arc<dyn Fetcher> {
+    Arc::new(LinearNotifications)
+}
+
+fn parse_options(raw: Option<&toml::Value>) -> Result<Options, FetchError> {
+    raw.map(|v| {
+        v.clone()
+            .try_into::<Options>()
+            .map_err(|e| FetchError::Failed(format!("invalid options: {e}")))
+    })
+    .unwrap_or_else(|| Ok(Options::default()))
+}
+
+fn matches_read(v: &NotifView, raw: Option<&str>) -> bool {
+    match raw.unwrap_or("unread").trim().to_lowercase().as_str() {
+        "read" => !v.is_unread,
+        "all" => true,
+        _ => v.is_unread,
+    }
+}
+
+fn matches_type(v: &NotifView, raw: Option<&str>) -> bool {
+    let kind = raw.unwrap_or("any").trim().to_lowercase();
+    if kind == "any" {
+        return true;
+    }
+    let t = v.notif_type.to_lowercase();
+    match kind.as_str() {
+        "mention" => t.contains("mention"),
+        "assigned" => t.contains("assigned"),
+        "comment" => t.contains("comment"),
+        "status_changed" => t.contains("status"),
+        "project_update" => t.starts_with("projectupdate"),
+        _ => true,
+    }
+}
+
+fn matches_team(v: &NotifView, raw: Option<&str>) -> bool {
+    let Some(team) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+        return true;
+    };
+    v.team_key.as_deref().is_some_and(|k| k == team)
+}
+
+fn to_view(api: ApiNotification) -> NotifView {
+    let type_label = pretty_type(&api.notif_type);
+    let actor = api.actor.and_then(|a| a.display_name.or(a.email));
+    let (subject_id, subject_title, subject_url, team_key) = if let Some(i) = api.issue {
+        (
+            Some(i.identifier),
+            Some(i.title),
+            Some(i.url),
+            i.team.map(|t| t.key),
+        )
+    } else if let Some(pr) = api.pull_request {
+        let repo = repo_from_pr_url(&pr.url);
+        let id = match repo {
+            Some(r) => format!("{r}#{}", pr.number),
+            None => format!("PR #{}", pr.number),
+        };
+        (Some(id), Some(pr.title), Some(pr.url), None)
+    } else if let Some(p) = api.project {
+        (None, Some(p.name), Some(p.url), None)
+    } else {
+        (None, None, None, None)
+    };
+    let snippet = api.comment.and_then(|c| c.body).and_then(short_snippet);
+    NotifView {
+        notif_type: api.notif_type,
+        type_label,
+        actor,
+        issue_identifier: subject_id,
+        issue_title: subject_title,
+        issue_url: subject_url,
+        team_key,
+        snippet,
+        created_ts: parse_ts(&api.created_at),
+        is_unread: api.read_at.is_none(),
+    }
+}
+
+/// Parse the `<owner>/<repo>` slug from a GitHub PR URL like
+/// `https://github.com/acme/widgets/pull/123`. Linear's `PullRequest` type doesn't expose
+/// the repo name as a field, so the URL is the only place that information lives.
+fn repo_from_pr_url(url: &str) -> Option<String> {
+    let path = url.split("github.com/").nth(1)?;
+    let mut parts = path.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        None
+    } else {
+        Some(format!("{owner}/{repo}"))
+    }
+}
+
+/// Reduce a comment body to a single-line snippet ≤ 80 chars. Returns `None` for empty input
+/// so downstream rendering can drop the part rather than emit a `· · ·` separator chain.
+fn short_snippet(body: String) -> Option<String> {
+    let line = body
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())?
+        .to_string();
+    if line.chars().count() > 80 {
+        Some(format!("{}…", line.chars().take(79).collect::<String>()))
+    } else {
+        Some(line)
+    }
+}
+
+fn pretty_type(raw: &str) -> String {
+    let lower = raw.to_lowercase();
+    if lower.contains("pullrequestreview") || lower.contains("reviewrequested") {
+        "PR review".into()
+    } else if lower.contains("pullrequest") {
+        "PR".into()
+    } else if lower.contains("mention") {
+        "mention".into()
+    } else if lower.contains("assigned") {
+        "assigned".into()
+    } else if lower.contains("comment") {
+        "comment".into()
+    } else if lower.contains("status") {
+        "status".into()
+    } else if lower.starts_with("projectupdate") {
+        "project update".into()
+    } else if lower.contains("subscribed") {
+        "subscribed".into()
+    } else if lower.contains("created") {
+        "created".into()
+    } else if lower.contains("due") || lower.contains("reminder") {
+        "reminder".into()
+    } else {
+        // Camel-case → spaced lowercase so an unknown `issueDoneSomething` reads as
+        // `"issue done something"` instead of leaking the raw API token.
+        humanize_camel(raw)
+    }
+}
+
+fn humanize_camel(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 4);
+    for (i, ch) in raw.chars().enumerate() {
+        if ch.is_ascii_uppercase() && i > 0 {
+            out.push(' ');
+        }
+        out.push(ch.to_ascii_lowercase());
+    }
+    out
+}
+
+fn parse_ts(raw: &str) -> i64 {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0)
+}
+
+fn render_body(views: &[NotifView], shape: Shape, limit: usize) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: format!("{} unread", views.iter().filter(|v| v.is_unread).count()),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: views.iter().take(limit).map(line_for).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: views
+                .iter()
+                .take(limit)
+                .map(markdown_line_for)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: views
+                .iter()
+                .take(limit)
+                .map(|v| LinkedLine {
+                    text: line_for(v),
+                    url: v.issue_url.clone(),
+                })
+                .collect(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: views
+                .iter()
+                .take(limit)
+                .map(|v| Entry {
+                    key: v
+                        .issue_identifier
+                        .clone()
+                        .unwrap_or_else(|| v.type_label.clone()),
+                    value: Some(entry_value(v)),
+                    status: v.is_unread.then_some(Status::Warn),
+                })
+                .collect(),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: tally_by_type(views),
+        }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: badge_status(views),
+            label: format!(
+                "linear inbox {}",
+                views.iter().filter(|v| v.is_unread).count()
+            ),
+        }),
+        Shape::Timeline => Body::Timeline(TimelineData {
+            events: views
+                .iter()
+                .take(limit)
+                .map(|v| TimelineEvent {
+                    timestamp: v.created_ts,
+                    title: timeline_title(v),
+                    detail: v.issue_title.clone(),
+                    status: v.is_unread.then_some(Status::Warn),
+                })
+                .collect(),
+        }),
+        _ => Body::TextBlock(TextBlockData {
+            lines: views.iter().take(limit).map(line_for).collect(),
+        }),
+    }
+}
+
+fn line_for(v: &NotifView) -> String {
+    join_parts(&[
+        v.issue_identifier.clone(),
+        Some(v.type_label.clone()),
+        v.actor.as_deref().map(|a| format!("by @{a}")),
+        v.issue_title.clone().or_else(|| v.snippet.clone()),
+    ])
+}
+
+fn markdown_line_for(v: &NotifView) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(id) = &v.issue_identifier {
+        parts.push(format!("**{id}**"));
+    }
+    parts.push(format!("*{}*", v.type_label));
+    if let Some(a) = &v.actor {
+        parts.push(format!("by @{a}"));
+    }
+    if let Some(title) = v.issue_title.as_ref().or(v.snippet.as_ref()) {
+        parts.push(title.clone());
+    }
+    format!("- {}", parts.join(" · "))
+}
+
+fn entry_value(v: &NotifView) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(a) = &v.actor {
+        parts.push(format!("@{a}"));
+    }
+    parts.push(v.type_label.clone());
+    if let Some(title) = v.issue_title.as_ref().or(v.snippet.as_ref()) {
+        parts.push(title.clone());
+    }
+    parts.join(" · ")
+}
+
+fn timeline_title(v: &NotifView) -> String {
+    line_for(v)
+}
+
+fn join_parts(parts: &[Option<String>]) -> String {
+    parts
+        .iter()
+        .filter_map(|p| p.as_deref().filter(|s| !s.is_empty()))
+        .collect::<Vec<_>>()
+        .join(" · ")
+}
+
+fn tally_by_type(views: &[NotifView]) -> Vec<Bar> {
+    let mut counts: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    for v in views {
+        let label = capitalize(&v.type_label);
+        *counts.entry(label).or_insert(0) += 1;
+    }
+    let mut bars: Vec<Bar> = counts
+        .into_iter()
+        .map(|(label, value)| Bar { label, value })
+        .collect();
+    bars.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.label.cmp(&b.label)));
+    bars
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    chars
+        .next()
+        .map(|c| c.to_uppercase().chain(chars).collect::<String>())
+        .unwrap_or_default()
+}
+
+fn badge_status(views: &[NotifView]) -> Status {
+    let unread = views.iter().filter(|v| v.is_unread).count();
+    match unread {
+        0 => Status::Ok,
+        1..=3 => Status::Ok,
+        4..=9 => Status::Warn,
+        _ => Status::Error,
+    }
+}
+
+fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_read_unread_default_keeps_only_unread_rows() {
+        let unread = view_for_test("issueMention", true, Some("E-1"));
+        let read = view_for_test("issueMention", false, Some("E-2"));
+        assert!(matches_read(&unread, None));
+        assert!(!matches_read(&read, None));
+    }
+
+    #[test]
+    fn matches_read_read_inverts_the_filter() {
+        let unread = view_for_test("issueMention", true, Some("E-1"));
+        let read = view_for_test("issueMention", false, Some("E-2"));
+        assert!(!matches_read(&unread, Some("read")));
+        assert!(matches_read(&read, Some("read")));
+    }
+
+    #[test]
+    fn matches_read_all_keeps_everything() {
+        let unread = view_for_test("issueMention", true, Some("E-1"));
+        let read = view_for_test("issueMention", false, Some("E-2"));
+        assert!(matches_read(&unread, Some("all")));
+        assert!(matches_read(&read, Some("all")));
+    }
+
+    #[test]
+    fn pretty_type_collapses_known_synonyms() {
+        assert_eq!(pretty_type("issueMention"), "mention");
+        assert_eq!(pretty_type("issueAssignedToYou"), "assigned");
+        assert_eq!(pretty_type("issueCommentMention"), "mention");
+        assert_eq!(pretty_type("issueStatusChanged"), "status");
+        assert_eq!(pretty_type("projectUpdateCreated"), "project update");
+    }
+
+    #[test]
+    fn matches_type_filters_by_substring() {
+        let v = view_for_test("issueMention", true, Some("ENG-1"));
+        assert!(matches_type(&v, Some("mention")));
+        assert!(!matches_type(&v, Some("assigned")));
+        assert!(matches_type(&v, Some("any")));
+    }
+
+    #[test]
+    fn matches_team_keeps_only_specified_team() {
+        let v = view_for_test("issueMention", true, Some("ENG-1"));
+        assert!(matches_team(&v, None));
+        assert!(matches_team(&v, Some("ENG")));
+        assert!(!matches_team(&v, Some("OPS")));
+    }
+
+    #[test]
+    fn render_text_emits_unread_count() {
+        let views = vec![
+            view_for_test("issueMention", true, Some("E-1")),
+            view_for_test("issueMention", false, Some("E-2")),
+        ];
+        let body = render_body(&views, Shape::Text, 10);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("1"));
+    }
+
+    #[test]
+    fn render_linked_text_block_carries_issue_url() {
+        let views = vec![view_for_test("issueMention", true, Some("ENG-7"))];
+        let body = render_body(&views, Shape::LinkedTextBlock, 10);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked");
+        };
+        assert!(b.items[0].url.as_deref().unwrap().contains("ENG-7"));
+    }
+
+    #[test]
+    fn render_bars_groups_by_pretty_type() {
+        let views = vec![
+            view_for_test("issueMention", true, Some("E-1")),
+            view_for_test("issueMention", true, Some("E-2")),
+            view_for_test("issueAssignedToYou", true, Some("E-3")),
+        ];
+        let body = render_body(&views, Shape::Bars, 10);
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].label, "Mention");
+        assert_eq!(b.bars[0].value, 2);
+    }
+
+    #[test]
+    fn badge_critical_when_many_unread() {
+        let views: Vec<NotifView> = (0..15)
+            .map(|i| view_for_test("issueMention", true, Some(&format!("E-{i}"))))
+            .collect();
+        let body = render_body(&views, Shape::Badge, 10);
+        let Body::Badge(b) = body else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Error);
+    }
+
+    fn view_for_test(notif_type: &str, unread: bool, identifier: Option<&str>) -> NotifView {
+        NotifView {
+            notif_type: notif_type.into(),
+            type_label: pretty_type(notif_type),
+            actor: Some("sarah".into()),
+            issue_identifier: identifier.map(String::from),
+            issue_title: identifier.map(|s| format!("Issue {s}")),
+            issue_url: identifier.map(|s| format!("https://linear.app/acme/issue/{s}")),
+            team_key: identifier.map(|_| "ENG".into()),
+            snippet: None,
+            created_ts: 1_745_896_800,
+            is_unread: unread,
+        }
+    }
+
+    #[test]
+    fn short_snippet_takes_first_non_empty_line_and_caps_length() {
+        let s = short_snippet("\n\n  Hello world\nsecond line".to_string()).unwrap();
+        assert_eq!(s, "Hello world");
+        let long = "x".repeat(120);
+        let trimmed = short_snippet(long).unwrap();
+        assert!(trimmed.chars().count() <= 80);
+        assert!(trimmed.ends_with('…'));
+    }
+
+    #[test]
+    fn repo_from_pr_url_extracts_owner_slash_repo() {
+        assert_eq!(
+            repo_from_pr_url("https://github.com/acme/widgets/pull/123"),
+            Some("acme/widgets".into())
+        );
+    }
+
+    #[test]
+    fn repo_from_pr_url_returns_none_for_non_github_host() {
+        assert_eq!(
+            repo_from_pr_url("https://gitlab.com/acme/widgets/-/merge_requests/9"),
+            None
+        );
+    }
+
+    #[test]
+    fn line_for_falls_back_to_snippet_when_no_issue_title() {
+        let mut v = view_for_test("pullRequestReviewRequested", true, None);
+        v.snippet = Some("Please review the auth refactor".into());
+        let line = line_for(&v);
+        assert!(line.contains("Please review"), "got: {line}");
+    }
+}

--- a/src/fetcher/linear/notifications.rs
+++ b/src/fetcher/linear/notifications.rs
@@ -300,7 +300,7 @@ impl Fetcher for LinearNotifications {
             .filter(|v| matches_type(v, opts.filter_type.as_deref()))
             .filter(|v| matches_team(v, opts.filter_team.as_deref()))
             .collect();
-        views.sort_by(|a, b| b.created_ts.cmp(&a.created_ts));
+        views.sort_by_key(|v| std::cmp::Reverse(v.created_ts));
         let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
         Ok(payload(render_body(&views, shape, limit)))

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -19,6 +19,7 @@ pub mod deariary;
 pub mod git;
 pub mod github;
 pub mod hackernews;
+pub mod linear;
 pub mod random_cat;
 pub mod random_dog;
 pub mod random_fortune;
@@ -324,6 +325,9 @@ impl Registry {
             r.register(f);
         }
         for f in hackernews::fetchers() {
+            r.register(f);
+        }
+        for f in linear::fetchers() {
             r.register(f);
         }
         for f in todoist::fetchers() {


### PR DESCRIPTION
## Summary

Three Linear fetchers covering the daily-driver surfaces, sharing a single GraphQL client and token-scoped cache key. Ticks `linear_issues` and adds two new boxes (`linear_notifications`, `linear_cycle`) under Linear in #66.

- **`linear_issues`** — filter-first issue list (status / assignee / team / project / priority / due / label / group_by / limit). 9 shapes, default `linked_text_block`. Mirrors the `todoist_tasks` pattern.
- **`linear_notifications`** — inbox snapshot (mentions / assignments / comments / status changes / GitHub PR notifications). 8 shapes, default `linked_text_block`. Filter-first (`filter_read` / `filter_type` / `filter_team` / `limit`). Covers `IssueNotification`, `ProjectNotification`, and `PullRequestNotification` (Linear's GitHub-integration subtype) — PR slug parsed from `pullRequest.url` since the `PullRequest` type doesn't expose a repo-name field.
- **`linear_cycle`** — current / next / previous / explicit cycle progress for a team. 10 shapes, default `Ratio` (completed/total). `NumberSeries` carries the burndown history (`completedIssueCountHistory`); `Bars` breaks down issue states; `Calendar` highlights cycle days + due dates; `Badge` flags `on track` / `at risk` / `behind` / `done` based on completion vs elapsed-time gap.

## Safety

`Safety::Safe` across the family — host is `api.linear.app` (fixed in `super::client`), so the personal API key (`options.token` or `LINEAR_TOKEN`) can never be redirected. OAuth flow intentionally not supported (no place for a callback in a CLI splash).

## Architectural notes

- Shared `linear/client.rs` owns the GraphQL POST, semaphore (4-permit), `Retry-After`-honoured 429 retry, token resolution, token-scope hash for disk-cache key partitioning. Mirrors the deariary client pattern.
- `linear_notifications` filters read state client-side because Linear's `NotificationFilter` doesn't expose `readAt`. `actor` is pulled inside each fragment because it lives on subtypes, not the `Notification` interface. PR notifications populate `pullRequest`, not `issue` — surfaced as `<owner>/<repo>#<number>` rows linked to the GitHub PR URL.
- `linear_cycle` returns `FetchError::Failed("no cycle matched filter")` when the team has no active / matching cycle — the user can switch `cycle = "next" | "previous"` to see planned or recently-finished sprints. NumberSeries values are derived from the API's `completedIssueCountHistory` (rounded to `u64`).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` green (54 new unit tests across the family — option parsing, filter building, sort ordering, render-body shape branches, snippet truncation, repo-from-PR-URL parsing)
- [x] `cargo run --bin splashboard -- catalog fetcher linear_{issues,notifications,cycle}` resolves all shapes against compatible renderers
- [x] Manual smoke test against a real Linear workspace covered: PR review notifications surface as `<owner>/<repo>#<n> · PR review · by @<actor> · <PR title>` rows (originally the rows were sparse because `PullRequestNotification` is a separate subtype not covered by `IssueNotification` fragment).

## Catalog

`#66` updated:
- `linear_issues` — keeps existing checkbox (will tick on merge)
- `linear_notifications` — new
- `linear_cycle` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)