### PR TITLE
fix(tests): serialize cache_key stability tests on TEST_ENV_LOCK

### DIFF
--- a/src/fetcher/code/loc.rs
+++ b/src/fetcher/code/loc.rs
@@ -884,6 +884,9 @@ mod tests {
 
     #[test]
     fn cache_key_changes_with_options() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let mut ctx = FetchContext {
             widget_id: "w".into(),
             ..Default::default()
@@ -899,6 +902,9 @@ mod tests {
 
     #[test]
     fn cache_key_is_stable_for_equivalent_options() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let mut ctx = FetchContext {
             widget_id: "w".into(),
             ..Default::default()

--- a/src/fetcher/code/todos.rs
+++ b/src/fetcher/code/todos.rs
@@ -615,6 +615,9 @@ mod tests {
 
     #[test]
     fn cache_key_is_stable_for_equivalent_options() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let mut ctx = FetchContext {
             widget_id: "w".into(),
             ..Default::default()


### PR DESCRIPTION
## Summary
- `fetcher::code::loc::tests::cache_key_is_stable_for_equivalent_options` flaked on `main` after the #197 merge ([failing run](https://github.com/unhappychoice/splashboard/actions/runs/25253561957)).
- Root cause: the test calls `CodeLoc::cache_key`, which routes through `repo_cache_key` → `discover_root()` → `std::env::current_dir()`. Sibling tests (`fetch_reads_cwd_repo_for_default_and_requested_shapes`, the git/code/github isolated-cwd tests landed in `731c9a6`) mutate cwd under `paths::TEST_ENV_LOCK`. When they raced with the stability test, the two `cache_key` calls observed different cwds and the repo-derived hash diverged.
- Fix: take `TEST_ENV_LOCK` in the loc/todos stability tests so they serialize with the cwd-mutating tests. Also locked `cache_key_changes_with_options` in `loc.rs` for symmetry, though its `assert_ne` would already pass under a race (different options → different opts hashes regardless of cwd).
- `code::todos` had a structurally identical stability test. Fixed preemptively for the same reason; only `loc.rs` happened to lose the race in this CI run.

## Test plan
- [x] `cargo test --lib` (1931 passed, 8 ignored)
- [x] `cargo test --lib cache_key` (55 passed)
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)