### PR TITLE
fix(render): force iTerm2 protocol for images under iTerm2

### DIFF
--- a/src/render/media_image.rs
+++ b/src/render/media_image.rs
@@ -3,7 +3,10 @@ use std::sync::OnceLock;
 
 use image::DynamicImage;
 use ratatui::{Frame, layout::Rect, style::Style, widgets::Paragraph};
-use ratatui_image::{Resize, StatefulImage, picker::{Picker, ProtocolType}};
+use ratatui_image::{
+    Resize, StatefulImage,
+    picker::{Picker, ProtocolType},
+};
 
 use crate::options::OptionSchema;
 use crate::payload::{Body, ImageData};
@@ -417,10 +420,9 @@ mod tests {
         };
         assert!(with(&[("TERM_PROGRAM", "iTerm.app")]));
         assert!(with(&[("LC_TERMINAL", "iTerm2")]));
-        assert!(with(&[
-            ("TERM_PROGRAM", "tmux"),
-            ("LC_TERMINAL", "iTerm2"),
-        ]));
+        assert!(with(
+            &[("TERM_PROGRAM", "tmux"), ("LC_TERMINAL", "iTerm2"),]
+        ));
         assert!(!with(&[("TERM_PROGRAM", "Apple_Terminal")]));
         assert!(!with(&[]));
     }

--- a/src/render/media_image.rs
+++ b/src/render/media_image.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use image::DynamicImage;
 use ratatui::{Frame, layout::Rect, style::Style, widgets::Paragraph};
-use ratatui_image::{Resize, StatefulImage, picker::Picker};
+use ratatui_image::{Resize, StatefulImage, picker::{Picker, ProtocolType}};
 
 use crate::options::OptionSchema;
 use crate::payload::{Body, ImageData};
@@ -177,11 +177,29 @@ fn picker() -> Picker {
 }
 
 fn detect_picker() -> Picker {
-    if std::io::stdin().is_terminal() {
+    let mut picker = if std::io::stdin().is_terminal() {
         Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks())
     } else {
         Picker::halfblocks()
+    };
+    if is_iterm2_env(|k| std::env::var(k).ok()) {
+        picker.set_protocol_type(ProtocolType::Iterm2);
     }
+    picker
+}
+
+/// iTerm2 (and tools that set `LC_TERMINAL=iTerm2`, e.g. iTerm2 over SSH) responds to the
+/// Kitty graphics capability query positively in current versions but doesn't render the
+/// resulting `APC G ...` chunks reliably — base64 payload bytes leak through as visible
+/// "garbage" characters. The native OSC 1337 inline-image protocol is the only thing iTerm2
+/// renders without artifacts, so force it whenever the environment says we're inside iTerm2.
+fn is_iterm2_env(env: impl Fn(&str) -> Option<String>) -> bool {
+    env("TERM_PROGRAM")
+        .as_deref()
+        .is_some_and(|s| s.contains("iTerm"))
+        || env("LC_TERMINAL")
+            .as_deref()
+            .is_some_and(|s| s.contains("iTerm"))
 }
 
 fn load_image(path: &str) -> Result<DynamicImage, String> {
@@ -386,5 +404,24 @@ mod tests {
         assert!(matches!(resize_mode(Some("stretch")), Resize::Scale(_)));
         assert!(matches!(resize_mode(Some("contain")), Resize::Fit(_)));
         assert!(matches!(resize_mode(None), Resize::Fit(_)));
+    }
+
+    #[test]
+    fn iterm2_env_detection_matches_expected_terminals() {
+        let with = |pairs: &[(&str, &str)]| {
+            let map: std::collections::HashMap<String, String> = pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            super::is_iterm2_env(|k| map.get(k).cloned())
+        };
+        assert!(with(&[("TERM_PROGRAM", "iTerm.app")]));
+        assert!(with(&[("LC_TERMINAL", "iTerm2")]));
+        assert!(with(&[
+            ("TERM_PROGRAM", "tmux"),
+            ("LC_TERMINAL", "iTerm2"),
+        ]));
+        assert!(!with(&[("TERM_PROGRAM", "Apple_Terminal")]));
+        assert!(!with(&[]));
     }
 }


### PR DESCRIPTION
## Summary

- `ratatui-image`'s `Picker::from_query_stdio()` queries terminal capabilities and iTerm2 3.6.10 responds positively to the Kitty graphics probe — the picker therefore selects Kitty and the image renderer emits `APC G ...` chunks.
- iTerm2 doesn't render those Kitty chunks reliably; the base64 payload bytes leak through as visible "garbage" characters near the splash. Captured a real session and confirmed: 192 `\x1b_G...` chunks, zero `\x1b]1337` (the iTerm2-native OSC 1337 inline image protocol).
- Override the resolved protocol to `ProtocolType::Iterm2` whenever `TERM_PROGRAM` / `LC_TERMINAL` advertise iTerm2 (covers iTerm2 over SSH too). The native OSC 1337 path renders cleanly.

Touches `src/render/media_image.rs` only.

## Test plan

- [x] `cargo test render::media_image` (11/11 pass, including new `iterm2_env_detection_matches_expected_terminals`)
- [ ] Manual: in iTerm2, run `script -q /tmp/splash.cap splashboard`, confirm `grep -c $'\x1b]1337' /tmp/splash.cap > 0` and `grep -c $'\x1b_G' /tmp/splash.cap == 0`
- [ ] Manual: avatar and `random_cat` widgets render without garbage characters in iTerm2 3.6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection of iTerm2 environment to enable the inline-image protocol when running in iTerm2 sessions.

* **Tests**
  * Extended test coverage to validate iTerm2 environment detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->