### PR TITLE
feat(fetcher): add weather_forecast + fix chart bg

### DIFF
--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -318,7 +318,6 @@ impl Registry {
         r.register(Arc::new(static_text::StaticText));
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(rss::RssFetcher));
-        r.register(Arc::new(weather::WeatherFetcher));
         r.register(Arc::new(crypto_watchlist::CryptoWatchlistFetcher));
         r.register(Arc::new(stock_watchlist::StockWatchlistFetcher));
         r.register(Arc::new(random_cat::RandomCatFetcher));
@@ -342,6 +341,9 @@ impl Registry {
             r.register(f);
         }
         for f in reddit::fetchers() {
+            r.register(f);
+        }
+        for f in weather::fetchers() {
             r.register(f);
         }
         for f in wikipedia::fetchers() {

--- a/src/fetcher/weather/common.rs
+++ b/src/fetcher/weather/common.rs
@@ -1,0 +1,135 @@
+//! Shared helpers for the `weather_*` family. The Open-Meteo API host is hardcoded so any
+//! fetcher routed through here keeps the `Safety::Safe` classification — config supplies
+//! coordinates, not URLs.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::payload::{BadgeData, Body, Payload, Status};
+
+pub const API_BASE: &str = "https://api.open-meteo.com/v1/forecast";
+pub const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Units {
+    #[default]
+    Metric,
+    Imperial,
+}
+
+impl Units {
+    pub fn temperature_label(self) -> &'static str {
+        match self {
+            Self::Metric => "°C",
+            Self::Imperial => "°F",
+        }
+    }
+
+    pub fn wind_label(self) -> &'static str {
+        match self {
+            Self::Metric => "m/s",
+            Self::Imperial => "mph",
+        }
+    }
+
+    /// Precipitation unit suffix. Open-Meteo reports mm on metric, inches on imperial when
+    /// `precipitation_unit=inch` is passed; we keep the metric default and label accordingly.
+    pub fn precipitation_label(self) -> &'static str {
+        match self {
+            Self::Metric => "mm",
+            Self::Imperial => "in",
+        }
+    }
+}
+
+/// WMO weather interpretation codes (Open-Meteo uses the standard table).
+pub fn weather_description(code: u16) -> (&'static str, &'static str) {
+    match code {
+        0 => ("🌞", "clear"),
+        1 => ("🌤", "mostly clear"),
+        2 => ("⛅", "partly cloudy"),
+        3 => ("☁", "overcast"),
+        45 | 48 => ("🌫", "fog"),
+        51 | 53 | 55 => ("🌦", "drizzle"),
+        56 | 57 => ("🌧", "freezing drizzle"),
+        61 | 63 | 65 => ("🌧", "rain"),
+        66 | 67 => ("🌧", "freezing rain"),
+        71 | 73 | 75 | 77 => ("🌨", "snow"),
+        80..=82 => ("🌦", "rain showers"),
+        85 | 86 => ("🌨", "snow showers"),
+        95 => ("⛈", "thunderstorm"),
+        96 | 99 => ("⛈", "thunderstorm w/ hail"),
+        _ => ("🌡", "unknown"),
+    }
+}
+
+/// Severity badge for a single WMO code. Multi-day fetchers compute it over the worst code
+/// in their window so the headline reflects the riskiest day.
+pub fn weather_badge(code: u16) -> BadgeData {
+    let (status, label) = match code {
+        95 | 96 | 99 => (Status::Error, "thunderstorm"),
+        56 | 57 | 66 | 67 => (Status::Warn, "freezing"),
+        65 | 75 | 82 | 86 => (Status::Warn, "heavy precip"),
+        61 | 63 | 71 | 73 | 80 | 81 | 85 => (Status::Warn, "precip"),
+        _ => {
+            let (_, desc) = weather_description(code);
+            (Status::Ok, desc)
+        }
+    };
+    BadgeData {
+        status,
+        label: label.into(),
+    }
+}
+
+/// Severity rank — higher = worse. Used to pick the worst weather code from a forecast window
+/// for the `Badge` shape. Matches the buckets in `weather_badge`.
+pub fn severity_rank(code: u16) -> u8 {
+    match code {
+        95 | 96 | 99 => 3,
+        56 | 57 | 66 | 67 | 65 | 75 | 82 | 86 => 2,
+        61 | 63 | 71 | 73 | 80 | 81 | 85 => 1,
+        _ => 0,
+    }
+}
+
+pub fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub fn parse_options<T: serde::de::DeserializeOwned>(
+    raw: Option<&toml::Value>,
+    fetcher: &str,
+) -> Result<T, String> {
+    match raw {
+        None => Err(format!(
+            "{fetcher} requires `latitude` and `longitude` options"
+        )),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+pub fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}

--- a/src/fetcher/weather/forecast.rs
+++ b/src/fetcher/weather/forecast.rs
@@ -1,0 +1,885 @@
+//! `weather_forecast` fetcher — Open-Meteo multi-day daily forecast for a fixed
+//! (latitude, longitude). Sibling of `weather` which covers current conditions only.
+//!
+//! Safety::Safe — host is hardcoded; config supplies coordinates / units / day count, never
+//! a URL. No API key.
+
+use async_trait::async_trait;
+use chrono::{Datelike, NaiveDate, Weekday};
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, NumberSeriesData, Payload, PointSeries,
+    PointSeriesData, RatioData, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+
+use super::super::github::common::cache_key;
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::common::{
+    API_BASE, Units, http, parse_options, payload, severity_rank, weather_badge,
+    weather_description,
+};
+
+const DEFAULT_DAYS: u8 = 3;
+const MIN_DAYS: u8 = 1;
+const MAX_DAYS: u8 = 7;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "latitude",
+        type_hint: "float (degrees)",
+        required: true,
+        default: None,
+        description: "Latitude of the location to query (e.g., `35.68` for Tokyo).",
+    },
+    OptionSchema {
+        name: "longitude",
+        type_hint: "float (degrees)",
+        required: true,
+        default: None,
+        description: "Longitude of the location to query (e.g., `139.76` for Tokyo).",
+    },
+    OptionSchema {
+        name: "units",
+        type_hint: "\"metric\" | \"imperial\"",
+        required: false,
+        default: Some("\"metric\""),
+        description: "Temperature unit system. Metric renders °C; imperial renders °F and reports precipitation in inches.",
+    },
+    OptionSchema {
+        name: "days",
+        type_hint: "int (1..=7)",
+        required: false,
+        default: Some("3"),
+        description: "How many days of forecast to fetch. Clamped to 1..=7 — Open-Meteo serves longer windows, but accuracy drops past a week.",
+    },
+];
+
+pub struct WeatherForecastFetcher;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WeatherForecastOptions {
+    pub latitude: f64,
+    pub longitude: f64,
+    #[serde(default)]
+    pub units: Option<Units>,
+    #[serde(default)]
+    pub days: Option<u8>,
+}
+
+#[async_trait]
+impl Fetcher for WeatherForecastFetcher {
+    fn name(&self) -> &str {
+        "weather_forecast"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Daily multi-day forecast for a fixed (latitude, longitude) via Open-Meteo. `TextBlock` / `Entries` / `Text` summarise highs / lows / precipitation per day; `Ratio` reports the worst precipitation probability in the window; `NumberSeries` carries per-day rainfall totals (tenths of mm or inch) for sparkline / histogram consumers; `Bars` carries per-day precipitation **probability** (%) so the bar chart stays informative even in dry forecasts; `PointSeries` carries high+low temperature curves across days; `Badge` flags the worst weather code; `Timeline` lays the days out chronologically. `days` defaults to 3 (range 1..=7), metric units by default, no API key required."
+    }
+    fn shapes(&self) -> &[Shape] {
+        &[
+            Shape::TextBlock,
+            Shape::Text,
+            Shape::Entries,
+            Shape::Ratio,
+            Shape::NumberSeries,
+            Shape::PointSeries,
+            Shape::Bars,
+            Shape::Badge,
+            Shape::Timeline,
+        ]
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(body_for_shape(&Forecast::sample(), shape))
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: WeatherForecastOptions =
+            parse_options(ctx.options.as_ref(), self.name()).map_err(FetchError::Failed)?;
+        let days = resolve_days(opts.days).map_err(FetchError::Failed)?;
+        let units = opts.units.unwrap_or_default();
+        let forecast = fetch_forecast(opts.latitude, opts.longitude, units, days).await?;
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
+        Ok(payload(body_for_shape(&forecast, shape)))
+    }
+}
+
+fn body_for_shape(forecast: &Forecast, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => text(forecast),
+        Shape::Entries => entries(forecast),
+        Shape::Ratio => ratio(forecast),
+        Shape::NumberSeries => number_series(forecast),
+        Shape::PointSeries => point_series(forecast),
+        Shape::Bars => bars(forecast),
+        Shape::Badge => badge(forecast),
+        Shape::Timeline => timeline(forecast),
+        _ => text_block(forecast),
+    }
+}
+
+fn resolve_days(raw: Option<u8>) -> Result<u8, String> {
+    let value = raw.unwrap_or(DEFAULT_DAYS);
+    if !(MIN_DAYS..=MAX_DAYS).contains(&value) {
+        return Err(format!(
+            "weather_forecast `days` must be between {MIN_DAYS} and {MAX_DAYS}, got {value}"
+        ));
+    }
+    Ok(value)
+}
+
+async fn fetch_forecast(
+    lat: f64,
+    lon: f64,
+    units: Units,
+    days: u8,
+) -> Result<Forecast, FetchError> {
+    let url = build_url(lat, lon, units, days);
+    let res = http()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("weather_forecast request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("weather_forecast {status}")));
+    }
+    let raw: ApiResponse = res
+        .json()
+        .await
+        .map_err(|e| FetchError::Failed(format!("weather_forecast json parse: {e}")))?;
+    Ok(Forecast {
+        days: days_from(&raw.daily),
+        units,
+    })
+}
+
+fn build_url(lat: f64, lon: f64, units: Units, days: u8) -> String {
+    let base = format!(
+        "{API_BASE}?latitude={lat}&longitude={lon}\
+         &daily=temperature_2m_max,temperature_2m_min,weather_code,precipitation_sum,precipitation_probability_max\
+         &forecast_days={days}\
+         &timezone=auto"
+    );
+    match units {
+        Units::Metric => base,
+        Units::Imperial => format!("{base}&temperature_unit=fahrenheit&precipitation_unit=inch"),
+    }
+}
+
+fn days_from(raw: &Daily) -> Vec<DayPoint> {
+    let len = raw
+        .time
+        .len()
+        .min(raw.temperature_2m_max.len())
+        .min(raw.temperature_2m_min.len())
+        .min(raw.weather_code.len());
+    (0..len)
+        .filter_map(|i| {
+            let date = NaiveDate::parse_from_str(&raw.time[i], "%Y-%m-%d").ok()?;
+            Some(DayPoint {
+                date,
+                weather_code: raw.weather_code[i],
+                high: raw.temperature_2m_max[i],
+                low: raw.temperature_2m_min[i],
+                precipitation: raw.precipitation_sum.get(i).copied().unwrap_or(0.0),
+                precip_probability: raw
+                    .precipitation_probability_max
+                    .get(i)
+                    .copied()
+                    .unwrap_or(0),
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    #[serde(default)]
+    daily: Daily,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Daily {
+    #[serde(default)]
+    time: Vec<String>,
+    #[serde(default)]
+    temperature_2m_max: Vec<f64>,
+    #[serde(default)]
+    temperature_2m_min: Vec<f64>,
+    #[serde(default)]
+    weather_code: Vec<u16>,
+    #[serde(default)]
+    precipitation_sum: Vec<f64>,
+    #[serde(default)]
+    precipitation_probability_max: Vec<u8>,
+}
+
+struct Forecast {
+    days: Vec<DayPoint>,
+    units: Units,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DayPoint {
+    date: NaiveDate,
+    weather_code: u16,
+    high: f64,
+    low: f64,
+    precipitation: f64,
+    precip_probability: u8,
+}
+
+impl Forecast {
+    fn sample() -> Self {
+        let base = NaiveDate::from_ymd_opt(2026, 5, 11).expect("valid date");
+        let days = [
+            (2u16, 22.4, 15.1, 0.0, 10u8),
+            (63, 18.2, 12.8, 8.4, 80),
+            (1, 20.5, 14.7, 0.0, 30),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(i, (code, high, low, precip, prob))| DayPoint {
+            date: base + chrono::Duration::days(i as i64),
+            weather_code: code,
+            high,
+            low,
+            precipitation: precip,
+            precip_probability: prob,
+        })
+        .collect();
+        Self {
+            days,
+            units: Units::Metric,
+        }
+    }
+}
+
+fn weekday_short(weekday: Weekday) -> &'static str {
+    match weekday {
+        Weekday::Mon => "Mon",
+        Weekday::Tue => "Tue",
+        Weekday::Wed => "Wed",
+        Weekday::Thu => "Thu",
+        Weekday::Fri => "Fri",
+        Weekday::Sat => "Sat",
+        Weekday::Sun => "Sun",
+    }
+}
+
+fn temp_range_label(day: &DayPoint, units: Units) -> String {
+    format!(
+        "{:.0}°/{:.0}°{}",
+        day.high,
+        day.low,
+        units.temperature_label().trim_start_matches('°')
+    )
+}
+
+fn precip_label(day: &DayPoint, units: Units) -> Option<String> {
+    if day.precipitation <= 0.0 {
+        return None;
+    }
+    let precision = match units {
+        Units::Metric => 1,
+        Units::Imperial => 2,
+    };
+    Some(format!(
+        "{:.*}{}",
+        precision,
+        day.precipitation,
+        units.precipitation_label()
+    ))
+}
+
+fn precip_summary(day: &DayPoint, units: Units) -> String {
+    match precip_label(day, units) {
+        Some(amount) => format!("💧{}% {amount}", day.precip_probability),
+        None => format!("💧{}%", day.precip_probability),
+    }
+}
+
+fn day_line(day: &DayPoint, units: Units) -> String {
+    let (emoji, _) = weather_description(day.weather_code);
+    format!(
+        "{}  {emoji} {}  {}",
+        weekday_short(day.date.weekday()),
+        temp_range_label(day, units),
+        precip_summary(day, units)
+    )
+}
+
+fn text_block(forecast: &Forecast) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: forecast
+            .days
+            .iter()
+            .map(|d| day_line(d, forecast.units))
+            .collect(),
+    })
+}
+
+fn text(forecast: &Forecast) -> Body {
+    let summary = forecast
+        .days
+        .iter()
+        .map(|d| {
+            let (emoji, _) = weather_description(d.weather_code);
+            format!("{emoji} {}", temp_range_label(d, forecast.units))
+        })
+        .collect::<Vec<_>>()
+        .join(" → ");
+    Body::Text(TextData { value: summary })
+}
+
+fn entries(forecast: &Forecast) -> Body {
+    Body::Entries(EntriesData {
+        items: forecast
+            .days
+            .iter()
+            .map(|d| {
+                let (emoji, _) = weather_description(d.weather_code);
+                Entry {
+                    key: format!("{} {emoji}", weekday_short(d.date.weekday())),
+                    value: Some(format!(
+                        "{}  {}",
+                        temp_range_label(d, forecast.units),
+                        precip_summary(d, forecast.units)
+                    )),
+                    status: None,
+                }
+            })
+            .collect(),
+    })
+}
+
+/// `Ratio` summarises the worst precipitation chance across the window. Pairs with
+/// `gauge_circle` / `gauge_battery` for a "umbrella?" glance — the single highest probability
+/// in the next few days, labelled with the day it falls on.
+fn ratio(forecast: &Forecast) -> Body {
+    let worst = forecast
+        .days
+        .iter()
+        .max_by_key(|d| d.precip_probability)
+        .copied();
+    let (value, label) = match worst {
+        Some(day) => (
+            f64::from(day.precip_probability) / 100.0,
+            Some(format!("{} rain risk", weekday_short(day.date.weekday()))),
+        ),
+        None => (0.0, None),
+    };
+    Body::Ratio(RatioData {
+        value,
+        label,
+        denominator: Some(100),
+    })
+}
+
+/// Per-day precipitation totals in tenths of mm (or inch for imperial). Same precision
+/// strategy as `weather`'s hourly precipitation — survives the `u64` round-trip without
+/// losing the sub-millimetre signal that distinguishes drizzle from "actually wet".
+fn number_series(forecast: &Forecast) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: forecast
+            .days
+            .iter()
+            .map(|d| (d.precipitation.max(0.0) * 10.0).round() as u64)
+            .collect(),
+    })
+}
+
+/// Two series — `high` and `low` temperatures — across days. `PointSeries` because
+/// temperature can go negative; `NumberSeries` would silently clamp.
+fn point_series(forecast: &Forecast) -> Body {
+    let unit = forecast.units.temperature_label();
+    let to_points = |pick: fn(&DayPoint) -> f64| -> Vec<(f64, f64)> {
+        forecast
+            .days
+            .iter()
+            .enumerate()
+            .map(|(i, d)| (i as f64, pick(d)))
+            .collect()
+    };
+    Body::PointSeries(PointSeriesData {
+        series: vec![
+            PointSeries {
+                name: format!("high ({unit})"),
+                points: to_points(|d| d.high),
+            },
+            PointSeries {
+                name: format!("low ({unit})"),
+                points: to_points(|d| d.low),
+            },
+        ],
+    })
+}
+
+/// Per-day precipitation **probability** (0..=100) with weekday labels. Probability rather
+/// than rainfall amount because most forecasts have wide stretches of `precipitation_sum =
+/// 0mm` even when chance-of-rain varies meaningfully (15% Tue, 35% Wed, 10% Thu). The
+/// amount sequence stays available on `NumberSeries` for sparkline / histogram consumers.
+fn bars(forecast: &Forecast) -> Body {
+    Body::Bars(BarsData {
+        bars: forecast
+            .days
+            .iter()
+            .map(|d| Bar {
+                label: weekday_short(d.date.weekday()).into(),
+                value: u64::from(d.precip_probability),
+            })
+            .collect(),
+    })
+}
+
+fn badge(forecast: &Forecast) -> Body {
+    let worst_code = forecast
+        .days
+        .iter()
+        .max_by_key(|d| severity_rank(d.weather_code))
+        .map(|d| d.weather_code)
+        .unwrap_or(0);
+    let mut data = weather_badge(worst_code);
+    if data.status == Status::Ok {
+        data = BadgeData {
+            status: Status::Ok,
+            label: "clear ahead".into(),
+        };
+    }
+    Body::Badge(data)
+}
+
+fn timeline(forecast: &Forecast) -> Body {
+    Body::Timeline(TimelineData {
+        events: forecast
+            .days
+            .iter()
+            .map(|d| {
+                let (emoji, condition) = weather_description(d.weather_code);
+                TimelineEvent {
+                    timestamp: d
+                        .date
+                        .and_hms_opt(0, 0, 0)
+                        .expect("midnight is always valid")
+                        .and_utc()
+                        .timestamp(),
+                    title: format!("{emoji} {condition}"),
+                    detail: Some(format!(
+                        "{}  {}",
+                        temp_range_label(d, forecast.units),
+                        precip_summary(d, forecast.units)
+                    )),
+                    status: Some(weather_badge(d.weather_code).status),
+                }
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn forecast_with(days: Vec<DayPoint>, units: Units) -> Forecast {
+        Forecast { days, units }
+    }
+
+    fn day(code: u16, high: f64, low: f64, precip: f64, prob: u8, date: NaiveDate) -> DayPoint {
+        DayPoint {
+            date,
+            weather_code: code,
+            high,
+            low,
+            precipitation: precip,
+            precip_probability: prob,
+        }
+    }
+
+    #[test]
+    fn build_url_metric_uses_timezone_auto_and_forecast_days() {
+        let url = build_url(35.68, 139.76, Units::Metric, 3);
+        assert!(url.contains("latitude=35.68"));
+        assert!(url.contains("longitude=139.76"));
+        assert!(url.contains("forecast_days=3"));
+        assert!(url.contains("timezone=auto"));
+        assert!(url.contains("temperature_2m_max"));
+        assert!(url.contains("precipitation_probability_max"));
+        assert!(!url.contains("fahrenheit"));
+        assert!(!url.contains("precipitation_unit=inch"));
+    }
+
+    #[test]
+    fn build_url_imperial_switches_temperature_and_precipitation_units() {
+        let url = build_url(40.71, -74.0, Units::Imperial, 5);
+        assert!(url.contains("forecast_days=5"));
+        assert!(url.contains("temperature_unit=fahrenheit"));
+        assert!(url.contains("precipitation_unit=inch"));
+    }
+
+    #[test]
+    fn resolve_days_defaults_to_three() {
+        assert_eq!(resolve_days(None).unwrap(), DEFAULT_DAYS);
+    }
+
+    #[test]
+    fn resolve_days_accepts_bounds() {
+        assert_eq!(resolve_days(Some(1)).unwrap(), 1);
+        assert_eq!(resolve_days(Some(7)).unwrap(), 7);
+    }
+
+    #[test]
+    fn resolve_days_rejects_out_of_range() {
+        assert!(resolve_days(Some(0)).is_err());
+        assert!(resolve_days(Some(8)).is_err());
+    }
+
+    #[test]
+    fn parse_options_requires_coordinates() {
+        let err: String = parse_options::<WeatherForecastOptions>(None, "weather_forecast")
+            .expect_err("missing options must fail");
+        assert!(err.contains("latitude"));
+    }
+
+    #[test]
+    fn parse_options_accepts_full_form() {
+        let raw: toml::Value =
+            toml::from_str("latitude = 35.68\nlongitude = 139.76\nunits = \"imperial\"\ndays = 5")
+                .unwrap();
+        let opts: WeatherForecastOptions = parse_options(Some(&raw), "weather_forecast").unwrap();
+        assert_eq!(opts.units, Some(Units::Imperial));
+        assert_eq!(opts.days, Some(5));
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_keys() {
+        let raw: toml::Value =
+            toml::from_str("latitude = 1.0\nlongitude = 2.0\nbogus = true").unwrap();
+        assert!(parse_options::<WeatherForecastOptions>(Some(&raw), "weather_forecast").is_err());
+    }
+
+    #[test]
+    fn daily_deserializes_open_meteo_payload() {
+        let raw = r#"{"daily":{"time":["2026-05-12","2026-05-13"],"temperature_2m_max":[22.4,18.2],"temperature_2m_min":[15.1,12.8],"weather_code":[2,63],"precipitation_sum":[0.0,8.4],"precipitation_probability_max":[10,80]}}"#;
+        let parsed: ApiResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.daily.time.len(), 2);
+        assert_eq!(parsed.daily.weather_code, vec![2, 63]);
+        let days = days_from(&parsed.daily);
+        assert_eq!(days.len(), 2);
+        assert_eq!(days[1].weather_code, 63);
+        assert_eq!(days[1].precip_probability, 80);
+    }
+
+    #[test]
+    fn days_from_skips_invalid_dates() {
+        let daily = Daily {
+            time: vec!["2026-05-12".into(), "not-a-date".into()],
+            temperature_2m_max: vec![22.0, 18.0],
+            temperature_2m_min: vec![15.0, 12.0],
+            weather_code: vec![2, 63],
+            precipitation_sum: vec![],
+            precipitation_probability_max: vec![],
+        };
+        let days = days_from(&daily);
+        assert_eq!(days.len(), 1);
+        assert_eq!(days[0].precipitation, 0.0);
+        assert_eq!(days[0].precip_probability, 0);
+    }
+
+    #[test]
+    fn text_block_emits_one_line_per_day() {
+        let forecast = Forecast::sample();
+        let Body::TextBlock(data) = text_block(&forecast) else {
+            panic!("expected text block");
+        };
+        assert_eq!(data.lines.len(), 3);
+        assert!(data.lines[0].starts_with("Mon  "));
+        assert!(data.lines[0].contains("22°/15°"));
+        assert!(data.lines[1].contains("💧80%"));
+        // Tue has 8.4mm precip → label includes the amount.
+        assert!(
+            data.lines[1].ends_with("8.4mm"),
+            "expected precip amount on rainy day: {:?}",
+            data.lines[1]
+        );
+        // Mon and Wed are dry → no mm suffix.
+        assert!(!data.lines[0].contains("mm"));
+        assert!(!data.lines[2].contains("mm"));
+    }
+
+    #[test]
+    fn precip_label_formats_metric_and_imperial_with_appropriate_precision() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 12).unwrap();
+        let wet = day(63, 18.0, 12.0, 8.4, 80, date);
+        let dry = day(0, 22.0, 16.0, 0.0, 10, date);
+        assert_eq!(precip_label(&wet, Units::Metric), Some("8.4mm".into()));
+        assert_eq!(precip_label(&wet, Units::Imperial), Some("8.40in".into()));
+        assert_eq!(precip_label(&dry, Units::Metric), None);
+    }
+
+    #[test]
+    fn text_emits_arrow_joined_summary() {
+        let Body::Text(data) = text(&Forecast::sample()) else {
+            panic!("expected text");
+        };
+        assert!(data.value.contains("→"));
+        assert_eq!(data.value.matches('→').count(), 2);
+        assert!(data.value.contains("22°/15°"));
+    }
+
+    #[test]
+    fn entries_emit_one_row_per_day_with_weekday_key() {
+        let Body::Entries(data) = entries(&Forecast::sample()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(data.items.len(), 3);
+        assert!(data.items[0].key.starts_with("Mon "));
+        assert!(data.items[0].value.as_deref().unwrap().contains("💧10%"));
+    }
+
+    #[test]
+    fn ratio_picks_max_precip_probability_and_names_the_day() {
+        let Body::Ratio(data) = ratio(&Forecast::sample()) else {
+            panic!("expected ratio");
+        };
+        assert!((data.value - 0.80).abs() < 1e-9);
+        assert_eq!(data.denominator, Some(100));
+        assert!(data.label.unwrap().starts_with("Tue "));
+    }
+
+    #[test]
+    fn number_series_holds_per_day_precipitation_in_tenths() {
+        let Body::NumberSeries(data) = number_series(&Forecast::sample()) else {
+            panic!("expected number series");
+        };
+        assert_eq!(data.values, vec![0, 84, 0]);
+    }
+
+    #[test]
+    fn point_series_carries_high_and_low_with_unit_labels() {
+        let Body::PointSeries(data) = point_series(&Forecast::sample()) else {
+            panic!("expected point series");
+        };
+        assert_eq!(data.series.len(), 2);
+        assert_eq!(data.series[0].name, "high (°C)");
+        assert_eq!(data.series[1].name, "low (°C)");
+        assert_eq!(data.series[0].points.len(), 3);
+        assert_eq!(data.series[0].points[1], (1.0, 18.2));
+        assert_eq!(data.series[1].points[2], (2.0, 14.7));
+    }
+
+    #[test]
+    fn point_series_preserves_negative_temperatures() {
+        let date = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let forecast = forecast_with(vec![day(71, -2.0, -8.5, 0.4, 60, date)], Units::Metric);
+        let Body::PointSeries(data) = point_series(&forecast) else {
+            panic!("expected point series");
+        };
+        assert_eq!(data.series[0].points[0].1, -2.0);
+        assert_eq!(data.series[1].points[0].1, -8.5);
+    }
+
+    #[test]
+    fn bars_carry_per_day_precipitation_probability_with_weekday_labels() {
+        let Body::Bars(data) = bars(&Forecast::sample()) else {
+            panic!("expected bars");
+        };
+        assert_eq!(data.bars.len(), 3);
+        assert_eq!(data.bars[0].label, "Mon");
+        // Sample probabilities: Mon=10, Tue=80, Wed=30. Bars now expose probability so the
+        // chart stays informative in dry forecasts where `precipitation_sum` is all zero.
+        assert_eq!(data.bars[0].value, 10);
+        assert_eq!(data.bars[1].value, 80);
+        assert_eq!(data.bars[2].value, 30);
+    }
+
+    #[test]
+    fn badge_picks_worst_severity_across_window() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 12).unwrap();
+        let forecast = forecast_with(
+            vec![
+                day(0, 22.0, 15.0, 0.0, 5, date),
+                day(63, 18.0, 12.0, 6.0, 70, date + chrono::Duration::days(1)),
+                day(95, 25.0, 17.0, 12.0, 90, date + chrono::Duration::days(2)),
+            ],
+            Units::Metric,
+        );
+        let Body::Badge(data) = badge(&forecast) else {
+            panic!("expected badge");
+        };
+        assert_eq!(data.status, Status::Error);
+        assert_eq!(data.label, "thunderstorm");
+    }
+
+    #[test]
+    fn badge_renames_all_clear_label_to_clear_ahead() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 12).unwrap();
+        let forecast = forecast_with(
+            vec![
+                day(0, 22.0, 15.0, 0.0, 0, date),
+                day(1, 23.0, 16.0, 0.0, 5, date + chrono::Duration::days(1)),
+            ],
+            Units::Metric,
+        );
+        let Body::Badge(data) = badge(&forecast) else {
+            panic!("expected badge");
+        };
+        assert_eq!(data.status, Status::Ok);
+        assert_eq!(data.label, "clear ahead");
+    }
+
+    #[test]
+    fn timeline_carries_one_event_per_day_with_midnight_utc_timestamps() {
+        let Body::Timeline(data) = timeline(&Forecast::sample()) else {
+            panic!("expected timeline");
+        };
+        assert_eq!(data.events.len(), 3);
+        // 2026-05-11 midnight UTC.
+        assert_eq!(data.events[0].timestamp, 1_778_457_600);
+        assert_eq!(data.events[1].timestamp - data.events[0].timestamp, 86_400);
+        assert!(data.events[0].title.contains("partly cloudy"));
+        assert_eq!(data.events[1].status, Some(Status::Warn));
+    }
+
+    #[test]
+    fn imperial_units_label_temperatures_in_fahrenheit() {
+        let forecast = Forecast {
+            units: Units::Imperial,
+            ..Forecast::sample()
+        };
+        let Body::PointSeries(data) = point_series(&forecast) else {
+            panic!("expected point series");
+        };
+        assert_eq!(data.series[0].name, "high (°F)");
+        let Body::TextBlock(block) = text_block(&forecast) else {
+            panic!("expected text block");
+        };
+        assert!(block.lines[0].contains("22°/15°F"));
+    }
+
+    #[test]
+    fn single_day_window_collapses_all_shapes_cleanly() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 12).unwrap();
+        let forecast = forecast_with(vec![day(2, 22.0, 15.0, 0.5, 20, date)], Units::Metric);
+        let Body::TextBlock(tb) = text_block(&forecast) else {
+            panic!("text block");
+        };
+        let Body::Text(t) = text(&forecast) else {
+            panic!("text");
+        };
+        let Body::Bars(b) = bars(&forecast) else {
+            panic!("bars");
+        };
+        assert_eq!(tb.lines.len(), 1);
+        assert!(!t.value.contains('→'));
+        assert_eq!(b.bars.len(), 1);
+    }
+
+    #[test]
+    fn fetcher_metadata_cache_key_and_samples_cover_supported_shapes() {
+        let fetcher = WeatherForecastFetcher;
+        let ctx = FetchContext {
+            widget_id: "weather_forecast".into(),
+            timeout: std::time::Duration::from_secs(1),
+            shape: Some(Shape::TextBlock),
+            ..Default::default()
+        };
+        let with_options = FetchContext {
+            options: Some(
+                toml::from_str("latitude = 35.68\nlongitude = 139.76\ndays = 5").unwrap(),
+            ),
+            ..ctx.clone()
+        };
+        assert_eq!(fetcher.name(), "weather_forecast");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("Open-Meteo"));
+        assert_eq!(
+            fetcher
+                .option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["latitude", "longitude", "units", "days"]
+        );
+        assert_eq!(fetcher.default_shape(), Shape::TextBlock);
+        assert_ne!(fetcher.cache_key(&ctx), fetcher.cache_key(&with_options));
+        for &shape in fetcher.shapes() {
+            let body = fetcher
+                .sample_body(shape)
+                .expect("sample for declared shape");
+            let ok = matches!(
+                (shape, &body),
+                (Shape::TextBlock, Body::TextBlock(_))
+                    | (Shape::Text, Body::Text(_))
+                    | (Shape::Entries, Body::Entries(_))
+                    | (Shape::Ratio, Body::Ratio(_))
+                    | (Shape::NumberSeries, Body::NumberSeries(_))
+                    | (Shape::PointSeries, Body::PointSeries(_))
+                    | (Shape::Bars, Body::Bars(_))
+                    | (Shape::Badge, Body::Badge(_))
+                    | (Shape::Timeline, Body::Timeline(_))
+            );
+            assert!(ok, "shape {shape:?} produced wrong body variant");
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_missing_options_before_network() {
+        let ctx = FetchContext {
+            widget_id: "weather_forecast".into(),
+            timeout: std::time::Duration::from_secs(1),
+            shape: Some(Shape::TextBlock),
+            ..Default::default()
+        };
+        let err = WeatherForecastFetcher.fetch(&ctx).await.unwrap_err();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("latitude")));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_out_of_range_days_before_network() {
+        let ctx = FetchContext {
+            widget_id: "weather_forecast".into(),
+            timeout: std::time::Duration::from_secs(1),
+            shape: Some(Shape::TextBlock),
+            options: Some(
+                toml::from_str("latitude = 35.68\nlongitude = 139.76\ndays = 30").unwrap(),
+            ),
+            ..Default::default()
+        };
+        let err = WeatherForecastFetcher.fetch(&ctx).await.unwrap_err();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("days")));
+    }
+
+    /// Live smoke test — hits Open-Meteo. `#[ignore]` keeps CI offline-safe. Run with
+    /// `cargo test -- --ignored fetcher::weather::forecast::tests::live` to verify the API
+    /// shape and weekday rendering for "today + 2".
+    #[tokio::test]
+    #[ignore]
+    async fn live_tokyo_forecast_populates_three_days() {
+        let forecast = fetch_forecast(35.68, 139.76, Units::Metric, 3)
+            .await
+            .unwrap();
+        assert_eq!(forecast.days.len(), 3);
+        let Body::TextBlock(block) = text_block(&forecast) else {
+            panic!("text block");
+        };
+        for line in &block.lines {
+            eprintln!("{line}");
+        }
+    }
+}

--- a/src/fetcher/weather/mod.rs
+++ b/src/fetcher/weather/mod.rs
@@ -1,0 +1,18 @@
+//! Weather fetchers. All `Safety::Safe` because every request targets `api.open-meteo.com`
+//! — the host is never config-driven. Config supplies coordinates / units / day count, not URLs.
+//! No API key is required and no token leaves the machine.
+
+use std::sync::Arc;
+
+pub(crate) mod common;
+mod forecast;
+mod now;
+
+use super::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        Arc::new(now::WeatherFetcher),
+        Arc::new(forecast::WeatherForecastFetcher),
+    ]
+}

--- a/src/fetcher/weather/now.rs
+++ b/src/fetcher/weather/now.rs
@@ -1,29 +1,27 @@
-//! `weather` fetcher — Open-Meteo forecast for a fixed (latitude, longitude).
+//! `weather` fetcher — Open-Meteo "current conditions" snapshot for a fixed
+//! (latitude, longitude). Multi-shape: Entries (default) / Text / PointSeries / NumberSeries /
+//! Bars / Badge.
 //!
 //! Safety::Safe because the host is hardcoded: the user supplies coordinates, not a URL, so
 //! config can't redirect traffic to an attacker-controlled origin. No API key is required and
 //! no token leaves the machine.
 
-use std::sync::OnceLock;
-use std::time::Duration;
-
 use async_trait::async_trait;
-use reqwest::Client;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
 use crate::payload::{
-    BadgeData, Bar, BarsData, Body, EntriesData, Entry, NumberSeriesData, Payload, PointSeries,
-    PointSeriesData, Status, TextData,
+    Bar, BarsData, Body, EntriesData, Entry, NumberSeriesData, Payload, PointSeries,
+    PointSeriesData, TextData,
 };
 use crate::render::Shape;
 
-use super::github::common::cache_key;
-use super::{FetchContext, FetchError, Fetcher, Safety};
+use super::super::github::common::cache_key;
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::common::{
+    API_BASE, Units, http, parse_options, payload, weather_badge, weather_description,
+};
 
-const API_BASE: &str = "https://api.open-meteo.com/v1/forecast";
-const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const HOURLY_HOURS: usize = 24;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -50,7 +48,7 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
     },
 ];
 
-/// Open-Meteo forecast widget. Entries shape (primary): condition / temp / wind / humidity.
+/// Open-Meteo "now" widget. Entries shape (primary): condition / temp / wind / humidity.
 pub struct WeatherFetcher;
 
 #[derive(Debug, Deserialize)]
@@ -60,14 +58,6 @@ pub struct WeatherOptions {
     pub longitude: f64,
     #[serde(default)]
     pub units: Option<Units>,
-}
-
-#[derive(Debug, Default, Clone, Copy, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Units {
-    #[default]
-    Metric,
-    Imperial,
 }
 
 #[async_trait]
@@ -118,7 +108,7 @@ impl Fetcher for WeatherFetcher {
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: WeatherOptions =
-            parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+            parse_options(ctx.options.as_ref(), self.name()).map_err(FetchError::Failed)?;
         let units = opts.units.unwrap_or_default();
         let report = fetch_report(opts.latitude, opts.longitude, units).await?;
         let body = match ctx.shape.unwrap_or(Shape::Entries) {
@@ -254,18 +244,10 @@ impl Default for Sample {
 
 impl Sample {
     fn temperature_label(&self) -> String {
-        let unit = match self.units {
-            Units::Metric => "°C",
-            Units::Imperial => "°F",
-        };
-        format!("{:.0}{unit}", self.temperature)
+        format!("{:.0}{}", self.temperature, self.units.temperature_label())
     }
     fn wind_label(&self) -> String {
-        let unit = match self.units {
-            Units::Metric => "m/s",
-            Units::Imperial => "mph",
-        };
-        format!("{:.0} {unit}", self.wind_speed)
+        format!("{:.0} {}", self.wind_speed, self.units.wind_label())
     }
     fn humidity_label(&self) -> String {
         format!("{}%", self.humidity)
@@ -282,13 +264,9 @@ impl Sample {
 }
 
 fn point_series(hourly: &[HourPoint], units: Units) -> Body {
-    let unit_label = match units {
-        Units::Metric => "°C",
-        Units::Imperial => "°F",
-    };
     Body::PointSeries(PointSeriesData {
         series: vec![PointSeries {
-            name: format!("temperature ({unit_label})"),
+            name: format!("temperature ({})", units.temperature_label()),
             points: hourly
                 .iter()
                 .map(|h| (f64::from(h.offset_hours), h.temperature))
@@ -324,23 +302,6 @@ fn precipitation_bars(hourly: &[HourPoint]) -> Body {
     })
 }
 
-fn weather_badge(code: u16) -> BadgeData {
-    let (status, label) = match code {
-        95 | 96 | 99 => (Status::Error, "thunderstorm"),
-        56 | 57 | 66 | 67 => (Status::Warn, "freezing"),
-        65 | 75 | 82 | 86 => (Status::Warn, "heavy precip"),
-        61 | 63 | 71 | 73 | 80 | 81 | 85 => (Status::Warn, "precip"),
-        _ => {
-            let (_, desc) = weather_description(code);
-            (Status::Ok, desc)
-        }
-    };
-    BadgeData {
-        status,
-        label: label.into(),
-    }
-}
-
 fn entries(s: &Sample) -> Body {
     let (emoji, condition) = weather_description(s.code);
     let rows = [
@@ -360,61 +321,10 @@ fn entries(s: &Sample) -> Body {
     })
 }
 
-/// WMO weather interpretation codes (Open-Meteo uses the standard table).
-fn weather_description(code: u16) -> (&'static str, &'static str) {
-    match code {
-        0 => ("🌞", "clear"),
-        1 => ("🌤", "mostly clear"),
-        2 => ("⛅", "partly cloudy"),
-        3 => ("☁", "overcast"),
-        45 | 48 => ("🌫", "fog"),
-        51 | 53 | 55 => ("🌦", "drizzle"),
-        56 | 57 => ("🌧", "freezing drizzle"),
-        61 | 63 | 65 => ("🌧", "rain"),
-        66 | 67 => ("🌧", "freezing rain"),
-        71 | 73 | 75 | 77 => ("🌨", "snow"),
-        80..=82 => ("🌦", "rain showers"),
-        85 | 86 => ("🌨", "snow showers"),
-        95 => ("⛈", "thunderstorm"),
-        96 | 99 => ("⛈", "thunderstorm w/ hail"),
-        _ => ("🌡", "unknown"),
-    }
-}
-
-fn http() -> &'static Client {
-    static CLIENT: OnceLock<Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        Client::builder()
-            .user_agent(USER_AGENT)
-            .timeout(REQUEST_TIMEOUT)
-            .gzip(true)
-            .build()
-            .expect("reqwest client should build with default config")
-    })
-}
-
-fn parse_options<T: serde::de::DeserializeOwned>(raw: Option<&toml::Value>) -> Result<T, String> {
-    match raw {
-        None => Err("weather requires `latitude` and `longitude` options".into()),
-        Some(value) => value
-            .clone()
-            .try_into::<T>()
-            .map_err(|e| format!("invalid options: {e}")),
-    }
-}
-
-fn payload(body: Body) -> Payload {
-    Payload {
-        icon: None,
-        status: None,
-        format: None,
-        body,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::payload::{BadgeData, Status};
 
     fn entries_data(body: Body) -> Option<EntriesData> {
         match body {
@@ -451,6 +361,13 @@ mod tests {
         }
     }
 
+    fn badge_data(body: Body) -> Option<BadgeData> {
+        match body {
+            Body::Badge(data) => Some(data),
+            _ => None,
+        }
+    }
+
     #[test]
     fn build_url_metric_requests_ms_wind() {
         let url = build_url(35.68, 139.76, Units::Metric);
@@ -466,16 +383,6 @@ mod tests {
         let url = build_url(40.71, -74.0, Units::Imperial);
         assert!(url.contains("temperature_unit=fahrenheit"));
         assert!(url.contains("wind_speed_unit=mph"));
-    }
-
-    #[test]
-    fn weather_description_covers_canonical_codes() {
-        assert_eq!(weather_description(0).1, "clear");
-        assert_eq!(weather_description(3).1, "overcast");
-        assert_eq!(weather_description(56).1, "freezing drizzle");
-        assert_eq!(weather_description(63).1, "rain");
-        assert_eq!(weather_description(95).1, "thunderstorm");
-        assert_eq!(weather_description(1234).1, "unknown");
     }
 
     #[test]
@@ -507,14 +414,14 @@ mod tests {
 
     #[test]
     fn parse_options_requires_latitude_and_longitude() {
-        let err: String = parse_options::<WeatherOptions>(None).unwrap_err();
+        let err: String = parse_options::<WeatherOptions>(None, "weather").unwrap_err();
         assert!(err.contains("latitude"));
     }
 
     #[test]
     fn parse_options_accepts_floats() {
         let raw: toml::Value = toml::from_str("latitude = 35.68\nlongitude = 139.76").unwrap();
-        let opts: WeatherOptions = parse_options(Some(&raw)).unwrap();
+        let opts: WeatherOptions = parse_options(Some(&raw), "weather").unwrap();
         assert_eq!(opts.latitude, 35.68);
         assert_eq!(opts.longitude, 139.76);
     }
@@ -523,7 +430,7 @@ mod tests {
     fn parse_options_rejects_unknown_keys() {
         let raw: toml::Value =
             toml::from_str("latitude = 1.0\nlongitude = 2.0\nbogus = true").unwrap();
-        assert!(parse_options::<WeatherOptions>(Some(&raw)).is_err());
+        assert!(parse_options::<WeatherOptions>(Some(&raw), "weather").is_err());
     }
 
     #[test]
@@ -539,7 +446,7 @@ mod tests {
         let hourly = vec![
             HourPoint {
                 offset_hours: 0,
-                temperature: -3.0, // negative temp must NOT clamp the precip slot to 0
+                temperature: -3.0,
                 precipitation: 0.6,
             },
             HourPoint {
@@ -554,14 +461,11 @@ mod tests {
             },
         ];
         let d = number_series_data(number_series(&hourly)).unwrap();
-        // 0.6 mm → 6 tenths, 0.0 → 0, 1.25 → 13 (rounded).
         assert_eq!(d.values, vec![6, 0, 13]);
     }
 
     #[test]
     fn point_series_temperature_preserves_negative_readings() {
-        // PointSeries is f64 — make sure sub-zero temps survive end-to-end (the bug fixed by
-        // moving temperature off `NumberSeries`, which would have clamped these to 0).
         let hourly = vec![
             HourPoint {
                 offset_hours: 0,
@@ -585,14 +489,6 @@ mod tests {
         assert_eq!(d.bars.len(), HOURLY_HOURS);
         assert_eq!(d.bars[0].label, "+0h");
         assert_eq!(d.bars[5].label, "+5h");
-    }
-
-    #[test]
-    fn weather_badge_severity_follows_wmo_groups() {
-        assert_eq!(weather_badge(0).status, Status::Ok);
-        assert_eq!(weather_badge(63).status, Status::Warn);
-        assert_eq!(weather_badge(75).status, Status::Warn);
-        assert_eq!(weather_badge(95).status, Status::Error);
     }
 
     #[test]
@@ -655,13 +551,18 @@ mod tests {
             .sample_body(Shape::PointSeries)
             .and_then(point_series_data)
             .unwrap();
+        let badge = fetcher
+            .sample_body(Shape::Badge)
+            .and_then(badge_data)
+            .unwrap();
         assert!(text.value.contains("💨"));
         assert_eq!(series.series[0].name, "temperature (°C)");
+        assert_eq!(badge.status, Status::Ok);
         assert!(fetcher.sample_body(Shape::Calendar).is_none());
     }
 
     #[test]
-    fn helper_paths_cover_padding_statuses_and_singletons() {
+    fn helper_paths_cover_padding_and_singletons() {
         let points = hourly_from(&Hourly {
             temperature_2m: (0..30).map(|i| i as f64).collect(),
             precipitation: vec![0.5],
@@ -673,23 +574,6 @@ mod tests {
         assert_eq!(points[23].offset_hours, 23);
         assert_eq!(series.series[0].name, "temperature (°F)");
         assert_eq!(text.value, "ok");
-        assert!(std::ptr::eq(http(), http()));
-        assert_eq!(weather_badge(56).label, "freezing");
-        assert_eq!(weather_badge(96).label, "thunderstorm");
-        assert_eq!(
-            [1, 2, 45, 51, 66, 71, 81, 86, 96].map(|code| weather_description(code).1),
-            [
-                "mostly clear",
-                "partly cloudy",
-                "fog",
-                "drizzle",
-                "freezing rain",
-                "snow",
-                "rain showers",
-                "snow showers",
-                "thunderstorm w/ hail",
-            ]
-        );
     }
 
     #[test]
@@ -714,10 +598,10 @@ mod tests {
     }
 
     /// Live smoke test — hits Open-Meteo. `#[ignore]` keeps CI offline-safe; run with
-    /// `cargo test -- --ignored fetcher::weather::tests::live` to verify real API shape.
+    /// `cargo test -- --ignored fetcher::weather::now::tests::live` to verify real API shape.
     #[tokio::test]
     #[ignore]
-    async fn live_tokyo_forecast_populates_entries() {
+    async fn live_tokyo_now_populates_entries() {
         let report = fetch_report(35.68, 139.76, Units::Metric).await.unwrap();
         let body = entries(&report);
         let Body::Entries(e) = body else {

--- a/src/render/chart_line.rs
+++ b/src/render/chart_line.rs
@@ -12,7 +12,7 @@ use crate::theme::{self, ColorKey, Theme};
 
 use super::{Registry, RenderOptions, Renderer, Shape};
 
-const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES, theme::PANEL_BORDER];
+const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES, theme::PANEL_BORDER, theme::BG];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -78,7 +78,13 @@ fn render_line_chart(
         .map(|(i, s)| to_dataset(s, theme.series_color(i)))
         .collect();
     let (x_bounds, y_bounds) = bounds(&data.series);
+    // `Chart` builds an internal `Canvas` per dataset and seeds it with
+    // `self.style.bg.unwrap_or(Color::Reset)` (ratatui 0.29 `chart.rs:1023`). Without an
+    // explicit `bg` here, the plot area paints `Color::Reset` and erases the surrounding
+    // panel surface (`theme.bg` or `bg = "subtle"`). Propagate `theme.bg` so the chart
+    // keeps the layout-painted background.
     let mut chart = Chart::new(datasets)
+        .style(Style::default().bg(theme.bg))
         .x_axis(Axis::default().bounds(x_bounds))
         .y_axis(Axis::default().bounds(y_bounds));
     if opts.axes.unwrap_or(false) {
@@ -200,6 +206,35 @@ mod tests {
         let top = line_text(&buf, 0);
         assert!(top.starts_with('┌'), "missing top-left border: {top:?}");
         assert!(top.contains('┐'), "missing top-right border: {top:?}");
+    }
+
+    #[test]
+    fn rendered_cells_inherit_theme_bg_rather_than_color_reset() {
+        // Regression for ratatui's `Chart` seeding its internal `Canvas` with
+        // `Color::Reset` — without `Chart::style().bg(theme.bg)` the plot area would
+        // overwrite the panel surface painted by the layout.
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("chart_line".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![series("temp", &[(0.0, 0.0), (1.0, 1.0)])]),
+            Some(&spec),
+            &registry,
+            20,
+            6,
+        );
+        let theme = Theme::default();
+        let mut bg_hits = 0;
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                if buf.cell((x, y)).unwrap().style().bg == Some(theme.bg) {
+                    bg_hits += 1;
+                }
+            }
+        }
+        assert!(
+            bg_hits > 0,
+            "expected at least one chart cell to carry theme.bg, got 0"
+        );
     }
 
     #[test]

--- a/src/render/chart_scatter.rs
+++ b/src/render/chart_scatter.rs
@@ -22,7 +22,7 @@ struct Options {
     pub marker: Option<String>,
 }
 
-const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES, theme::PANEL_BORDER];
+const COLOR_KEYS: &[ColorKey] = &[theme::PALETTE_SERIES, theme::PANEL_BORDER, theme::BG];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -86,7 +86,11 @@ fn render_scatter(
 ) {
     let specific: Options = opts.parse_specific();
     let (x_bounds, y_bounds) = bounds(&data.series);
+    // ratatui's `Canvas` paints `background_color` (defaulting to `Color::Reset`) across the
+    // whole plot area, overwriting any panel surface the layout already painted. Anchor it
+    // to `theme.bg` so the scatter plot keeps the surrounding bg.
     let mut canvas = Canvas::default()
+        .background_color(theme.bg)
         .x_bounds(x_bounds)
         .y_bounds(y_bounds)
         .marker(parse_marker(specific.marker.as_deref()))
@@ -218,6 +222,33 @@ mod tests {
         let top = line_text(&buf, 0);
         assert!(top.starts_with('┌'), "missing top-left border: {top:?}");
         assert!(top.contains('┐'), "missing top-right border: {top:?}");
+    }
+
+    #[test]
+    fn rendered_cells_inherit_theme_bg_rather_than_color_reset() {
+        // Regression for `Canvas::default()` seeding `background_color = Color::Reset`.
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("chart_scatter".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![series("temp", &[(0.0, 0.0), (1.0, 1.0)])]),
+            Some(&spec),
+            &registry,
+            20,
+            6,
+        );
+        let theme = Theme::default();
+        let mut bg_hits = 0;
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                if buf.cell((x, y)).unwrap().style().bg == Some(theme.bg) {
+                    bg_hits += 1;
+                }
+            }
+        }
+        assert!(
+            bg_hits > 0,
+            "expected at least one scatter cell to carry theme.bg, got 0"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- New `weather_forecast` fetcher — Open-Meteo daily multi-day forecast (default 3 days, range 1..=7) for a fixed `(latitude, longitude)`. Sibling of `weather` (now). 9 shapes covering everything from a one-liner headline to a `Timeline` of per-day events.
- `weather.rs` split into `src/fetcher/weather/{mod,common,now,forecast}.rs` mirroring the `github/` family layout. `weather`'s registered name / behaviour / tests are unchanged.
- Drive-by bg fix for `chart_line` / `chart_scatter` — ratatui's `Chart` / `Canvas` were painting `Color::Reset` across the plot area, erasing the panel `theme.bg`. Anchored both to `theme.bg`.

Refs #41 — ticks the `weather_forecast` box on #68.

## `weather_forecast` reference

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `text_block` (default), `text`, `entries`, `ratio`, `number_series`, `point_series`, `bars`, `badge`, `timeline` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `latitude` | float (degrees) | yes | — | Latitude of the location to query (e.g., `35.68` for Tokyo). |
| `longitude` | float (degrees) | yes | — | Longitude of the location to query. |
| `units` | `"metric"` \| `"imperial"` | no | `"metric"` | Metric renders °C; imperial renders °F and reports precipitation in inches. |
| `days` | int (1..=7) | no | `3` | Forecast window. Open-Meteo serves longer windows but accuracy drops past a week. |

### Compatible renderers (per shape)

| Shape | Default renderers |
| --- | --- |
| `text_block` | [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) |
| `text` | [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/) |
| `entries` | [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/) |
| `ratio` | [`gauge_battery`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_battery/), [`gauge_circle`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_circle/), [`gauge_line`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_line/), [`gauge_segment`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_segment/), [`gauge_thermometer`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_thermometer/) |
| `number_series` | [`chart_histogram`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_histogram/), [`chart_sparkline`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_sparkline/) |
| `point_series` | [`chart_line`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_line/), [`chart_scatter`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_scatter/) |
| `bars` | [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar/), [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie/), [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking/) |
| `badge` | [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/) |
| `timeline` | [`list_timeline`](https://splashboard.unhappychoice.com/reference/renderers/list/list_timeline/) |

### Theme tokens

`Bars` carries per-day precipitation **probability** (%), not rainfall amount, so `chart_bar` stays informative in dry forecasts. `NumberSeries` keeps the rainfall amount in tenths-of-mm/inch for sparkline / histogram consumers. Textual shapes append precipitation amount only when > 0 (`Tue  🌧 18°/13°C  💧80% 8.4mm`).

## `chart_line` / `chart_scatter` bg fix

ratatui 0.29's `Chart` widget seeds its internal `Canvas` with `self.style.bg.unwrap_or(Color::Reset)` (`chart.rs:1023`); `Canvas::default()` defaults `background_color` to `Color::Reset` (`canvas.rs:639`). Either path painted the terminal default across the plot area and erased the panel surface (`theme.bg` or `bg = "subtle"`).

- `chart_line`: `Chart::new(...).style(Style::default().bg(theme.bg))` propagates the bg into the inner Canvas.
- `chart_scatter`: `Canvas::default().background_color(theme.bg)`.

`theme::BG` added to each renderer's `COLOR_KEYS` so the docs / catalog surface the theme dependency. Regression tests assert rendered cells carry `Theme::default().bg`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` (2054 lib + 28 + 12 integration, all green; 12 live-network tests `#[ignore]`d)
- [x] `cargo run --bin splashboard -- catalog fetcher weather_forecast` shows 9 shapes + 4 options + every compatible renderer
- [x] Hand-rolled `.splashboard/dashboard.toml` smoke-tested locally across 8 panels (TextBlock / Entries / PointSeries chart_line / Bars chart_bar / Ratio gauge_battery / Badge / Timeline / Text centered)
- [ ] Verify `chart_line` panel bg matches sibling panels under both `theme.bg` and `bg = "subtle"` layouts in production
- [ ] Catalog checkbox at #68 → flip `weather_forecast` to `[x]` after merge