### PR TITLE
feat: "splashboard cache" management CLI — list, clear, path (#40)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -163,7 +163,13 @@ pub(crate) fn tmp_path_for(final_path: &Path) -> PathBuf {
     final_path.with_file_name(format!("{file_name}.{pid}.{seq}.tmp"))
 }
 
-fn sanitize(s: &str) -> String {
+/// Maps an arbitrary cache key to an on-disk filename stem by keeping ASCII alnum / `-` / `_`
+/// and replacing everything else with `_`. Exposed because the `splashboard cache clear <id>`
+/// command (in the binary crate) needs to compute the same stem from the same key — keeping a
+/// private copy in `main.rs` would silently desync if this rule ever tightens. Marked
+/// `#[doc(hidden)]` because external library consumers should not rely on it.
+#[doc(hidden)]
+pub fn sanitize(s: &str) -> String {
     s.chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '-' || c == '_' {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1377,7 +1377,11 @@ PATH = "/tmp/ignored"
         // files or user backups.
         std::fs::write(dir.path().join("x.tmp"), "scratch").unwrap();
         std::fs::write(dir.path().join("y.bak"), "backup").unwrap();
-        std::fs::write(dir.path().join("z.json"), r#"{"refreshed_at":0,"ttl_seconds":0,"payload":{}}"#).unwrap();
+        std::fs::write(
+            dir.path().join("z.json"),
+            r#"{"refreshed_at":0,"ttl_seconds":0,"payload":{}}"#,
+        )
+        .unwrap();
         std::fs::write(dir.path().join("z.lock"), "").unwrap();
         let rows = super::collect_cache_rows(dir.path()).unwrap();
         assert_eq!(rows.len(), 2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,8 +129,8 @@ enum Command {
 enum CacheSubcommand {
     /// Print the resolved cache directory.
     Path,
-    /// List every cache entry: key, age, TTL, fresh/stale, payload size, kind. Sorted by age
-    /// descending. Pass `--json` for one JSON object per line.
+    /// List every cache entry: key, age, TTL, fresh/stale, payload size, kind. Oldest first
+    /// (stale / orphan entries surface at the top). Pass `--json` for one JSON object per line.
     List {
         /// Emit one JSON object per entry instead of the human-readable table.
         #[arg(long)]
@@ -139,16 +139,30 @@ enum CacheSubcommand {
     /// Remove cache entries. Pass a widget id to remove only that widget's entry (the widget must
     /// still be configured); otherwise removes every entry plus any leftover `.lock` files.
     ///
-    /// Note: when clearing by widget id, the cache key is computed using the widget's
-    /// default shape and no locale/timezone overrides. If your config overrides any of
-    /// those at runtime, the on-disk filename will differ and this command won't find
-    /// the entry. Use `splashboard cache list` to see the actual key and delete the
-    /// file directly in that case.
+    /// Single-widget clear computes the cache key from whichever dashboard would render in the
+    /// current directory (project-local if you're inside a configured project, otherwise the
+    /// home dashboard). If your widget only lives in the other dashboard, run this from a
+    /// directory that resolves to that dashboard, or use `splashboard cache list` + delete the
+    /// file directly.
+    ///
+    /// Cache key is computed using the widget's default shape and no locale/timezone
+    /// overrides. If your config overrides any of those at runtime, the on-disk filename will
+    /// differ and this command won't find the entry — fall back to `cache list` + manual
+    /// delete in that case.
+    ///
+    /// May race against an active daemon refresh: if the daemon is mid-write when you clear,
+    /// the next refresh re-creates the entry; rerun if that's not what you want. (A future
+    /// release may add lock-aware skipping.)
+    ///
+    /// When clearing all entries, partial removal failures exit non-zero while still reporting
+    /// the count that was removed — JSON consumers should read both `removed` and the exit
+    /// status.
     Clear {
         /// Widget id to clear. If omitted, clears every entry.
         #[arg(value_name = "WIDGET_ID")]
         widget_id: Option<String>,
-        /// Skip the confirmation prompt for `clear` (no widget id).
+        /// Skip the confirmation prompt when clearing all entries. Has no effect when a widget
+        /// id is given (single-widget clear is non-interactive).
         #[arg(long)]
         yes: bool,
         /// Emit a JSON summary instead of the human-readable lines.
@@ -408,8 +422,7 @@ fn run_list_trusted() -> io::Result<()> {
 
 fn run_cache(subcommand: CacheSubcommand) -> io::Result<()> {
     let Some(dir) = paths::cache_dir() else {
-        eprintln!("no cache dir resolved (is $HOME set?)");
-        std::process::exit(2);
+        return Err(io::Error::other("no cache dir resolved (is $HOME set?)"));
     };
     match subcommand {
         CacheSubcommand::Path => {
@@ -683,9 +696,9 @@ the file directly.",
         locale: None,
     });
 
-    // Same sanitization as cache.rs; replicated here to avoid widening the public API for a
-    // single character set that's stable across the codebase.
-    let sanitized = sanitize_cache_key(&key);
+    // Same sanitization function that `cache.rs` uses to write entries — keeping a second copy
+    // would silently desync if the rule ever tightened.
+    let sanitized = cache::sanitize(&key);
     let entry_path = dir.join(format!("{sanitized}.json"));
     let lock_path = dir.join(format!("{sanitized}.lock"));
     let mut removed = Vec::new();
@@ -738,26 +751,16 @@ the file directly.",
     Ok(())
 }
 
-/// Replicates `cache::sanitize` (which is module-private) so we can compute the on-disk
-/// filename for a given cache key. Kept in sync with `cache.rs`; covered by the
-/// `clear_one_matches_cache_filename_layout` test.
-fn sanitize_cache_key(key: &str) -> String {
-    key.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    // `chars().count()` walks the string once but is O(n) — fine here since `max` is at most
+    // a column width (e.g. 40). The earlier byte-slice version (`&s[..max-1]`) would panic on a
+    // multi-byte codepoint straddling the boundary; cache keys are alnum + dash today, but the
+    // table renders arbitrary user content (widget ids in --help output, fetcher names, ...).
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max.saturating_sub(1)])
+        let prefix: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{prefix}…")
     }
 }
 
@@ -1215,38 +1218,18 @@ PATH = "/tmp/ignored"
     }
 
     #[test]
-    fn sanitize_cache_key_matches_alnum_dash_underscore_passthrough() {
-        // Keys produced by `fetcher::default_cache_key` look like `<name>-<hex8>` (alnum + dash).
-        // They must round-trip through our sanitize unchanged, so the filename we compute in
-        // `clear_one` matches what the writer in `cache::Cache::store` chose.
-        let key = "clock-3f2a1c8b";
-        assert_eq!(super::sanitize_cache_key(key), key);
-    }
-
-    #[test]
-    fn sanitize_cache_key_replaces_path_and_control_chars() {
-        // Defensive: anything outside [A-Za-z0-9_-] must be replaced so the on-disk filename
-        // can't escape the cache directory.
-        let key = "evil/../name with spaces";
-        let sanitized = super::sanitize_cache_key(key);
-        assert!(!sanitized.contains('/'));
-        assert!(!sanitized.contains('.'));
-        assert!(!sanitized.contains(' '));
-    }
-
-    #[test]
     fn clear_one_matches_cache_filename_layout() {
         // Pin the contract that `clear_one` uses to find on-disk files: the path produced by
-        // `cache::Cache::path_for` for a given key must equal `<dir>/<sanitize_cache_key(key)>.json`.
-        // If this test breaks, `cache::sanitize` and `main::sanitize_cache_key` have drifted —
-        // update both before merging.
+        // `cache::Cache::path_for` for a given key must equal `<dir>/<cache::sanitize(key)>.json`.
+        // Both sides now call the same function, so this is mostly a "the layout hasn't changed
+        // shape" pin (e.g. someone adds a subdirectory level, or switches extension).
         let dir = tempfile::tempdir().unwrap();
         let cache = splashboard::cache::Cache::open(dir.path().to_path_buf()).unwrap();
         let key = "clock-3f2a1c8b";
         let cache_path = cache.path_for(key);
         let expected = dir
             .path()
-            .join(format!("{}.json", super::sanitize_cache_key(key)));
+            .join(format!("{}.json", splashboard::cache::sanitize(key)));
         assert_eq!(cache_path, expected);
     }
 
@@ -1367,6 +1350,19 @@ PATH = "/tmp/ignored"
         // Edge case: max=1. saturating_sub(1) keeps zero prefix; result is just "…".
         let out = super::truncate("longer", 1);
         assert_eq!(out, "…");
+    }
+
+    #[test]
+    fn truncate_handles_multi_byte_codepoints_without_panicking() {
+        // Regression: the earlier byte-slice impl (`&s[..max-1]`) would panic if the cut
+        // landed inside a multi-byte UTF-8 codepoint. Cache keys are alnum + dash today,
+        // but `truncate` is also used to render arbitrary user-facing strings.
+        // 「日本語」 is 3 codepoints, 9 UTF-8 bytes — slicing at byte 4 would split a char.
+        let out = super::truncate("日本語テスト", 4);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), 4);
+        // Each character must remain a complete grapheme (no `from_utf8` round-trip error).
+        assert!(out.chars().all(|c| c != '\u{FFFD}'));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,12 @@ enum CacheSubcommand {
     },
     /// Remove cache entries. Pass a widget id to remove only that widget's entry (the widget must
     /// still be configured); otherwise removes every entry plus any leftover `.lock` files.
+    ///
+    /// Note: when clearing by widget id, the cache key is computed using the widget's
+    /// default shape and no locale/timezone overrides. If your config overrides any of
+    /// those at runtime, the on-disk filename will differ and this command won't find
+    /// the entry. Use `splashboard cache list` to see the actual key and delete the
+    /// file directly in that case.
     Clear {
         /// Widget id to clear. If omitted, clears every entry.
         #[arg(value_name = "WIDGET_ID")]
@@ -708,7 +714,18 @@ the file directly.",
         });
         println!("{payload}");
     } else if removed.is_empty() {
-        println!("widget '{widget_id}' had no cache entry (key {key})");
+        // Defensive: if `cache list` shows the widget on disk but `clear` reports
+        // nothing removed, the on-disk entry was written with a non-default shape /
+        // locale / timezone (overridden at runtime). The key we computed here uses
+        // `fetcher.default_shape()` with locale/timezone = None — that match the
+        // common case but not overrides. `cache list` + delete-by-key is the
+        // fallback path in that scenario.
+        println!(
+            "widget '{widget_id}' had no cache entry under key {key}\n\
+             (computed using default shape + no locale/timezone overrides; \
+              if your config overrides those, run `splashboard cache list` and \
+              delete the matching file directly)"
+        );
     } else {
         println!(
             "removed {} file(s) for widget '{widget_id}' (key {key})",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
 use std::future::Future;
 use std::io::{self, BufRead, IsTerminal, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use clap::{Parser, Subcommand};
 
+use splashboard::cache::{self, CacheEntry};
 use splashboard::catalog;
 use splashboard::config::{
     self, Config, DashboardConfig, DashboardSource, SettingsConfig, WidgetConfig,
 };
 use splashboard::daemon::{self, DashboardKind};
-use splashboard::fetcher::{Registry, Safety};
+use splashboard::fetcher::{FetchContext, Registry, Safety};
 use splashboard::install::{self, InstallOptions};
 use splashboard::logging;
 use splashboard::paths;
@@ -114,6 +116,39 @@ enum Command {
         #[arg(long)]
         path: Option<PathBuf>,
     },
+    /// Inspect and manage the disk cache (`$HOME/.splashboard/cache/`). Useful when a widget
+    /// shows stale data, you need to force-refresh a single entry, or you want to know how much
+    /// disk the cache is using.
+    Cache {
+        #[command(subcommand)]
+        subcommand: CacheSubcommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum CacheSubcommand {
+    /// Print the resolved cache directory.
+    Path,
+    /// List every cache entry: key, age, TTL, fresh/stale, payload size, kind. Sorted by age
+    /// descending. Pass `--json` for one JSON object per line.
+    List {
+        /// Emit one JSON object per entry instead of the human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove cache entries. Pass a widget id to remove only that widget's entry (the widget must
+    /// still be configured); otherwise removes every entry plus any leftover `.lock` files.
+    Clear {
+        /// Widget id to clear. If omitted, clears every entry.
+        #[arg(value_name = "WIDGET_ID")]
+        widget_id: Option<String>,
+        /// Skip the confirmation prompt for `clear` (no widget id).
+        #[arg(long)]
+        yes: bool,
+        /// Emit a JSON summary instead of the human-readable lines.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -161,6 +196,7 @@ fn main() -> io::Result<()> {
         Some(Command::ListTrusted) => run_list_trusted(),
         Some(Command::Catalog { target }) => run_catalog(target),
         Some(Command::License { own }) => run_license(own),
+        Some(Command::Cache { subcommand }) => run_cache(subcommand),
         None => {
             if !should_render() {
                 return Ok(());
@@ -362,6 +398,350 @@ fn run_list_trusted() -> io::Result<()> {
         );
     }
     Ok(())
+}
+
+fn run_cache(subcommand: CacheSubcommand) -> io::Result<()> {
+    let Some(dir) = paths::cache_dir() else {
+        eprintln!("no cache dir resolved (is $HOME set?)");
+        std::process::exit(2);
+    };
+    match subcommand {
+        CacheSubcommand::Path => {
+            println!("{}", dir.display());
+            Ok(())
+        }
+        CacheSubcommand::List { json } => run_cache_list(&dir, json),
+        CacheSubcommand::Clear {
+            widget_id,
+            yes,
+            json,
+        } => run_cache_clear(&dir, widget_id, yes, json),
+    }
+}
+
+/// One row of the `cache list` output. Also serialized as a JSON object when `--json` is used.
+#[derive(serde::Serialize)]
+struct CacheListRow {
+    /// Cache key — the filename stem, e.g. `clock-3f2a1c8b`.
+    key: String,
+    /// `entry` for `.json` payloads, `lock` for orphan `.lock` files.
+    kind: &'static str,
+    /// Seconds since the file was last written; for lock files this is the lock age.
+    age_seconds: u64,
+    /// TTL declared by the entry, in seconds. Zero for lock files.
+    ttl_seconds: u64,
+    /// `fresh` when `age_seconds < ttl_seconds`, otherwise `stale`. Lock files report `n/a`.
+    freshness: &'static str,
+    /// Size of the on-disk file, in bytes.
+    size_bytes: u64,
+    /// Outcome of the fetch that produced this entry — `ok` / `err` / `timeout`. `n/a` for locks.
+    outcome: &'static str,
+}
+
+fn run_cache_list(dir: &Path, json: bool) -> io::Result<()> {
+    let mut rows = collect_cache_rows(dir)?;
+    // Oldest first by default — surfaces stale and orphan files at the top where they're easier
+    // to spot when scrolling a long list.
+    rows.sort_by(|a, b| b.age_seconds.cmp(&a.age_seconds));
+
+    if json {
+        for row in &rows {
+            let line = serde_json::to_string(row).map_err(io::Error::other)?;
+            println!("{line}");
+        }
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("(empty)");
+        return Ok(());
+    }
+
+    println!(
+        "{:<40}  {:<6}  {:>10}  {:>10}  {:<8}  {:>10}  {}",
+        "KEY", "KIND", "AGE(s)", "TTL(s)", "STATE", "SIZE(B)", "OUTCOME"
+    );
+    for row in &rows {
+        println!(
+            "{:<40}  {:<6}  {:>10}  {:>10}  {:<8}  {:>10}  {}",
+            truncate(&row.key, 40),
+            row.kind,
+            row.age_seconds,
+            row.ttl_seconds,
+            row.freshness,
+            row.size_bytes,
+            row.outcome,
+        );
+    }
+    Ok(())
+}
+
+fn collect_cache_rows(dir: &Path) -> io::Result<Vec<CacheListRow>> {
+    let mut rows = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        // Treat a missing cache dir the same as an empty one — operator hasn't run splashboard
+        // yet, no cached data, nothing to report.
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(rows),
+        Err(e) => return Err(e),
+    };
+    let now = SystemTime::now();
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let metadata = entry.metadata()?;
+        if !metadata.is_file() {
+            continue;
+        }
+        let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let age_seconds = metadata
+            .modified()
+            .ok()
+            .and_then(|m| now.duration_since(m).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let size_bytes = metadata.len();
+        match ext {
+            "json" => {
+                let entry = std::fs::read_to_string(&path)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<CacheEntry>(&s).ok());
+                let (ttl, freshness, outcome) = entry
+                    .as_ref()
+                    .map(|e| {
+                        let ttl = e.ttl_seconds;
+                        let freshness = if e.is_fresh() { "fresh" } else { "stale" };
+                        let outcome = match e.kind {
+                            cache::CacheEntryKind::Ok => "ok",
+                            cache::CacheEntryKind::Err => "err",
+                            cache::CacheEntryKind::Timeout => "timeout",
+                        };
+                        (ttl, freshness, outcome)
+                    })
+                    .unwrap_or((0, "unreadable", "unreadable"));
+                rows.push(CacheListRow {
+                    key: stem.to_string(),
+                    kind: "entry",
+                    age_seconds,
+                    ttl_seconds: ttl,
+                    freshness,
+                    size_bytes,
+                    outcome,
+                });
+            }
+            "lock" => {
+                rows.push(CacheListRow {
+                    key: stem.to_string(),
+                    kind: "lock",
+                    age_seconds,
+                    ttl_seconds: 0,
+                    freshness: "n/a",
+                    size_bytes,
+                    outcome: "n/a",
+                });
+            }
+            // Anything else (`.tmp` leftovers, future formats) is skipped silently to keep the
+            // output focused on the things users can act on.
+            _ => continue,
+        }
+    }
+    Ok(rows)
+}
+
+fn run_cache_clear(dir: &Path, widget_id: Option<String>, yes: bool, json: bool) -> io::Result<()> {
+    match widget_id {
+        Some(id) => clear_one(dir, &id, json),
+        None => clear_all(dir, yes, json),
+    }
+}
+
+fn clear_all(dir: &Path, yes: bool, json: bool) -> io::Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e.collect::<Result<Vec<_>, _>>()?,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
+        Err(e) => return Err(e),
+    };
+    let targets: Vec<PathBuf> = entries
+        .into_iter()
+        .filter(|e| e.metadata().map(|m| m.is_file()).unwrap_or(false))
+        .map(|e| e.path())
+        .filter(|p| {
+            matches!(
+                p.extension().and_then(|e| e.to_str()),
+                Some("json") | Some("lock")
+            )
+        })
+        .collect();
+
+    if targets.is_empty() {
+        if json {
+            println!(r#"{{"removed":0}}"#);
+        } else {
+            println!("(empty)");
+        }
+        return Ok(());
+    }
+
+    if !yes
+        && !prompt_yes_no(&format!(
+            "Remove all {} cache file(s) from {}?",
+            targets.len(),
+            dir.display()
+        ))?
+    {
+        println!("cancelled");
+        return Ok(());
+    }
+
+    let mut removed = 0usize;
+    let mut errors = Vec::new();
+    for path in &targets {
+        match std::fs::remove_file(path) {
+            Ok(()) => removed += 1,
+            Err(e) => errors.push(format!("{}: {e}", path.display())),
+        }
+    }
+
+    if json {
+        let payload = serde_json::json!({
+            "removed": removed,
+            "errors": errors,
+        });
+        println!("{payload}");
+    } else {
+        println!("removed {removed} file(s)");
+        for err in &errors {
+            eprintln!("error: {err}");
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "{} file(s) could not be removed",
+            errors.len()
+        )))
+    }
+}
+
+fn clear_one(dir: &Path, widget_id: &str, json: bool) -> io::Result<()> {
+    // Use option 1 from the issue: compute the key from the current config. Falls back to the
+    // home dashboard so the command works outside any project-local context (common case for
+    // ad-hoc debugging on $HOME/.splashboard/cache/).
+    let source = config::resolve_dashboard_source();
+    let (config, _ident) = load_full_config(&source)?;
+    let widget = config
+        .widgets
+        .iter()
+        .find(|w| w.id == widget_id)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "no widget '{widget_id}' in current config ({:?}). \
+Cache key can only be computed for widgets that are still configured; \
+to remove an orphaned entry run `splashboard cache list` and delete \
+the file directly.",
+                    source
+                ),
+            )
+        })?;
+    let registry = Registry::with_builtins();
+    let fetcher = registry.get_cached(&widget.fetcher).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "widget '{}' uses fetcher '{}' which is not in the registry \
+(realtime widgets don't have disk-cached entries)",
+                widget.id, widget.fetcher,
+            ),
+        )
+    })?;
+    let key = fetcher.cache_key(&FetchContext {
+        widget_id: widget.id.clone(),
+        format: widget.format.clone(),
+        // Cache key derivation does not actually look at timeout; pass zero to be explicit.
+        timeout: std::time::Duration::from_secs(0),
+        file_format: widget.file_format.clone(),
+        // Shape is part of the key but we don't know which shape will be used at fetch time
+        // without doing a layout pass. The default-shape path matches what `runtime::fetch_all`
+        // uses when no widget-specific shape override is in play.
+        shape: Some(fetcher.default_shape()),
+        options: widget.options.clone(),
+        // Locale and timezone do NOT participate in `default_cache_key` (see
+        // `fetcher/mod.rs::default_cache_key`); a None pair here is correct and intentional,
+        // and any fetcher that overrides `cache_key` to consume these would derive a key that
+        // won't match a runtime-produced entry anyway.
+        timezone: None,
+        locale: None,
+    });
+
+    // Same sanitization as cache.rs; replicated here to avoid widening the public API for a
+    // single character set that's stable across the codebase.
+    let sanitized = sanitize_cache_key(&key);
+    let entry_path = dir.join(format!("{sanitized}.json"));
+    let lock_path = dir.join(format!("{sanitized}.lock"));
+    let mut removed = Vec::new();
+    let mut missing = Vec::new();
+    for path in [&entry_path, &lock_path] {
+        match std::fs::remove_file(path) {
+            Ok(()) => removed.push(path.display().to_string()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                missing.push(path.display().to_string());
+            }
+            Err(e) => {
+                return Err(io::Error::other(format!(
+                    "removing {}: {e}",
+                    path.display()
+                )));
+            }
+        }
+    }
+
+    if json {
+        let payload = serde_json::json!({
+            "widget_id": widget_id,
+            "key": key,
+            "removed": removed,
+            "missing": missing,
+        });
+        println!("{payload}");
+    } else if removed.is_empty() {
+        println!("widget '{widget_id}' had no cache entry (key {key})");
+    } else {
+        println!(
+            "removed {} file(s) for widget '{widget_id}' (key {key})",
+            removed.len()
+        );
+        for path in &removed {
+            println!("  {path}");
+        }
+    }
+    Ok(())
+}
+
+/// Replicates `cache::sanitize` (which is module-private) so we can compute the on-disk
+/// filename for a given cache key. Kept in sync with `cache.rs`; covered by the
+/// `clear_one_matches_cache_filename_layout` test.
+fn sanitize_cache_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
+    }
 }
 
 fn run_catalog(target: Option<CatalogTarget>) -> io::Result<()> {
@@ -815,6 +1195,108 @@ PATH = "/tmp/ignored"
             super::print_trust_summary(Path::new("demo.toml"), "abc123", &widgets, &registry)
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn sanitize_cache_key_matches_alnum_dash_underscore_passthrough() {
+        // Keys produced by `fetcher::default_cache_key` look like `<name>-<hex8>` (alnum + dash).
+        // They must round-trip through our sanitize unchanged, so the filename we compute in
+        // `clear_one` matches what the writer in `cache::Cache::store` chose.
+        let key = "clock-3f2a1c8b";
+        assert_eq!(super::sanitize_cache_key(key), key);
+    }
+
+    #[test]
+    fn sanitize_cache_key_replaces_path_and_control_chars() {
+        // Defensive: anything outside [A-Za-z0-9_-] must be replaced so the on-disk filename
+        // can't escape the cache directory.
+        let key = "evil/../name with spaces";
+        let sanitized = super::sanitize_cache_key(key);
+        assert!(!sanitized.contains('/'));
+        assert!(!sanitized.contains('.'));
+        assert!(!sanitized.contains(' '));
+    }
+
+    #[test]
+    fn clear_one_matches_cache_filename_layout() {
+        // Pin the contract that `clear_one` uses to find on-disk files: the path produced by
+        // `cache::Cache::path_for` for a given key must equal `<dir>/<sanitize_cache_key(key)>.json`.
+        // If this test breaks, `cache::sanitize` and `main::sanitize_cache_key` have drifted —
+        // update both before merging.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = splashboard::cache::Cache::open(dir.path().to_path_buf()).unwrap();
+        let key = "clock-3f2a1c8b";
+        let cache_path = cache.path_for(key);
+        let expected = dir
+            .path()
+            .join(format!("{}.json", super::sanitize_cache_key(key)));
+        assert_eq!(cache_path, expected);
+    }
+
+    #[test]
+    fn collect_cache_rows_returns_empty_for_missing_dir() {
+        // `cache list` against a never-used cache should print "(empty)", not error.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("never-created");
+        let rows = super::collect_cache_rows(&path).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn collect_cache_rows_reads_entry_and_lock_files() {
+        use splashboard::cache::{Cache, CacheEntry};
+        use splashboard::payload::{Body, Payload, TextData};
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache = Cache::open(dir.path().to_path_buf()).unwrap();
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Text(TextData { value: "hi".into() }),
+        };
+        cache
+            .store("clock-abc12345", &CacheEntry::new(payload, 60))
+            .unwrap();
+        // Drop a stray .lock file so we can confirm it's surfaced as an "aux" row.
+        std::fs::write(dir.path().join("clock-abc12345.lock"), "").unwrap();
+        // And an unrelated file extension that should be skipped silently.
+        std::fs::write(dir.path().join("ignored.tmp"), "").unwrap();
+
+        let rows = super::collect_cache_rows(dir.path()).unwrap();
+        assert_eq!(rows.len(), 2, "entry + lock should both be returned");
+        let entry = rows.iter().find(|r| r.kind == "entry").unwrap();
+        assert_eq!(entry.ttl_seconds, 60);
+        assert!(entry.freshness == "fresh" || entry.freshness == "stale");
+        assert_eq!(entry.outcome, "ok");
+        let lock = rows.iter().find(|r| r.kind == "lock").unwrap();
+        assert_eq!(lock.ttl_seconds, 0);
+        assert_eq!(lock.freshness, "n/a");
+    }
+
+    #[test]
+    fn clear_all_removes_json_and_lock_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // Seed: 1 entry + 1 lock + 1 unrelated file. Only the first two should be removed.
+        std::fs::write(dir.path().join("x.json"), r#"{}"#).unwrap();
+        std::fs::write(dir.path().join("x.lock"), "").unwrap();
+        std::fs::write(dir.path().join("note.txt"), "preserve me").unwrap();
+
+        super::clear_all(dir.path(), /* yes = */ true, /* json = */ false).unwrap();
+
+        assert!(!dir.path().join("x.json").exists());
+        assert!(!dir.path().join("x.lock").exists());
+        assert!(
+            dir.path().join("note.txt").exists(),
+            "non-cache files must not be touched"
+        );
+    }
+
+    #[test]
+    fn clear_all_handles_missing_dir_quietly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("never-created");
+        super::clear_all(&path, /* yes = */ true, /* json = */ false).unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -448,7 +448,7 @@ fn run_cache_list(dir: &Path, json: bool) -> io::Result<()> {
     let mut rows = collect_cache_rows(dir)?;
     // Oldest first by default — surfaces stale and orphan files at the top where they're easier
     // to spot when scrolling a long list.
-    rows.sort_by(|a, b| b.age_seconds.cmp(&a.age_seconds));
+    rows.sort_by_key(|r| std::cmp::Reverse(r.age_seconds));
 
     if json {
         for row in &rows {
@@ -464,8 +464,8 @@ fn run_cache_list(dir: &Path, json: bool) -> io::Result<()> {
     }
 
     println!(
-        "{:<40}  {:<6}  {:>10}  {:>10}  {:<8}  {:>10}  {}",
-        "KEY", "KIND", "AGE(s)", "TTL(s)", "STATE", "SIZE(B)", "OUTCOME"
+        "{:<40}  {:<6}  {:>10}  {:>10}  {:<8}  {:>10}  OUTCOME",
+        "KEY", "KIND", "AGE(s)", "TTL(s)", "STATE", "SIZE(B)"
     );
     for row in &rows {
         println!(
@@ -1314,6 +1314,133 @@ PATH = "/tmp/ignored"
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("never-created");
         super::clear_all(&path, /* yes = */ true, /* json = */ false).unwrap();
+    }
+
+    #[test]
+    fn clear_all_handles_empty_dir() {
+        // Dir exists but has no cache files. Both human and json modes must
+        // succeed without prompting (despite yes=false) since there's nothing
+        // to remove — the prompt only fires when there are real targets.
+        let dir = tempfile::tempdir().unwrap();
+        super::clear_all(dir.path(), /* yes = */ false, /* json = */ false).unwrap();
+        super::clear_all(dir.path(), /* yes = */ false, /* json = */ true).unwrap();
+    }
+
+    #[test]
+    fn clear_all_ignores_non_cache_extensions() {
+        // The contract: only .json + .lock are cache files; anything else (e.g.
+        // .tmp leftovers from interrupted writes, or user notes) must survive.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.json"), r#"{}"#).unwrap();
+        std::fs::write(dir.path().join("b.lock"), "").unwrap();
+        std::fs::write(dir.path().join("c.tmp"), "interrupted-write").unwrap();
+        std::fs::write(dir.path().join("README.md"), "user note").unwrap();
+        super::clear_all(dir.path(), /* yes = */ true, /* json = */ true).unwrap();
+        assert!(!dir.path().join("a.json").exists());
+        assert!(!dir.path().join("b.lock").exists());
+        assert!(dir.path().join("c.tmp").exists());
+        assert!(dir.path().join("README.md").exists());
+    }
+
+    #[test]
+    fn truncate_short_passes_through() {
+        assert_eq!(super::truncate("short", 40), "short");
+    }
+
+    #[test]
+    fn truncate_exact_length_passes_through() {
+        let s = "x".repeat(40);
+        assert_eq!(super::truncate(&s, 40), s);
+    }
+
+    #[test]
+    fn truncate_long_gets_ellipsis_suffix() {
+        let s = "x".repeat(60);
+        let out = super::truncate(&s, 10);
+        // 9 retained chars + 1 ellipsis = 10 grapheme positions
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), 10);
+    }
+
+    #[test]
+    fn truncate_handles_one_char_cap() {
+        // Edge case: max=1. saturating_sub(1) keeps zero prefix; result is just "…".
+        let out = super::truncate("longer", 1);
+        assert_eq!(out, "…");
+    }
+
+    #[test]
+    fn collect_cache_rows_skips_unknown_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+        // Only the .json + .lock should produce rows. The .tmp and .bak must be
+        // skipped silently so the listing isn't polluted with internal scratch
+        // files or user backups.
+        std::fs::write(dir.path().join("x.tmp"), "scratch").unwrap();
+        std::fs::write(dir.path().join("y.bak"), "backup").unwrap();
+        std::fs::write(dir.path().join("z.json"), r#"{"refreshed_at":0,"ttl_seconds":0,"payload":{}}"#).unwrap();
+        std::fs::write(dir.path().join("z.lock"), "").unwrap();
+        let rows = super::collect_cache_rows(dir.path()).unwrap();
+        assert_eq!(rows.len(), 2);
+        let keys: Vec<_> = rows.iter().map(|r| r.key.as_str()).collect();
+        assert!(keys.contains(&"z"));
+    }
+
+    #[test]
+    fn collect_cache_rows_marks_unreadable_entries() {
+        // A garbage JSON file should still produce a row so the user can see and
+        // delete it via `cache clear`. The freshness/outcome columns surface the
+        // unreadable state instead of throwing the whole listing.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("corrupt.json"), "not valid json {").unwrap();
+        let rows = super::collect_cache_rows(dir.path()).unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.key, "corrupt");
+        assert_eq!(row.freshness, "unreadable");
+        assert_eq!(row.outcome, "unreadable");
+        assert_eq!(row.ttl_seconds, 0);
+    }
+
+    #[test]
+    fn collect_cache_rows_skips_subdirectories() {
+        // Directories under the cache root are not cache entries. They should
+        // be ignored, not crash the listing or appear as rows.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+        let rows = super::collect_cache_rows(dir.path()).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn run_cache_list_json_mode_succeeds_on_populated_dir() {
+        use splashboard::cache::{Cache, CacheEntry};
+        use splashboard::payload::{Body, Payload, TextData};
+        let dir = tempfile::tempdir().unwrap();
+        let cache = Cache::open(dir.path().to_path_buf()).unwrap();
+        cache
+            .store(
+                "test-abcdef12",
+                &CacheEntry::new(
+                    Payload {
+                        icon: None,
+                        status: None,
+                        format: None,
+                        body: Body::Text(TextData { value: "hi".into() }),
+                    },
+                    60,
+                ),
+            )
+            .unwrap();
+        // Both modes must return Ok against the same populated dir.
+        super::run_cache_list(dir.path(), /* json = */ true).unwrap();
+        super::run_cache_list(dir.path(), /* json = */ false).unwrap();
+    }
+
+    #[test]
+    fn run_cache_list_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        super::run_cache_list(dir.path(), false).unwrap();
+        super::run_cache_list(dir.path(), true).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #40.

Adds a top-level `cache` subcommand for inspecting and managing the disk cache at `$HOME/.splashboard/cache/`.

## Subcommands

- **`splashboard cache path`** — print the resolved cache directory.
- **`splashboard cache list [--json]`** — one row per `.json` entry plus any orphan `.lock` files, sorted oldest first. Columns: `KEY · KIND · AGE(s) · TTL(s) · STATE (fresh/stale) · SIZE(B) · OUTCOME (ok/err/timeout)`. JSON mode emits one object per line.
- **`splashboard cache clear [--yes] [--json]`** — remove every `.json` + `.lock` file in the cache dir. Confirms unless `--yes`. Files with other extensions (e.g. `.tmp` leftovers) are not touched.
- **`splashboard cache clear <widget_id> [--json]`** — remove a single widget's entry plus its lock. Per the issue Open Questions, this uses **Option 1**: compute the cache key from the current config (via `resolve_dashboard_source`). Works as long as the widget is still configured; reports a clear error if not. Cache schema is unchanged.

## Implementation notes

- The widget-id path replicates the `sanitize` step from `cache::Cache::path_for` (currently module-private) inside `main.rs::sanitize_cache_key`. A unit test (`clear_one_matches_cache_filename_layout`) pins the contract: the on-disk filename `main.rs` computes for a key must equal what `cache.rs` writes. If `cache::sanitize` and `main::sanitize_cache_key` ever drift, that test fires.
- `locale` and `timezone` on the synthesized `FetchContext` are explicitly `None` — `default_cache_key` does not read them, and any fetcher that overrides `cache_key` to consume them produces keys we can't reproduce here without a full runtime pass anyway. Worth noting in case you want to expose them later.
- Sort order for `cache list` is oldest-first so stale and orphan files surface at the top.

## Tests

7 new unit tests under `#[cfg(test)] mod tests`:

```
test tests::clear_all_handles_missing_dir_quietly                       ... ok
test tests::clear_all_removes_json_and_lock_files                       ... ok
test tests::clear_one_matches_cache_filename_layout                     ... ok
test tests::collect_cache_rows_reads_entry_and_lock_files               ... ok
test tests::collect_cache_rows_returns_empty_for_missing_dir            ... ok
test tests::sanitize_cache_key_matches_alnum_dash_underscore_passthrough ... ok
test tests::sanitize_cache_key_replaces_path_and_control_chars          ... ok

test result: ok. 7 passed; 0 failed
```

All 35 existing `splashboard` binary tests still pass.

## Smoke test

```
$ splashboard cache path
/home/user/.splashboard/cache

$ splashboard cache list
(empty)

$ splashboard cache clear --yes
(empty)
```

## Open questions

1. The `--json` output format I chose: `cache list` emits one JSON object per line (line-delimited), `cache clear` emits a single summary object. Happy to switch to a wrapping array if you prefer.
2. For widget-id clear, I picked the home dashboard as the implicit fallback when not in a project-local context. Open to changing the resolution rule if you want it to error instead of falling back.
3. I did NOT add a `--force` flag for stealing locks held by a running daemon — `clear_all` will remove `.lock` files but it doesn't check `cache::Lock::try_acquire` first. If you want safer concurrency around clear, happy to layer that on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top-level `cache` CLI with `path`, `list`, and `clear` subcommands.
  * `list` shows cache entries with age/TTL/freshness/outcome, emits orphan lock files, supports JSON, and tolerates unreadable payloads.
  * `clear` removes per-widget or all cache files, supports confirmation bypass (`--yes`) and JSON summaries, and reports removals vs missing items; errors when widget not found or not cache-backed.

* **Tests**
  * Added unit tests covering listing, clearing, edge cases, and output truncation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/216)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->