### PR TITLE
feat(render): add list_cards renderer + ImageLinkedList shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "image",
  "ratatui",
  "ratatui-image",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tracing-appender = "0.2"
 tui-markdown = "0.3.7"
 feed-rs = { version = "2", default-features = false }
 tokei = { version = "14", default-features = false }
+regex = "1.12.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -32,6 +32,7 @@ pub mod rss;
 pub mod static_text;
 pub mod stock_watchlist;
 pub mod system;
+pub mod thumbnails;
 pub mod todoist;
 pub mod weather;
 pub mod wikipedia;

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 
 use crate::payload::{
-    Bar, BarsData, Body, CalendarData, EntriesData, HeatmapData, ImageData, NumberSeriesData,
-    Payload, PointSeriesData, RatioData, TextBlockData, TextData,
+    Bar, BarsData, Body, CalendarData, EntriesData, HeatmapData, ImageData, ImageLinkedListData,
+    NumberSeriesData, Payload, PointSeriesData, RatioData, TextBlockData, TextData,
 };
 use crate::render::Shape;
 
@@ -22,6 +22,7 @@ const READ_STORE_SHAPES: &[Shape] = &[
     Shape::PointSeries,
     Shape::Bars,
     Shape::Image,
+    Shape::ImageLinkedList,
     Shape::Calendar,
     Shape::Heatmap,
 ];
@@ -174,6 +175,7 @@ fn from_json(text: &str, shape: Shape) -> Result<Body, FetchError> {
         Shape::PointSeries => parse_as!(PointSeriesData, PointSeries),
         Shape::Bars => parse_as!(BarsData, Bars),
         Shape::Image => parse_as!(ImageData, Image),
+        Shape::ImageLinkedList => parse_as!(ImageLinkedListData, ImageLinkedList),
         Shape::Calendar => parse_as!(CalendarData, Calendar),
         Shape::Heatmap => parse_as!(HeatmapData, Heatmap),
         other => Err(FetchError::Failed(format!(
@@ -200,6 +202,7 @@ fn from_toml(text: &str, shape: Shape) -> Result<Body, FetchError> {
         Shape::PointSeries => parse_as!(PointSeriesData, PointSeries),
         Shape::Bars => parse_as!(BarsData, Bars),
         Shape::Image => parse_as!(ImageData, Image),
+        Shape::ImageLinkedList => parse_as!(ImageLinkedListData, ImageLinkedList),
         Shape::Calendar => parse_as!(CalendarData, Calendar),
         Shape::Heatmap => parse_as!(HeatmapData, Heatmap),
         other => Err(FetchError::Failed(format!(
@@ -230,6 +233,7 @@ fn empty_body(shape: Shape) -> Body {
         Shape::Image => Body::Image(ImageData {
             path: String::new(),
         }),
+        Shape::ImageLinkedList => Body::ImageLinkedList(ImageLinkedListData { items: Vec::new() }),
         Shape::Calendar => Body::Calendar(CalendarData {
             year: 1970,
             month: 1,
@@ -324,6 +328,37 @@ mod tests {
         match p.body {
             Body::TextBlock(d) => assert_eq!(d.lines, vec!["one", "two", "three"]),
             other => panic!("expected text_block body, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reads_image_linked_list_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(
+            store.join("cards.json"),
+            r#"{"items":[
+                {"title":"first","url":"https://example.com/1","thumbnail_path":"/tmp/a.png","subtitle":"src · 2h"},
+                {"title":"second"}
+            ]}"#,
+        )
+        .unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let p = ReadStoreFetcher
+            .fetch(&ctx("cards", Shape::ImageLinkedList, "json"))
+            .await
+            .unwrap();
+        match p.body {
+            Body::ImageLinkedList(d) => {
+                assert_eq!(d.items.len(), 2);
+                assert_eq!(d.items[0].title, "first");
+                assert_eq!(d.items[0].url.as_deref(), Some("https://example.com/1"));
+                assert_eq!(d.items[0].thumbnail_path.as_deref(), Some("/tmp/a.png"));
+                assert_eq!(d.items[1].url, None);
+                assert_eq!(d.items[1].thumbnail_path, None);
+            }
+            other => panic!("expected image_linked_list body, got {other:?}"),
         }
     }
 

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -363,6 +363,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn missing_image_linked_list_file_renders_empty_for_declared_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = ScopedHome::new(tmp.path());
+        let p = ReadStoreFetcher
+            .fetch(&ctx("absent_cards", Shape::ImageLinkedList, "json"))
+            .await
+            .unwrap();
+        match p.body {
+            Body::ImageLinkedList(d) => assert!(d.items.is_empty()),
+            other => panic!("expected empty image_linked_list body, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn missing_file_renders_empty_for_declared_shape() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = ScopedHome::new(tmp.path());

--- a/src/fetcher/reddit/common.rs
+++ b/src/fetcher/reddit/common.rs
@@ -6,13 +6,29 @@ use serde::Deserialize;
 use crate::fetcher::FetchContext;
 use crate::fetcher::FetchError;
 use crate::fetcher::github::common::cache_key;
-use crate::payload::{Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, TextBlockData};
+use crate::payload::{
+    Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData, LinkedLine,
+    LinkedTextBlockData, TextBlockData,
+};
 use crate::render::Shape;
 use crate::samples;
 
 use super::client::SITE_BASE;
 
-pub(super) const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Entries];
+/// Shapes the post-listing fetchers (`reddit_subreddit_posts`, `reddit_user_posts`) emit.
+/// Includes `ImageLinkedList` because Reddit posts can carry thumbnails.
+pub(super) const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Entries,
+];
+
+/// Shapes for the comment fetcher (`reddit_user_comments`). Excludes `ImageLinkedList`
+/// because Reddit comments don't have images — declaring it would lie about the output
+/// contract.
+pub(super) const COMMENT_SHAPES: &[Shape] =
+    &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Entries];
 
 pub(super) const DEFAULT_COUNT: u32 = 10;
 pub(super) const MIN_COUNT: u32 = 1;
@@ -97,6 +113,14 @@ pub(super) fn network_unavailable_body(shape: Shape, err: &str) -> Body {
                 url: None,
             }],
         }),
+        Shape::ImageLinkedList => Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![ImageLinkedItem {
+                title: line,
+                url: None,
+                thumbnail_path: None,
+                subtitle: None,
+            }],
+        }),
         _ => Body::TextBlock(TextBlockData { lines: vec![line] }),
     }
 }
@@ -115,6 +139,22 @@ pub(super) struct Post {
     pub permalink: Option<String>,
     #[serde(default)]
     pub url: Option<String>,
+    /// Reddit returns one of: a thumbnail URL (http/https), the strings `"self"` / `"default"`
+    /// / `"nsfw"` / `"spoiler"`, or an empty string. Only the URL form is usable as an image —
+    /// see [`Post::thumbnail_url`].
+    #[serde(default)]
+    pub thumbnail: Option<String>,
+}
+
+impl Post {
+    /// HTTP(S) thumbnail URL if Reddit gave us one. Filters out the placeholder strings Reddit
+    /// returns when the post isn't a media post (`"self"`, `"default"`, …) and the empty case.
+    pub(super) fn thumbnail_url(&self) -> Option<&str> {
+        self.thumbnail
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| s.starts_with("http://") || s.starts_with("https://"))
+    }
 }
 
 pub(super) fn render_posts(posts: &[Post], shape: Shape) -> Body {
@@ -138,6 +178,7 @@ pub(super) fn render_posts(posts: &[Post], shape: Shape) -> Body {
                 })
                 .collect(),
         }),
+        Shape::ImageLinkedList => render_posts_image_linked(posts, &vec![None; posts.len()]),
         _ => Body::TextBlock(TextBlockData {
             lines: posts
                 .iter()
@@ -145,6 +186,31 @@ pub(super) fn render_posts(posts: &[Post], shape: Shape) -> Body {
                 .collect(),
         }),
     }
+}
+
+/// `ImageLinkedList` rendering with pre-resolved thumbnail paths. Kept separate from
+/// [`render_posts`] because the thumbnail download is async — callers run it once at fetch
+/// time and pass the resolved paths back in, so the sync renderer path can still serve
+/// thumbnail-less callers (`sample_post_body`, error fallbacks) without an executor.
+pub(super) fn render_posts_image_linked(
+    posts: &[Post],
+    thumbnail_paths: &[Option<std::path::PathBuf>],
+) -> Body {
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: posts
+            .iter()
+            .enumerate()
+            .map(|(i, post)| ImageLinkedItem {
+                title: post_title(post),
+                url: post_link(post),
+                thumbnail_path: thumbnail_paths
+                    .get(i)
+                    .and_then(|p| p.as_ref())
+                    .map(|p| p.to_string_lossy().into_owned()),
+                subtitle: Some(post_meta(post)),
+            })
+            .collect(),
+    })
 }
 
 pub(super) fn sample_post_body(shape: Shape) -> Option<Body> {
@@ -157,6 +223,20 @@ pub(super) fn sample_post_body(shape: Shape) -> Option<Body> {
             (
                 "r/rust · 934↑ 104c  Why async Rust feels different from Go",
                 Some("https://example.com/async-rust-vs-go"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "Show: terminal dashboard with local trust model",
+                Some("https://www.reddit.com/r/programming/comments/abc123/demo/"),
+                None,
+                Some("r/programming · 1520↑ 218c"),
+            ),
+            (
+                "Why async Rust feels different from Go",
+                Some("https://example.com/async-rust-vs-go"),
+                None,
+                Some("r/rust · 934↑ 104c"),
             ),
         ]),
         Shape::TextBlock => samples::text_block(&[
@@ -267,6 +347,7 @@ mod tests {
             subreddit: Some("rust".into()),
             permalink: None,
             url: None,
+            thumbnail: None,
         };
         assert_eq!(post_meta(&post), "r/rust · 12↑ 3c");
     }
@@ -280,6 +361,7 @@ mod tests {
             subreddit: Some("rust".into()),
             permalink: None,
             url: None,
+            thumbnail: None,
         };
         assert_eq!(post_meta(&post), "r/rust · -5↑ 0c");
     }
@@ -362,6 +444,7 @@ mod tests {
             subreddit: Some("rust".into()),
             permalink: Some("/r/rust/comments/xyz/hello/".into()),
             url: None,
+            thumbnail: None,
         }];
         let body = render_posts(&posts, Shape::LinkedTextBlock);
         let Body::LinkedTextBlock(b) = body else {
@@ -382,6 +465,7 @@ mod tests {
             subreddit: None,
             permalink: None,
             url: None,
+            thumbnail: None,
         }];
         let body = render_posts(&posts, Shape::TextBlock);
         let Body::TextBlock(t) = body else {
@@ -459,12 +543,75 @@ mod tests {
 
     #[test]
     fn sample_post_body_returns_some_for_supported_shapes() {
-        for shape in [Shape::LinkedTextBlock, Shape::TextBlock, Shape::Entries] {
+        for shape in [
+            Shape::LinkedTextBlock,
+            Shape::ImageLinkedList,
+            Shape::TextBlock,
+            Shape::Entries,
+        ] {
             assert!(
                 sample_post_body(shape).is_some(),
                 "expected sample for {shape:?}"
             );
         }
+    }
+
+    #[test]
+    fn thumbnail_url_filters_placeholder_strings() {
+        let mut post = Post {
+            title: None,
+            score: None,
+            num_comments: None,
+            subreddit: None,
+            permalink: None,
+            url: None,
+            thumbnail: Some("self".into()),
+        };
+        assert_eq!(post.thumbnail_url(), None);
+        post.thumbnail = Some("default".into());
+        assert_eq!(post.thumbnail_url(), None);
+        post.thumbnail = Some("nsfw".into());
+        assert_eq!(post.thumbnail_url(), None);
+        post.thumbnail = Some(String::new());
+        assert_eq!(post.thumbnail_url(), None);
+        post.thumbnail = Some("https://b.thumbs.redditmedia.com/x.jpg".into());
+        assert_eq!(
+            post.thumbnail_url(),
+            Some("https://b.thumbs.redditmedia.com/x.jpg"),
+        );
+    }
+
+    #[test]
+    fn render_posts_image_linked_pins_thumbnail_paths() {
+        let posts = vec![
+            Post {
+                title: Some("first".into()),
+                score: Some(1),
+                num_comments: Some(0),
+                subreddit: Some("rust".into()),
+                permalink: None,
+                url: Some("https://example.com/a".into()),
+                thumbnail: None,
+            },
+            Post {
+                title: Some("second".into()),
+                score: Some(2),
+                num_comments: Some(1),
+                subreddit: Some("rust".into()),
+                permalink: None,
+                url: Some("https://example.com/b".into()),
+                thumbnail: None,
+            },
+        ];
+        let paths = vec![Some(std::path::PathBuf::from("/tmp/a.png")), None];
+        let body = render_posts_image_linked(&posts, &paths);
+        let Body::ImageLinkedList(b) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(b.items[0].title, "first");
+        assert_eq!(b.items[0].thumbnail_path.as_deref(), Some("/tmp/a.png"));
+        assert!(b.items[0].subtitle.as_deref().unwrap().contains("r/rust"));
+        assert_eq!(b.items[1].thumbnail_path, None);
     }
 
     #[test]
@@ -480,6 +627,7 @@ mod tests {
             subreddit: Some("rust".into()),
             permalink: Some("/r/rust/comments/abc/t/".into()),
             url: url.map(String::from),
+            thumbnail: None,
         }
     }
 }

--- a/src/fetcher/reddit/common.rs
+++ b/src/fetcher/reddit/common.rs
@@ -401,6 +401,29 @@ mod tests {
             panic!("expected text_block");
         };
         assert!(t.lines[0].contains("boom"));
+
+        let cards = network_unavailable_body(Shape::ImageLinkedList, "reddit 429");
+        let Body::ImageLinkedList(cards) = cards else {
+            panic!("expected image_linked_list");
+        };
+        assert!(cards.items[0].title.contains("reddit 429"));
+        assert_eq!(cards.items[0].thumbnail_path, None);
+    }
+
+    #[test]
+    fn render_posts_image_linked_via_render_posts_emits_blank_thumbnails() {
+        // The sync `render_posts` path can't run the async download — it ships cards with
+        // no thumbnails. Callers that want thumbnails go through the family-specific
+        // `render_for_shape` wrapper. Documented as the contract here so a future
+        // refactor doesn't silently flip the default to a panicking unimplemented arm.
+        let posts = vec![sample_post(Some("https://example.com/a"))];
+        let body = render_posts(&posts, Shape::ImageLinkedList);
+        let Body::ImageLinkedList(b) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(b.items[0].thumbnail_path, None);
+        assert_eq!(b.items[0].title, "t");
     }
 
     #[test]

--- a/src/fetcher/reddit/subreddit_posts.rs
+++ b/src/fetcher/reddit/subreddit_posts.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::fetcher::github::common::{parse_options, payload};
+use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
@@ -12,7 +13,7 @@ use crate::render::Shape;
 use super::client::fetch_listing;
 use super::common::{
     Post, SHAPES, cache_key_for, network_unavailable_body, normalize_subreddit, normalized_count,
-    render_posts, sample_post_body,
+    render_posts, render_posts_image_linked, sample_post_body,
 };
 
 const DEFAULT_SUBREDDIT: &str = "programming";
@@ -145,10 +146,26 @@ impl Fetcher for RedditSubredditPostsFetcher {
         let subreddit =
             normalize_subreddit(opts.subreddit.as_deref().unwrap_or(DEFAULT_SUBREDDIT))?;
         match fetch_subreddit_posts(&subreddit, count, listing_type, period).await {
-            Ok(posts) => Ok(payload(render_posts(&posts, shape))),
+            Ok(posts) => Ok(payload(render_for_shape(&posts, shape).await)),
             Err(err) => Ok(payload(network_unavailable_body(shape, &format!("{err}")))),
         }
     }
+}
+
+/// Wraps the sync [`render_posts`] but takes the async detour for `ImageLinkedList`: downloads
+/// each post's thumbnail (Reddit serves them as remote URLs) into the shared cache and pins the
+/// resolved local paths onto each card. Posts without a thumbnail keep `None`, so the renderer
+/// shows a blank thumbnail cell rather than an error.
+async fn render_for_shape(posts: &[Post], shape: Shape) -> Body {
+    if !matches!(shape, Shape::ImageLinkedList) {
+        return render_posts(posts, shape);
+    }
+    let urls: Vec<Option<String>> = posts
+        .iter()
+        .map(|p| p.thumbnail_url().map(str::to_string))
+        .collect();
+    let paths = thumbnails::download_many(&urls).await;
+    render_posts_image_linked(posts, &paths)
 }
 
 async fn fetch_subreddit_posts(
@@ -295,6 +312,10 @@ mod tests {
         assert!(matches!(
             fetcher.sample_body(Shape::Entries),
             Some(Body::Entries(_))
+        ));
+        assert!(matches!(
+            fetcher.sample_body(Shape::ImageLinkedList),
+            Some(Body::ImageLinkedList(_))
         ));
         assert!(fetcher.sample_body(Shape::Ratio).is_none());
     }

--- a/src/fetcher/reddit/user_comments.rs
+++ b/src/fetcher/reddit/user_comments.rs
@@ -14,7 +14,8 @@ use crate::samples;
 
 use super::client::{SITE_BASE, fetch_listing};
 use super::common::{
-    SHAPES, cache_key_for, network_unavailable_body, normalize_user, normalized_count,
+    COMMENT_SHAPES as SHAPES, cache_key_for, network_unavailable_body, normalize_user,
+    normalized_count,
 };
 
 const DEFAULT_USER: &str = "spez";

--- a/src/fetcher/reddit/user_posts.rs
+++ b/src/fetcher/reddit/user_posts.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::fetcher::github::common::{parse_options, payload};
+use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
@@ -12,7 +13,7 @@ use crate::render::Shape;
 use super::client::fetch_listing;
 use super::common::{
     Post, SHAPES, cache_key_for, network_unavailable_body, normalize_user, normalized_count,
-    render_posts, sample_post_body,
+    render_posts, render_posts_image_linked, sample_post_body,
 };
 
 const DEFAULT_USER: &str = "spez";
@@ -74,10 +75,25 @@ impl Fetcher for RedditUserPostsFetcher {
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
         let user = normalize_user(opts.user.as_deref().unwrap_or(DEFAULT_USER))?;
         match fetch_user_posts(&user, count).await {
-            Ok(posts) => Ok(payload(render_posts(&posts, shape))),
+            Ok(posts) => Ok(payload(render_for_shape(&posts, shape).await)),
             Err(err) => Ok(payload(network_unavailable_body(shape, &format!("{err}")))),
         }
     }
+}
+
+/// Sibling of [`reddit_subreddit_posts::render_for_shape`]: pre-downloads thumbnails for the
+/// `ImageLinkedList` shape so the renderer can show them, and falls through to the sync
+/// `render_posts` for every other shape.
+async fn render_for_shape(posts: &[Post], shape: Shape) -> Body {
+    if !matches!(shape, Shape::ImageLinkedList) {
+        return render_posts(posts, shape);
+    }
+    let urls: Vec<Option<String>> = posts
+        .iter()
+        .map(|p| p.thumbnail_url().map(str::to_string))
+        .collect();
+    let paths = thumbnails::download_many(&urls).await;
+    render_posts_image_linked(posts, &paths)
 }
 
 async fn fetch_user_posts(user: &str, count: usize) -> Result<Vec<Post>, FetchError> {

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -831,6 +831,50 @@ mod tests {
     }
 
     #[test]
+    fn thumbnail_url_for_returns_none_when_no_source_available() {
+        let empty = Entry::default();
+        assert!(super::thumbnail_url_for(&empty).is_none());
+    }
+
+    #[test]
+    fn subtitle_for_returns_none_when_no_signal() {
+        // No date, no link → no useful subtitle. Returning None lets the renderer omit the
+        // subtitle row entirely rather than draw a blank line.
+        let entry = Entry::default();
+        assert!(super::subtitle_for(&entry, None, None).is_none());
+    }
+
+    #[test]
+    fn subtitle_for_falls_back_to_date_only_when_link_missing() {
+        let entry = Entry {
+            published: Some(chrono::Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()),
+            ..Default::default()
+        };
+        let sub = super::subtitle_for(&entry, Some("UTC"), None).unwrap();
+        assert_eq!(sub, "Apr 26");
+        assert!(!sub.contains('·'));
+    }
+
+    #[test]
+    fn subtitle_for_falls_back_to_host_only_when_date_missing() {
+        use feed_rs::model::Link;
+        let entry = Entry {
+            links: vec![Link {
+                href: "https://blog.rust-lang.org/post".into(),
+                rel: None,
+                media_type: None,
+                href_lang: None,
+                title: None,
+                length: None,
+            }],
+            ..Default::default()
+        };
+        let sub = super::subtitle_for(&entry, Some("UTC"), None).unwrap();
+        assert_eq!(sub, "blog.rust-lang.org");
+        assert!(!sub.contains('·'));
+    }
+
+    #[test]
     fn subtitle_combines_date_and_host_when_both_present() {
         use feed_rs::model::Link;
         let entry = Entry {

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -15,14 +15,19 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use feed_rs::model::{Entry, Feed};
 use feed_rs::parser;
+use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
 
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
-use crate::payload::{Body, LinkedLine, LinkedTextBlockData, Payload, TextBlockData};
+use crate::payload::{
+    Body, ImageLinkedItem, ImageLinkedListData, LinkedLine, LinkedTextBlockData, Payload,
+    TextBlockData,
+};
 use crate::render::Shape;
 use crate::samples;
 use crate::time as t;
@@ -36,7 +41,11 @@ const MAX_BYTES: usize = 5 * 1024 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
 
-const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -101,6 +110,26 @@ impl Fetcher for RssFetcher {
                 ),
                 ("Apr 22  A short note", Some("https://example.com/post-3")),
             ]),
+            Shape::ImageLinkedList => samples::image_linked_list(&[
+                (
+                    "Why X over Y",
+                    Some("https://example.com/post-1"),
+                    None,
+                    Some("Apr 26"),
+                ),
+                (
+                    "Release notes 0.42",
+                    Some("https://example.com/post-2"),
+                    None,
+                    Some("Apr 24"),
+                ),
+                (
+                    "A short note",
+                    Some("https://example.com/post-3"),
+                    None,
+                    Some("Apr 22"),
+                ),
+            ]),
             Shape::TextBlock => samples::text_block(&[
                 "Apr 26  Why X over Y",
                 "Apr 24  Release notes 0.42",
@@ -119,13 +148,18 @@ impl Fetcher for RssFetcher {
         let bytes = fetch_bytes(&url).await?;
         let feed = parser::parse(bytes.as_slice())
             .map_err(|e| FetchError::Failed(format!("rss parse: {e}")))?;
-        Ok(payload(render_body(
-            &feed,
-            count,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-            ctx.timezone.as_deref(),
-            ctx.locale.as_deref(),
-        )))
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = match shape {
+            Shape::ImageLinkedList => render_image_linked(&feed, count, ctx).await,
+            other => render_body(
+                &feed,
+                count,
+                other,
+                ctx.timezone.as_deref(),
+                ctx.locale.as_deref(),
+            ),
+        };
+        Ok(payload(body))
     }
 }
 
@@ -177,6 +211,105 @@ async fn fetch_bytes(url: &Url) -> Result<Vec<u8>, FetchError> {
         )));
     }
     Ok(bytes.to_vec())
+}
+
+async fn render_image_linked(feed: &Feed, count: usize, ctx: &FetchContext) -> Body {
+    let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
+    let thumbnail_urls: Vec<Option<String>> =
+        entries.iter().map(|e| thumbnail_url_for(e)).collect();
+    let thumbnail_paths = thumbnails::download_many(&thumbnail_urls).await;
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: entries
+            .iter()
+            .zip(thumbnail_paths)
+            .map(|(e, path)| ImageLinkedItem {
+                title: title_or_placeholder(e),
+                url: link_for(e),
+                thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
+                subtitle: subtitle_for(e, ctx.timezone.as_deref(), ctx.locale.as_deref()),
+            })
+            .collect(),
+    })
+}
+
+/// Best-effort image URL for the entry, in order of preference:
+///
+/// 1. `media:thumbnail` (RSS Media spec) — explicit thumbnail.
+/// 2. `media:content` URL — full media, usually an image.
+/// 3. First `<img src="http(s)://...">` in the entry's HTML `<content>` or `<summary>` —
+///    covers Atom feeds without media extensions (Rust blog, most personal blogs) where the
+///    cover image is inlined in the body markup.
+///
+/// `image.uri` on a thumbnail is always a string; `MediaContent` returns a `Url` we serialise
+/// back to `String` so the cache key (sha of the URL string) stays stable.
+fn thumbnail_url_for(entry: &Entry) -> Option<String> {
+    entry
+        .media
+        .iter()
+        .flat_map(|m| m.thumbnails.iter().map(|t| t.image.uri.clone()))
+        .find(|s| !s.is_empty())
+        .or_else(|| {
+            entry
+                .media
+                .iter()
+                .flat_map(|m| m.content.iter().filter_map(|c| c.url.as_ref()))
+                .map(|u| u.to_string())
+                .find(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            entry
+                .content
+                .as_ref()
+                .and_then(|c| c.body.as_deref())
+                .and_then(first_inline_image_src)
+        })
+        .or_else(|| {
+            entry
+                .summary
+                .as_ref()
+                .and_then(|s| first_inline_image_src(&s.content))
+        })
+}
+
+/// Extracts the `src` attribute of the first HTTP(S) `<img>` tag in `html`. Used to recover a
+/// thumbnail when the feed doesn't expose `media:thumbnail` — most Atom blogs (Rust blog,
+/// personal sites) only ship the cover image inline inside the HTML body. Encoded entities
+/// (`&amp;`) are decoded back to `&` so the URL works as-is. Returns `None` when the body has
+/// no `<img>` or only data: / cid: / file: URIs.
+fn first_inline_image_src(html: &str) -> Option<String> {
+    static IMG_SRC_RE: OnceLock<Regex> = OnceLock::new();
+    // `(?is)`: case-insensitive + dot matches newlines. The regex is forgiving about
+    // attribute order — `src` may be preceded by any number of non-`>` attributes.
+    let re = IMG_SRC_RE
+        .get_or_init(|| Regex::new(r#"(?is)<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']"#).unwrap());
+    re.captures_iter(html)
+        .map(|cap| decode_html_entities(&cap[1]))
+        .find(|src| src.starts_with("http://") || src.starts_with("https://"))
+}
+
+fn decode_html_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&#x2F;", "/")
+        .replace("&#x3D;", "=")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+/// Subtitle for the card layout: `"<date> · <source-host>"`, or just one half when the other is
+/// missing. The full-line `"<date>  <title>"` rhythm from `LinkedTextBlock` doesn't fit the
+/// thumbnail layout because the title gets its own bold row.
+fn subtitle_for(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> Option<String> {
+    let date = date_label(entry, timezone, locale);
+    let host = link_for(entry)
+        .as_deref()
+        .and_then(|u| Url::parse(u).ok())
+        .and_then(|u| u.host_str().map(str::to_string));
+    match (date.is_empty(), host) {
+        (true, None) => None,
+        (false, None) => Some(date),
+        (true, Some(h)) => Some(h),
+        (false, Some(h)) => Some(format!("{date} · {h}")),
+    }
 }
 
 fn render_body(
@@ -554,17 +687,167 @@ mod tests {
     }
 
     #[test]
-    fn sample_body_covers_both_shapes() {
+    fn sample_body_covers_every_declared_shape() {
         let f = RssFetcher;
         assert!(matches!(
             f.sample_body(Shape::LinkedTextBlock),
             Some(Body::LinkedTextBlock(_))
         ));
         assert!(matches!(
+            f.sample_body(Shape::ImageLinkedList),
+            Some(Body::ImageLinkedList(_))
+        ));
+        assert!(matches!(
             f.sample_body(Shape::TextBlock),
             Some(Body::TextBlock(_))
         ));
         assert!(f.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn first_inline_image_src_extracts_first_http_src() {
+        let html = r#"<p>intro</p><img src="https://example.com/cover.jpg" /><img src="https://example.com/second.png">"#;
+        assert_eq!(
+            super::first_inline_image_src(html).as_deref(),
+            Some("https://example.com/cover.jpg"),
+        );
+    }
+
+    #[test]
+    fn first_inline_image_src_skips_data_and_cid_uris() {
+        let html =
+            r#"<img src="data:image/png;base64,AAAA"><img src="https://example.com/real.png">"#;
+        assert_eq!(
+            super::first_inline_image_src(html).as_deref(),
+            Some("https://example.com/real.png"),
+        );
+    }
+
+    #[test]
+    fn first_inline_image_src_decodes_encoded_amp_entities() {
+        // Real-world Atom feeds (e.g. Rust blog) HTML-encode the entry body, so query
+        // strings appear as `?a&amp;b=1`. Without decoding, the URL doesn't match what the
+        // origin actually serves.
+        let html = r#"<img src="https://example.com/img.png?a&amp;b&#x3D;1">"#;
+        assert_eq!(
+            super::first_inline_image_src(html).as_deref(),
+            Some("https://example.com/img.png?a&b=1"),
+        );
+    }
+
+    #[test]
+    fn first_inline_image_src_returns_none_without_img() {
+        assert!(super::first_inline_image_src("<p>no images here</p>").is_none());
+        assert!(super::first_inline_image_src("").is_none());
+    }
+
+    #[test]
+    fn thumbnail_url_falls_back_to_html_img_when_media_absent() {
+        use feed_rs::model::Content;
+        let entry = Entry {
+            content: Some(Content {
+                body: Some(r#"<p>lead</p><img src="https://example.com/hero.jpg"/>"#.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            super::thumbnail_url_for(&entry).as_deref(),
+            Some("https://example.com/hero.jpg"),
+        );
+    }
+
+    #[test]
+    fn thumbnail_url_picks_media_thumbnail_first_then_content() {
+        use feed_rs::model::{Image, MediaContent, MediaObject, MediaThumbnail};
+        let mut entry = Entry::default();
+        let media = MediaObject {
+            title: None,
+            content: vec![MediaContent {
+                url: Some(Url::parse("https://example.com/big.jpg").unwrap()),
+                content_type: None,
+                height: None,
+                width: None,
+                duration: None,
+                size: None,
+                rating: None,
+            }],
+            duration: None,
+            thumbnails: vec![MediaThumbnail {
+                image: Image {
+                    uri: "https://example.com/thumb.jpg".into(),
+                    title: None,
+                    link: None,
+                    width: None,
+                    height: None,
+                    description: None,
+                },
+                time: None,
+            }],
+            texts: vec![],
+            description: None,
+            community: None,
+            credits: vec![],
+        };
+        entry.media = vec![media];
+        assert_eq!(
+            super::thumbnail_url_for(&entry).as_deref(),
+            Some("https://example.com/thumb.jpg"),
+        );
+
+        let mut entry_no_thumb = Entry::default();
+        let mut media_content_only =
+            entry_no_thumb
+                .media
+                .first()
+                .cloned()
+                .unwrap_or_else(|| feed_rs::model::MediaObject {
+                    title: None,
+                    content: vec![MediaContent {
+                        url: Some(Url::parse("https://example.com/big.jpg").unwrap()),
+                        content_type: None,
+                        height: None,
+                        width: None,
+                        duration: None,
+                        size: None,
+                        rating: None,
+                    }],
+                    duration: None,
+                    thumbnails: vec![],
+                    texts: vec![],
+                    description: None,
+                    community: None,
+                    credits: vec![],
+                });
+        media_content_only.thumbnails.clear();
+        entry_no_thumb.media = vec![media_content_only];
+        assert_eq!(
+            super::thumbnail_url_for(&entry_no_thumb).as_deref(),
+            Some("https://example.com/big.jpg"),
+        );
+
+        let empty = Entry::default();
+        assert!(super::thumbnail_url_for(&empty).is_none());
+    }
+
+    #[test]
+    fn subtitle_combines_date_and_host_when_both_present() {
+        use feed_rs::model::Link;
+        let entry = Entry {
+            published: Some(chrono::Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()),
+            links: vec![Link {
+                href: "https://blog.rust-lang.org/post".into(),
+                rel: None,
+                media_type: None,
+                href_lang: None,
+                title: None,
+                length: None,
+            }],
+            ..Default::default()
+        };
+        let sub = super::subtitle_for(&entry, Some("UTC"), None).unwrap();
+        assert!(sub.contains("Apr 26"));
+        assert!(sub.contains("blog.rust-lang.org"));
     }
 
     #[test]
@@ -715,5 +998,35 @@ mod tests {
                 eprintln!("{}  -> {:?}", it.text, it.url);
             }
         }
+    }
+
+    /// Live verification that the `media:thumbnail` extraction path works against a real
+    /// feed. BBC Tech ships `<media:thumbnail>` per item so every entry should resolve a
+    /// URL. The Rust blog has no images at all (not even inline `<img>` — text-only posts)
+    /// and would not satisfy this assertion. Run with
+    /// `cargo test -- --ignored fetcher::rss::tests::live_bbc_tech_thumbnail_url`.
+    #[tokio::test]
+    #[ignore]
+    async fn live_bbc_tech_thumbnail_url_extracts_media_thumbnail() {
+        let url = validated_url(Some("https://feeds.bbci.co.uk/news/technology/rss.xml")).unwrap();
+        let bytes = fetch_bytes(&url).await.unwrap();
+        let feed = parser::parse(bytes.as_slice()).unwrap();
+        let with_thumb = feed
+            .entries
+            .iter()
+            .take(5)
+            .filter(|e| super::thumbnail_url_for(e).is_some())
+            .count();
+        for entry in feed.entries.iter().take(5) {
+            eprintln!(
+                "{:?} -> {:?}",
+                entry.title.as_ref().map(|t| &t.content),
+                super::thumbnail_url_for(entry),
+            );
+        }
+        assert!(
+            with_thumb > 0,
+            "expected at least one entry with a media:thumbnail",
+        );
     }
 }

--- a/src/fetcher/thumbnails.rs
+++ b/src/fetcher/thumbnails.rs
@@ -179,4 +179,46 @@ mod tests {
     fn hex_round_trips() {
         assert_eq!(hex(&[0x12, 0xab, 0xff, 0x00]), "12abff00");
     }
+
+    #[tokio::test]
+    async fn download_many_preserves_order_and_passes_none_through() {
+        // Empty + None + non-http URLs all resolve to None (no network involved) in input
+        // order, so the renderer can zip them back against the source list without
+        // misalignment.
+        let urls = vec![
+            None,
+            Some(String::new()),
+            Some("file:///etc/passwd".into()),
+            Some("not-a-url".into()),
+        ];
+        let paths = download_many(&urls).await;
+        assert_eq!(paths.len(), 4);
+        assert!(paths.iter().all(|p| p.is_none()));
+    }
+
+    #[test]
+    fn existing_cached_returns_first_matching_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let hash = "deadbeef";
+        // No file yet — None.
+        assert!(existing_cached(dir, hash).is_none());
+        // .jpg exists alongside no .png — picks .jpg.
+        let jpg = dir.join(format!("{hash}.jpg"));
+        std::fs::write(&jpg, b"jpeg-bytes").unwrap();
+        assert_eq!(existing_cached(dir, hash), Some(jpg.clone()));
+        // .png also exists — preference order in the helper is png, jpg, webp, gif, so png wins.
+        let png = dir.join(format!("{hash}.png"));
+        std::fs::write(&png, b"png-bytes").unwrap();
+        assert_eq!(existing_cached(dir, hash), Some(png));
+    }
+
+    #[tokio::test]
+    async fn download_to_cache_no_home_yields_failed_error() {
+        // Bypass network: an unsupported scheme returns Ok(None) without touching the cache
+        // dir at all, so we don't need to mock $HOME for that path. This complements the
+        // happy-path coverage which lives under the live ignored tests in fetcher/rss.rs.
+        let res = download_to_cache("ftp://example.com/x.png").await.unwrap();
+        assert!(res.is_none());
+    }
 }

--- a/src/fetcher/thumbnails.rs
+++ b/src/fetcher/thumbnails.rs
@@ -1,0 +1,182 @@
+//! Shared helper for the `ImageLinkedList` family of fetchers (`rss`,
+//! `reddit_subreddit_posts`, `wikipedia_featured`, …): take a remote image URL, download it
+//! once into `$SPLASHBOARD_HOME/cache/thumbnails/`, and return the local path so
+//! `ratatui-image` can read it on render.
+//!
+//! Filename derives from a sha256 of the URL so two widgets sharing a thumbnail dedupe to one
+//! file. Magic-byte sniffing picks the on-disk extension (`.png` / `.jpg` / `.webp` / `.gif`)
+//! because servers happily send any format under any URL suffix. Size capped to keep a hostile
+//! feed from filling the disk.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use sha2::{Digest, Sha256};
+
+use crate::fetcher::FetchError;
+use crate::paths;
+
+const MAX_BYTES: usize = 4 * 1024 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+
+/// Download `url` once, returning the local file path. Cached on disk forever (callers rely on
+/// the cache being content-addressed by URL hash so cache-busting requires a new URL). Returns
+/// `Ok(None)` when `url` is empty or unsupported.
+pub async fn download_to_cache(url: &str) -> Result<Option<PathBuf>, FetchError> {
+    let url = url.trim();
+    if url.is_empty() || !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Ok(None);
+    }
+    let dir = thumbnail_dir()
+        .ok_or_else(|| FetchError::Failed("$HOME not available for thumbnail cache".into()))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| FetchError::Failed(format!("create thumbnail cache dir: {e}")))?;
+    let hash = hex(&Sha256::digest(url.as_bytes()));
+    // Reuse the existing file regardless of extension; the on-disk magic byte detection picks
+    // the canonical suffix, so once a URL is cached its extension never drifts.
+    if let Some(existing) = existing_cached(&dir, &hash) {
+        return Ok(Some(existing));
+    }
+    let bytes = fetch_bytes(url).await?;
+    let ext = image_extension(&bytes);
+    let path = dir.join(format!("{hash}.{ext}"));
+    std::fs::write(&path, &bytes)
+        .map_err(|e| FetchError::Failed(format!("write thumbnail: {e}")))?;
+    Ok(Some(path))
+}
+
+/// Download every URL sequentially, in input order. Failures collapse to `None` so a single
+/// broken image never turns a feed into an error — the widget shows the bad row with an empty
+/// thumbnail cell next to the title. Sequential rather than parallel because feed widgets cap
+/// at 20 entries and the cache absorbs repeat-runs; keeping the implementation dependency-free
+/// (no `futures` crate) is the better tradeoff.
+pub async fn download_many(urls: &[Option<String>]) -> Vec<Option<PathBuf>> {
+    let mut out = Vec::with_capacity(urls.len());
+    for maybe in urls {
+        let path = match maybe.as_deref() {
+            Some(u) => download_to_cache(u).await.ok().flatten(),
+            None => None,
+        };
+        out.push(path);
+    }
+    out
+}
+
+fn thumbnail_dir() -> Option<PathBuf> {
+    paths::cache_dir().map(|d| d.join("thumbnails"))
+}
+
+fn existing_cached(dir: &std::path::Path, hash: &str) -> Option<PathBuf> {
+    ["png", "jpg", "webp", "gif"]
+        .iter()
+        .map(|ext| dir.join(format!("{hash}.{ext}")))
+        .find(|p| p.is_file())
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+async fn fetch_bytes(url: &str) -> Result<Vec<u8>, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("thumbnail request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("thumbnail {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("thumbnail body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "thumbnail response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes.to_vec())
+}
+
+fn image_extension(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        "png"
+    } else if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        "jpg"
+    } else if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        "webp"
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        "gif"
+    } else {
+        // Unknown signatures fall back to `.png` — same heuristic `github_avatar` uses. The
+        // `image` crate will surface a decode error at render time if the bytes are genuinely
+        // not an image.
+        "png"
+    }
+}
+
+fn hex(digest: &[u8]) -> String {
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_extension_detects_known_signatures() {
+        assert_eq!(image_extension(b"\x89PNG\r\n\x1a\nrest"), "png");
+        assert_eq!(image_extension(&[0xff, 0xd8, 0xff, 0xdb, 0]), "jpg");
+        assert_eq!(image_extension(b"GIF89a..."), "gif");
+        let mut webp = Vec::from(*b"RIFF");
+        webp.extend_from_slice(&[0, 0, 0, 0]);
+        webp.extend_from_slice(b"WEBPVP8 ");
+        assert_eq!(image_extension(&webp), "webp");
+    }
+
+    #[test]
+    fn image_extension_falls_back_to_png() {
+        assert_eq!(image_extension(&[0, 0, 0, 0]), "png");
+        assert_eq!(image_extension(&[]), "png");
+    }
+
+    #[tokio::test]
+    async fn empty_url_returns_none() {
+        assert!(download_to_cache("").await.unwrap().is_none());
+        assert!(download_to_cache("   ").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn non_http_url_returns_none() {
+        assert!(
+            download_to_cache("file:///etc/passwd")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            download_to_cache("ftp://example.com/x.png")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn hex_round_trips() {
+        assert_eq!(hex(&[0x12, 0xab, 0xff, 0x00]), "12abff00");
+    }
+}

--- a/src/fetcher/wikipedia/client.rs
+++ b/src/fetcher/wikipedia/client.rs
@@ -418,4 +418,68 @@ mod tests {
             FetchError::Failed(message) if message.contains("wikipedia json parse")
         ));
     }
+
+    #[test]
+    fn thumbnail_url_returns_some_for_non_empty_source() {
+        let s = PageSummary {
+            title: "x".into(),
+            extract: None,
+            content_urls: None,
+            thumbnail: Some(PageThumbnail {
+                source: "https://upload.wikimedia.org/x.jpg".into(),
+            }),
+        };
+        assert_eq!(
+            s.thumbnail_url(),
+            Some("https://upload.wikimedia.org/x.jpg"),
+        );
+    }
+
+    #[test]
+    fn thumbnail_url_returns_none_for_missing_or_empty() {
+        // Missing thumbnail block.
+        assert!(summary_with(None, None).thumbnail_url().is_none());
+        // Empty `source` string — REST sometimes returns the block with a blank URL.
+        let s = PageSummary {
+            title: "x".into(),
+            extract: None,
+            content_urls: None,
+            thumbnail: Some(PageThumbnail {
+                source: String::new(),
+            }),
+        };
+        assert!(s.thumbnail_url().is_none());
+    }
+
+    #[test]
+    fn render_image_linked_list_pins_thumbnail_path_and_first_sentence_subtitle() {
+        let s = summary_with(Some("It hops. Other stuff."), Some("https://example.com/q"));
+        let body = render_page_summary_with_thumbnail(
+            &s,
+            Shape::ImageLinkedList,
+            Some(std::path::PathBuf::from("/tmp/quokka.jpg")),
+        );
+        let Body::ImageLinkedList(b) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(b.items[0].title, "Quokka");
+        assert_eq!(b.items[0].url.as_deref(), Some("https://example.com/q"));
+        assert_eq!(
+            b.items[0].thumbnail_path.as_deref(),
+            Some("/tmp/quokka.jpg")
+        );
+        assert_eq!(b.items[0].subtitle.as_deref(), Some("It hops."));
+    }
+
+    #[test]
+    fn render_image_linked_list_without_path_leaves_thumbnail_empty() {
+        let s = summary_with(None, None);
+        let body = render_page_summary_with_thumbnail(&s, Shape::ImageLinkedList, None);
+        let Body::ImageLinkedList(b) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(b.items[0].thumbnail_path, None);
+        assert_eq!(b.items[0].subtitle, None);
+    }
 }

--- a/src/fetcher/wikipedia/client.rs
+++ b/src/fetcher/wikipedia/client.rs
@@ -65,6 +65,16 @@ pub struct PageSummary {
     pub extract: Option<String>,
     #[serde(default)]
     pub content_urls: Option<ContentUrls>,
+    /// REST API `thumbnail.source` — a remote `*.wikipedia.org` image URL. Optional because not
+    /// every page has a thumbnail; the JSON omits the whole block in that case.
+    #[serde(default)]
+    pub thumbnail: Option<PageThumbnail>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PageThumbnail {
+    #[serde(default)]
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -88,6 +98,17 @@ impl PageSummary {
             .map(|p| p.page.clone())
     }
 
+    /// Remote URL of the page's thumbnail image (typically `upload.wikimedia.org/...`). Returns
+    /// `None` when the REST API omits the thumbnail or returns an empty source. Callers feed
+    /// this through [`crate::fetcher::thumbnails::download_to_cache`] before handing the local
+    /// path to a `list_cards`-style renderer.
+    pub fn thumbnail_url(&self) -> Option<&str> {
+        self.thumbnail
+            .as_ref()
+            .map(|t| t.source.as_str())
+            .filter(|s| !s.is_empty())
+    }
+
     /// First sentence of the extract — split at the first `". "` so the Text shape can carry a
     /// preview without the whole multi-paragraph body. Returns `None` when the extract is
     /// missing or empty.
@@ -104,12 +125,33 @@ impl PageSummary {
 /// Shape-aware rendering for a single page summary — shared by `wikipedia_featured` and
 /// `wikipedia_random` since both fetchers expose the same `{title, extract, url}` triplet.
 pub fn render_page_summary(summary: &PageSummary, shape: Shape) -> Body {
+    render_page_summary_with_thumbnail(summary, shape, None)
+}
+
+/// Render variant that pins a pre-resolved local thumbnail path onto the `ImageLinkedList`
+/// shape's single card. Other shapes ignore the thumbnail (Text / TextBlock have no place to
+/// surface it). The thumbnail download itself is async, so callers run
+/// [`crate::fetcher::thumbnails::download_to_cache`] before calling this and pass the local
+/// path in.
+pub fn render_page_summary_with_thumbnail(
+    summary: &PageSummary,
+    shape: Shape,
+    thumbnail_path: Option<std::path::PathBuf>,
+) -> Body {
     match shape {
         Shape::Text => Body::Text(TextData {
             value: text_line(summary),
         }),
         Shape::TextBlock => Body::TextBlock(TextBlockData {
             lines: text_block_lines(summary),
+        }),
+        Shape::ImageLinkedList => Body::ImageLinkedList(crate::payload::ImageLinkedListData {
+            items: vec![crate::payload::ImageLinkedItem {
+                title: summary.title.clone(),
+                url: summary.url(),
+                thumbnail_path: thumbnail_path.map(|p| p.to_string_lossy().into_owned()),
+                subtitle: summary.first_sentence(),
+            }],
         }),
         _ => Body::LinkedTextBlock(LinkedTextBlockData {
             items: vec![LinkedLine {
@@ -153,6 +195,7 @@ mod tests {
                 desktop: Some(UrlsByPlatform { page: p.into() }),
                 mobile: None,
             }),
+            thumbnail: None,
         }
     }
 
@@ -208,6 +251,7 @@ mod tests {
                     page: "https://en.m.wikipedia.org/wiki/x".into(),
                 }),
             }),
+            thumbnail: None,
         };
         assert_eq!(
             s.url().as_deref(),

--- a/src/fetcher/wikipedia/featured.rs
+++ b/src/fetcher/wikipedia/featured.rs
@@ -207,6 +207,10 @@ mod tests {
             fetcher.sample_body(Shape::Text),
             Some(Body::Text(_))
         ));
+        assert!(matches!(
+            fetcher.sample_body(Shape::ImageLinkedList),
+            Some(Body::ImageLinkedList(_))
+        ));
         assert!(fetcher.sample_body(Shape::Entries).is_none());
     }
 

--- a/src/fetcher/wikipedia/featured.rs
+++ b/src/fetcher/wikipedia/featured.rs
@@ -10,15 +10,24 @@ use chrono::{Datelike, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
 use crate::samples;
 
-use super::client::{DEFAULT_LANG, PageSummary, get, render_page_summary, rest_api_base};
+use super::client::{
+    DEFAULT_LANG, PageSummary, get, render_page_summary, render_page_summary_with_thumbnail,
+    rest_api_base,
+};
 
-const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Text];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     name: "lang",
@@ -68,6 +77,12 @@ impl Fetcher for WikipediaFeaturedFetcher {
                 "Hyperion (poem)",
                 Some("https://en.wikipedia.org/wiki/Hyperion_(poem)"),
             )]),
+            Shape::ImageLinkedList => samples::image_linked_list(&[(
+                "Hyperion (poem)",
+                Some("https://en.wikipedia.org/wiki/Hyperion_(poem)"),
+                None,
+                Some("Hyperion is an unfinished epic poem by John Keats."),
+            )]),
             Shape::TextBlock => samples::text_block(&[
                 "Hyperion (poem)",
                 "Hyperion is an unfinished epic poem by John Keats, recounting the despair of the Titans after their defeat by the Olympians.",
@@ -83,7 +98,17 @@ impl Fetcher for WikipediaFeaturedFetcher {
         let lang = opts.lang.as_deref().unwrap_or(DEFAULT_LANG);
         let summary = fetch_tfa(lang).await?;
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
-        Ok(payload(render_page_summary(&summary, shape)))
+        let body = match shape {
+            Shape::ImageLinkedList => {
+                let path = match summary.thumbnail_url() {
+                    Some(url) => thumbnails::download_to_cache(url).await.ok().flatten(),
+                    None => None,
+                };
+                render_page_summary_with_thumbnail(&summary, shape, path)
+            }
+            _ => render_page_summary(&summary, shape),
+        };
+        Ok(payload(body))
     }
 }
 

--- a/src/fetcher/wikipedia/on_this_day.rs
+++ b/src/fetcher/wikipedia/on_this_day.rs
@@ -310,6 +310,7 @@ mod tests {
                 desktop: Some(UrlsByPlatform { page: url.into() }),
                 mobile: None,
             }),
+            thumbnail: None,
         }
     }
 

--- a/src/fetcher/wikipedia/random.rs
+++ b/src/fetcher/wikipedia/random.rs
@@ -186,6 +186,10 @@ mod tests {
         if let Some(Body::Text(text)) = text {
             assert!(text.value.starts_with("Quokka:"));
         }
+        assert!(matches!(
+            fetcher.sample_body(Shape::ImageLinkedList),
+            Some(Body::ImageLinkedList(_)),
+        ));
         assert!(fetcher.sample_body(Shape::Entries).is_none());
 
         let a = fetcher.cache_key(&ctx(Some("lang = \"en\""), Some(Shape::TextBlock)));

--- a/src/fetcher/wikipedia/random.rs
+++ b/src/fetcher/wikipedia/random.rs
@@ -9,15 +9,24 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
 use crate::samples;
 
-use super::client::{DEFAULT_LANG, PageSummary, get, render_page_summary, rest_api_base};
+use super::client::{
+    DEFAULT_LANG, PageSummary, get, render_page_summary, render_page_summary_with_thumbnail,
+    rest_api_base,
+};
 
-const SHAPES: &[Shape] = &[Shape::LinkedTextBlock, Shape::TextBlock, Shape::Text];
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     name: "lang",
@@ -67,6 +76,12 @@ impl Fetcher for WikipediaRandomFetcher {
                 "Quokka",
                 Some("https://en.wikipedia.org/wiki/Quokka"),
             )]),
+            Shape::ImageLinkedList => samples::image_linked_list(&[(
+                "Quokka",
+                Some("https://en.wikipedia.org/wiki/Quokka"),
+                None,
+                Some("A small macropod native to southwestern Australia."),
+            )]),
             Shape::TextBlock => samples::text_block(&[
                 "Quokka",
                 "The quokka is a small macropod about the size of a domestic cat, native to small islands and a small mainland area of southwestern Australia.",
@@ -82,7 +97,17 @@ impl Fetcher for WikipediaRandomFetcher {
         let lang = opts.lang.as_deref().unwrap_or(DEFAULT_LANG);
         let summary = fetch_random(lang).await?;
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
-        Ok(payload(render_page_summary(&summary, shape)))
+        let body = match shape {
+            Shape::ImageLinkedList => {
+                let path = match summary.thumbnail_url() {
+                    Some(url) => thumbnails::download_to_cache(url).await.ok().flatten(),
+                    None => None,
+                };
+                render_page_summary_with_thumbnail(&summary, shape, path)
+            }
+            _ => render_page_summary(&summary, shape),
+        };
+        Ok(payload(body))
     }
 }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -39,6 +39,12 @@ pub enum Body {
     /// links can ignore the urls and render the text only. Right for feeds — HN top, GitHub
     /// PRs/issues/releases — where each row has a canonical "open this" target.
     LinkedTextBlock(LinkedTextBlockData),
+    /// `LinkedTextBlock` with a thumbnail column. Each item is a `(thumbnail?, title, url?,
+    /// subtitle?)` tuple. Right for media-feed widgets (RSS with images, YouTube channels,
+    /// Plex / Jellyfin recently-added, Reddit-with-thumbnails) where the thumbnail carries as
+    /// much glance value as the title. Items without `thumbnail_path` get a blank cell of the
+    /// same width so the text column stays aligned across rows.
+    ImageLinkedList(ImageLinkedListData),
     /// Key/value rows. Used by system info, env dumps, anything label:value shaped.
     Entries(EntriesData),
     /// A single 0..=1 value with an optional display label. Gauges, progress bars, donuts.
@@ -141,6 +147,22 @@ pub struct LinkedLine {
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ImageLinkedListData {
+    pub items: Vec<ImageLinkedItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ImageLinkedItem {
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumbnail_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -380,6 +402,61 @@ mod tests {
         }));
         let json = serde_json::to_string(&p).unwrap();
         assert!(!json.contains("\"url\""), "json: {json:?}");
+    }
+
+    #[test]
+    fn image_linked_list_round_trips() {
+        let p = bare(Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![
+                ImageLinkedItem {
+                    title: "Rust 1.99 released".into(),
+                    url: Some("https://example.com/rust".into()),
+                    thumbnail_path: Some("/tmp/rust.png".into()),
+                    subtitle: Some("rust-lang.org · 2h ago".into()),
+                },
+                ImageLinkedItem {
+                    title: "no thumbnail here".into(),
+                    url: None,
+                    thumbnail_path: None,
+                    subtitle: None,
+                },
+            ],
+        }));
+        assert_eq!(p, round_trip(&p));
+    }
+
+    #[test]
+    fn image_linked_list_serializes_with_expected_shape_tag() {
+        let p = bare(Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![ImageLinkedItem {
+                title: "hello".into(),
+                url: Some("https://example.com".into()),
+                thumbnail_path: Some("/tmp/x.png".into()),
+                subtitle: None,
+            }],
+        }));
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["shape"], "image_linked_list");
+        assert_eq!(v["data"]["items"][0]["title"], "hello");
+        assert_eq!(v["data"]["items"][0]["url"], "https://example.com");
+        assert_eq!(v["data"]["items"][0]["thumbnail_path"], "/tmp/x.png");
+        assert!(v["data"]["items"][0].get("subtitle").is_none());
+    }
+
+    #[test]
+    fn image_linked_list_omits_optional_fields_when_none() {
+        let p = bare(Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![ImageLinkedItem {
+                title: "only title".into(),
+                url: None,
+                thumbnail_path: None,
+                subtitle: None,
+            }],
+        }));
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(!json.contains("\"url\""), "json: {json:?}");
+        assert!(!json.contains("\"thumbnail_path\""), "json: {json:?}");
+        assert!(!json.contains("\"subtitle\""), "json: {json:?}");
     }
 
     #[test]

--- a/src/render/list_cards.rs
+++ b/src/render/list_cards.rs
@@ -271,6 +271,139 @@ mod tests {
     }
 
     #[test]
+    fn renderer_contract_exposes_image_linked_list_surface() {
+        let renderer = ListCardsRenderer;
+        assert_eq!(renderer.name(), "list_cards");
+        assert!(!renderer.animates());
+        assert_eq!(renderer.accepts(), &[Shape::ImageLinkedList]);
+        assert_eq!(
+            renderer
+                .color_keys()
+                .iter()
+                .map(|k| k.name)
+                .collect::<Vec<_>>(),
+            vec![theme::TEXT.name, theme::TEXT_DIM.name],
+        );
+        assert_eq!(
+            renderer
+                .option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["max_items", "thumbnail_width", "row_height", "gap", "fit"],
+        );
+        assert!(renderer.description().contains("thumbnail"));
+    }
+
+    #[test]
+    fn zero_area_does_not_panic() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        // 0×0, 1×0, 0×1 all need to no-op rather than touch a zero-sized buffer.
+        for (w, h) in [(0u16, 0u16), (0, 5), (10, 0)] {
+            let _ = render_to_buffer_with_spec(
+                &payload(vec![item("ignored", None, None)]),
+                Some(&spec),
+                &registry,
+                w.max(1),
+                h.max(1),
+            );
+        }
+    }
+
+    #[test]
+    fn narrow_area_truncates_text_without_panicking() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        // 8 cells: 6 (thumb) + 1 (gap) leaves 1 cell for text. The renderer must clip,
+        // not crash. Confirm a buffer comes back populated to whatever the cell allows.
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("very long title", None, None)]),
+            Some(&spec),
+            &registry,
+            8,
+            3,
+        );
+        let row: String = (buf.area.x..buf.area.right())
+            .map(|x| buf[(x, 0)].symbol().to_string())
+            .collect();
+        // The first character of the title (`v`) lands at x=7 (6 thumb + 1 gap).
+        assert!(row.contains('v'));
+    }
+
+    #[test]
+    fn area_narrower_than_thumb_column_skips_text() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        // 4 cells total — narrower than the default 6-cell thumbnail width. The thumbnail
+        // cell saturates to the full row width, leaving no room for the gap or text.
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("hidden title", None, None)]),
+            Some(&spec),
+            &registry,
+            4,
+            3,
+        );
+        let row: String = (buf.area.x..buf.area.right())
+            .map(|x| buf[(x, 0)].symbol().to_string())
+            .collect();
+        // Text must be entirely suppressed when there's no room for it after the thumbnail.
+        assert!(
+            !row.contains("hidden"),
+            "text leaked past thumbnail column: {row:?}",
+        );
+    }
+
+    #[test]
+    fn gap_option_shifts_text_column() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        // thumbnail_width=4, gap=3 ⇒ text column starts at x=7.
+        let w: W =
+            toml::from_str(r#"render = { type = "list_cards", thumbnail_width = 4, gap = 3 }"#)
+                .unwrap();
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("X", None, None)]),
+            Some(&w.render),
+            &registry,
+            20,
+            3,
+        );
+        let row: String = (buf.area.x..buf.area.right())
+            .map(|x| buf[(x, 0)].symbol().to_string())
+            .collect();
+        assert_eq!(row.find('X'), Some(7), "row: {row:?}");
+    }
+
+    #[test]
+    fn fit_option_parses_without_error() {
+        // We can't visually verify `fit` in the ASCII buffer (no real image is drawn for an
+        // empty thumbnail_path), but we can ensure each accepted value parses and the render
+        // path stays panic-free.
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        for fit in &["contain", "cover", "stretch"] {
+            let w: W = toml::from_str(&format!(
+                r#"render = {{ type = "list_cards", fit = "{fit}" }}"#
+            ))
+            .unwrap();
+            let _ = render_to_buffer_with_spec(
+                &payload(vec![item("x", None, None)]),
+                Some(&w.render),
+                &registry,
+                20,
+                3,
+            );
+        }
+    }
+
+    #[test]
     fn renders_title_and_subtitle_per_row() {
         let registry = Registry::with_builtins();
         let spec = RenderSpec::Short("list_cards".into());

--- a/src/render/list_cards.rs
+++ b/src/render/list_cards.rs
@@ -1,0 +1,438 @@
+//! `list_cards` — `ImageLinkedList` rendered as card rows: a thumbnail cell on the left,
+//! title (+ optional subtitle) on the right, with rows that carry a `url` wrapped in OSC 8
+//! hyperlinks so modern terminals make them clickable. Rows without a thumbnail keep a blank
+//! cell of the same width so the text column stays column-aligned across rows.
+//!
+//! Pairs with media-feed fetchers (`rss` with `media:thumbnail`, `reddit_subreddit_posts`,
+//! `wikipedia_featured` / `wikipedia_random`) where the thumbnail carries as much glance
+//! value as the title.
+
+use ratatui::{
+    Frame,
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+};
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{Body, ImageLinkedItem, ImageLinkedListData};
+use crate::theme::{self, ColorKey, Theme};
+
+use super::list_links::wrap_osc8;
+use super::media_image::draw_thumbnail;
+use super::{Registry, RenderOptions, Renderer, Shape};
+
+const COLOR_KEYS: &[ColorKey] = &[theme::TEXT, theme::TEXT_DIM];
+
+const DEFAULT_THUMBNAIL_WIDTH: u16 = 6;
+const DEFAULT_ROW_HEIGHT: u16 = 3;
+const DEFAULT_GAP: u16 = 1;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "max_items",
+        type_hint: "positive integer",
+        required: false,
+        default: Some("all rows"),
+        description: "Cap on rendered cards. Truncates from the end when the input has more rows than the cap.",
+    },
+    OptionSchema {
+        name: "thumbnail_width",
+        type_hint: "cells (u16)",
+        required: false,
+        default: Some("6"),
+        description: "Width in cells of the thumbnail column. Rows without a thumbnail still consume this width as blank space so the text column stays aligned.",
+    },
+    OptionSchema {
+        name: "row_height",
+        type_hint: "cells (u16)",
+        required: false,
+        default: Some("3"),
+        description: "Height in cells of each card row. Row 0 carries the title (linked when `url` is set), row 1 the optional subtitle, row 2 is breathing room.",
+    },
+    OptionSchema {
+        name: "gap",
+        type_hint: "cells (u16)",
+        required: false,
+        default: Some("1"),
+        description: "Horizontal gap in cells between the thumbnail column and the text column.",
+    },
+    OptionSchema {
+        name: "fit",
+        type_hint: "\"contain\" | \"cover\" | \"stretch\"",
+        required: false,
+        default: Some("\"contain\""),
+        description: "How each thumbnail is sized into its cell. Matches `media_image`'s `fit`.",
+    },
+];
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    pub thumbnail_width: Option<u16>,
+    #[serde(default)]
+    pub row_height: Option<u16>,
+    #[serde(default)]
+    pub gap: Option<u16>,
+    #[serde(default)]
+    pub fit: Option<String>,
+}
+
+pub struct ListCardsRenderer;
+
+impl Renderer for ListCardsRenderer {
+    fn name(&self) -> &str {
+        "list_cards"
+    }
+    fn description(&self) -> &'static str {
+        "Card-shaped rows with a thumbnail on the left and title (+ optional subtitle) on the right. Rows that carry a URL get an OSC 8 hyperlink wrap on the title so terminals make it clickable. Use this for media-feed widgets (RSS with images, subreddit posts, Wikipedia featured) where the thumbnail is part of the headline."
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::ImageLinkedList]
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        _registry: &Registry,
+    ) {
+        if let Body::ImageLinkedList(d) = body {
+            render_cards(frame, area, d, opts, theme);
+        }
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        _max_width: u16,
+        _registry: &Registry,
+    ) -> u16 {
+        if let Body::ImageLinkedList(d) = body {
+            let cap = opts.max_items.unwrap_or(usize::MAX);
+            let count = d.items.len().min(cap) as u16;
+            let row_h = row_height(opts);
+            return count.saturating_mul(row_h);
+        }
+        1
+    }
+}
+
+fn render_cards(
+    frame: &mut Frame,
+    area: Rect,
+    data: &ImageLinkedListData,
+    opts: &RenderOptions,
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let cap = opts.max_items.unwrap_or(usize::MAX);
+    let row_h = row_height(opts);
+    let thumb_w = thumb_width(opts, area.width);
+    let gap = gap(opts);
+    let specific: Options = opts.parse_specific();
+    let fit = specific.fit.as_deref();
+    let max_rows = (area.height / row_h.max(1)) as usize;
+    data.items
+        .iter()
+        .take(cap)
+        .take(max_rows)
+        .enumerate()
+        .for_each(|(i, item)| {
+            let y = area.y + i as u16 * row_h;
+            let row = Rect {
+                x: area.x,
+                y,
+                width: area.width,
+                height: row_h.min(area.y + area.height - y),
+            };
+            draw_card(frame, row, item, thumb_w, gap, fit, theme);
+        });
+}
+
+fn draw_card(
+    frame: &mut Frame,
+    row: Rect,
+    item: &ImageLinkedItem,
+    thumb_w: u16,
+    gap: u16,
+    fit: Option<&str>,
+    theme: &Theme,
+) {
+    let thumb_rect = Rect {
+        x: row.x,
+        y: row.y,
+        width: thumb_w.min(row.width),
+        height: row.height,
+    };
+    if let Some(path) = item.thumbnail_path.as_deref().filter(|s| !s.is_empty()) {
+        let _ = draw_thumbnail(frame, thumb_rect, path, fit, theme);
+    }
+    let text_x = row.x + thumb_rect.width + gap;
+    if text_x >= row.x + row.width {
+        return;
+    }
+    let text_w = row.x + row.width - text_x;
+    draw_text(
+        frame.buffer_mut(),
+        text_x,
+        row.y,
+        text_w,
+        row.height,
+        item,
+        theme,
+    );
+}
+
+fn draw_text(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    width: u16,
+    height: u16,
+    item: &ImageLinkedItem,
+    theme: &Theme,
+) {
+    if width == 0 || height == 0 {
+        return;
+    }
+    let title_style = Style::default().fg(theme.text).add_modifier(Modifier::BOLD);
+    let (end_x, _) = buf.set_stringn(x, y, &item.title, width as usize, title_style);
+    if let Some(url) = item.url.as_deref().filter(|u| !u.is_empty()) {
+        wrap_osc8(buf, x, y, end_x, url, title_style);
+    }
+    if height >= 2
+        && let Some(sub) = item.subtitle.as_deref().filter(|s| !s.is_empty())
+    {
+        let sub_style = Style::default().fg(theme.text_dim);
+        buf.set_stringn(x, y + 1, sub, width as usize, sub_style);
+    }
+}
+
+fn row_height(opts: &RenderOptions) -> u16 {
+    let specific: Options = opts.parse_specific();
+    specific.row_height.unwrap_or(DEFAULT_ROW_HEIGHT).max(1)
+}
+
+fn thumb_width(opts: &RenderOptions, area_width: u16) -> u16 {
+    let specific: Options = opts.parse_specific();
+    specific
+        .thumbnail_width
+        .unwrap_or(DEFAULT_THUMBNAIL_WIDTH)
+        .min(area_width)
+}
+
+fn gap(opts: &RenderOptions) -> u16 {
+    let specific: Options = opts.parse_specific();
+    specific.gap.unwrap_or(DEFAULT_GAP)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{ImageLinkedItem, ImageLinkedListData, Payload};
+    use crate::render::test_utils::render_to_buffer_with_spec;
+    use crate::render::{Registry, RenderSpec};
+
+    fn payload(items: Vec<ImageLinkedItem>) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::ImageLinkedList(ImageLinkedListData { items }),
+        }
+    }
+
+    fn item(title: &str, url: Option<&str>, sub: Option<&str>) -> ImageLinkedItem {
+        ImageLinkedItem {
+            title: title.into(),
+            url: url.map(String::from),
+            thumbnail_path: None,
+            subtitle: sub.map(String::from),
+        }
+    }
+
+    fn row_text(buf: &ratatui::buffer::Buffer, y: u16) -> String {
+        (buf.area.x..buf.area.right())
+            .map(|x| buf[(x, y)].symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn renders_title_and_subtitle_per_row() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item(
+                "Rust 1.99 released",
+                None,
+                Some("rust-lang.org · 2h"),
+            )]),
+            Some(&spec),
+            &registry,
+            40,
+            3,
+        );
+        assert!(row_text(&buf, 0).contains("Rust 1.99 released"));
+        assert!(row_text(&buf, 1).contains("rust-lang.org"));
+    }
+
+    #[test]
+    fn linked_row_wraps_title_with_osc_8() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("hello", Some("https://example.com"), None)]),
+            Some(&spec),
+            &registry,
+            30,
+            3,
+        );
+        let row = row_text(&buf, 0);
+        assert!(
+            row.contains("\x1b]8;;https://example.com\x1b\\"),
+            "missing OSC 8 open: {row:?}",
+        );
+        assert!(
+            row.contains("\x1b]8;;\x1b\\"),
+            "missing OSC 8 close: {row:?}"
+        );
+    }
+
+    #[test]
+    fn missing_thumbnail_keeps_text_column_aligned() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("first", None, None), item("second", None, None)]),
+            Some(&spec),
+            &registry,
+            40,
+            6,
+        );
+        // With default thumb_width=6 + gap=1, text starts at x=7. The blank thumb column on
+        // both rows means both titles share the same starting column.
+        let row0 = row_text(&buf, 0);
+        let row1 = row_text(&buf, 3);
+        let pos0 = row0.find("first").unwrap();
+        let pos1 = row1.find("second").unwrap();
+        assert_eq!(pos0, pos1, "text columns must align: {row0:?} vs {row1:?}");
+    }
+
+    #[test]
+    fn empty_body_does_not_panic() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        // Empty body short-circuits to the shared placeholder, so we just assert no panic.
+        let _ = render_to_buffer_with_spec(&payload(vec![]), Some(&spec), &registry, 30, 3);
+    }
+
+    #[test]
+    fn max_items_caps_rendered_cards() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(r#"render = { type = "list_cards", max_items = 1 }"#).unwrap();
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("first", None, None), item("second", None, None)]),
+            Some(&w.render),
+            &registry,
+            40,
+            9,
+        );
+        assert!(row_text(&buf, 0).contains("first"));
+        // Row 3 would carry the second card with the default row_height=3; with the cap it stays
+        // blank.
+        assert!(!row_text(&buf, 3).contains("second"));
+    }
+
+    #[test]
+    fn area_height_caps_rendered_cards() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        // Buffer only fits one full 3-cell row; the second card has no space and is dropped.
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("first", None, None), item("second", None, None)]),
+            Some(&spec),
+            &registry,
+            40,
+            3,
+        );
+        assert!(row_text(&buf, 0).contains("first"));
+        // Verify the second card never appears anywhere in the small buffer.
+        let joined: String = (0..3).map(|y| row_text(&buf, y)).collect();
+        assert!(!joined.contains("second"));
+    }
+
+    #[test]
+    fn natural_height_scales_with_item_count() {
+        let registry = Registry::with_builtins();
+        let renderer = ListCardsRenderer;
+        let body = Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![
+                item("a", None, None),
+                item("b", None, None),
+                item("c", None, None),
+            ],
+        });
+        // 3 items * default row_height=3 = 9 cells.
+        assert_eq!(
+            renderer.natural_height(&body, &RenderOptions::default(), 40, &registry),
+            9
+        );
+    }
+
+    #[test]
+    fn natural_height_respects_max_items() {
+        let registry = Registry::with_builtins();
+        let renderer = ListCardsRenderer;
+        let body = Body::ImageLinkedList(ImageLinkedListData {
+            items: (0..5).map(|_| item("x", None, None)).collect(),
+        });
+        let opts = RenderOptions {
+            max_items: Some(2),
+            ..RenderOptions::default()
+        };
+        assert_eq!(renderer.natural_height(&body, &opts, 40, &registry), 6);
+    }
+
+    #[test]
+    fn custom_row_height_and_thumb_width_apply() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(
+            r#"render = { type = "list_cards", row_height = 2, thumbnail_width = 4, gap = 2 }"#,
+        )
+        .unwrap();
+        let buf = render_to_buffer_with_spec(
+            &payload(vec![item("a", None, None), item("b", None, None)]),
+            Some(&w.render),
+            &registry,
+            40,
+            4,
+        );
+        // With row_height=2, the second item lives on y=2.
+        assert!(row_text(&buf, 0).contains('a'));
+        assert!(row_text(&buf, 2).contains('b'));
+        // thumb_width(4) + gap(2) = 6, so the text column starts at x=6.
+        let row0 = row_text(&buf, 0);
+        assert_eq!(row0.find('a'), Some(6));
+    }
+}

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -155,6 +155,15 @@ fn osc8_suppressed() -> bool {
     OSC8_SUPPRESSED.with(StdCell::get)
 }
 
+/// Re-export of the OSC 8 wrapping helper so sibling renderers (`list_cards`) can reuse the
+/// `set_skip` plumbing without duplicating the escape-sequence dance.
+pub(crate) fn wrap_osc8(buf: &mut Buffer, x: u16, y: u16, end_x: u16, url: &str, style: Style) {
+    if osc8_suppressed() {
+        return;
+    }
+    wrap_link(buf, x, y, end_x, url, style);
+}
+
 fn wrap_link(buf: &mut Buffer, x: u16, y: u16, end_x: u16, url: &str, style: Style) {
     let visible: String = (x..end_x)
         .filter_map(|col| buf.cell((col, y)).map(|c| c.symbol().to_string()))

--- a/src/render/media_image.rs
+++ b/src/render/media_image.rs
@@ -128,13 +128,30 @@ fn render_image(
     theme: &Theme,
 ) -> Result<(), String> {
     let specific: Options = opts.parse_specific();
+    draw_thumbnail(frame, area, path, specific.fit.as_deref(), theme)
+}
+
+/// Draws an image file into `area` using the shared `ratatui-image` pipeline. Exposed for
+/// renderers that need a thumbnail cell inside a larger composition (`list_cards`) without
+/// duplicating the picker / load / theme-bg plumbing. Returns the same `Err` strings
+/// `media_image` would surface so callers can fall back to a blank cell or text glyph.
+pub(crate) fn draw_thumbnail(
+    frame: &mut Frame,
+    area: Rect,
+    path: &str,
+    fit: Option<&str>,
+    theme: &Theme,
+) -> Result<(), String> {
+    if area.width == 0 || area.height == 0 {
+        return Ok(());
+    }
     let img = load_image(path)?;
     let mut p = picker();
     if let Some(rgba) = solid_rgba(theme.bg) {
         p.set_background_color(Some(rgba));
     }
     let mut protocol = p.new_resize_protocol(img);
-    let widget = StatefulImage::default().resize(resize_mode(specific.fit.as_deref()));
+    let widget = StatefulImage::default().resize(resize_mode(fit));
     frame.render_stateful_widget(widget, area, &mut protocol);
     Ok(())
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -836,8 +836,8 @@ mod tests {
     #[test]
     fn is_empty_body_matches_expectations() {
         use crate::payload::{
-            BarsData, EntriesData, HeatmapData, ImageData, NumberSeriesData, PointSeriesData,
-            RatioData, TextBlockData, TextData,
+            BarsData, EntriesData, HeatmapData, ImageData, ImageLinkedItem, ImageLinkedListData,
+            NumberSeriesData, PointSeriesData, RatioData, TextBlockData, TextData,
         };
         // Empty cases.
         assert!(is_empty_body(&Body::Text(TextData {
@@ -866,6 +866,30 @@ mod tests {
             row_labels: None,
             col_labels: None,
         })));
+        assert!(is_empty_body(&Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![],
+        })));
+        // All-empty-titles is also collapsed to the placeholder so a feed that came back with
+        // structurally-present-but-content-less rows reads as "nothing here yet" rather than a
+        // wall of blank cards.
+        assert!(is_empty_body(&Body::ImageLinkedList(ImageLinkedListData {
+            items: vec![ImageLinkedItem {
+                title: String::new(),
+                url: None,
+                thumbnail_path: None,
+                subtitle: None,
+            }],
+        })));
+        assert!(!is_empty_body(&Body::ImageLinkedList(
+            ImageLinkedListData {
+                items: vec![ImageLinkedItem {
+                    title: "a card".into(),
+                    url: None,
+                    thumbnail_path: None,
+                    subtitle: None,
+                }],
+            }
+        )));
         // Non-empty and "structurally always present" cases.
         assert!(!is_empty_body(&Body::Text(TextData { value: "x".into() })));
         assert!(!is_empty_body(&Body::TextBlock(TextBlockData {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -35,6 +35,7 @@ mod gauge_thermometer;
 mod grid_calendar;
 mod grid_heatmap;
 mod grid_table;
+pub mod list_cards;
 pub mod list_links;
 mod list_plain;
 mod list_ranking;
@@ -58,6 +59,7 @@ pub enum Shape {
     TextBlock,
     MarkdownTextBlock,
     LinkedTextBlock,
+    ImageLinkedList,
     Entries,
     Ratio,
     NumberSeries,
@@ -80,6 +82,7 @@ pub fn shape_of(body: &Body) -> Shape {
         Body::TextBlock(_) => Shape::TextBlock,
         Body::MarkdownTextBlock(_) => Shape::MarkdownTextBlock,
         Body::LinkedTextBlock(_) => Shape::LinkedTextBlock,
+        Body::ImageLinkedList(_) => Shape::ImageLinkedList,
         Body::Entries(_) => Shape::Entries,
         Body::Ratio(_) => Shape::Ratio,
         Body::NumberSeries(_) => Shape::NumberSeries,
@@ -103,6 +106,7 @@ impl Shape {
             Self::TextBlock => "text_block",
             Self::MarkdownTextBlock => "markdown_text_block",
             Self::LinkedTextBlock => "linked_text_block",
+            Self::ImageLinkedList => "image_linked_list",
             Self::Entries => "entries",
             Self::Ratio => "ratio",
             Self::NumberSeries => "number_series",
@@ -369,6 +373,7 @@ impl Registry {
         r.register(Arc::new(animated_wave::AnimatedWaveRenderer));
         r.register(Arc::new(status_badge::StatusBadgeRenderer));
         r.register(Arc::new(list_plain::ListPlainRenderer));
+        r.register(Arc::new(list_cards::ListCardsRenderer));
         r.register(Arc::new(list_links::ListLinksRenderer));
         r.register(Arc::new(list_ranking::ListRankingRenderer));
         r.register(Arc::new(grid_table::GridTableRenderer));
@@ -412,6 +417,7 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
         Shape::TextBlock => "list_plain",
         Shape::MarkdownTextBlock => "text_markdown",
         Shape::LinkedTextBlock => "list_links",
+        Shape::ImageLinkedList => "list_cards",
         Shape::Entries => "grid_table",
         Shape::Ratio => "gauge_circle",
         Shape::NumberSeries => "chart_sparkline",
@@ -523,6 +529,9 @@ pub fn is_empty_body(body: &Body) -> bool {
         Body::TextBlock(d) => d.lines.is_empty() || d.lines.iter().all(|l| l.is_empty()),
         Body::MarkdownTextBlock(d) => d.value.is_empty(),
         Body::LinkedTextBlock(d) => d.items.is_empty() || d.items.iter().all(|i| i.text.is_empty()),
+        Body::ImageLinkedList(d) => {
+            d.items.is_empty() || d.items.iter().all(|i| i.title.is_empty())
+        }
         Body::Entries(d) => d.items.is_empty(),
         Body::NumberSeries(d) => d.values.is_empty(),
         Body::PointSeries(d) => d.series.iter().all(|s| s.points.is_empty()),
@@ -705,6 +714,7 @@ mod tests {
             "animated_wave",
             "status_badge",
             "list_plain",
+            "list_cards",
             "list_links",
             "list_ranking",
             "list_timeline",
@@ -735,6 +745,7 @@ mod tests {
             Shape::TextBlock,
             Shape::MarkdownTextBlock,
             Shape::LinkedTextBlock,
+            Shape::ImageLinkedList,
             Shape::Entries,
             Shape::Ratio,
             Shape::NumberSeries,

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -11,9 +11,10 @@
 //! any future CLI that wants to preview what a fetcher emits without hitting I/O.
 
 use crate::payload::{
-    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData, LinkedLine,
-    LinkedTextBlockData, MarkdownTextBlockData, NumberSeriesData, PointSeries, PointSeriesData,
-    RatioData, Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+    BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData, ImageLinkedItem,
+    ImageLinkedListData, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, NumberSeriesData,
+    PointSeries, PointSeriesData, RatioData, Status, TextBlockData, TextData, TimelineData,
+    TimelineEvent,
 };
 use crate::render::Shape;
 
@@ -30,6 +31,15 @@ pub fn canonical_sample(shape: Shape) -> Option<Body> {
         Shape::LinkedTextBlock => linked_text_block(&[
             ("splashboard greets on cd", Some("https://example.com/")),
             ("recent commit landed", None),
+        ]),
+        Shape::ImageLinkedList => image_linked_list(&[
+            (
+                "splashboard greets on cd",
+                Some("https://example.com/"),
+                None,
+                Some("docs · 2h"),
+            ),
+            ("recent commit landed", None, None, None),
         ]),
         Shape::Entries => entries(&[("key", "value"), ("foo", "bar"), ("baz", "qux")]),
         Shape::Ratio => ratio(0.67, "used"),
@@ -77,6 +87,25 @@ pub fn linked_text_block(rows: &[(&str, Option<&str>)]) -> Body {
             .map(|(text, url)| LinkedLine {
                 text: (*text).to_string(),
                 url: url.map(String::from),
+            })
+            .collect(),
+    })
+}
+
+/// Test-helper alias for `image_linked_list` rows. Keeps the call site readable as
+/// `(title, url, thumbnail_path, subtitle)` quadruples without tripping clippy's
+/// `type_complexity` lint on the public sample helper.
+pub type SampleImageLinkedRow<'a> = (&'a str, Option<&'a str>, Option<&'a str>, Option<&'a str>);
+
+pub fn image_linked_list(rows: &[SampleImageLinkedRow<'_>]) -> Body {
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: rows
+            .iter()
+            .map(|(title, url, thumb, sub)| ImageLinkedItem {
+                title: (*title).to_string(),
+                url: url.map(String::from),
+                thumbnail_path: thumb.map(String::from),
+                subtitle: sub.map(String::from),
             })
             .collect(),
     })
@@ -191,6 +220,7 @@ mod tests {
             Shape::TextBlock,
             Shape::MarkdownTextBlock,
             Shape::LinkedTextBlock,
+            Shape::ImageLinkedList,
             Shape::Entries,
             Shape::Ratio,
             Shape::NumberSeries,

--- a/xtask/src/snapshots.rs
+++ b/xtask/src/snapshots.rs
@@ -139,6 +139,7 @@ fn representative_fetcher(shape: Shape, fetchers: &FetcherRegistry) -> String {
         Shape::TextBlock => "git_recent_commits",
         Shape::MarkdownTextBlock => "wikipedia_featured",
         Shape::LinkedTextBlock => "rss",
+        Shape::ImageLinkedList => "rss",
         Shape::Entries => "system",
         Shape::Ratio => "clock_ratio",
         Shape::NumberSeries => "git_commits_activity",


### PR DESCRIPTION
## Summary

Adds a card-shaped feed renderer (`list_cards`) and a matching `ImageLinkedList` shape — feed entries become rows with a thumbnail on the left and a (clickable) title + subtitle on the right. Wires up every existing fetcher whose upstream payload actually carries images so the renderer is usable out of the box.

Ticks the `list_cards` checkbox on #61.

## Renderer

`list_cards` (single shape: `ImageLinkedList`)

### Options

| name | type | required | default | description |
|---|---|---|---|---|
| `max_items` | positive integer | optional | all rows | Cap on rendered cards. Truncates from the end when the input has more rows than the cap. |
| `thumbnail_width` | cells (u16) | optional | `6` | Width in cells of the thumbnail column. Rows without a thumbnail still consume this width as blank space so the text column stays aligned. |
| `row_height` | cells (u16) | optional | `3` | Height in cells of each card row. Row 0 carries the title (linked when `url` is set), row 1 the optional subtitle, row 2 is breathing room. |
| `gap` | cells (u16) | optional | `1` | Horizontal gap in cells between the thumbnail column and the text column. |
| `fit` | `"contain" \| "cover" \| "stretch"` | optional | `"contain"` | How each thumbnail is sized into its cell. Matches `media_image`'s `fit`. |

### Theme tokens

`theme.text` (title), `theme.text_dim` (subtitle).

### Compatible fetchers

`basic_read_store`, `reddit_subreddit_posts`, `reddit_user_posts`, `rss`, `wikipedia_featured`, `wikipedia_random`.

## Fetcher wiring

- **`rss`** — extracts `media:thumbnail` → `media:content` → first HTTP(S) `<img>` in `<content>` / `<summary>` (with HTML-entity decoding). Live-verified against the BBC tech feed.
- **`reddit_subreddit_posts`** / **`reddit_user_posts`** — extracts the per-post `thumbnail` URL, filtering Reddit's placeholder strings (`"self"`, `"default"`, `"nsfw"`, `"spoiler"`, empty). `reddit_user_comments` deliberately stays without `ImageLinkedList` — comments don't carry thumbnails.
- **`wikipedia_featured`** / **`wikipedia_random`** — deserialises the REST API's `thumbnail.source` block on `PageSummary` and downloads it. `wikipedia_on_this_day` keeps its existing shape set (no single canonical image per event row).
- **`basic_read_store`** — accepts `ImageLinkedList` JSON / TOML directly, so users can author cards without writing a fetcher.

Remote URLs are routed through a new shared `fetcher::thumbnails` helper that caches to `$HOME/.splashboard/cache/thumbnails/<sha256>.<ext>` with magic-byte sniffing and a 4 MB size cap. Per-row failures collapse to `None` so a single broken image never breaks a feed.

## Commit layout

Stacked, each green on its own:

1. `refactor(render): extract draw_thumbnail and wrap_osc8 helpers`
2. `feat(render): add list_cards renderer over a new ImageLinkedList shape`
3. `feat(fetcher): add shared thumbnail downloader`
4. `feat(fetcher): basic_read_store accepts ImageLinkedList`
5. `feat(fetcher/rss): emit ImageLinkedList with thumbnails`
6. `feat(fetcher/reddit): emit ImageLinkedList for post listings`
7. `feat(fetcher/wikipedia): emit ImageLinkedList with REST thumbnail.source`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 2086 passed, 0 failed (+13 ignored network-live tests)
- [x] Smoke-tested locally: BBC tech RSS feed renders cards with real thumbnails, Wikipedia featured-article thumbnail loads via REST `thumbnail.source`, ReadStore JSON cards render with explicit `thumbnail_path`
- [x] Live network checks (`-- --ignored`): `live_bbc_tech_thumbnail_url_extracts_media_thumbnail` passes (5/5 entries with thumbnails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)