### PR TITLE
feat(fetcher/news): add news_* family with 93 curated sources / 20 sub-genres

### DIFF
--- a/src/fetcher/feed.rs
+++ b/src/fetcher/feed.rs
@@ -1,0 +1,259 @@
+//! Shared feed pipeline for `rss` and the `news_*` family.
+//!
+//! All three concerns of fetch-and-render — HTTP retrieval, feed-rs parsing, and entry-to-body
+//! mapping — live here. Both callers re-use the same parser limits (5 MB body cap, 10 s timeout)
+//! and the same row formatting (`MMM DD  Title`) so widgets stay visually consistent regardless
+//! of which fetcher emits them. The `label` argument that threads through fetch / parse errors
+//! is the caller's display name (`"rss"` / `"news_bbc"`), so the operator sees which feed broke.
+//!
+//! The only thing each caller owns separately is option parsing (rss takes `url`; news_* takes
+//! `feed` as a key into a hardcoded table) and the Fetcher trait wiring.
+//!
+//! Constants are pub(crate) so test code in `rss.rs` can still assert against `MAX_BYTES` /
+//! `DEFAULT_COUNT` etc. without re-declaring them.
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use feed_rs::model::{Entry, Feed};
+use feed_rs::parser;
+use regex::Regex;
+use reqwest::Client;
+use url::Url;
+
+use crate::fetcher::thumbnails;
+use crate::fetcher::{FetchContext, FetchError};
+use crate::payload::{
+    Body, ImageLinkedItem, ImageLinkedListData, LinkedLine, LinkedTextBlockData, TextBlockData,
+};
+use crate::render::Shape;
+use crate::time as t;
+
+pub(crate) const DEFAULT_COUNT: u32 = 5;
+pub(crate) const MIN_COUNT: u32 = 1;
+pub(crate) const MAX_COUNT: u32 = 20;
+
+/// Cap raw response bytes so a hostile / runaway feed can't OOM the daemon.
+pub(crate) const MAX_BYTES: usize = 5 * 1024 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub(crate) async fn fetch_bytes(url: &Url, label: &str) -> Result<Vec<u8>, FetchError> {
+    let res = http()
+        .get(url.as_str())
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("{label} request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("{label} {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("{label} read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "{label} response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes.to_vec())
+}
+
+pub(crate) fn parse_feed(bytes: &[u8], label: &str) -> Result<Feed, FetchError> {
+    parser::parse(bytes).map_err(|e| FetchError::Failed(format!("{label} parse: {e}")))
+}
+
+pub(crate) fn render_body(
+    feed: &Feed,
+    count: usize,
+    shape: Shape,
+    timezone: Option<&str>,
+    locale: Option<&str>,
+) -> Body {
+    let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
+    match shape {
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: entries
+                .iter()
+                .map(|e| line_text(e, timezone, locale))
+                .collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: entries
+                .iter()
+                .map(|e| LinkedLine {
+                    text: line_text(e, timezone, locale),
+                    url: link_for(e),
+                })
+                .collect(),
+        }),
+    }
+}
+
+pub(crate) async fn render_image_linked(feed: &Feed, count: usize, ctx: &FetchContext) -> Body {
+    let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
+    let thumbnail_urls: Vec<Option<String>> =
+        entries.iter().map(|e| thumbnail_url_for(e)).collect();
+    let thumbnail_paths = thumbnails::download_many(&thumbnail_urls).await;
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: entries
+            .iter()
+            .zip(thumbnail_paths)
+            .map(|(e, path)| ImageLinkedItem {
+                title: title_or_placeholder(e),
+                url: link_for(e),
+                thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
+                subtitle: subtitle_for(e, ctx.timezone.as_deref(), ctx.locale.as_deref()),
+            })
+            .collect(),
+    })
+}
+
+/// Best-effort image URL for the entry, in order of preference:
+///
+/// 1. `media:thumbnail` (RSS Media spec) — explicit thumbnail.
+/// 2. `media:content` URL — full media, usually an image.
+/// 3. First `<img src="http(s)://...">` in the entry's HTML `<content>` or `<summary>` —
+///    covers Atom feeds without media extensions (Rust blog, most personal blogs) where the
+///    cover image is inlined in the body markup.
+pub(crate) fn thumbnail_url_for(entry: &Entry) -> Option<String> {
+    entry
+        .media
+        .iter()
+        .flat_map(|m| m.thumbnails.iter().map(|t| t.image.uri.clone()))
+        .find(|s| !s.is_empty())
+        .or_else(|| {
+            entry
+                .media
+                .iter()
+                .flat_map(|m| m.content.iter().filter_map(|c| c.url.as_ref()))
+                .map(|u| u.to_string())
+                .find(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            entry
+                .content
+                .as_ref()
+                .and_then(|c| c.body.as_deref())
+                .and_then(first_inline_image_src)
+        })
+        .or_else(|| {
+            entry
+                .summary
+                .as_ref()
+                .and_then(|s| first_inline_image_src(&s.content))
+        })
+}
+
+/// Extracts the `src` attribute of the first HTTP(S) `<img>` tag in `html`. Used to recover a
+/// thumbnail when the feed doesn't expose `media:thumbnail` — most Atom blogs only ship the
+/// cover image inline inside the HTML body. Encoded entities (`&amp;`) are decoded back to `&`
+/// so the URL works as-is.
+pub(crate) fn first_inline_image_src(html: &str) -> Option<String> {
+    static IMG_SRC_RE: OnceLock<Regex> = OnceLock::new();
+    let re = IMG_SRC_RE
+        .get_or_init(|| Regex::new(r#"(?is)<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']"#).unwrap());
+    re.captures_iter(html)
+        .map(|cap| decode_html_entities(&cap[1]))
+        .find(|src| src.starts_with("http://") || src.starts_with("https://"))
+}
+
+fn decode_html_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&#x2F;", "/")
+        .replace("&#x3D;", "=")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+/// Subtitle for the card layout: `"<date> · <source-host>"`, or just one half when the other is
+/// missing.
+pub(crate) fn subtitle_for(
+    entry: &Entry,
+    timezone: Option<&str>,
+    locale: Option<&str>,
+) -> Option<String> {
+    let date = date_label(entry, timezone, locale);
+    let host = link_for(entry)
+        .as_deref()
+        .and_then(|u| Url::parse(u).ok())
+        .and_then(|u| u.host_str().map(str::to_string));
+    match (date.is_empty(), host) {
+        (true, None) => None,
+        (false, None) => Some(date),
+        (true, Some(h)) => Some(h),
+        (false, Some(h)) => Some(format!("{date} · {h}")),
+    }
+}
+
+pub(crate) fn line_text(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> String {
+    let date = date_label(entry, timezone, locale);
+    let title = title_or_placeholder(entry);
+    if date.is_empty() {
+        title
+    } else {
+        format!("{date}  {title}")
+    }
+}
+
+fn date_label(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> String {
+    entry
+        .published
+        .or(entry.updated)
+        .map(|dt| format_short(dt, timezone, locale))
+        .unwrap_or_default()
+}
+
+pub(crate) fn format_short(
+    dt: DateTime<Utc>,
+    timezone: Option<&str>,
+    locale: Option<&str>,
+) -> String {
+    let local = match t::parse_tz(timezone) {
+        Some(tz) => dt.with_timezone(&tz).fixed_offset(),
+        None => dt.with_timezone(&chrono::Local).fixed_offset(),
+    };
+    t::format_local(&local, "%b %d", locale)
+}
+
+fn title_or_placeholder(entry: &Entry) -> String {
+    entry
+        .title
+        .as_ref()
+        .map(|t| collapse_whitespace(&t.content))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "(no title)".into())
+}
+
+pub(crate) fn collapse_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Atom entries can carry multiple `<link>` with `rel` discriminators (`alternate`, `self`,
+/// `enclosure`, `via`, …). Per RFC 4287 the article URL is `rel="alternate"`, which is also
+/// the default when `rel` is absent — matching RSS 2.0's single-link case. Picking the first
+/// non-empty href would otherwise grab `rel="self"` (a self-pointer back into the feed) on
+/// common Atom shapes.
+pub(crate) fn link_for(entry: &Entry) -> Option<String> {
+    let alternate = entry
+        .links
+        .iter()
+        .find(|l| !l.href.is_empty() && matches!(l.rel.as_deref(), None | Some("alternate")));
+    alternate
+        .or_else(|| entry.links.iter().find(|l| !l.href.is_empty()))
+        .map(|l| l.href.clone())
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -17,11 +17,13 @@ pub mod clock;
 pub mod code;
 pub mod crypto_watchlist;
 pub mod deariary;
+pub mod feed;
 pub mod git;
 pub mod github;
 pub mod hackernews;
 pub mod linear;
 pub mod lobsters;
+pub mod news;
 pub mod random_cat;
 pub mod random_dog;
 pub mod random_fortune;
@@ -336,6 +338,9 @@ impl Registry {
             r.register(f);
         }
         for f in lobsters::fetchers() {
+            r.register(f);
+        }
+        for f in news::fetchers() {
             r.register(f);
         }
         for f in todoist::fetchers() {

--- a/src/fetcher/news/mod.rs
+++ b/src/fetcher/news/mod.rs
@@ -1,0 +1,436 @@
+//! `news_*` — curated single-source feed family.
+//!
+//! Each `NewsSource` in [`sources::SOURCES`] is exposed as a separate `news_<slug>` fetcher with
+//! a hardcoded feed URL set. Compared to the generic [`crate::fetcher::rss::RssFetcher`]:
+//!
+//! - URLs are baked at compile time (no `url` option), so the family is `Safety::Safe` —
+//!   trust-gate friction drops, and a per-dir `.splashboard/dashboard.toml` shipped with a repo
+//!   renders for cloners without `splashboard trust`.
+//! - Each source can carry multiple sub-feeds (`feed = "tech"`); config picks among them via a
+//!   closed enum, but cannot inject new destinations.
+//!
+//! Parsing / fetching / row-formatting live in [`crate::fetcher::feed`], shared with `rss`.
+
+mod sources;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use url::Url;
+
+pub use sources::{NewsCategory, NewsFeed, NewsSource, SOURCES};
+
+use crate::fetcher::feed;
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "feed",
+        type_hint: "string (source-specific key)",
+        required: false,
+        default: Some("first sub-feed of the source"),
+        description: "Sub-feed key to select (e.g. `\"world\"` / `\"tech\"`). Run `splashboard catalog fetcher news_<source>` to list available keys.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("5"),
+        description: "Number of feed entries to display.",
+    },
+];
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    SOURCES
+        .iter()
+        .map(|source| -> Arc<dyn Fetcher> { Arc::new(NewsFeedFetcher { source }) })
+        .collect()
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    feed: Option<String>,
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+pub struct NewsFeedFetcher {
+    source: &'static NewsSource,
+}
+
+#[async_trait]
+impl Fetcher for NewsFeedFetcher {
+    fn name(&self) -> &str {
+        self.source.name
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        self.source.description
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.source.name, ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        let display = self.source.display;
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    &format!("Apr 26  {display}: top story"),
+                    Some("https://example.com/article-1"),
+                ),
+                (
+                    &format!("Apr 25  {display}: feature piece"),
+                    Some("https://example.com/article-2"),
+                ),
+                (
+                    &format!("Apr 24  {display}: shorter update"),
+                    Some("https://example.com/article-3"),
+                ),
+            ]),
+            Shape::ImageLinkedList => samples::image_linked_list(&[
+                (
+                    "Top story",
+                    Some("https://example.com/article-1"),
+                    None,
+                    Some("Apr 26"),
+                ),
+                (
+                    "Feature piece",
+                    Some("https://example.com/article-2"),
+                    None,
+                    Some("Apr 25"),
+                ),
+                (
+                    "Shorter update",
+                    Some("https://example.com/article-3"),
+                    None,
+                    Some("Apr 24"),
+                ),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                &format!("Apr 26  {display}: top story"),
+                &format!("Apr 25  {display}: feature piece"),
+                &format!("Apr 24  {display}: shorter update"),
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let selected = resolve_feed(self.source, opts.feed.as_deref())?;
+        let url = Url::parse(selected.url).map_err(|e| {
+            FetchError::Failed(format!(
+                "{}: bundled feed url for `{}` is malformed: {e}",
+                self.source.name, selected.key
+            ))
+        })?;
+        let count = opts
+            .count
+            .unwrap_or(feed::DEFAULT_COUNT)
+            .clamp(feed::MIN_COUNT, feed::MAX_COUNT) as usize;
+        let bytes = feed::fetch_bytes(&url, self.source.name).await?;
+        let parsed = feed::parse_feed(&bytes, self.source.name)?;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = match shape {
+            Shape::ImageLinkedList => feed::render_image_linked(&parsed, count, ctx).await,
+            other => feed::render_body(
+                &parsed,
+                count,
+                other,
+                ctx.timezone.as_deref(),
+                ctx.locale.as_deref(),
+            ),
+        };
+        Ok(payload(body))
+    }
+}
+
+fn resolve_feed(
+    source: &'static NewsSource,
+    requested: Option<&str>,
+) -> Result<&'static NewsFeed, FetchError> {
+    let Some(key) = requested.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(source.default_feed());
+    };
+    source.find_feed(key).ok_or_else(|| {
+        let available = source
+            .feeds
+            .iter()
+            .map(|f| f.key)
+            .collect::<Vec<_>>()
+            .join(", ");
+        FetchError::Failed(format!(
+            "{}: unknown feed key `{key}` (available: {available})",
+            source.name
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn ctx(shape: Option<Shape>, options: Option<toml::Value>) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options,
+            ..Default::default()
+        }
+    }
+
+    fn parse_opts(raw: &str) -> toml::Value {
+        toml::from_str(raw).expect("test toml must parse")
+    }
+
+    fn bbc() -> &'static NewsSource {
+        SOURCES
+            .iter()
+            .find(|s| s.name == "news_bbc")
+            .expect("bbc source must exist")
+    }
+
+    fn aljazeera() -> &'static NewsSource {
+        SOURCES
+            .iter()
+            .find(|s| s.name == "news_aljazeera")
+            .expect("aljazeera source must exist")
+    }
+
+    #[test]
+    fn all_sources_are_news_prefixed_and_have_at_least_one_feed() {
+        for source in SOURCES {
+            assert!(
+                source.name.starts_with("news_"),
+                "source name must use `news_` prefix: {}",
+                source.name
+            );
+            assert!(!source.feeds.is_empty(), "{} has no feeds", source.name);
+            for feed in source.feeds {
+                assert!(!feed.key.is_empty(), "{} has empty feed key", source.name);
+                assert!(
+                    feed.url.starts_with("http://") || feed.url.starts_with("https://"),
+                    "{}: feed `{}` has non-http url: {}",
+                    source.name,
+                    feed.key,
+                    feed.url
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn source_names_are_unique() {
+        let mut names: Vec<_> = SOURCES.iter().map(|s| s.name).collect();
+        names.sort();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(count, names.len(), "duplicate source names in SOURCES");
+    }
+
+    #[test]
+    fn feed_keys_are_unique_within_each_source() {
+        for source in SOURCES {
+            let mut keys: Vec<_> = source.feeds.iter().map(|f| f.key).collect();
+            keys.sort();
+            let count = keys.len();
+            keys.dedup();
+            assert_eq!(
+                count,
+                keys.len(),
+                "duplicate feed keys in source {}",
+                source.name
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_feed_defaults_to_first_entry_when_unset() {
+        let resolved = resolve_feed(bbc(), None).unwrap();
+        assert_eq!(resolved.key, bbc().feeds[0].key);
+    }
+
+    #[test]
+    fn resolve_feed_defaults_when_key_is_whitespace() {
+        let resolved = resolve_feed(bbc(), Some("  ")).unwrap();
+        assert_eq!(resolved.key, bbc().feeds[0].key);
+    }
+
+    #[test]
+    fn resolve_feed_picks_matching_sub_feed() {
+        let resolved = resolve_feed(bbc(), Some("tech")).unwrap();
+        assert_eq!(resolved.key, "tech");
+    }
+
+    #[test]
+    fn resolve_feed_errors_on_unknown_key_and_lists_options() {
+        let err = resolve_feed(bbc(), Some("zzz")).unwrap_err();
+        match err {
+            FetchError::Failed(m) => {
+                assert!(m.contains("unknown feed key"), "msg: {m}");
+                assert!(m.contains("zzz"), "msg: {m}");
+                assert!(m.contains("world"), "msg should list available keys: {m}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn options_parse_feed_and_count() {
+        let raw = parse_opts("feed = \"tech\"\ncount = 7");
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.feed.as_deref(), Some("tech"));
+        assert_eq!(opts.count, Some(7));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw = parse_opts("feed = \"tech\"\nbogus = 1");
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_exposes_safety_safe_and_name_from_source() {
+        let f = NewsFeedFetcher { source: bbc() };
+        assert_eq!(f.name(), "news_bbc");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(f.shapes(), SHAPES);
+        assert_eq!(
+            f.option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["feed", "count"]
+        );
+        assert!(f.description().contains("BBC"));
+    }
+
+    #[test]
+    fn sample_body_covers_every_declared_shape() {
+        let f = NewsFeedFetcher {
+            source: aljazeera(),
+        };
+        assert!(matches!(
+            f.sample_body(Shape::LinkedTextBlock),
+            Some(Body::LinkedTextBlock(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::ImageLinkedList),
+            Some(Body::ImageLinkedList(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::TextBlock),
+            Some(Body::TextBlock(_))
+        ));
+        assert!(f.sample_body(Shape::Text).is_none());
+    }
+
+    #[test]
+    fn cache_key_differs_between_sub_feeds() {
+        let f = NewsFeedFetcher { source: bbc() };
+        let mut a = ctx(None, None);
+        let mut b = ctx(None, None);
+        a.options = Some(parse_opts("feed = \"world\""));
+        b.options = Some(parse_opts("feed = \"tech\""));
+        assert_ne!(f.cache_key(&a), f.cache_key(&b));
+    }
+
+    #[test]
+    fn fetchers_entry_point_registers_every_source() {
+        let registered: Vec<_> = fetchers().iter().map(|f| f.name().to_string()).collect();
+        assert_eq!(registered.len(), SOURCES.len());
+        for source in SOURCES {
+            assert!(
+                registered.iter().any(|n| n == source.name),
+                "{} missing from fetchers()",
+                source.name
+            );
+        }
+    }
+
+    /// Live smoke test for every bundled `news_*` feed. Hits each URL in parallel, parses with
+    /// feed-rs, and asserts at least one entry comes back. `#[ignore]` keeps CI offline-safe;
+    /// run with `cargo test -- --ignored fetcher::news::tests::live_every_bundled_feed_parses`
+    /// to surface dead feeds (404, redirect to login, schema change). The report includes per-
+    /// feed `(source, key, entries)` rows on success and the failing URL + reason otherwise.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore]
+    async fn live_every_bundled_feed_parses() {
+        let targets: Vec<(&'static str, &'static str, &'static str)> = SOURCES
+            .iter()
+            .flat_map(|s| s.feeds.iter().map(move |f| (s.name, f.key, f.url)))
+            .collect();
+        let mut tasks = tokio::task::JoinSet::new();
+        for (source_name, key, raw_url) in targets {
+            tasks.spawn(async move {
+                let url = match Url::parse(raw_url) {
+                    Ok(u) => u,
+                    Err(e) => return (source_name, key, raw_url, Err(format!("parse url: {e}"))),
+                };
+                let bytes = match feed::fetch_bytes(&url, source_name).await {
+                    Ok(b) => b,
+                    Err(e) => return (source_name, key, raw_url, Err(format!("fetch: {e}"))),
+                };
+                let parsed = match feed::parse_feed(&bytes, source_name) {
+                    Ok(p) => p,
+                    Err(e) => return (source_name, key, raw_url, Err(format!("parse: {e}"))),
+                };
+                (source_name, key, raw_url, Ok(parsed.entries.len()))
+            });
+        }
+        let mut failures = Vec::new();
+        let mut successes = Vec::new();
+        while let Some(joined) = tasks.join_next().await {
+            let (source, key, url, outcome) = joined.expect("join must succeed");
+            match outcome {
+                Ok(0) => failures.push(format!("{source} [{key}]  {url}  EMPTY")),
+                Ok(n) => successes.push(format!("{source} [{key}]  {n} entries")),
+                Err(e) => failures.push(format!("{source} [{key}]  {url}  {e}")),
+            }
+        }
+        successes.sort();
+        failures.sort();
+        for line in &successes {
+            eprintln!("OK {line}");
+        }
+        for line in &failures {
+            eprintln!("FAIL {line}");
+        }
+        assert!(
+            failures.is_empty(),
+            "{} of {} bundled news feeds failed to parse — see eprintln output above",
+            failures.len(),
+            successes.len() + failures.len()
+        );
+    }
+}

--- a/src/fetcher/news/mod.rs
+++ b/src/fetcher/news/mod.rs
@@ -238,8 +238,8 @@ mod tests {
             for feed in source.feeds {
                 assert!(!feed.key.is_empty(), "{} has empty feed key", source.name);
                 assert!(
-                    feed.url.starts_with("http://") || feed.url.starts_with("https://"),
-                    "{}: feed `{}` has non-http url: {}",
+                    feed.url.starts_with("https://"),
+                    "{}: feed `{}` must use https:// (got {})",
                     source.name,
                     feed.key,
                     feed.url

--- a/src/fetcher/news/sources.rs
+++ b/src/fetcher/news/sources.rs
@@ -101,32 +101,32 @@ pub const SOURCES: &[NewsSource] = &[
         feeds: &[
             NewsFeed {
                 key: "world",
-                url: "http://feeds.bbci.co.uk/news/world/rss.xml",
+                url: "https://feeds.bbci.co.uk/news/world/rss.xml",
                 label: "World",
             },
             NewsFeed {
                 key: "top",
-                url: "http://feeds.bbci.co.uk/news/rss.xml",
+                url: "https://feeds.bbci.co.uk/news/rss.xml",
                 label: "Top stories",
             },
             NewsFeed {
                 key: "business",
-                url: "http://feeds.bbci.co.uk/news/business/rss.xml",
+                url: "https://feeds.bbci.co.uk/news/business/rss.xml",
                 label: "Business",
             },
             NewsFeed {
                 key: "tech",
-                url: "http://feeds.bbci.co.uk/news/technology/rss.xml",
+                url: "https://feeds.bbci.co.uk/news/technology/rss.xml",
                 label: "Technology",
             },
             NewsFeed {
                 key: "science",
-                url: "http://feeds.bbci.co.uk/news/science_and_environment/rss.xml",
+                url: "https://feeds.bbci.co.uk/news/science_and_environment/rss.xml",
                 label: "Science & environment",
             },
             NewsFeed {
                 key: "politics",
-                url: "http://feeds.bbci.co.uk/news/politics/rss.xml",
+                url: "https://feeds.bbci.co.uk/news/politics/rss.xml",
                 label: "Politics",
             },
         ],
@@ -760,7 +760,7 @@ pub const SOURCES: &[NewsSource] = &[
         description: "Slashdot — news for nerds, stuff that matters.",
         feeds: &[NewsFeed {
             key: "main",
-            url: "http://rss.slashdot.org/Slashdot/slashdotMain",
+            url: "https://rss.slashdot.org/Slashdot/slashdotMain",
             label: "Main",
         }],
     },
@@ -919,7 +919,7 @@ pub const SOURCES: &[NewsSource] = &[
         description: "DistroWatch — Linux distribution release announcements and database updates.",
         feeds: &[NewsFeed {
             key: "main",
-            url: "http://distrowatch.com/news/dwd.xml",
+            url: "https://distrowatch.com/news/dwd.xml",
             label: "Weekly",
         }],
     },

--- a/src/fetcher/news/sources.rs
+++ b/src/fetcher/news/sources.rs
@@ -1,0 +1,677 @@
+//! Static table of curated news sources for the `news_*` family. Adding a source = appending
+//! one `NewsSource` row; registration in `mod.rs` is automatic.
+//!
+//! Each entry hardcodes its feed URL set. Config picks among `feeds` via the `feed` option key,
+//! but cannot inject a new URL — that's what keeps the family Safety::Safe.
+//!
+//! `feeds[0]` is the default rendered when no `feed` option is set. Sub-feeds are only listed
+//! for sources whose sections we've confirmed expose stable RSS endpoints; mid-tier sources
+//! typically just have one entry. New sub-feeds slot in via single-row catalog adds.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NewsCategory {
+    General,
+    Tech,
+    Gadget,
+    Business,
+    Science,
+    Security,
+    Linux,
+    Gaming,
+    Ai,
+    Hardware,
+    Web,
+    Apple,
+    Android,
+    Space,
+    Climate,
+}
+
+impl NewsCategory {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::General => "general",
+            Self::Tech => "tech",
+            Self::Gadget => "gadget",
+            Self::Business => "business",
+            Self::Science => "science",
+            Self::Security => "security",
+            Self::Linux => "linux",
+            Self::Gaming => "gaming",
+            Self::Ai => "ai",
+            Self::Hardware => "hardware",
+            Self::Web => "web",
+            Self::Apple => "apple",
+            Self::Android => "android",
+            Self::Space => "space",
+            Self::Climate => "climate",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct NewsFeed {
+    /// Config key (`feed = "world"`). Must be unique within the source.
+    pub key: &'static str,
+    pub url: &'static str,
+    /// Short human-readable label, used in the description blurb.
+    pub label: &'static str,
+}
+
+#[derive(Debug)]
+pub struct NewsSource {
+    /// Full fetcher name, registered as-is (`"news_bbc"`).
+    pub name: &'static str,
+    pub display: &'static str,
+    pub category: NewsCategory,
+    /// One-sentence blurb shown in the generated catalog. Mention the source positioning so
+    /// config authors can decide between siblings.
+    pub description: &'static str,
+    /// Hardcoded feed URL set. `[0]` is the default.
+    pub feeds: &'static [NewsFeed],
+}
+
+impl NewsSource {
+    pub fn default_feed(&self) -> &'static NewsFeed {
+        &self.feeds[0]
+    }
+
+    pub fn find_feed(&self, key: &str) -> Option<&'static NewsFeed> {
+        self.feeds.iter().find(|f| f.key == key)
+    }
+}
+
+pub const SOURCES: &[NewsSource] = &[
+    // ---------- General ----------
+    NewsSource {
+        name: "news_bbc",
+        display: "BBC",
+        category: NewsCategory::General,
+        description: "BBC News headline feed. Sub-feeds cover world, top stories, business, technology, science, and politics.",
+        feeds: &[
+            NewsFeed {
+                key: "world",
+                url: "http://feeds.bbci.co.uk/news/world/rss.xml",
+                label: "World",
+            },
+            NewsFeed {
+                key: "top",
+                url: "http://feeds.bbci.co.uk/news/rss.xml",
+                label: "Top stories",
+            },
+            NewsFeed {
+                key: "business",
+                url: "http://feeds.bbci.co.uk/news/business/rss.xml",
+                label: "Business",
+            },
+            NewsFeed {
+                key: "tech",
+                url: "http://feeds.bbci.co.uk/news/technology/rss.xml",
+                label: "Technology",
+            },
+            NewsFeed {
+                key: "science",
+                url: "http://feeds.bbci.co.uk/news/science_and_environment/rss.xml",
+                label: "Science & environment",
+            },
+            NewsFeed {
+                key: "politics",
+                url: "http://feeds.bbci.co.uk/news/politics/rss.xml",
+                label: "Politics",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_guardian",
+        display: "The Guardian",
+        category: NewsCategory::General,
+        description: "The Guardian section feeds. Sub-feeds cover world, UK, US, business, technology, and science.",
+        feeds: &[
+            NewsFeed {
+                key: "world",
+                url: "https://www.theguardian.com/world/rss",
+                label: "World",
+            },
+            NewsFeed {
+                key: "uk",
+                url: "https://www.theguardian.com/uk-news/rss",
+                label: "UK news",
+            },
+            NewsFeed {
+                key: "us",
+                url: "https://www.theguardian.com/us-news/rss",
+                label: "US news",
+            },
+            NewsFeed {
+                key: "business",
+                url: "https://www.theguardian.com/uk/business/rss",
+                label: "Business",
+            },
+            NewsFeed {
+                key: "tech",
+                url: "https://www.theguardian.com/uk/technology/rss",
+                label: "Technology",
+            },
+            NewsFeed {
+                key: "science",
+                url: "https://www.theguardian.com/science/rss",
+                label: "Science",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_aljazeera",
+        display: "Al Jazeera",
+        category: NewsCategory::General,
+        description: "Al Jazeera English aggregate news feed.",
+        feeds: &[NewsFeed {
+            key: "all",
+            url: "https://www.aljazeera.com/xml/rss/all.xml",
+            label: "All news",
+        }],
+    },
+    NewsSource {
+        name: "news_npr",
+        display: "NPR",
+        category: NewsCategory::General,
+        description: "NPR top stories headline feed.",
+        feeds: &[NewsFeed {
+            key: "top",
+            url: "https://feeds.npr.org/1001/rss.xml",
+            label: "Top stories",
+        }],
+    },
+    // ---------- Tech ----------
+    NewsSource {
+        name: "news_arstechnica",
+        display: "Ars Technica",
+        category: NewsCategory::Tech,
+        description: "Ars Technica section feeds. Sub-feeds cover the front page, features, tech policy, science, and gaming culture.",
+        feeds: &[
+            NewsFeed {
+                key: "main",
+                url: "https://feeds.arstechnica.com/arstechnica/index",
+                label: "Front page",
+            },
+            NewsFeed {
+                key: "features",
+                url: "https://feeds.arstechnica.com/arstechnica/features",
+                label: "Features",
+            },
+            NewsFeed {
+                key: "tech_policy",
+                url: "https://feeds.arstechnica.com/arstechnica/tech-policy",
+                label: "Tech policy",
+            },
+            NewsFeed {
+                key: "science",
+                url: "https://feeds.arstechnica.com/arstechnica/science",
+                label: "Science",
+            },
+            NewsFeed {
+                key: "gaming",
+                url: "https://feeds.arstechnica.com/arstechnica/gaming",
+                label: "Gaming & culture",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_techcrunch",
+        display: "TechCrunch",
+        category: NewsCategory::Tech,
+        description: "TechCrunch startups + venture news. Default is the all-stories feed.",
+        feeds: &[
+            NewsFeed {
+                key: "main",
+                url: "https://techcrunch.com/feed/",
+                label: "All stories",
+            },
+            NewsFeed {
+                key: "startups",
+                url: "https://techcrunch.com/category/startups/feed/",
+                label: "Startups",
+            },
+            NewsFeed {
+                key: "venture",
+                url: "https://techcrunch.com/category/venture/feed/",
+                label: "Venture",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_theverge",
+        display: "The Verge",
+        category: NewsCategory::Tech,
+        description: "The Verge section feeds. Sub-feeds cover the front page, gaming, tech, entertainment, and science.",
+        feeds: &[
+            NewsFeed {
+                key: "main",
+                url: "https://www.theverge.com/rss/index.xml",
+                label: "Front page",
+            },
+            NewsFeed {
+                key: "tech",
+                url: "https://www.theverge.com/rss/tech/index.xml",
+                label: "Tech",
+            },
+            NewsFeed {
+                key: "gaming",
+                url: "https://www.theverge.com/rss/games/index.xml",
+                label: "Gaming",
+            },
+            NewsFeed {
+                key: "entertainment",
+                url: "https://www.theverge.com/rss/entertainment/index.xml",
+                label: "Entertainment",
+            },
+            NewsFeed {
+                key: "science",
+                url: "https://www.theverge.com/rss/science/index.xml",
+                label: "Science",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_wired",
+        display: "WIRED",
+        category: NewsCategory::Tech,
+        description: "WIRED section feeds. Sub-feeds cover the front page, business, culture, gear, science, and security.",
+        feeds: &[
+            NewsFeed {
+                key: "main",
+                url: "https://www.wired.com/feed/rss",
+                label: "Front page",
+            },
+            NewsFeed {
+                key: "business",
+                url: "https://www.wired.com/feed/category/business/latest/rss",
+                label: "Business",
+            },
+            NewsFeed {
+                key: "culture",
+                url: "https://www.wired.com/feed/category/culture/latest/rss",
+                label: "Culture",
+            },
+            NewsFeed {
+                key: "gear",
+                url: "https://www.wired.com/feed/category/gear/latest/rss",
+                label: "Gear",
+            },
+            NewsFeed {
+                key: "science",
+                url: "https://www.wired.com/feed/category/science/latest/rss",
+                label: "Science",
+            },
+            NewsFeed {
+                key: "security",
+                url: "https://www.wired.com/feed/category/security/latest/rss",
+                label: "Security",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_hackernoon",
+        display: "HackerNoon",
+        category: NewsCategory::Tech,
+        description: "HackerNoon's site-wide latest stories.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://hackernoon.com/feed",
+            label: "Latest",
+        }],
+    },
+    // ---------- Gadget ----------
+    NewsSource {
+        name: "news_engadget",
+        display: "Engadget",
+        category: NewsCategory::Gadget,
+        description: "Engadget consumer-electronics headlines.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.engadget.com/rss.xml",
+            label: "All stories",
+        }],
+    },
+    NewsSource {
+        name: "news_gizmodo",
+        display: "Gizmodo",
+        category: NewsCategory::Gadget,
+        description: "Gizmodo consumer-electronics + nerd-culture headlines.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://gizmodo.com/rss",
+            label: "All stories",
+        }],
+    },
+    // ---------- Business ----------
+    NewsSource {
+        name: "news_ft",
+        display: "Financial Times",
+        category: NewsCategory::Business,
+        description: "Financial Times technology section, the FT subset that doesn't require a subscription to read in-app.",
+        feeds: &[NewsFeed {
+            key: "tech",
+            url: "https://www.ft.com/technology?format=rss",
+            label: "Technology",
+        }],
+    },
+    NewsSource {
+        name: "news_marketwatch",
+        display: "MarketWatch",
+        category: NewsCategory::Business,
+        description: "MarketWatch top stories — US-leaning market news.",
+        feeds: &[NewsFeed {
+            key: "top",
+            url: "https://feeds.content.dowjones.io/public/rss/mw_topstories",
+            label: "Top stories",
+        }],
+    },
+    NewsSource {
+        name: "news_yahoo_finance",
+        display: "Yahoo Finance",
+        category: NewsCategory::Business,
+        description: "Yahoo Finance — US-leaning aggregated market and business headlines.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://finance.yahoo.com/news/rssindex",
+            label: "Latest",
+        }],
+    },
+    // ---------- Science ----------
+    NewsSource {
+        name: "news_nature",
+        display: "Nature",
+        category: NewsCategory::Science,
+        description: "Nature, the weekly international science journal.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.nature.com/nature.rss",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_scientific_american",
+        display: "Scientific American",
+        category: NewsCategory::Science,
+        description: "Scientific American global English-language feed.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.scientificamerican.com/platform/syndication/rss/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_quanta_magazine",
+        display: "Quanta Magazine",
+        category: NewsCategory::Science,
+        description: "Quanta Magazine, long-form math / physics / biology / computer science journalism.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://api.quantamagazine.org/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Security ----------
+    NewsSource {
+        name: "news_krebs",
+        display: "Krebs on Security",
+        category: NewsCategory::Security,
+        description: "Brian Krebs's investigative reporting on cybercrime.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://krebsonsecurity.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_bleeping_computer",
+        display: "Bleeping Computer",
+        category: NewsCategory::Security,
+        description: "Bleeping Computer's news desk, focused on malware, ransomware, and patch reporting.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.bleepingcomputer.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_schneier",
+        display: "Schneier on Security",
+        category: NewsCategory::Security,
+        description: "Bruce Schneier's blog — long-form security commentary + weekly squid post.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.schneier.com/feed/atom/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Linux / FOSS ----------
+    NewsSource {
+        name: "news_lwn",
+        display: "LWN",
+        category: NewsCategory::Linux,
+        description: "LWN.net headlines — kernel + Linux ecosystem long-form.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://lwn.net/headlines/rss",
+            label: "Headlines",
+        }],
+    },
+    NewsSource {
+        name: "news_phoronix",
+        display: "Phoronix",
+        category: NewsCategory::Linux,
+        description: "Phoronix Linux hardware, kernel, and benchmarking news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.phoronix.com/rss.php",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_omg_ubuntu",
+        display: "OMG! Ubuntu",
+        category: NewsCategory::Linux,
+        description: "OMG! Ubuntu — Ubuntu / GNOME desktop app + distro news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.omgubuntu.co.uk/feed",
+            label: "Latest",
+        }],
+    },
+    // ---------- Gaming ----------
+    NewsSource {
+        name: "news_polygon",
+        display: "Polygon",
+        category: NewsCategory::Gaming,
+        description: "Polygon video-game news + culture coverage.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.polygon.com/rss/index.xml",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_eurogamer",
+        display: "Eurogamer",
+        category: NewsCategory::Gaming,
+        description: "Eurogamer video-game news from the UK / EU desk.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.eurogamer.net/feed",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_rockpapershotgun",
+        display: "Rock Paper Shotgun",
+        category: NewsCategory::Gaming,
+        description: "Rock Paper Shotgun, PC-game-centric news and features.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.rockpapershotgun.com/feed",
+            label: "Latest",
+        }],
+    },
+    // ---------- AI / ML ----------
+    NewsSource {
+        name: "news_import_ai",
+        display: "Import AI",
+        category: NewsCategory::Ai,
+        description: "Jack Clark's weekly Import AI newsletter, covering policy + research developments.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://importai.substack.com/feed",
+            label: "Issues",
+        }],
+    },
+    NewsSource {
+        name: "news_ai_news",
+        display: "AI News",
+        category: NewsCategory::Ai,
+        description: "artificialintelligence-news.com — industry AI / ML news desk, complement to long-form newsletters like Import AI.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.artificialintelligence-news.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Hardware / makers ----------
+    NewsSource {
+        name: "news_hackaday",
+        display: "Hackaday",
+        category: NewsCategory::Hardware,
+        description: "Hackaday — DIY electronics + maker projects daily.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://hackaday.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_tomshardware",
+        display: "Tom's Hardware",
+        category: NewsCategory::Hardware,
+        description: "Tom's Hardware — PC component + benchmark news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.tomshardware.com/feeds/all",
+            label: "Latest",
+        }],
+    },
+    // ---------- Web / design ----------
+    NewsSource {
+        name: "news_smashing_magazine",
+        display: "Smashing Magazine",
+        category: NewsCategory::Web,
+        description: "Smashing Magazine — front-end + UX + accessibility articles.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.smashingmagazine.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_css_tricks",
+        display: "CSS-Tricks",
+        category: NewsCategory::Web,
+        description: "CSS-Tricks — CSS, HTML, and JavaScript tips and articles.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://css-tricks.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Apple ecosystem ----------
+    NewsSource {
+        name: "news_9to5mac",
+        display: "9to5Mac",
+        category: NewsCategory::Apple,
+        description: "9to5Mac — Apple ecosystem news (Mac, iPhone, iPad, services).",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://9to5mac.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_macrumors",
+        display: "MacRumors",
+        category: NewsCategory::Apple,
+        description: "MacRumors — Apple rumors, news, and product reviews.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.macrumors.com/macrumors.xml",
+            label: "Latest",
+        }],
+    },
+    // ---------- Android ----------
+    NewsSource {
+        name: "news_android_police",
+        display: "Android Police",
+        category: NewsCategory::Android,
+        description: "Android Police — Android phones, apps, and Google product news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.androidpolice.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_9to5google",
+        display: "9to5Google",
+        category: NewsCategory::Android,
+        description: "9to5Google — Android, Pixel, and broader Google service news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://9to5google.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Space / astronomy ----------
+    NewsSource {
+        name: "news_spacenews",
+        display: "SpaceNews",
+        category: NewsCategory::Space,
+        description: "SpaceNews — commercial + government space industry coverage.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://spacenews.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_universe_today",
+        display: "Universe Today",
+        category: NewsCategory::Space,
+        description: "Universe Today — astronomy + space exploration daily.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.universetoday.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Climate / environment ----------
+    NewsSource {
+        name: "news_yale_climate",
+        display: "Yale Climate Connections",
+        category: NewsCategory::Climate,
+        description: "Yale Climate Connections — climate science + policy reporting.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://yaleclimateconnections.org/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_inside_climate",
+        display: "Inside Climate News",
+        category: NewsCategory::Climate,
+        description: "Inside Climate News — climate investigative journalism.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://insideclimatenews.org/feed/",
+            label: "Latest",
+        }],
+    },
+];

--- a/src/fetcher/news/sources.rs
+++ b/src/fetcher/news/sources.rs
@@ -25,6 +25,11 @@ pub enum NewsCategory {
     Android,
     Space,
     Climate,
+    Politics,
+    Photography,
+    Entertainment,
+    Music,
+    Crypto,
 }
 
 impl NewsCategory {
@@ -45,6 +50,11 @@ impl NewsCategory {
             Self::Android => "android",
             Self::Space => "space",
             Self::Climate => "climate",
+            Self::Politics => "politics",
+            Self::Photography => "photography",
+            Self::Entertainment => "entertainment",
+            Self::Music => "music",
+            Self::Crypto => "crypto",
         }
     }
 }
@@ -671,6 +681,610 @@ pub const SOURCES: &[NewsSource] = &[
         feeds: &[NewsFeed {
             key: "main",
             url: "https://insideclimatenews.org/feed/",
+            label: "Latest",
+        }],
+    },
+    // ========== Batch 2 expansion ==========
+    // ---------- General (cont.) ----------
+    NewsSource {
+        name: "news_france24",
+        display: "France 24",
+        category: NewsCategory::General,
+        description: "France 24 English-language international news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.france24.com/en/rss",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_dw",
+        display: "Deutsche Welle",
+        category: NewsCategory::General,
+        description: "Deutsche Welle English — Germany's international broadcaster.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://rss.dw.com/rdf/rss-en-all",
+            label: "All news",
+        }],
+    },
+    NewsSource {
+        name: "news_sky_news",
+        display: "Sky News",
+        category: NewsCategory::General,
+        description: "Sky News world headlines.",
+        feeds: &[NewsFeed {
+            key: "world",
+            url: "https://feeds.skynews.com/feeds/rss/world.xml",
+            label: "World",
+        }],
+    },
+    NewsSource {
+        name: "news_cbs",
+        display: "CBS News",
+        category: NewsCategory::General,
+        description: "CBS News top stories.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.cbsnews.com/latest/rss/main",
+            label: "Latest",
+        }],
+    },
+    // ---------- Tech (cont.) ----------
+    NewsSource {
+        name: "news_the_register",
+        display: "The Register",
+        category: NewsCategory::Tech,
+        description: "The Register — UK-based enterprise IT news with a distinctive voice.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.theregister.com/headlines.atom",
+            label: "Headlines",
+        }],
+    },
+    NewsSource {
+        name: "news_zdnet",
+        display: "ZDNET",
+        category: NewsCategory::Tech,
+        description: "ZDNET — enterprise technology news, reviews, and analysis.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.zdnet.com/news/rss.xml",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_slashdot",
+        display: "Slashdot",
+        category: NewsCategory::Tech,
+        description: "Slashdot — news for nerds, stuff that matters.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "http://rss.slashdot.org/Slashdot/slashdotMain",
+            label: "Main",
+        }],
+    },
+    NewsSource {
+        name: "news_venturebeat",
+        display: "VentureBeat",
+        category: NewsCategory::Tech,
+        description: "VentureBeat — tech industry news with a startup-funding lens.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://venturebeat.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Gadget (cont.) ----------
+    NewsSource {
+        name: "news_techradar",
+        display: "TechRadar",
+        category: NewsCategory::Gadget,
+        description: "TechRadar — consumer technology product news and reviews.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.techradar.com/rss",
+            label: "Latest",
+        }],
+    },
+    // ---------- Business (cont.) ----------
+    NewsSource {
+        name: "news_forbes",
+        display: "Forbes",
+        category: NewsCategory::Business,
+        description: "Forbes Business section — companies, markets, and entrepreneurship.",
+        feeds: &[NewsFeed {
+            key: "business",
+            url: "https://www.forbes.com/business/feed/",
+            label: "Business",
+        }],
+    },
+    NewsSource {
+        name: "news_economist",
+        display: "The Economist",
+        category: NewsCategory::Business,
+        description: "The Economist Business section.",
+        feeds: &[NewsFeed {
+            key: "business",
+            url: "https://www.economist.com/business/rss.xml",
+            label: "Business",
+        }],
+    },
+    NewsSource {
+        name: "news_fortune",
+        display: "Fortune",
+        category: NewsCategory::Business,
+        description: "Fortune — corporate strategy, executives, and market trends.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://fortune.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Science (cont.) ----------
+    NewsSource {
+        name: "news_new_scientist",
+        display: "New Scientist",
+        category: NewsCategory::Science,
+        description: "New Scientist — magazine-style coverage of science and technology.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.newscientist.com/feed/home/",
+            label: "Home",
+        }],
+    },
+    NewsSource {
+        name: "news_sciencedaily",
+        display: "ScienceDaily",
+        category: NewsCategory::Science,
+        description: "ScienceDaily — research news across all scientific fields.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.sciencedaily.com/rss/all.xml",
+            label: "All news",
+        }],
+    },
+    NewsSource {
+        name: "news_phys_org",
+        display: "Phys.org",
+        category: NewsCategory::Science,
+        description: "Phys.org — physics, materials science, and broader hard-science coverage.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://phys.org/rss-feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Security (cont.) ----------
+    NewsSource {
+        name: "news_the_hacker_news",
+        display: "The Hacker News",
+        category: NewsCategory::Security,
+        description: "The Hacker News — daily cybersecurity news and analysis.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://feeds.feedburner.com/TheHackersNews",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_threatpost",
+        display: "Threatpost",
+        category: NewsCategory::Security,
+        description: "Threatpost — vulnerability and malware reporting.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://threatpost.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_dark_reading",
+        display: "Dark Reading",
+        category: NewsCategory::Security,
+        description: "Dark Reading — enterprise security news and analysis.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.darkreading.com/rss.xml",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_graham_cluley",
+        display: "Graham Cluley",
+        category: NewsCategory::Security,
+        description: "Graham Cluley's security blog — practical, accessible coverage of threats and breaches.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://grahamcluley.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Linux / FOSS (cont.) ----------
+    NewsSource {
+        name: "news_its_foss",
+        display: "It's FOSS",
+        category: NewsCategory::Linux,
+        description: "It's FOSS — Linux, open-source applications, and tutorials.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://itsfoss.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_distrowatch",
+        display: "DistroWatch",
+        category: NewsCategory::Linux,
+        description: "DistroWatch — Linux distribution release announcements and database updates.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "http://distrowatch.com/news/dwd.xml",
+            label: "Weekly",
+        }],
+    },
+    // ---------- Gaming (cont.) ----------
+    NewsSource {
+        name: "news_kotaku",
+        display: "Kotaku",
+        category: NewsCategory::Gaming,
+        description: "Kotaku — video-game news, criticism, and culture writing.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://kotaku.com/rss",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_ign",
+        display: "IGN",
+        category: NewsCategory::Gaming,
+        description: "IGN — broad video-game and entertainment news with reviews.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://feeds.ign.com/ign/games-all",
+            label: "Games",
+        }],
+    },
+    NewsSource {
+        name: "news_pc_gamer",
+        display: "PC Gamer",
+        category: NewsCategory::Gaming,
+        description: "PC Gamer — PC-focused gaming news, hardware reviews, and previews.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.pcgamer.com/rss/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_vg247",
+        display: "VG247",
+        category: NewsCategory::Gaming,
+        description: "VG247 — video-game news, deals, and guides.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.vg247.com/feed/articles",
+            label: "Articles",
+        }],
+    },
+    // ---------- AI / ML (cont.) ----------
+    NewsSource {
+        name: "news_hugging_face_blog",
+        display: "Hugging Face Blog",
+        category: NewsCategory::Ai,
+        description: "Hugging Face — research, tooling, and model-release write-ups from the HF team and community.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://huggingface.co/blog/feed.xml",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_the_gradient",
+        display: "The Gradient",
+        category: NewsCategory::Ai,
+        description: "The Gradient — long-form essays on AI / ML research.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://thegradient.pub/rss/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_mit_tr_ai",
+        display: "MIT Technology Review AI",
+        category: NewsCategory::Ai,
+        description: "MIT Technology Review — AI coverage subset of the broader publication.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.technologyreview.com/feed/?topic=artificial-intelligence",
+            label: "AI topic",
+        }],
+    },
+    // ---------- Hardware (cont.) ----------
+    NewsSource {
+        name: "news_techpowerup",
+        display: "TechPowerUp",
+        category: NewsCategory::Hardware,
+        description: "TechPowerUp — PC component news, driver releases, and database updates.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.techpowerup.com/rss/news",
+            label: "News",
+        }],
+    },
+    NewsSource {
+        name: "news_ifixit",
+        display: "iFixit Blog",
+        category: NewsCategory::Hardware,
+        description: "iFixit Blog — repairability news, teardowns, and right-to-repair advocacy.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.ifixit.com/blog/feed",
+            label: "Latest",
+        }],
+    },
+    // ---------- Web / design (cont.) ----------
+    NewsSource {
+        name: "news_a_list_apart",
+        display: "A List Apart",
+        category: NewsCategory::Web,
+        description: "A List Apart — long-running web standards and design writing.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://alistapart.com/main/feed",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_ux_collective",
+        display: "UX Collective",
+        category: NewsCategory::Web,
+        description: "UX Collective — Medium publication on UX design, research, and practice.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://uxdesign.cc/feed",
+            label: "Latest",
+        }],
+    },
+    // ---------- Apple (cont.) ----------
+    NewsSource {
+        name: "news_daring_fireball",
+        display: "Daring Fireball",
+        category: NewsCategory::Apple,
+        description: "Daring Fireball — John Gruber's long-running blog on Apple, design, and software.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://daringfireball.net/feeds/main",
+            label: "Main",
+        }],
+    },
+    NewsSource {
+        name: "news_appleinsider",
+        display: "AppleInsider",
+        category: NewsCategory::Apple,
+        description: "AppleInsider — Apple ecosystem news, rumors, and reviews.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://appleinsider.com/rss/news/",
+            label: "News",
+        }],
+    },
+    // ---------- Android (cont.) ----------
+    NewsSource {
+        name: "news_android_authority",
+        display: "Android Authority",
+        category: NewsCategory::Android,
+        description: "Android Authority — Android phones, reviews, and Google ecosystem coverage.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.androidauthority.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_xda",
+        display: "XDA Developers",
+        category: NewsCategory::Android,
+        description: "XDA Developers — Android customization, ROMs, and developer-focused phone news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.xda-developers.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Space (cont.) ----------
+    NewsSource {
+        name: "news_nasa_news",
+        display: "NASA News",
+        category: NewsCategory::Space,
+        description: "NASA breaking-news feed — mission updates, science releases, agency announcements.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.nasa.gov/rss/dyn/breaking_news.rss",
+            label: "Breaking news",
+        }],
+    },
+    NewsSource {
+        name: "news_space_com",
+        display: "Space.com",
+        category: NewsCategory::Space,
+        description: "Space.com — space news, astronomy, and skywatching guides.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.space.com/feeds/all",
+            label: "All",
+        }],
+    },
+    // ---------- Climate (cont.) ----------
+    NewsSource {
+        name: "news_carbon_brief",
+        display: "Carbon Brief",
+        category: NewsCategory::Climate,
+        description: "Carbon Brief — climate science, policy, and energy reporting.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.carbonbrief.org/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Politics ----------
+    NewsSource {
+        name: "news_politico",
+        display: "Politico",
+        category: NewsCategory::Politics,
+        description: "Politico — US politics and policy reporting.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://rss.politico.com/politics-news.xml",
+            label: "Politics",
+        }],
+    },
+    NewsSource {
+        name: "news_propublica",
+        display: "ProPublica",
+        category: NewsCategory::Politics,
+        description: "ProPublica — investigative journalism on US institutions and policy.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.propublica.org/feeds/propublica/main",
+            label: "Main",
+        }],
+    },
+    NewsSource {
+        name: "news_vox",
+        display: "Vox",
+        category: NewsCategory::Politics,
+        description: "Vox — explanatory journalism on politics, policy, and culture.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.vox.com/rss/index.xml",
+            label: "Latest",
+        }],
+    },
+    // ---------- Photography ----------
+    NewsSource {
+        name: "news_dpreview",
+        display: "DPReview",
+        category: NewsCategory::Photography,
+        description: "DPReview — digital camera reviews, gear announcements, and industry news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.dpreview.com/feeds/news.xml",
+            label: "News",
+        }],
+    },
+    NewsSource {
+        name: "news_petapixel",
+        display: "PetaPixel",
+        category: NewsCategory::Photography,
+        description: "PetaPixel — photography news, tutorials, and gear coverage.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://petapixel.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_fstoppers",
+        display: "Fstoppers",
+        category: NewsCategory::Photography,
+        description: "Fstoppers — professional photography and videography community.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://fstoppers.com/rss.xml",
+            label: "Latest",
+        }],
+    },
+    // ---------- Entertainment ----------
+    NewsSource {
+        name: "news_variety",
+        display: "Variety",
+        category: NewsCategory::Entertainment,
+        description: "Variety — entertainment industry news (film, TV, music, theater).",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://variety.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_deadline",
+        display: "Deadline",
+        category: NewsCategory::Entertainment,
+        description: "Deadline — Hollywood breaking news and box office reporting.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://deadline.com/feed/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_indiewire",
+        display: "IndieWire",
+        category: NewsCategory::Entertainment,
+        description: "IndieWire — independent film, festival, and award-season coverage.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.indiewire.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Music ----------
+    NewsSource {
+        name: "news_pitchfork",
+        display: "Pitchfork",
+        category: NewsCategory::Music,
+        description: "Pitchfork — music criticism, news, and reviews.",
+        feeds: &[NewsFeed {
+            key: "news",
+            url: "https://pitchfork.com/rss/news/",
+            label: "News",
+        }],
+    },
+    NewsSource {
+        name: "news_stereogum",
+        display: "Stereogum",
+        category: NewsCategory::Music,
+        description: "Stereogum — indie / alternative music news and commentary.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.stereogum.com/feed/",
+            label: "Latest",
+        }],
+    },
+    // ---------- Crypto ----------
+    NewsSource {
+        name: "news_coindesk",
+        display: "CoinDesk",
+        category: NewsCategory::Crypto,
+        description: "CoinDesk — cryptocurrency and blockchain industry news.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.coindesk.com/arc/outboundfeeds/rss/",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_the_block",
+        display: "The Block",
+        category: NewsCategory::Crypto,
+        description: "The Block — investigative crypto industry journalism.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://www.theblock.co/rss.xml",
+            label: "Latest",
+        }],
+    },
+    NewsSource {
+        name: "news_decrypt",
+        display: "Decrypt",
+        category: NewsCategory::Crypto,
+        description: "Decrypt — crypto, Web3, and AI news with a consumer lens.",
+        feeds: &[NewsFeed {
+            key: "main",
+            url: "https://decrypt.co/feed",
             label: "Latest",
         }],
     },

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -4,42 +4,22 @@
 //! local-config they trust) types. Local configs must be `splashboard trust`-ed before this
 //! widget runs; global config is implicitly trusted.
 //!
-//! Output shapes: `LinkedTextBlock` (default — clickable rows for `list_links`) and `TextBlock`
-//! (titles only). Lines are `MMM DD  Article title`, mirroring `hackernews_top`'s
-//! `234pt 56c  Title` rhythm so the same renderer slot stays visually consistent.
-
-use std::sync::OnceLock;
-use std::time::Duration;
+//! Output shapes: `LinkedTextBlock` (default — clickable rows for `list_links`),
+//! `ImageLinkedList` (cards with thumbnails), and `TextBlock` (titles only). All wiring around
+//! HTTP retrieval, feed-rs parsing, and entry-to-row formatting lives in `crate::fetcher::feed`
+//! so the `news_*` family can reuse it.
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use feed_rs::model::{Entry, Feed};
-use feed_rs::parser;
-use regex::Regex;
-use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
 
+use crate::fetcher::feed;
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
-use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
-use crate::payload::{
-    Body, ImageLinkedItem, ImageLinkedListData, LinkedLine, LinkedTextBlockData, Payload,
-    TextBlockData,
-};
+use crate::payload::{Body, Payload};
 use crate::render::Shape;
 use crate::samples;
-use crate::time as t;
-
-const DEFAULT_COUNT: u32 = 5;
-const MIN_COUNT: u32 = 1;
-const MAX_COUNT: u32 = 20;
-
-/// Cap raw response bytes so a hostile / runaway feed can't OOM the daemon.
-const MAX_BYTES: usize = 5 * 1024 * 1024;
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
 
 const SHAPES: &[Shape] = &[
     Shape::LinkedTextBlock,
@@ -143,16 +123,15 @@ impl Fetcher for RssFetcher {
         let url = validated_url(opts.url.as_deref())?;
         let count = opts
             .count
-            .unwrap_or(DEFAULT_COUNT)
-            .clamp(MIN_COUNT, MAX_COUNT) as usize;
-        let bytes = fetch_bytes(&url).await?;
-        let feed = parser::parse(bytes.as_slice())
-            .map_err(|e| FetchError::Failed(format!("rss parse: {e}")))?;
+            .unwrap_or(feed::DEFAULT_COUNT)
+            .clamp(feed::MIN_COUNT, feed::MAX_COUNT) as usize;
+        let bytes = feed::fetch_bytes(&url, "rss").await?;
+        let parsed = feed::parse_feed(&bytes, "rss")?;
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
         let body = match shape {
-            Shape::ImageLinkedList => render_image_linked(&feed, count, ctx).await,
-            other => render_body(
-                &feed,
+            Shape::ImageLinkedList => feed::render_image_linked(&parsed, count, ctx).await,
+            other => feed::render_body(
+                &parsed,
                 count,
                 other,
                 ctx.timezone.as_deref(),
@@ -178,229 +157,17 @@ fn validated_url(raw: Option<&str>) -> Result<Url, FetchError> {
     }
 }
 
-fn http() -> &'static Client {
-    static CLIENT: OnceLock<Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        Client::builder()
-            .user_agent(USER_AGENT)
-            .timeout(REQUEST_TIMEOUT)
-            .gzip(true)
-            .build()
-            .expect("reqwest client should build with default config")
-    })
-}
-
-async fn fetch_bytes(url: &Url) -> Result<Vec<u8>, FetchError> {
-    let res = http()
-        .get(url.as_str())
-        .send()
-        .await
-        .map_err(|e| FetchError::Failed(format!("rss request failed: {e}")))?;
-    let status = res.status();
-    if !status.is_success() {
-        return Err(FetchError::Failed(format!("rss {status}")));
-    }
-    let bytes = res
-        .bytes()
-        .await
-        .map_err(|e| FetchError::Failed(format!("rss read body: {e}")))?;
-    if bytes.len() > MAX_BYTES {
-        return Err(FetchError::Failed(format!(
-            "rss response too large ({} bytes, cap {MAX_BYTES})",
-            bytes.len()
-        )));
-    }
-    Ok(bytes.to_vec())
-}
-
-async fn render_image_linked(feed: &Feed, count: usize, ctx: &FetchContext) -> Body {
-    let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
-    let thumbnail_urls: Vec<Option<String>> =
-        entries.iter().map(|e| thumbnail_url_for(e)).collect();
-    let thumbnail_paths = thumbnails::download_many(&thumbnail_urls).await;
-    Body::ImageLinkedList(ImageLinkedListData {
-        items: entries
-            .iter()
-            .zip(thumbnail_paths)
-            .map(|(e, path)| ImageLinkedItem {
-                title: title_or_placeholder(e),
-                url: link_for(e),
-                thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
-                subtitle: subtitle_for(e, ctx.timezone.as_deref(), ctx.locale.as_deref()),
-            })
-            .collect(),
-    })
-}
-
-/// Best-effort image URL for the entry, in order of preference:
-///
-/// 1. `media:thumbnail` (RSS Media spec) — explicit thumbnail.
-/// 2. `media:content` URL — full media, usually an image.
-/// 3. First `<img src="http(s)://...">` in the entry's HTML `<content>` or `<summary>` —
-///    covers Atom feeds without media extensions (Rust blog, most personal blogs) where the
-///    cover image is inlined in the body markup.
-///
-/// `image.uri` on a thumbnail is always a string; `MediaContent` returns a `Url` we serialise
-/// back to `String` so the cache key (sha of the URL string) stays stable.
-fn thumbnail_url_for(entry: &Entry) -> Option<String> {
-    entry
-        .media
-        .iter()
-        .flat_map(|m| m.thumbnails.iter().map(|t| t.image.uri.clone()))
-        .find(|s| !s.is_empty())
-        .or_else(|| {
-            entry
-                .media
-                .iter()
-                .flat_map(|m| m.content.iter().filter_map(|c| c.url.as_ref()))
-                .map(|u| u.to_string())
-                .find(|s| !s.is_empty())
-        })
-        .or_else(|| {
-            entry
-                .content
-                .as_ref()
-                .and_then(|c| c.body.as_deref())
-                .and_then(first_inline_image_src)
-        })
-        .or_else(|| {
-            entry
-                .summary
-                .as_ref()
-                .and_then(|s| first_inline_image_src(&s.content))
-        })
-}
-
-/// Extracts the `src` attribute of the first HTTP(S) `<img>` tag in `html`. Used to recover a
-/// thumbnail when the feed doesn't expose `media:thumbnail` — most Atom blogs (Rust blog,
-/// personal sites) only ship the cover image inline inside the HTML body. Encoded entities
-/// (`&amp;`) are decoded back to `&` so the URL works as-is. Returns `None` when the body has
-/// no `<img>` or only data: / cid: / file: URIs.
-fn first_inline_image_src(html: &str) -> Option<String> {
-    static IMG_SRC_RE: OnceLock<Regex> = OnceLock::new();
-    // `(?is)`: case-insensitive + dot matches newlines. The regex is forgiving about
-    // attribute order — `src` may be preceded by any number of non-`>` attributes.
-    let re = IMG_SRC_RE
-        .get_or_init(|| Regex::new(r#"(?is)<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']"#).unwrap());
-    re.captures_iter(html)
-        .map(|cap| decode_html_entities(&cap[1]))
-        .find(|src| src.starts_with("http://") || src.starts_with("https://"))
-}
-
-fn decode_html_entities(s: &str) -> String {
-    s.replace("&amp;", "&")
-        .replace("&#x2F;", "/")
-        .replace("&#x3D;", "=")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-}
-
-/// Subtitle for the card layout: `"<date> · <source-host>"`, or just one half when the other is
-/// missing. The full-line `"<date>  <title>"` rhythm from `LinkedTextBlock` doesn't fit the
-/// thumbnail layout because the title gets its own bold row.
-fn subtitle_for(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> Option<String> {
-    let date = date_label(entry, timezone, locale);
-    let host = link_for(entry)
-        .as_deref()
-        .and_then(|u| Url::parse(u).ok())
-        .and_then(|u| u.host_str().map(str::to_string));
-    match (date.is_empty(), host) {
-        (true, None) => None,
-        (false, None) => Some(date),
-        (true, Some(h)) => Some(h),
-        (false, Some(h)) => Some(format!("{date} · {h}")),
-    }
-}
-
-fn render_body(
-    feed: &Feed,
-    count: usize,
-    shape: Shape,
-    timezone: Option<&str>,
-    locale: Option<&str>,
-) -> Body {
-    let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
-    match shape {
-        Shape::TextBlock => Body::TextBlock(TextBlockData {
-            lines: entries
-                .iter()
-                .map(|e| line_text(e, timezone, locale))
-                .collect(),
-        }),
-        _ => Body::LinkedTextBlock(LinkedTextBlockData {
-            items: entries
-                .iter()
-                .map(|e| LinkedLine {
-                    text: line_text(e, timezone, locale),
-                    url: link_for(e),
-                })
-                .collect(),
-        }),
-    }
-}
-
-fn line_text(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> String {
-    let date = date_label(entry, timezone, locale);
-    let title = title_or_placeholder(entry);
-    if date.is_empty() {
-        title
-    } else {
-        format!("{date}  {title}")
-    }
-}
-
-fn date_label(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> String {
-    entry
-        .published
-        .or(entry.updated)
-        .map(|dt| format_short(dt, timezone, locale))
-        .unwrap_or_default()
-}
-
-fn format_short(dt: DateTime<Utc>, timezone: Option<&str>, locale: Option<&str>) -> String {
-    let local = match t::parse_tz(timezone) {
-        Some(tz) => dt.with_timezone(&tz).fixed_offset(),
-        None => dt.with_timezone(&chrono::Local).fixed_offset(),
-    };
-    t::format_local(&local, "%b %d", locale)
-}
-
-fn title_or_placeholder(entry: &Entry) -> String {
-    entry
-        .title
-        .as_ref()
-        .map(|t| collapse_whitespace(&t.content))
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "(no title)".into())
-}
-
-fn collapse_whitespace(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn link_for(entry: &Entry) -> Option<String> {
-    // Atom entries can carry multiple <link> with `rel` discriminators (`alternate`, `self`,
-    // `enclosure`, `via`, …). Per RFC 4287 the article URL is `rel="alternate"`, which is also
-    // the default when `rel` is absent — matching RSS 2.0's single-link case. Picking the first
-    // non-empty href would otherwise grab `rel="self"` (a self-pointer back into the feed) on
-    // common Atom shapes.
-    let alternate = entry
-        .links
-        .iter()
-        .find(|l| !l.href.is_empty() && matches!(l.rel.as_deref(), None | Some("alternate")));
-    alternate
-        .or_else(|| entry.links.iter().find(|l| !l.href.is_empty()))
-        .map(|l| l.href.clone())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{TimeZone, Utc};
+    use feed_rs::model::{Entry, Feed};
+    use feed_rs::parser;
     use std::future::Future;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use std::time::Duration;
 
     fn ctx(shape: Option<Shape>, options: Option<toml::Value>) -> FetchContext {
         FetchContext {
@@ -546,14 +313,14 @@ mod tests {
   </entry>
 </feed>"#;
 
-    fn parse(fixture: &str) -> Feed {
+    fn parse_fixture(fixture: &str) -> Feed {
         parser::parse(fixture.as_bytes()).expect("fixture must parse")
     }
 
     #[test]
     fn rss_parses_into_linked_text_block_with_dates_and_urls() {
-        let feed = parse(RSS_FIXTURE);
-        let body = render_body(&feed, 5, Shape::LinkedTextBlock, None, None);
+        let feed_doc = parse_fixture(RSS_FIXTURE);
+        let body = feed::render_body(&feed_doc, 5, Shape::LinkedTextBlock, None, None);
         let Body::LinkedTextBlock(b) = body else {
             panic!("expected linked text block");
         };
@@ -565,8 +332,8 @@ mod tests {
 
     #[test]
     fn rss_parses_into_text_block_without_urls() {
-        let feed = parse(RSS_FIXTURE);
-        let body = render_body(&feed, 5, Shape::TextBlock, None, None);
+        let feed_doc = parse_fixture(RSS_FIXTURE);
+        let body = feed::render_body(&feed_doc, 5, Shape::TextBlock, None, None);
         let Body::TextBlock(t) = body else {
             panic!("expected text block");
         };
@@ -576,8 +343,8 @@ mod tests {
 
     #[test]
     fn atom_parses_with_link_and_date() {
-        let feed = parse(ATOM_FIXTURE);
-        let body = render_body(&feed, 5, Shape::LinkedTextBlock, None, None);
+        let feed_doc = parse_fixture(ATOM_FIXTURE);
+        let body = feed::render_body(&feed_doc, 5, Shape::LinkedTextBlock, None, None);
         let Body::LinkedTextBlock(b) = body else {
             panic!("expected linked text block");
         };
@@ -591,24 +358,24 @@ mod tests {
 
     #[test]
     fn line_text_without_date_uses_title_only() {
-        let mut feed = parse(RSS_FIXTURE);
-        feed.entries[0].published = None;
-        feed.entries[0].updated = None;
-        let text = line_text(&feed.entries[0], None, None);
+        let mut feed_doc = parse_fixture(RSS_FIXTURE);
+        feed_doc.entries[0].published = None;
+        feed_doc.entries[0].updated = None;
+        let text = feed::line_text(&feed_doc.entries[0], None, None);
         assert_eq!(text, "First post");
     }
 
     #[test]
     fn format_short_uses_explicit_timezone() {
         let dt = Utc.with_ymd_and_hms(2026, 4, 30, 23, 30, 0).unwrap();
-        assert_eq!(format_short(dt, Some("UTC"), None), "Apr 30");
-        assert_eq!(format_short(dt, Some("Asia/Tokyo"), None), "May 01");
+        assert_eq!(feed::format_short(dt, Some("UTC"), None), "Apr 30");
+        assert_eq!(feed::format_short(dt, Some("Asia/Tokyo"), None), "May 01");
     }
 
     #[test]
     fn count_caps_entries() {
-        let feed = parse(RSS_FIXTURE);
-        let body = render_body(&feed, 1, Shape::LinkedTextBlock, None, None);
+        let feed_doc = parse_fixture(RSS_FIXTURE);
+        let body = feed::render_body(&feed_doc, 1, Shape::LinkedTextBlock, None, None);
         let Body::LinkedTextBlock(b) = body else {
             panic!("expected linked text block");
         };
@@ -637,7 +404,7 @@ mod tests {
             ttl: None,
             entries: vec![],
         };
-        let body = render_body(&empty, 5, Shape::LinkedTextBlock, None, None);
+        let body = feed::render_body(&empty, 5, Shape::LinkedTextBlock, None, None);
         let Body::LinkedTextBlock(b) = body else {
             panic!("expected linked text block");
         };
@@ -646,9 +413,9 @@ mod tests {
 
     #[test]
     fn missing_title_falls_back_to_placeholder() {
-        let mut feed = parse(RSS_FIXTURE);
-        feed.entries[0].title = None;
-        let body = render_body(&feed, 1, Shape::TextBlock, None, None);
+        let mut feed_doc = parse_fixture(RSS_FIXTURE);
+        feed_doc.entries[0].title = None;
+        let body = feed::render_body(&feed_doc, 1, Shape::TextBlock, None, None);
         let Body::TextBlock(t) = body else {
             panic!("expected text block");
         };
@@ -657,18 +424,26 @@ mod tests {
 
     #[test]
     fn collapses_whitespace_in_titles() {
-        // RSS titles sometimes have embedded newlines / runs of spaces — render on one line.
         assert_eq!(
-            collapse_whitespace("hello\n  world\t!"),
+            feed::collapse_whitespace("hello\n  world\t!"),
             "hello world !".to_string()
         );
     }
 
     #[test]
     fn count_clamps_extremes() {
-        assert_eq!(0u32.clamp(MIN_COUNT, MAX_COUNT), MIN_COUNT);
-        assert_eq!(999u32.clamp(MIN_COUNT, MAX_COUNT), MAX_COUNT);
-        assert_eq!(DEFAULT_COUNT.clamp(MIN_COUNT, MAX_COUNT), DEFAULT_COUNT);
+        assert_eq!(
+            0u32.clamp(feed::MIN_COUNT, feed::MAX_COUNT),
+            feed::MIN_COUNT
+        );
+        assert_eq!(
+            999u32.clamp(feed::MIN_COUNT, feed::MAX_COUNT),
+            feed::MAX_COUNT
+        );
+        assert_eq!(
+            feed::DEFAULT_COUNT.clamp(feed::MIN_COUNT, feed::MAX_COUNT),
+            feed::DEFAULT_COUNT
+        );
     }
 
     #[test]
@@ -708,7 +483,7 @@ mod tests {
     fn first_inline_image_src_extracts_first_http_src() {
         let html = r#"<p>intro</p><img src="https://example.com/cover.jpg" /><img src="https://example.com/second.png">"#;
         assert_eq!(
-            super::first_inline_image_src(html).as_deref(),
+            feed::first_inline_image_src(html).as_deref(),
             Some("https://example.com/cover.jpg"),
         );
     }
@@ -718,27 +493,24 @@ mod tests {
         let html =
             r#"<img src="data:image/png;base64,AAAA"><img src="https://example.com/real.png">"#;
         assert_eq!(
-            super::first_inline_image_src(html).as_deref(),
+            feed::first_inline_image_src(html).as_deref(),
             Some("https://example.com/real.png"),
         );
     }
 
     #[test]
     fn first_inline_image_src_decodes_encoded_amp_entities() {
-        // Real-world Atom feeds (e.g. Rust blog) HTML-encode the entry body, so query
-        // strings appear as `?a&amp;b=1`. Without decoding, the URL doesn't match what the
-        // origin actually serves.
         let html = r#"<img src="https://example.com/img.png?a&amp;b&#x3D;1">"#;
         assert_eq!(
-            super::first_inline_image_src(html).as_deref(),
+            feed::first_inline_image_src(html).as_deref(),
             Some("https://example.com/img.png?a&b=1"),
         );
     }
 
     #[test]
     fn first_inline_image_src_returns_none_without_img() {
-        assert!(super::first_inline_image_src("<p>no images here</p>").is_none());
-        assert!(super::first_inline_image_src("").is_none());
+        assert!(feed::first_inline_image_src("<p>no images here</p>").is_none());
+        assert!(feed::first_inline_image_src("").is_none());
     }
 
     #[test]
@@ -752,7 +524,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            super::thumbnail_url_for(&entry).as_deref(),
+            feed::thumbnail_url_for(&entry).as_deref(),
             Some("https://example.com/hero.jpg"),
         );
     }
@@ -791,57 +563,24 @@ mod tests {
         };
         entry.media = vec![media];
         assert_eq!(
-            super::thumbnail_url_for(&entry).as_deref(),
+            feed::thumbnail_url_for(&entry).as_deref(),
             Some("https://example.com/thumb.jpg"),
         );
 
-        let mut entry_no_thumb = Entry::default();
-        let mut media_content_only =
-            entry_no_thumb
-                .media
-                .first()
-                .cloned()
-                .unwrap_or_else(|| feed_rs::model::MediaObject {
-                    title: None,
-                    content: vec![MediaContent {
-                        url: Some(Url::parse("https://example.com/big.jpg").unwrap()),
-                        content_type: None,
-                        height: None,
-                        width: None,
-                        duration: None,
-                        size: None,
-                        rating: None,
-                    }],
-                    duration: None,
-                    thumbnails: vec![],
-                    texts: vec![],
-                    description: None,
-                    community: None,
-                    credits: vec![],
-                });
-        media_content_only.thumbnails.clear();
-        entry_no_thumb.media = vec![media_content_only];
-        assert_eq!(
-            super::thumbnail_url_for(&entry_no_thumb).as_deref(),
-            Some("https://example.com/big.jpg"),
-        );
-
         let empty = Entry::default();
-        assert!(super::thumbnail_url_for(&empty).is_none());
+        assert!(feed::thumbnail_url_for(&empty).is_none());
     }
 
     #[test]
     fn thumbnail_url_for_returns_none_when_no_source_available() {
         let empty = Entry::default();
-        assert!(super::thumbnail_url_for(&empty).is_none());
+        assert!(feed::thumbnail_url_for(&empty).is_none());
     }
 
     #[test]
     fn subtitle_for_returns_none_when_no_signal() {
-        // No date, no link → no useful subtitle. Returning None lets the renderer omit the
-        // subtitle row entirely rather than draw a blank line.
         let entry = Entry::default();
-        assert!(super::subtitle_for(&entry, None, None).is_none());
+        assert!(feed::subtitle_for(&entry, None, None).is_none());
     }
 
     #[test]
@@ -850,7 +589,7 @@ mod tests {
             published: Some(chrono::Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()),
             ..Default::default()
         };
-        let sub = super::subtitle_for(&entry, Some("UTC"), None).unwrap();
+        let sub = feed::subtitle_for(&entry, Some("UTC"), None).unwrap();
         assert_eq!(sub, "Apr 26");
         assert!(!sub.contains('·'));
     }
@@ -869,7 +608,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let sub = super::subtitle_for(&entry, Some("UTC"), None).unwrap();
+        let sub = feed::subtitle_for(&entry, Some("UTC"), None).unwrap();
         assert_eq!(sub, "blog.rust-lang.org");
         assert!(!sub.contains('·'));
     }
@@ -889,7 +628,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let sub = super::subtitle_for(&entry, Some("UTC"), None).unwrap();
+        let sub = feed::subtitle_for(&entry, Some("UTC"), None).unwrap();
         assert!(sub.contains("Apr 26"));
         assert!(sub.contains("blog.rust-lang.org"));
     }
@@ -914,9 +653,9 @@ mod tests {
 
     #[test]
     fn whitespace_only_titles_fall_back_to_placeholder() {
-        let mut feed = parse(RSS_FIXTURE);
-        feed.entries[0].title.as_mut().unwrap().content = " \n\t ".into();
-        let body = render_body(&feed, 1, Shape::TextBlock, None, None);
+        let mut feed_doc = parse_fixture(RSS_FIXTURE);
+        feed_doc.entries[0].title.as_mut().unwrap().content = " \n\t ".into();
+        let body = feed::render_body(&feed_doc, 1, Shape::TextBlock, None, None);
         let Body::TextBlock(t) = body else {
             panic!("expected text block");
         };
@@ -964,15 +703,15 @@ mod tests {
     fn fetch_bytes_reports_http_status_and_size_cap() {
         let (status_url, status_server) =
             serve_once("500 Internal Server Error", "text/plain", b"oops");
-        let status_err =
-            run_async(fetch_bytes(&validated_url(Some(&status_url)).unwrap())).unwrap_err();
+        let url = validated_url(Some(&status_url)).unwrap();
+        let status_err = run_async(feed::fetch_bytes(&url, "rss")).unwrap_err();
         status_server.join().unwrap();
         assert_failed_contains(status_err, "rss 500");
 
-        let oversized = vec![b'x'; MAX_BYTES + 1];
+        let oversized = vec![b'x'; feed::MAX_BYTES + 1];
         let (size_url, size_server) = serve_once("200 OK", "application/octet-stream", &oversized);
-        let size_err =
-            run_async(fetch_bytes(&validated_url(Some(&size_url)).unwrap())).unwrap_err();
+        let url = validated_url(Some(&size_url)).unwrap();
+        let size_err = run_async(feed::fetch_bytes(&url, "rss")).unwrap_err();
         size_server.join().unwrap();
         assert_failed_contains(size_err, "too large");
     }
@@ -996,8 +735,8 @@ mod tests {
 
     #[test]
     fn link_prefers_alternate_over_self_in_atom() {
-        let feed = parse(ATOM_MULTI_REL_FIXTURE);
-        let body = render_body(&feed, 5, Shape::LinkedTextBlock, None, None);
+        let feed_doc = parse_fixture(ATOM_MULTI_REL_FIXTURE);
+        let body = feed::render_body(&feed_doc, 5, Shape::LinkedTextBlock, None, None);
         let Body::LinkedTextBlock(b) = body else {
             panic!("expected linked text block");
         };
@@ -1009,10 +748,10 @@ mod tests {
 
     #[test]
     fn link_falls_back_to_first_non_empty_href_when_no_alternate_exists() {
-        let mut feed = parse(ATOM_FIXTURE);
-        feed.entries[0].links[0].rel = Some("self".into());
+        let mut feed_doc = parse_fixture(ATOM_FIXTURE);
+        feed_doc.entries[0].links[0].rel = Some("self".into());
         assert_eq!(
-            link_for(&feed.entries[0]).as_deref(),
+            feed::link_for(&feed_doc.entries[0]).as_deref(),
             Some("https://example.com/atom-1")
         );
     }
@@ -1020,23 +759,21 @@ mod tests {
     #[test]
     fn fetch_bytes_reports_request_failure_for_unreachable_host() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let url = format!("http://{}/feed.xml", listener.local_addr().unwrap());
+        let url_str = format!("http://{}/feed.xml", listener.local_addr().unwrap());
         drop(listener);
-
-        let err = run_async(fetch_bytes(&validated_url(Some(&url)).unwrap())).unwrap_err();
+        let url = validated_url(Some(&url_str)).unwrap();
+        let err = run_async(feed::fetch_bytes(&url, "rss")).unwrap_err();
         assert_failed_contains(err, "rss request failed");
     }
 
-    /// Live smoke test — hits the Rust blog's feed. `#[ignore]` keeps CI offline-safe; run with
-    /// `cargo test -- --ignored fetcher::rss::tests::live` to verify the real fetch path.
     #[tokio::test]
     #[ignore]
     async fn live_rust_blog_feed_returns_at_least_one_entry() {
         let url = validated_url(Some("https://blog.rust-lang.org/feed.xml")).unwrap();
-        let bytes = fetch_bytes(&url).await.unwrap();
-        let feed = parser::parse(bytes.as_slice()).unwrap();
-        assert!(!feed.entries.is_empty());
-        let body = render_body(&feed, 3, Shape::LinkedTextBlock, None, None);
+        let bytes = feed::fetch_bytes(&url, "rss").await.unwrap();
+        let feed_doc = feed::parse_feed(&bytes, "rss").unwrap();
+        assert!(!feed_doc.entries.is_empty());
+        let body = feed::render_body(&feed_doc, 3, Shape::LinkedTextBlock, None, None);
         if let Body::LinkedTextBlock(b) = body {
             for it in &b.items {
                 eprintln!("{}  -> {:?}", it.text, it.url);
@@ -1044,28 +781,23 @@ mod tests {
         }
     }
 
-    /// Live verification that the `media:thumbnail` extraction path works against a real
-    /// feed. BBC Tech ships `<media:thumbnail>` per item so every entry should resolve a
-    /// URL. The Rust blog has no images at all (not even inline `<img>` — text-only posts)
-    /// and would not satisfy this assertion. Run with
-    /// `cargo test -- --ignored fetcher::rss::tests::live_bbc_tech_thumbnail_url`.
     #[tokio::test]
     #[ignore]
     async fn live_bbc_tech_thumbnail_url_extracts_media_thumbnail() {
         let url = validated_url(Some("https://feeds.bbci.co.uk/news/technology/rss.xml")).unwrap();
-        let bytes = fetch_bytes(&url).await.unwrap();
-        let feed = parser::parse(bytes.as_slice()).unwrap();
-        let with_thumb = feed
+        let bytes = feed::fetch_bytes(&url, "rss").await.unwrap();
+        let feed_doc = feed::parse_feed(&bytes, "rss").unwrap();
+        let with_thumb = feed_doc
             .entries
             .iter()
             .take(5)
-            .filter(|e| super::thumbnail_url_for(e).is_some())
+            .filter(|e| feed::thumbnail_url_for(e).is_some())
             .count();
-        for entry in feed.entries.iter().take(5) {
+        for entry in feed_doc.entries.iter().take(5) {
             eprintln!(
                 "{:?} -> {:?}",
                 entry.title.as_ref().map(|t| &t.content),
-                super::thumbnail_url_for(entry),
+                feed::thumbnail_url_for(entry),
             );
         }
         assert!(


### PR DESCRIPTION
## Summary

Adds a `news_*` fetcher family. Each entry in a static `NewsSource` table registers as a separate `news_<slug>` fetcher with a hardcoded feed URL set, so the family is `Safety::Safe` (no trust-gate friction, drop-in usable in a fresh install) and config can pick among a closed enum of sub-feeds via `feed = "<key>"` without injecting new destinations.

**93 sources / 120 feeds / 20 sub-genres:**

| Sub-genre | Sources |
| --- | --- |
| general | bbc, guardian, aljazeera, npr, france24, dw, sky_news, cbs |
| tech | arstechnica, techcrunch, theverge, wired, hackernoon, the_register, zdnet, slashdot, venturebeat |
| gadget | engadget, gizmodo, techradar |
| business | ft, marketwatch, yahoo_finance, forbes, economist, fortune |
| science | nature, scientific_american, quanta_magazine, new_scientist, sciencedaily, phys_org |
| security | krebs, bleeping_computer, schneier, the_hacker_news, threatpost, dark_reading, graham_cluley |
| linux | lwn, phoronix, omg_ubuntu, its_foss, distrowatch |
| gaming | polygon, eurogamer, rockpapershotgun, kotaku, ign, pc_gamer, vg247 |
| ai | import_ai, ai_news, hugging_face_blog, the_gradient, mit_tr_ai |
| hardware | hackaday, tomshardware, techpowerup, ifixit |
| web | smashing_magazine, css_tricks, a_list_apart, ux_collective |
| apple | 9to5mac, macrumors, daring_fireball, appleinsider |
| android | android_police, 9to5google, android_authority, xda |
| space | spacenews, universe_today, nasa_news, space_com |
| climate | yale_climate, inside_climate, carbon_brief |
| politics | politico, propublica, vox |
| photography | dpreview, petapixel, fstoppers |
| entertainment | variety, deadline, indiewire |
| music | pitchfork, stereogum |
| crypto | coindesk, the_block, decrypt |

Six sources (BBC, Guardian, ArsTechnica, TechCrunch, Verge, WIRED) expose multiple sub-feeds; the rest expose a single default feed. **Adding more sources = appending one row to `sources.rs`**; registration in `mod.rs` is automatic.

Refactors `rss`'s HTTP + feed-rs + entry-to-row pipeline into a shared `src/fetcher/feed.rs` so `rss` (generic Network feed) and `news_*` (curated Safe feeds) reuse it. `rss` behaviour and test surface unchanged.

### Live verification

`#[ignore]`-d test hits every bundled feed in parallel and asserts at least one entry parses; surfaces feed-URL rot via:

```
cargo test --lib -- --ignored fetcher::news::tests::live_every_bundled_feed_parses
```

Confirmed locally — all 120 feeds returned ≥5 entries (smallest: Quanta Magazine with 5; largest: Hugging Face Blog with 777).

### Source choices worth flagging

- **Sophos Naked Security** shut down in 2024, replaced with **Graham Cluley** (former Sophos blogger, same niche).
- **sidebar.io** and **designernews.co** are both returning connection failures, replaced with **UX Collective** (uxdesign.cc).
- **Bloomberg / WSJ Markets** RSS endpoints have been killed, replaced with **MarketWatch + Yahoo Finance** for the business category.
- **hugging_face_blog** is a corporate-research blog rather than third-party news — included intentionally since HF's blog is the canonical source for HF research releases, distinct from `github_blog` / `cloudflare_blog`-style product PR.

### Auto-generated reference (preview of `/reference/fetchers/news/news_bbc/`)

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `linked_text_block`, `image_linked_list`, `text_block` |

**Options**

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `feed` | string (source-specific key) | no | first sub-feed of the source | Sub-feed key to select (e.g. `"world"` / `"tech"`). Run `splashboard catalog fetcher news_<source>` to list available keys. |
| `count` | integer (1..=20) | no | 5 | Number of feed entries to display. |

**Compatible renderers**

| Shape | Renderers |
| --- | --- |
| `linked_text_block` | [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/) |
| `image_linked_list` | [`list_cards`](https://splashboard.unhappychoice.com/reference/renderers/list/list_cards/) |
| `text_block` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (2126 tests pass, including 13 news tests + 41 unchanged rss tests)
- [x] `cargo test -- --ignored fetcher::news::tests::live_every_bundled_feed_parses` (all 120 feeds parse ≥5 entries each)
- [x] Local smoke via `cargo run --bin splashboard` with a per-dir `.splashboard/dashboard.toml` exercising default sub-feed, explicit sub-feed, `TextBlock`/`list_plain`, and `ImageLinkedList`/`list_cards` paths

Ticks the corresponding `news_*` checkboxes on #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a curated catalog of news feed sources across many categories (Tech, Business, Science, Security, Linux, Gaming, AI, Hardware, Web, Apple, Android, Space, Climate, etc.).
  * New "news_*" fetcher family with per-feed options to select sub-feeds and limit entry counts; clear errors for unknown sub-feed keys.

* **Refactor**
  * Shared feed processing extracted into a common module used by RSS and news fetchers; unified rendering supports thumbnails, formatted dates/subtitles, and improved text/link handling.

* **Tests**
  * Added unit tests and a live smoke verification for bundled feeds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/218)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->