### PR TITLE
feat(fetcher/news): add news_bloomberg + news_wsj (correction to #218)

### DIFF
--- a/src/fetcher/news/sources.rs
+++ b/src/fetcher/news/sources.rs
@@ -789,6 +789,72 @@ pub const SOURCES: &[NewsSource] = &[
     },
     // ---------- Business (cont.) ----------
     NewsSource {
+        name: "news_bloomberg",
+        display: "Bloomberg",
+        category: NewsCategory::Business,
+        description: "Bloomberg section feeds. Sub-feeds cover markets (default), technology, business, politics, economics, and wealth.",
+        feeds: &[
+            NewsFeed {
+                key: "markets",
+                url: "https://feeds.bloomberg.com/markets/news.rss",
+                label: "Markets",
+            },
+            NewsFeed {
+                key: "technology",
+                url: "https://feeds.bloomberg.com/technology/news.rss",
+                label: "Technology",
+            },
+            NewsFeed {
+                key: "business",
+                url: "https://feeds.bloomberg.com/business/news.rss",
+                label: "Business",
+            },
+            NewsFeed {
+                key: "politics",
+                url: "https://feeds.bloomberg.com/politics/news.rss",
+                label: "Politics",
+            },
+            NewsFeed {
+                key: "economics",
+                url: "https://feeds.bloomberg.com/economics/news.rss",
+                label: "Economics",
+            },
+            NewsFeed {
+                key: "wealth",
+                url: "https://feeds.bloomberg.com/wealth/news.rss",
+                label: "Wealth",
+            },
+        ],
+    },
+    NewsSource {
+        name: "news_wsj",
+        display: "Wall Street Journal",
+        category: NewsCategory::Business,
+        description: "Wall Street Journal section feeds. Sub-feeds cover markets (default), tech (WSJ.D), world, and opinion.",
+        feeds: &[
+            NewsFeed {
+                key: "markets",
+                url: "https://feeds.content.dowjones.io/public/rss/RSSMarketsMain",
+                label: "Markets",
+            },
+            NewsFeed {
+                key: "tech",
+                url: "https://feeds.content.dowjones.io/public/rss/RSSWSJD",
+                label: "Tech (WSJ.D)",
+            },
+            NewsFeed {
+                key: "world",
+                url: "https://feeds.content.dowjones.io/public/rss/RSSWorldNews",
+                label: "World",
+            },
+            NewsFeed {
+                key: "opinion",
+                url: "https://feeds.content.dowjones.io/public/rss/RSSOpinion",
+                label: "Opinion",
+            },
+        ],
+    },
+    NewsSource {
         name: "news_forbes",
         display: "Forbes",
         category: NewsCategory::Business,


### PR DESCRIPTION
## Summary

Correction to #218 — Bloomberg and WSJ Markets RSS endpoints were wrongly claimed dead and dropped from the initial batch. Both publish multi-section RSS that's actively serving content; I dropped them based on a stale assumption without HEAD-checking. This PR adds them back.

- `news_bloomberg` — 6 sub-feeds: markets (default), technology, business, politics, economics, wealth.
- `news_wsj` — 4 sub-feeds: markets (default), tech (WSJ.D), world, opinion.

Both surface under the business category alongside the existing `news_ft` / `news_marketwatch` / `news_yahoo_finance` / `news_forbes` / `news_economist` / `news_fortune`.

Totals after merge: **95 sources / 130 feeds**.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib fetcher::news` (13 tests pass, including `all_sources_are_news_prefixed_and_have_at_least_one_feed` covering the new entries)
- [x] `cargo test --lib -- --ignored fetcher::news::tests::live_every_bundled_feed_parses` (all feeds including 10 new Bloomberg + WSJ sub-feeds parse ≥1 entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bloomberg as a new news source with feeds: markets (default), technology, business, politics, economics, and wealth
  * Added Wall Street Journal as a new news source with feeds: markets (default), tech, world, and opinion

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->