### PR TITLE
feat(fetcher/youtube): add youtube_channel

### DIFF
--- a/src/fetcher/feed.rs
+++ b/src/fetcher/feed.rs
@@ -24,7 +24,9 @@ use url::Url;
 use crate::fetcher::thumbnails;
 use crate::fetcher::{FetchContext, FetchError};
 use crate::payload::{
-    Body, ImageLinkedItem, ImageLinkedListData, LinkedLine, LinkedTextBlockData, TextBlockData,
+    Body, EntriesData, Entry as PayloadEntry, ImageData, ImageLinkedItem, ImageLinkedListData,
+    LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, TextBlockData, TextData, TimelineData,
+    TimelineEvent,
 };
 use crate::render::Shape;
 use crate::time as t;
@@ -86,10 +88,48 @@ pub(crate) fn render_body(
 ) -> Body {
     let entries: Vec<&Entry> = feed.entries.iter().take(count).collect();
     match shape {
+        Shape::Text => Body::Text(TextData {
+            value: entries
+                .first()
+                .map(|e| title_or_placeholder(e))
+                .unwrap_or_default(),
+        }),
         Shape::TextBlock => Body::TextBlock(TextBlockData {
             lines: entries
                 .iter()
                 .map(|e| line_text(e, timezone, locale))
+                .collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: entries
+                .iter()
+                .map(|e| markdown_line(e, timezone, locale))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: entries
+                .iter()
+                .map(|e| PayloadEntry {
+                    key: title_or_placeholder(e),
+                    value: Some(date_label(e, timezone, locale)).filter(|s| !s.is_empty()),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Timeline => Body::Timeline(TimelineData {
+            events: entries
+                .iter()
+                .map(|e| TimelineEvent {
+                    timestamp: e
+                        .published
+                        .or(e.updated)
+                        .map(|d| d.timestamp())
+                        .unwrap_or(0),
+                    title: title_or_placeholder(e),
+                    detail: link_host(e),
+                    status: None,
+                })
                 .collect(),
         }),
         _ => Body::LinkedTextBlock(LinkedTextBlockData {
@@ -102,6 +142,43 @@ pub(crate) fn render_body(
                 .collect(),
         }),
     }
+}
+
+/// Async-only because it downloads the latest entry's thumbnail. Returns an empty `Body::Image`
+/// (path "") when the feed has no entries or no resolvable thumbnail — `is_empty_body` treats
+/// that as a placeholder.
+pub(crate) async fn render_image_body(feed: &Feed) -> Body {
+    let path = match feed.entries.first().and_then(thumbnail_url_for) {
+        Some(url) => thumbnails::download_to_cache(&url)
+            .await
+            .ok()
+            .flatten()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        None => String::new(),
+    };
+    Body::Image(ImageData { path })
+}
+
+fn markdown_line(entry: &Entry, timezone: Option<&str>, locale: Option<&str>) -> String {
+    let date = date_label(entry, timezone, locale);
+    let title = title_or_placeholder(entry);
+    let labeled = if date.is_empty() {
+        title
+    } else {
+        format!("{date}  {title}")
+    };
+    match link_for(entry) {
+        Some(url) => format!("- [{labeled}]({url})"),
+        None => format!("- {labeled}"),
+    }
+}
+
+fn link_host(entry: &Entry) -> Option<String> {
+    link_for(entry)
+        .as_deref()
+        .and_then(|u| Url::parse(u).ok())
+        .and_then(|u| u.host_str().map(str::to_string))
 }
 
 pub(crate) async fn render_image_linked(feed: &Feed, count: usize, ctx: &FetchContext) -> Body {

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -38,6 +38,7 @@ pub mod thumbnails;
 pub mod todoist;
 pub mod weather;
 pub mod wikipedia;
+pub mod youtube;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Safety {
@@ -325,6 +326,7 @@ impl Registry {
         r.register(Arc::new(stock_watchlist::StockWatchlistFetcher));
         r.register(Arc::new(random_cat::RandomCatFetcher));
         r.register(Arc::new(random_dog::RandomDogFetcher));
+        r.register(Arc::new(youtube::YoutubeChannelFetcher));
         for f in calendar::fetchers() {
             r.register(f);
         }

--- a/src/fetcher/news/mod.rs
+++ b/src/fetcher/news/mod.rs
@@ -33,6 +33,11 @@ const SHAPES: &[Shape] = &[
     Shape::LinkedTextBlock,
     Shape::ImageLinkedList,
     Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Image,
+    Shape::Timeline,
 ];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -139,6 +144,20 @@ impl Fetcher for NewsFeedFetcher {
                 &format!("Apr 25  {display}: feature piece"),
                 &format!("Apr 24  {display}: shorter update"),
             ]),
+            Shape::Text => samples::text(&format!("{display}: top story")),
+            Shape::MarkdownTextBlock => samples::markdown(&format!(
+                "- [Apr 26  {display}: top story](https://example.com/article-1)\n- [Apr 25  {display}: feature piece](https://example.com/article-2)\n- [Apr 24  {display}: shorter update](https://example.com/article-3)",
+            )),
+            Shape::Entries => samples::entries(&[
+                ("top story", "Apr 26"),
+                ("feature piece", "Apr 25"),
+                ("shorter update", "Apr 24"),
+            ]),
+            Shape::Timeline => samples::timeline(&[
+                (1_745_625_600, "top story", Some("example.com")),
+                (1_745_539_200, "feature piece", Some("example.com")),
+                (1_745_452_800, "shorter update", Some("example.com")),
+            ]),
             _ => return None,
         })
     }
@@ -160,6 +179,7 @@ impl Fetcher for NewsFeedFetcher {
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
         let body = match shape {
             Shape::ImageLinkedList => feed::render_image_linked(&parsed, count, ctx).await,
+            Shape::Image => feed::render_image_body(&parsed).await,
             other => feed::render_body(
                 &parsed,
                 count,
@@ -352,7 +372,23 @@ mod tests {
             f.sample_body(Shape::TextBlock),
             Some(Body::TextBlock(_))
         ));
-        assert!(f.sample_body(Shape::Text).is_none());
+        assert!(matches!(f.sample_body(Shape::Text), Some(Body::Text(_))));
+        assert!(matches!(
+            f.sample_body(Shape::MarkdownTextBlock),
+            Some(Body::MarkdownTextBlock(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::Entries),
+            Some(Body::Entries(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::Timeline),
+            Some(Body::Timeline(_))
+        ));
+        // Image samples need a real on-disk path; skipped like `random_cat`.
+        assert!(f.sample_body(Shape::Image).is_none());
+        // Shapes outside SHAPES still return None.
+        assert!(f.sample_body(Shape::Ratio).is_none());
     }
 
     #[test]

--- a/src/fetcher/rss.rs
+++ b/src/fetcher/rss.rs
@@ -25,6 +25,11 @@ const SHAPES: &[Shape] = &[
     Shape::LinkedTextBlock,
     Shape::ImageLinkedList,
     Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Image,
+    Shape::Timeline,
 ];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -115,6 +120,20 @@ impl Fetcher for RssFetcher {
                 "Apr 24  Release notes 0.42",
                 "Apr 22  A short note",
             ]),
+            Shape::Text => samples::text("Why X over Y"),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- [Apr 26  Why X over Y](https://example.com/post-1)\n- [Apr 24  Release notes 0.42](https://example.com/post-2)\n- [Apr 22  A short note](https://example.com/post-3)",
+            ),
+            Shape::Entries => samples::entries(&[
+                ("Why X over Y", "Apr 26"),
+                ("Release notes 0.42", "Apr 24"),
+                ("A short note", "Apr 22"),
+            ]),
+            Shape::Timeline => samples::timeline(&[
+                (1_745_625_600, "Why X over Y", Some("example.com")),
+                (1_745_452_800, "Release notes 0.42", Some("example.com")),
+                (1_745_280_000, "A short note", Some("example.com")),
+            ]),
             _ => return None,
         })
     }
@@ -130,6 +149,7 @@ impl Fetcher for RssFetcher {
         let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
         let body = match shape {
             Shape::ImageLinkedList => feed::render_image_linked(&parsed, count, ctx).await,
+            Shape::Image => feed::render_image_body(&parsed).await,
             other => feed::render_body(
                 &parsed,
                 count,
@@ -476,7 +496,24 @@ mod tests {
             f.sample_body(Shape::TextBlock),
             Some(Body::TextBlock(_))
         ));
-        assert!(f.sample_body(Shape::Text).is_none());
+        assert!(matches!(f.sample_body(Shape::Text), Some(Body::Text(_))));
+        assert!(matches!(
+            f.sample_body(Shape::MarkdownTextBlock),
+            Some(Body::MarkdownTextBlock(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::Entries),
+            Some(Body::Entries(_))
+        ));
+        assert!(matches!(
+            f.sample_body(Shape::Timeline),
+            Some(Body::Timeline(_))
+        ));
+        // Image samples need a real on-disk path, which test data can't supply portably —
+        // `random_cat` skips it the same way.
+        assert!(f.sample_body(Shape::Image).is_none());
+        // Shapes outside SHAPES still return None.
+        assert!(f.sample_body(Shape::Ratio).is_none());
     }
 
     #[test]

--- a/src/fetcher/youtube.rs
+++ b/src/fetcher/youtube.rs
@@ -1,0 +1,568 @@
+//! `youtube_channel` — recent uploads from one or more public YouTube channels.
+//!
+//! Reads `https://www.youtube.com/feeds/videos.xml` per channel. No API key, no OAuth — public
+//! uploads only.
+//!
+//! Two endpoint variants, matching the glanceapp/glance pattern:
+//! - default (`include_shorts = false`): rewrite `UC...` → `UULF...` and use
+//!   `?playlist_id=UULF...`, the channel's auto-generated long-form-uploads playlist (excludes
+//!   Shorts).
+//! - `include_shorts = true`: keep `?channel_id=UC...`, which returns every upload.
+//!
+//! As of 2026 the YouTube RSS endpoint is intermittently broken (glanceapp/glance #910): the
+//! channel_id and playlist_id forms occasionally return 404 for valid IDs. Per-channel
+//! failures fall through silently as long as one channel succeeds; only all-fail surfaces an
+//! error.
+//!
+//! Safety::Safe. The host is hardcoded; each `channel_id` is validated against
+//! `^UC[A-Za-z0-9_-]{22}$` before it reaches the URL, so a config can't inject path / query
+//! bytes that escape youtube.com. Multi-channel = parallel fetch + merge by `published` desc.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use feed_rs::model::{Entry, Feed, FeedType};
+use regex::Regex;
+use serde::Deserialize;
+use tokio::task::JoinSet;
+use url::Url;
+
+use crate::fetcher::feed;
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+const FEED_BASE: &str = "https://www.youtube.com/feeds/videos.xml";
+const DEFAULT_COUNT: u32 = 5;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 20;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::ImageLinkedList,
+    Shape::Entries,
+    Shape::Image,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "channel_ids",
+        type_hint: "array of strings (UC… channel IDs)",
+        required: true,
+        default: None,
+        description: "One or more YouTube channel IDs. Each ID must match `UC` + 22 chars from `[A-Za-z0-9_-]` (visible in the channel URL `https://www.youtube.com/channel/UC...`).",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("5"),
+        description: "Number of merged uploads to display, sorted newest first across all channels.",
+    },
+    OptionSchema {
+        name: "include_shorts",
+        type_hint: "boolean",
+        required: false,
+        default: Some("false"),
+        description: "When `false` (default), uploads are pulled from each channel's auto-generated `UULF` long-form-uploads playlist — Shorts are excluded. Set to `true` to read the channel feed directly and include Shorts.",
+    },
+];
+
+pub struct YoutubeChannelFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub channel_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub count: Option<u32>,
+    #[serde(default)]
+    pub include_shorts: Option<bool>,
+}
+
+#[async_trait]
+impl Fetcher for YoutubeChannelFetcher {
+    fn name(&self) -> &str {
+        "youtube_channel"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Recent uploads from one or more public YouTube channels, merged newest-first. Reads each channel's Atom feed at `youtube.com/feeds/videos.xml`; no API key or OAuth required."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                (
+                    "Apr 26  Channel A: new tutorial",
+                    Some("https://www.youtube.com/watch?v=aaaaaaaaaaA"),
+                ),
+                (
+                    "Apr 25  Channel B: release recap",
+                    Some("https://www.youtube.com/watch?v=bbbbbbbbbbB"),
+                ),
+                (
+                    "Apr 24  Channel A: behind the scenes",
+                    Some("https://www.youtube.com/watch?v=ccccccccccC"),
+                ),
+            ]),
+            Shape::TextBlock => samples::text_block(&[
+                "Apr 26  Channel A: new tutorial",
+                "Apr 25  Channel B: release recap",
+                "Apr 24  Channel A: behind the scenes",
+            ]),
+            Shape::Text => samples::text("Channel A: new tutorial"),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- [Apr 26  Channel A: new tutorial](https://www.youtube.com/watch?v=aaaaaaaaaaA)\n- [Apr 25  Channel B: release recap](https://www.youtube.com/watch?v=bbbbbbbbbbB)\n- [Apr 24  Channel A: behind the scenes](https://www.youtube.com/watch?v=ccccccccccC)",
+            ),
+            Shape::ImageLinkedList => samples::image_linked_list(&[
+                (
+                    "Channel A: new tutorial",
+                    Some("https://www.youtube.com/watch?v=aaaaaaaaaaA"),
+                    None,
+                    Some("Apr 26"),
+                ),
+                (
+                    "Channel B: release recap",
+                    Some("https://www.youtube.com/watch?v=bbbbbbbbbbB"),
+                    None,
+                    Some("Apr 25"),
+                ),
+                (
+                    "Channel A: behind the scenes",
+                    Some("https://www.youtube.com/watch?v=ccccccccccC"),
+                    None,
+                    Some("Apr 24"),
+                ),
+            ]),
+            Shape::Entries => samples::entries(&[
+                ("Channel A: new tutorial", "Apr 26"),
+                ("Channel B: release recap", "Apr 25"),
+                ("Channel A: behind the scenes", "Apr 24"),
+            ]),
+            Shape::Timeline => samples::timeline(&[
+                (
+                    1_745_625_600,
+                    "Channel A: new tutorial",
+                    Some("www.youtube.com"),
+                ),
+                (
+                    1_745_539_200,
+                    "Channel B: release recap",
+                    Some("www.youtube.com"),
+                ),
+                (
+                    1_745_452_800,
+                    "Channel A: behind the scenes",
+                    Some("www.youtube.com"),
+                ),
+            ]),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let channel_ids = validated_channel_ids(opts.channel_ids.as_deref())?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let include_shorts = opts.include_shorts.unwrap_or(false);
+        let merged = fetch_and_merge(&channel_ids, include_shorts).await?;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = match shape {
+            Shape::ImageLinkedList => feed::render_image_linked(&merged, count, ctx).await,
+            Shape::Image => feed::render_image_body(&merged).await,
+            other => feed::render_body(
+                &merged,
+                count,
+                other,
+                ctx.timezone.as_deref(),
+                ctx.locale.as_deref(),
+            ),
+        };
+        Ok(payload(body))
+    }
+}
+
+fn channel_id_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^UC[A-Za-z0-9_-]{22}$").unwrap())
+}
+
+fn validated_channel_ids(raw: Option<&[String]>) -> Result<Vec<String>, FetchError> {
+    let ids = raw.filter(|v| !v.is_empty()).ok_or_else(|| {
+        FetchError::Failed(
+            "youtube_channel: option `channel_ids` is required (at least one UC...)".into(),
+        )
+    })?;
+    let re = channel_id_regex();
+    for id in ids {
+        if !re.is_match(id) {
+            return Err(FetchError::Failed(format!(
+                "youtube_channel: invalid channel_id `{id}` (must match `^UC[A-Za-z0-9_-]{{22}}$`)"
+            )));
+        }
+    }
+    Ok(ids.to_vec())
+}
+
+/// Build the Atom feed URL for a single channel.
+///
+/// `include_shorts = false` rewrites `UC<22>` → `UULF<22>` and queries the uploads-playlist
+/// endpoint, which YouTube auto-generates for every channel and which excludes Shorts. This
+/// mirrors the glanceapp/glance trick — Shorts otherwise dominate many channels' chronological
+/// upload streams.
+///
+/// `include_shorts = true` falls back to `?channel_id=...`, the raw uploads feed.
+fn channel_feed_url(channel_id: &str, include_shorts: bool) -> Url {
+    let query = if include_shorts {
+        format!("channel_id={channel_id}")
+    } else {
+        let playlist_id = format!("UULF{}", &channel_id[2..]);
+        format!("playlist_id={playlist_id}")
+    };
+    Url::parse(&format!("{FEED_BASE}?{query}"))
+        .expect("channel_id is regex-validated to URL-safe bytes before this is called")
+}
+
+/// Fetches each channel's Atom feed in parallel and merges entries newest-first. Per-channel
+/// failures are tolerated when at least one channel succeeds — a 5-channel widget with one 404
+/// still renders the surviving 4. When *every* channel fails, the first error is surfaced so the
+/// user can see why (a silent empty-placeholder would hide a misspelled ID or a YouTube outage).
+async fn fetch_and_merge(channel_ids: &[String], include_shorts: bool) -> Result<Feed, FetchError> {
+    let mut set: JoinSet<Result<Vec<Entry>, FetchError>> = JoinSet::new();
+    for id in channel_ids {
+        let url = channel_feed_url(id, include_shorts);
+        set.spawn(async move {
+            let bytes = feed::fetch_bytes(&url, "youtube_channel").await?;
+            let parsed = feed::parse_feed(&bytes, "youtube_channel")?;
+            Ok(parsed.entries)
+        });
+    }
+    let mut entries: Vec<Entry> = Vec::new();
+    let mut first_error: Option<FetchError> = None;
+    let mut any_success = false;
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(Ok(chunk)) => {
+                any_success = true;
+                entries.extend(chunk);
+            }
+            Ok(Err(e)) => {
+                first_error.get_or_insert(e);
+            }
+            Err(e) => {
+                first_error.get_or_insert(FetchError::Failed(format!("youtube_channel join: {e}")));
+            }
+        }
+    }
+    if !any_success {
+        return Err(first_error.unwrap_or_else(|| {
+            FetchError::Failed("youtube_channel: no channels yielded entries".into())
+        }));
+    }
+    entries.sort_by_key(|e| std::cmp::Reverse(e.published.or(e.updated)));
+    Ok(empty_feed_with_entries(entries))
+}
+
+fn empty_feed_with_entries(entries: Vec<Entry>) -> Feed {
+    Feed {
+        feed_type: FeedType::Atom,
+        id: String::new(),
+        updated: None,
+        authors: vec![],
+        title: None,
+        description: None,
+        links: vec![],
+        categories: vec![],
+        contributors: vec![],
+        generator: None,
+        icon: None,
+        language: None,
+        logo: None,
+        published: None,
+        rating: None,
+        rights: None,
+        ttl: None,
+        entries,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(shape: Option<Shape>, options: Option<toml::Value>) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            shape,
+            options,
+            ..FetchContext::default()
+        }
+    }
+
+    fn parse_opts(raw: &str) -> toml::Value {
+        toml::from_str(raw).expect("test toml must parse")
+    }
+
+    #[test]
+    fn options_default_to_none_for_all_fields() {
+        let opts = Options::default();
+        assert!(opts.channel_ids.is_none());
+        assert!(opts.count.is_none());
+        assert!(opts.include_shorts.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_channel_ids_count_and_include_shorts() {
+        let raw = parse_opts(
+            "channel_ids = [\"UC_x5XG1OV2P6uZZ5FSM9Ttw\", \"UCXuqSBlHAE6Xw-yeJA0Tunw\"]\ncount = 8\ninclude_shorts = true",
+        );
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.channel_ids.as_deref().map(<[_]>::len), Some(2));
+        assert_eq!(opts.count, Some(8));
+        assert_eq!(opts.include_shorts, Some(true));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw = parse_opts("channel_ids = [\"UC_x5XG1OV2P6uZZ5FSM9Ttw\"]\nbogus = 1");
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn channel_id_regex_accepts_well_known_channels() {
+        for id in [
+            "UC_x5XG1OV2P6uZZ5FSM9Ttw",
+            "UCXuqSBlHAE6Xw-yeJA0Tunw",
+            "UCBJycsmduvYEL83R_U4JriQ",
+        ] {
+            assert!(
+                channel_id_regex().is_match(id),
+                "valid id should match: {id}",
+            );
+        }
+    }
+
+    #[test]
+    fn channel_id_regex_rejects_malformed_ids() {
+        for bad in [
+            "",
+            "UC_short",
+            "uc_lowercase_prefix_aaaaa",
+            "UC_x5XG1OV2P6uZZ5FSM9Tt!",  // bad char
+            "UC_x5XG1OV2P6uZZ5FSM9Ttw ", // trailing space
+            "ABXuqSBlHAE6Xw-yeJA0Tunw",  // wrong prefix
+            "UCXuqSBlHAE6Xw-yeJA0Tunwx", // 23 chars after UC
+        ] {
+            assert!(!channel_id_regex().is_match(bad), "should reject: {bad:?}",);
+        }
+    }
+
+    #[test]
+    fn validated_channel_ids_requires_at_least_one_id() {
+        let none = validated_channel_ids(None);
+        assert!(matches!(none, Err(FetchError::Failed(m)) if m.contains("required")));
+        let empty: Vec<String> = vec![];
+        let none_again = validated_channel_ids(Some(&empty));
+        assert!(matches!(none_again, Err(FetchError::Failed(m)) if m.contains("required")));
+    }
+
+    #[test]
+    fn validated_channel_ids_passes_through_valid_list() {
+        let ids = vec!["UC_x5XG1OV2P6uZZ5FSM9Ttw".to_string()];
+        let ok = validated_channel_ids(Some(&ids)).unwrap();
+        assert_eq!(ok, ids);
+    }
+
+    #[test]
+    fn validated_channel_ids_rejects_any_invalid_member() {
+        let ids = vec![
+            "UC_x5XG1OV2P6uZZ5FSM9Ttw".to_string(),
+            "not-a-channel".to_string(),
+        ];
+        let err = validated_channel_ids(Some(&ids)).unwrap_err();
+        match err {
+            FetchError::Failed(m) => assert!(m.contains("invalid channel_id"), "msg: {m}"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_feed_url_default_uses_uulf_uploads_playlist() {
+        let url = channel_feed_url("UC_x5XG1OV2P6uZZ5FSM9Ttw", false);
+        assert_eq!(url.host_str(), Some("www.youtube.com"));
+        assert_eq!(url.path(), "/feeds/videos.xml");
+        // UC + 22-char suffix → UULF + same suffix; excludes Shorts.
+        assert_eq!(url.query(), Some("playlist_id=UULF_x5XG1OV2P6uZZ5FSM9Ttw"),);
+    }
+
+    #[test]
+    fn channel_feed_url_include_shorts_keeps_channel_id_form() {
+        let url = channel_feed_url("UC_x5XG1OV2P6uZZ5FSM9Ttw", true);
+        assert_eq!(url.host_str(), Some("www.youtube.com"));
+        assert_eq!(url.path(), "/feeds/videos.xml");
+        assert_eq!(url.query(), Some("channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw"));
+    }
+
+    #[test]
+    fn empty_feed_with_entries_carries_entries_and_atom_type() {
+        let e = Entry {
+            id: "video-id".into(),
+            ..Entry::default()
+        };
+        let feed = empty_feed_with_entries(vec![e]);
+        assert!(matches!(feed.feed_type, FeedType::Atom));
+        assert_eq!(feed.entries.len(), 1);
+        assert_eq!(feed.entries[0].id, "video-id");
+    }
+
+    #[test]
+    fn fetcher_catalog_surface_matches_contract() {
+        let f = YoutubeChannelFetcher;
+        assert_eq!(f.name(), "youtube_channel");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(f.shapes(), SHAPES);
+        assert_eq!(
+            f.option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["channel_ids", "count", "include_shorts"],
+        );
+        assert!(f.description().contains("YouTube"));
+    }
+
+    #[test]
+    fn sample_body_covers_every_declared_shape() {
+        // Image-shaped samples require a real on-disk path, which test data can't supply
+        // portably — `random_cat` / `rss` skip it the same way.
+        let f = YoutubeChannelFetcher;
+        for shape in SHAPES {
+            if matches!(shape, Shape::Image) {
+                assert!(
+                    f.sample_body(*shape).is_none(),
+                    "Image sample should be None"
+                );
+                continue;
+            }
+            assert!(
+                f.sample_body(*shape).is_some(),
+                "sample missing for {:?}",
+                shape,
+            );
+        }
+        assert!(f.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn cache_key_changes_with_options_and_shape() {
+        let f = YoutubeChannelFetcher;
+        let base = f.cache_key(&ctx(
+            Some(Shape::LinkedTextBlock),
+            Some(parse_opts(
+                "channel_ids = [\"UC_x5XG1OV2P6uZZ5FSM9Ttw\"]\ncount = 5",
+            )),
+        ));
+        let same = f.cache_key(&ctx(
+            Some(Shape::LinkedTextBlock),
+            Some(parse_opts(
+                "channel_ids = [\"UC_x5XG1OV2P6uZZ5FSM9Ttw\"]\ncount = 5",
+            )),
+        ));
+        let different_shape = f.cache_key(&ctx(
+            Some(Shape::Timeline),
+            Some(parse_opts(
+                "channel_ids = [\"UC_x5XG1OV2P6uZZ5FSM9Ttw\"]\ncount = 5",
+            )),
+        ));
+        let different_channel = f.cache_key(&ctx(
+            Some(Shape::LinkedTextBlock),
+            Some(parse_opts(
+                "channel_ids = [\"UCXuqSBlHAE6Xw-yeJA0Tunw\"]\ncount = 5",
+            )),
+        ));
+        assert_eq!(base, same);
+        assert_ne!(base, different_shape);
+        assert_ne!(base, different_channel);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_missing_channel_ids_before_network() {
+        let err = YoutubeChannelFetcher
+            .fetch(&ctx(None, Some(parse_opts("count = 3"))))
+            .await
+            .unwrap_err();
+        match err {
+            FetchError::Failed(m) => assert!(m.contains("channel_ids"), "msg: {m}"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_channel_id_before_network() {
+        let err = YoutubeChannelFetcher
+            .fetch(&ctx(
+                None,
+                Some(parse_opts("channel_ids = [\"not-a-channel\"]")),
+            ))
+            .await
+            .unwrap_err();
+        match err {
+            FetchError::Failed(m) => assert!(m.contains("invalid channel_id"), "msg: {m}"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    /// Live smoke test against Google Developers' channel. `#[ignore]` keeps CI offline-safe;
+    /// run with `cargo test -- --ignored fetcher::youtube::tests::live_google_developers_channel`.
+    /// Prints the upstream error message on failure so a YouTube outage (the endpoint has
+    /// been intermittently 404-ing across all clients since late 2025; see glanceapp/glance
+    /// #910) is distinguishable from an empty feed.
+    #[tokio::test]
+    #[ignore]
+    async fn live_google_developers_channel_returns_entries() {
+        let ids = vec!["UC_x5XG1OV2P6uZZ5FSM9Ttw".to_string()];
+        match fetch_and_merge(&ids, false).await {
+            Ok(feed) => {
+                assert!(
+                    !feed.entries.is_empty(),
+                    "expected at least one upload from Google Developers",
+                );
+                for e in feed.entries.iter().take(3) {
+                    eprintln!(
+                        "{}  {:?}",
+                        e.title.as_ref().map(|t| t.content.as_str()).unwrap_or(""),
+                        e.published.map(|d| d.to_rfc3339()),
+                    );
+                }
+            }
+            Err(e) => panic!("youtube_channel live fetch failed: {e}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New \`youtube_channel\` fetcher: recent uploads from one or more public YouTube channels, merged newest-first. No API key, no OAuth.
- \`Safety::Safe\` — host hardcoded to \`www.youtube.com\`; each \`channel_id\` is regex-validated to \`^UC[A-Za-z0-9_-]{22}$\` before it touches the URL.
- Multi-channel = parallel fetch + merge by \`published\` desc. Per-channel failures fall through silently when at least one channel succeeds; only all-fail surfaces an error so a YouTube outage is visible (the endpoint is intermittently broken in 2026 — see [glanceapp/glance#910](https://github.com/glanceapp/glance/issues/910); uptime sits around 95% over the last 3 weeks).
- Adopts the glanceapp/glance trick: \`include_shorts = false\` (default) rewrites \`UC...\` → \`UULF...\` and queries \`?playlist_id=UULF...\`, the channel's auto-generated long-form-uploads playlist, which excludes Shorts. \`include_shorts = true\` falls back to the raw \`?channel_id=\` feed.
- Eight shapes (\`linked_text_block\` default + \`text_block\` / \`text\` / \`markdown_text_block\` / \`image_linked_list\` / \`entries\` / \`image\` / \`timeline\`) via five new helpers added to the shared \`feed::*\` pipeline. \`rss\` and the \`news_*\` family widen their \`SHAPES\` lists in lockstep, so all 93 news sources gain the same eight shapes too.

Ticks the \`youtube_channel\` and \`youtube_channels\` boxes on #67 — both collapse into one fetcher since \`channel_ids: Vec<String>\` covers single- and multi-channel cases.

## Catalog surface

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | \`linked_text_block\`, \`text_block\`, \`text\`, \`markdown_text_block\`, \`image_linked_list\`, \`entries\`, \`image\`, \`timeline\` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| \`channel_ids\` | array of strings (UC… channel IDs) | yes | — | One or more YouTube channel IDs. Each must match \`UC\` + 22 chars from \`[A-Za-z0-9_-]\`. |
| \`count\` | integer (1..=20) | no | 5 | Number of merged uploads to display, sorted newest first across all channels. |
| \`include_shorts\` | boolean | no | false | When \`false\`, uploads come from the \`UULF\` long-form-uploads playlist (excludes Shorts). \`true\` reads the channel feed directly and includes Shorts. |

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| \`linked_text_block\` | [\`list_links\`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/) |
| \`text_block\` | [\`list_plain\`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) + the \`animated_*\` wrappers |
| \`text\` | [\`text_plain\`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [\`text_ascii\`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), animation wrappers |
| \`markdown_text_block\` | [\`text_markdown\`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/) |
| \`image_linked_list\` | [\`list_cards\`](https://splashboard.unhappychoice.com/reference/renderers/list/list_cards/) |
| \`entries\` | [\`grid_table\`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/) + animation wrappers |
| \`image\` | [\`media_image\`](https://splashboard.unhappychoice.com/reference/renderers/media/media_image/) + animation wrappers |
| \`timeline\` | [\`list_timeline\`](https://splashboard.unhappychoice.com/reference/renderers/list/list_timeline/) + animation wrappers |

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` (2188 passing, 0 failing, 1 \`#[ignore]\` live smoke test for the YouTube endpoint)
- [x] Catalog surface verified: \`cargo run --bin splashboard -- catalog fetcher youtube_channel\` lists all 8 shapes + 3 options + every compatible renderer
- [x] \`cargo xtask\` regenerates the reference doc cleanly
- [ ] End-to-end smoke test in a real terminal — endpoint is intermittently 404-ing today; the fetcher surfaces \`youtube_channel 404 Not Found\` on those windows and renders cached / live entries when the endpoint is up

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * YouTube channel support: fetch public YouTube Atom feeds with configurable channel options including Shorts inclusion.
  * Multiple display formats: expanded feed rendering to support text, entries, timeline, and image layouts across news and RSS feeds.
  * Image caching: automated thumbnail retrieval and caching for feed entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/220)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->