### PR TITLE
fix(release): create release as draft and publish after assets upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.new_version }}
           name: Release ${{ steps.version.outputs.new_version }}
           body: ${{ steps.extract_notes.outputs.RELEASE_NOTES }}
-          draft: false
+          draft: true
           prerelease: false
 
   build-and-upload:
@@ -186,6 +186,18 @@ jobs:
           asset_name: splashboard-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.zip
           asset_content_type: application/zip
 
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: [release, build-and-upload]
+    permissions:
+      contents: write
+    steps:
+      - name: Mark release as published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ needs.release.outputs.new_version }} --draft=false --repo ${{ github.repository }}
+
   publish-crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
@@ -248,7 +260,7 @@ jobs:
   update-homebrew:
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
-    needs: [release, build-and-upload]
+    needs: [release, publish-release]
     steps:
       - name: Checkout homebrew tap
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Create the GitHub Release as a draft (`draft: true`) so the `releases/latest` API keeps returning the previous version while binaries are still being built and uploaded.
- Add a new `publish-release` job that runs after `build-and-upload` and flips the draft to published via `gh release edit --draft=false`.
- Move `update-homebrew` to depend on `publish-release` since it `curl`s the public asset URLs (which 404 while the release is still draft).

## Why

Today the release job creates a published release immediately, but the matrix build (`build-and-upload`) takes several minutes. During that window, `install.sh` resolves the new tag from `releases/latest` and tries to download `splashboard-vX.Y.Z-<platform>.tar.gz`, which doesn't exist yet → install fails for anyone hitting the install script during that window.

A draft release is excluded from `releases/latest`, so the install script transparently keeps installing the previous version until the new one is fully ready.

## Test plan

- [ ] Next manual release dispatch: confirm the GitHub release shows up as Draft initially, then flips to Latest after `build-and-upload` completes.
- [ ] Confirm `curl -sL https://api.github.com/repos/unhappychoice/splashboard/releases/latest` returns the previous version while the new draft is in-flight.
- [ ] Confirm `update-homebrew` still runs and tags pass (relies on public asset URLs being downloadable).
- [ ] Confirm `update-flake-hashes` still works (uses `nix flake prefetch github:.../$VERSION` — only needs the git tag, which is pushed before the release is created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow enhanced with a staged publication process: GitHub releases are now initially created as drafts before being finalized and automatically published
  * Release pipeline job dependencies optimized to ensure correct execution ordering between release publication and dependent downstream automation tasks

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/221)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->