### PR TITLE
feat(runtime): make scrollback flush opt-in via general.flush_to_scrollback

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,15 @@ pub struct General {
     /// `true`. Set to `false` to disable per-`cd` repaints without unwiring the shell rc.
     #[serde(default = "default_true")]
     pub auto_on_cd: bool,
+    /// When the configured dashboard is taller than the terminal viewport, push the
+    /// overflowing top rows into shell scrollback (so the user can scroll up to see them)
+    /// instead of just clipping with a `… +N rows` hint. Default `false`: the flush path
+    /// drags every renderer through ratatui's `insert_before` write loop, which doesn't
+    /// honour `Cell::skip` and visibly overdraws stateful image protocols (kitty / iTerm2 /
+    /// sixel) in the scrollback portion. Opt in only when the dashboard is text-only and
+    /// you specifically want the overflow in scrollback.
+    #[serde(default)]
+    pub flush_to_scrollback: bool,
 }
 
 fn default_true() -> bool {
@@ -97,6 +106,7 @@ impl Default for General {
             locale: None,
             auto_home: true,
             auto_on_cd: true,
+            flush_to_scrollback: false,
         }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -810,11 +810,16 @@ fn draw_final<B: Backend>(
     Ok(())
 }
 
-/// End-of-run draw: when the configured height doesn't fit the terminal, flush the top rows
-/// into scrollback via [`Terminal::insert_before`] and repaint the viewport with the bottom
-/// slice — no clip hint. This way the animation plays in the clamped viewport, then scrolls up
-/// at exit so the full splash is visible (bottom on screen, rest scrollable). When the layout
-/// fits, falls through to the regular [`draw_final`].
+/// End-of-run draw. By default, when the configured height doesn't fit the terminal, the
+/// overflow rows are dropped and the bottom of the viewport carries a `… +N rows` clip hint
+/// — same behaviour as the animation-loop frames. With `general.flush_to_scrollback = true`,
+/// the top rows are pushed into shell scrollback via [`Terminal::insert_before`] and the
+/// viewport repaints with the bottom slice (full splash visible by scrolling up).
+///
+/// Flush is off by default because ratatui's `insert_before` write loop doesn't honour
+/// `Cell::skip`, which `ratatui-image`'s stateful protocols (kitty / iTerm2 / sixel) rely on
+/// to keep cells around the image untouched. The flush path overdraws those cells with
+/// spaces and visibly chews up the image.
 #[allow(clippy::too_many_arguments)]
 fn finalize_draw<B: Backend>(
     terminal: &mut Terminal<B>,
@@ -833,6 +838,20 @@ fn finalize_draw<B: Backend>(
     if scrollback_rows == 0 {
         return draw_final(
             terminal, root, payloads, specs, registry, theme, general, padding, 0, loading,
+        );
+    }
+    if !general.flush_to_scrollback {
+        return draw_final(
+            terminal,
+            root,
+            payloads,
+            specs,
+            registry,
+            theme,
+            general,
+            padding,
+            scrollback_rows + 1,
+            loading,
         );
     }
     flush_full_to_scrollback(
@@ -1331,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn finalize_draw_flushes_top_rows_and_reveals_bottom() {
+    fn finalize_draw_flushes_top_rows_and_reveals_bottom_when_opted_in() {
         let root = single_widget_tree("x");
         let mut payloads = HashMap::new();
         payloads.insert(
@@ -1342,6 +1361,57 @@ mod tests {
         let registry = render::Registry::with_builtins();
         // 10-row terminal, 4-row inline viewport, 8-row requested layout: 4 rows are pushed to
         // scrollback (rows r0..r3), bottom 4 rows (r4..r7) land in the viewport. No clip hint.
+        let backend = TestBackend::new(20, 10);
+        let mut terminal = make_terminal(backend, 4).unwrap();
+        let theme = Theme::default();
+        let loading = HashMap::new();
+        let general = General {
+            flush_to_scrollback: true,
+            ..General::default()
+        };
+        finalize_draw(
+            &mut terminal,
+            &root,
+            &payloads,
+            &specs,
+            &registry,
+            &theme,
+            &general,
+            (0, 0),
+            8,
+            4,
+            &loading,
+        )
+        .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let rows: Vec<String> = (0..buf.area.height)
+            .map(|y| row_text(&buf, y).trim_end().to_string())
+            .collect();
+        let combined = rows.join("\n");
+        assert!(
+            rows.iter().any(|r| r.contains("r7")),
+            "bottom row r7 missing: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|r| r.contains("r0")),
+            "scrollback row r0 missing: {rows:?}"
+        );
+        assert!(
+            !combined.contains("…"),
+            "clip hint should be suppressed after flush: {combined:?}"
+        );
+    }
+
+    #[test]
+    fn finalize_draw_defaults_to_clip_hint_when_taller_than_viewport() {
+        let root = single_widget_tree("x");
+        let mut payloads = HashMap::new();
+        payloads.insert(
+            "x".into(),
+            text_block_payload(&["r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7"]),
+        );
+        let specs = HashMap::new();
+        let registry = render::Registry::with_builtins();
         let backend = TestBackend::new(20, 10);
         let mut terminal = make_terminal(backend, 4).unwrap();
         let theme = Theme::default();
@@ -1366,16 +1436,12 @@ mod tests {
             .collect();
         let combined = rows.join("\n");
         assert!(
-            rows.iter().any(|r| r.contains("r7")),
-            "bottom row r7 missing: {rows:?}"
+            combined.contains("…"),
+            "clip hint should fire when flush is off: {combined:?}"
         );
         assert!(
-            rows.iter().any(|r| r.contains("r0")),
-            "scrollback row r0 missing: {rows:?}"
-        );
-        assert!(
-            !combined.contains("…"),
-            "clip hint should be suppressed after flush: {combined:?}"
+            !rows.iter().any(|r| r.contains("r7")),
+            "bottom rows should be clipped (not flushed to scrollback): {rows:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `general.flush_to_scrollback` (default `false`). When the configured dashboard is taller than the viewport, the default now mirrors what the animation loop already does: clip the overflow and show a `… +N rows` hint at the bottom of the viewport.
- Opt in (`flush_to_scrollback = true`) for the old behaviour: push the top rows into shell scrollback via `Terminal::insert_before`. Recommended only for text-only dashboards.

Closes #222.

## Why

The flush path runs the rendered buffer through ratatui's `insert_before`, which writes every cell verbatim and ignores `Cell::skip`:

- `ratatui-image`'s kitty / iTerm2 / sixel protocols leave the cells around their image-protocol escape marked with `set_skip(true)`. The flush overdraws those cells with spaces, visibly chewing the image.
- When `requested_height` is much larger than the terminal, `viewport_top` collapses to 1, so the scroll loop turns into single-row DECSTBM pushes that many terminals don't honour at all — every flushed row is silently dropped. Symptom: a fixed number of top rows go missing, proportional to terminal height. We saw this in practice with the `scrolling-regions` experiment in #223.

The clip-hint path is what the animation loop has always used during the wait window; the worst that happens is the bottom-of-viewport hint tells the user how many rows didn't fit. No images chewed up, no rows disappeared into the void.

## Behaviour matrix

| dashboard fits viewport? | `flush_to_scrollback` | result |
|---|---|---|
| yes | (any) | full dashboard rendered, no hint |
| no | `false` (default) | top rows shown + bottom row carries `… +N rows` hint |
| no | `true` | top rows pushed to scrollback via `insert_before`, viewport shows bottom slice — current behaviour |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (existing `finalize_draw_flushes_top_rows_and_reveals_bottom` renamed and gated behind `flush_to_scrollback = true`; new `finalize_draw_defaults_to_clip_hint_when_taller_than_viewport` covers the new default)
- [ ] Smoke-test with a dashboard taller than the terminal viewport: confirm clip hint appears and images render fully.
- [ ] Smoke-test with `general.flush_to_scrollback = true` on a text-only dashboard: confirm scrollback flush still works as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `flush_to_scrollback` configuration option to control output display behavior when layouts exceed viewport height. Disabled by default, showing a row-count indicator; enable it to flush excess content to scrollback history instead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->