### PR TITLE
fix(fetcher): align system kind fallbacks with `(unset)` convention

### DIFF
--- a/src/fetcher/system.rs
+++ b/src/fetcher/system.rs
@@ -471,7 +471,7 @@ fn detect_terminal() -> String {
         Some("Hyper") => "Hyper".into(),
         Some("vscode") => "VS Code".into(),
         Some(other) if !other.is_empty() => other.into(),
-        _ => "terminal".into(),
+        _ => "(unset)".into(),
     }
 }
 
@@ -483,7 +483,7 @@ fn detect_shell() -> String {
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
         })
-        .unwrap_or_else(|| "shell".into())
+        .unwrap_or_else(|| "(unset)".into())
 }
 
 fn parse_options<T: serde::de::DeserializeOwned + Default>(
@@ -1573,7 +1573,7 @@ mod tests {
             detect_terminal_with(&[("TERM_PROGRAM", "CustomTerm")]),
             "CustomTerm"
         );
-        assert_eq!(detect_terminal_with(&[]), "terminal");
+        assert_eq!(detect_terminal_with(&[]), "(unset)");
     }
 
     #[test]
@@ -1611,7 +1611,7 @@ mod tests {
         drop(_guard);
 
         let _guard = EnvGuard::set(&[("SHELL", None)]);
-        assert_eq!(detect_shell(), "shell");
+        assert_eq!(detect_shell(), "(unset)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`shell` returned `"shell"` and `terminal` returned `"terminal"` when their env signals were missing, producing `shell: shell` / `terminal: terminal` in widgets that pair the label with the value. Same usability bug already fixed for `editor` / `visual` / `pager` in #225, just not propagated to the pre-existing kinds.

Standardize on `"(unset)"` for env-driven kinds. Other fallbacks keep their distinct semantics so the meaning is readable from the output alone:

| Fallback | Meaning | Used by |
|---|---|---|
| `(unset)` | env var not set | `terminal`, `shell`, `editor`, `visual`, `pager` |
| `unknown` | read failed where the platform should expose it | `kernel_version`, `hostname`, `os`, `cpu_model`, `cpu_vendor` |
| `n/a` | platform doesn't expose the field | DMI kinds on macOS / Windows |
| `tty` | host has no DE / WM | `de` when XDG vars unset |

Spotted via the smoke test on #225.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (2200 tests, all green)
- [x] Updated `detect_terminal_with(&[])` and `detect_shell` (SHELL unset) assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal and shell detection fallback behavior to display "(unset)" instead of generic default names when values cannot be detected, providing clearer information about actual detection results.

* **Tests**
  * Updated unit tests to reflect new fallback values for terminal and shell detection scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->