### PR TITLE
docs: add Support section with star and share links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ ISC
 - [gitlogue](https://github.com/unhappychoice/gitlogue) — cinematic git history replay
 - [gittype](https://github.com/unhappychoice/gittype) — CLI typing game from your source code
 - [mdts](https://github.com/unhappychoice/mdts) — local Markdown tree server
+
+## Support
+
+If you find this project useful, please consider:
+
+- ⭐️ [Star on GitHub](https://github.com/unhappychoice/splashboard)
+- 🐦 [Share on X](https://x.com/intent/post?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8&url=https%3A//github.com/unhappychoice/splashboard&hashtags=splashboard)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8%20%23splashboard%20https%3A//github.com/unhappychoice/splashboard)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8%20%23splashboard%20https%3A//github.com/unhappychoice/splashboard)
+- 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/splashboard)
+- 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/splashboard)
+- 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/splashboard&t=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8)
+
+Every bit of support helps. Thanks!

--- a/README.md
+++ b/README.md
@@ -95,5 +95,7 @@ If you find this project useful, please consider:
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/splashboard)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/splashboard)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/splashboard&t=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8)
+- 💬 Drop it into your Discord server or developer chat
+- ✍️ Write about it on your blog or in a newsletter
 
 Every bit of support helps. Thanks!

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ ISC
 If you find this project useful, please consider:
 
 - ⭐️ [Star on GitHub](https://github.com/unhappychoice/splashboard)
-- 🐦 [Share on X](https://x.com/intent/post?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8&url=https%3A//github.com/unhappychoice/splashboard&hashtags=splashboard)
-- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8%20%23splashboard%20https%3A//github.com/unhappychoice/splashboard)
-- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8%20%23splashboard%20https%3A//github.com/unhappychoice/splashboard)
+- 🐦 [Share on X](https://x.com/intent/post?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8&url=https%3A//github.com/unhappychoice/splashboard&hashtags=splashboard,CLI,Rust,terminal)
+- 🦋 [Share on Bluesky](https://bsky.app/intent/compose?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8%20%23splashboard%20%23CLI%20%23Rust%20%23terminal%20https%3A//github.com/unhappychoice/splashboard)
+- 🧵 [Share on Threads](https://www.threads.net/intent/post?text=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8%20%23splashboard%20%23CLI%20%23Rust%20%23terminal%20https%3A//github.com/unhappychoice/splashboard)
 - 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A//github.com/unhappychoice/splashboard)
 - 📘 [Share on Facebook](https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/unhappychoice/splashboard)
 - 🟧 [Submit to Hacker News](https://news.ycombinator.com/submitlink?u=https%3A//github.com/unhappychoice/splashboard&t=splashboard%3A%20a%20customizable%20terminal%20splash%20screen%20with%20plugin-based%20data%20sources.%20Pretty%20up%20your%20shell%20startup%20%E2%9C%A8)


### PR DESCRIPTION
## Summary

- Add a Support section at the end of README with links to star the repo and share it on X, Bluesky, Threads, LinkedIn, Facebook, and Hacker News.
- Each share link is pre-filled with a short pitch and the `#splashboard` hashtag where supported.

## Test plan

- [x] README renders correctly on GitHub
- [ ] Each share link opens the target platform's composer with the expected text and URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)