### PR TITLE
feat(fetcher): complete the basic_* family (11 new fetchers, one per Shape)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      # cache-bin: false — never cache ~/.cargo/bin. Restoring it clobbers the fresh
+      # toolchain dtolnay/rust-toolchain just installed; a stale archive once left `cargo`
+      # acting as `rustup-init` on macOS. prefix-key bump abandons those poisoned v0 caches.
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1"
+          cache-bin: false
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -31,6 +37,9 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1"
+          cache-bin: false
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
@@ -47,6 +56,9 @@ jobs:
         with:
           components: ${{ matrix.os == 'ubuntu-latest' && 'llvm-tools-preview' || '' }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1"
+          cache-bin: false
       - if: matrix.os == 'ubuntu-latest'
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests

--- a/src/fetcher/basic/badge.rs
+++ b/src/fetcher/basic/badge.rs
@@ -1,0 +1,136 @@
+//! `basic_badge` — fixed status pill emitted from inline config. Common use: tagging a
+//! per-directory dashboard with the environment it represents (`staging`, `prod`, `WIP`).
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{BadgeData, Body, Payload, Status};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Badge];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "status",
+        type_hint: "\"ok\" | \"warn\" | \"error\"",
+        required: false,
+        default: Some("\"ok\""),
+        description: "Tone of the pill. Drives the renderer's colour pick (green / yellow / red).",
+    },
+    OptionSchema {
+        name: "label",
+        type_hint: "string",
+        required: true,
+        default: None,
+        description: "Short text shown inside the pill.",
+    },
+];
+
+pub struct BasicBadge;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub status: Option<Status>,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+impl RealtimeFetcher for BasicBadge {
+    fn name(&self) -> &str {
+        "basic_badge"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a single status pill from `[widget.options]`. `status` picks the tone (`ok` / `warn` / `error`), `label` the visible text. Right for tagging a per-directory splash with its environment (`staging`, `prod`), or pinning a stale-data warning."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Badge).then(|| {
+            Body::Badge(BadgeData {
+                status: Status::Warn,
+                label: "staging".into(),
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        let Some(label) = opts.label.filter(|l| !l.trim().is_empty()) else {
+            return common::placeholder("basic_badge: `label` is required");
+        };
+        common::bare(Body::Badge(BadgeData {
+            status: opts.status.unwrap_or(Status::Ok),
+            label,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicBadge.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        let f = BasicBadge;
+        assert_eq!(f.name(), "basic_badge");
+        assert_eq!(f.shapes(), &[Shape::Badge]);
+        assert_eq!(f.safety(), Safety::Safe);
+    }
+
+    #[test]
+    fn defaults_status_to_ok() {
+        let p = compute(r#"label = "ready""#);
+        assert_eq!(
+            p.body,
+            Body::Badge(BadgeData {
+                status: Status::Ok,
+                label: "ready".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_each_status_variant() {
+        for (raw, expected) in [
+            ("ok", Status::Ok),
+            ("warn", Status::Warn),
+            ("error", Status::Error),
+        ] {
+            let p = compute(&format!(r#"status = "{raw}"{NL}label = "x""#, NL = "\n"));
+            let Body::Badge(d) = p.body else {
+                panic!("expected badge");
+            };
+            assert_eq!(d.status, expected);
+        }
+    }
+
+    #[test]
+    fn missing_label_renders_placeholder() {
+        let p = BasicBadge.compute(&FetchContext::default());
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`label` is required"));
+    }
+}

--- a/src/fetcher/basic/badge.rs
+++ b/src/fetcher/basic/badge.rs
@@ -133,4 +133,13 @@ mod tests {
         };
         assert!(d.lines[0].contains("`label` is required"));
     }
+
+    #[test]
+    fn whitespace_only_label_renders_placeholder() {
+        let p = compute(r#"label = "   ""#);
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`label` is required"));
+    }
 }

--- a/src/fetcher/basic/bars.rs
+++ b/src/fetcher/basic/bars.rs
@@ -1,0 +1,135 @@
+//! `basic_bars` — labeled bars authored inline. Right for ad-hoc comparisons that don't
+//! warrant a dedicated fetcher (manual team-by-team counts, "books read per year", etc.).
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Bar, BarsData, Body, Payload};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Bars];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "bars",
+    type_hint: "list of {label, value: u64}",
+    required: false,
+    default: Some("[]"),
+    description: "Labeled bars. Order is preserved (sorting / ranking lives in the renderer via `style = \"medal\"` / `max_items`).",
+}];
+
+pub struct BasicBars;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub bars: Vec<BarConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BarConfig {
+    pub label: String,
+    pub value: u64,
+}
+
+impl RealtimeFetcher for BasicBars {
+    fn name(&self) -> &str {
+        "basic_bars"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a `Bars` payload from inline `[widget.options].bars = [{label, value}]`. Row order is preserved as authored; sorting / ranking is a renderer concern (`list_ranking`, `chart_bar`'s sort option)."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Bars).then(|| {
+            Body::Bars(BarsData {
+                bars: vec![
+                    Bar {
+                        label: "alice".into(),
+                        value: 12,
+                    },
+                    Bar {
+                        label: "bob".into(),
+                        value: 7,
+                    },
+                ],
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        common::bare(Body::Bars(BarsData {
+            bars: opts
+                .bars
+                .into_iter()
+                .map(|b| Bar {
+                    label: b.label,
+                    value: b.value,
+                })
+                .collect(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicBars.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicBars.name(), "basic_bars");
+        assert_eq!(BasicBars.shapes(), &[Shape::Bars]);
+    }
+
+    #[test]
+    fn emits_bars_preserving_input_order() {
+        let p = compute(
+            r#"
+            [[bars]]
+            label = "alice"
+            value = 12
+            [[bars]]
+            label = "bob"
+            value = 7
+            "#,
+        );
+        let Body::Bars(d) = p.body else {
+            panic!("expected Bars");
+        };
+        assert_eq!(d.bars.len(), 2);
+        assert_eq!(d.bars[0].label, "alice");
+        assert_eq!(d.bars[0].value, 12);
+        assert_eq!(d.bars[1].label, "bob");
+    }
+
+    #[test]
+    fn no_bars_yields_empty_payload() {
+        let p = BasicBars.compute(&FetchContext::default());
+        let Body::Bars(d) = p.body else {
+            panic!("expected Bars");
+        };
+        assert!(d.bars.is_empty());
+    }
+}

--- a/src/fetcher/basic/calendar.rs
+++ b/src/fetcher/basic/calendar.rs
@@ -109,10 +109,10 @@ impl RealtimeFetcher for BasicCalendar {
         if !(1..=12).contains(&month) {
             return common::placeholder("basic_calendar: `month` must be 1..=12");
         }
-        if let Some(d) = day {
-            if !(1..=31).contains(&d) {
-                return common::placeholder("basic_calendar: `day` must be 1..=31");
-            }
+        if let Some(d) = day
+            && !(1..=31).contains(&d)
+        {
+            return common::placeholder("basic_calendar: `day` must be 1..=31");
         }
         common::bare(Body::Calendar(CalendarData {
             year,

--- a/src/fetcher/basic/calendar.rs
+++ b/src/fetcher/basic/calendar.rs
@@ -1,0 +1,194 @@
+//! `basic_calendar` — month view authored inline. `year` / `month` / `day` default to today
+//! in the resolved timezone, so a fresh widget shows the current month without configuration;
+//! `events` highlights extra days.
+
+use chrono::Datelike;
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, CalendarData, Payload};
+use crate::render::Shape;
+use crate::time as t;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Calendar];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "year",
+        type_hint: "i32",
+        required: false,
+        default: Some("current year"),
+        description: "ISO year. Defaults to today's year in the resolved timezone.",
+    },
+    OptionSchema {
+        name: "month",
+        type_hint: "u8 (1..=12)",
+        required: false,
+        default: Some("current month"),
+        description: "Month number. Defaults to today's month.",
+    },
+    OptionSchema {
+        name: "day",
+        type_hint: "u8 (1..=31)",
+        required: false,
+        default: Some("current day"),
+        description: "Focused / highlighted day. Defaults to today.",
+    },
+    OptionSchema {
+        name: "events",
+        type_hint: "list of u8 (1..=31)",
+        required: false,
+        default: Some("[]"),
+        description: "Additional days to highlight in the month grid (1..=31).",
+    },
+    OptionSchema {
+        name: "timezone",
+        type_hint: "IANA timezone",
+        required: false,
+        default: Some("[general].timezone"),
+        description: "Timezone for the today fallback. Omit to use the project-wide setting.",
+    },
+];
+
+pub struct BasicCalendar;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub year: Option<i32>,
+    #[serde(default)]
+    pub month: Option<u8>,
+    #[serde(default)]
+    pub day: Option<u8>,
+    #[serde(default)]
+    pub events: Vec<u8>,
+    #[serde(default)]
+    pub timezone: Option<String>,
+}
+
+impl RealtimeFetcher for BasicCalendar {
+    fn name(&self) -> &str {
+        "basic_calendar"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a `Calendar` payload from inline options. `year` / `month` / `day` default to today in the resolved timezone so a fresh config shows the current month with today highlighted; `events` lists extra days to mark."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Calendar).then(|| {
+            Body::Calendar(CalendarData {
+                year: 2026,
+                month: 5,
+                day: Some(14),
+                events: vec![3, 14, 27],
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        let tz = opts.timezone.as_deref().or(ctx.timezone.as_deref());
+        let now = t::now_in(tz);
+        let year = opts.year.unwrap_or(now.year());
+        let month = opts.month.unwrap_or(now.month() as u8);
+        let day = opts.day.or(Some(now.day() as u8));
+        if !(1..=12).contains(&month) {
+            return common::placeholder("basic_calendar: `month` must be 1..=12");
+        }
+        if let Some(d) = day {
+            if !(1..=31).contains(&d) {
+                return common::placeholder("basic_calendar: `day` must be 1..=31");
+            }
+        }
+        common::bare(Body::Calendar(CalendarData {
+            year,
+            month,
+            day,
+            events: opts.events,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicCalendar.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicCalendar.name(), "basic_calendar");
+        assert_eq!(BasicCalendar.shapes(), &[Shape::Calendar]);
+    }
+
+    #[test]
+    fn explicit_year_month_day_overrides_today() {
+        let p = compute(
+            r#"
+            year = 2024
+            month = 6
+            day = 15
+            events = [1, 7, 14]
+            "#,
+        );
+        assert_eq!(
+            p.body,
+            Body::Calendar(CalendarData {
+                year: 2024,
+                month: 6,
+                day: Some(15),
+                events: vec![1, 7, 14],
+            })
+        );
+    }
+
+    #[test]
+    fn no_options_defaults_to_today() {
+        let p = BasicCalendar.compute(&FetchContext::default());
+        let Body::Calendar(d) = p.body else {
+            panic!("expected Calendar");
+        };
+        // Year / month / day come from the system clock — assert they're populated and in range
+        // rather than testing exact values (which would make the test flaky on month boundaries).
+        assert!(d.year >= 2020);
+        assert!((1..=12).contains(&d.month));
+        assert!(matches!(d.day, Some(d) if (1..=31).contains(&d)));
+    }
+
+    #[test]
+    fn invalid_month_renders_placeholder() {
+        let p = compute(r#"month = 13"#);
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`month` must be 1..=12"));
+    }
+
+    #[test]
+    fn invalid_day_renders_placeholder() {
+        let p = compute(r#"day = 32"#);
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`day` must be 1..=31"));
+    }
+}

--- a/src/fetcher/basic/common.rs
+++ b/src/fetcher/basic/common.rs
@@ -1,0 +1,40 @@
+//! Shared helpers for the `basic_*` family. Each sibling parses its own typed `Options` struct
+//! from `ctx.options` via [`parse_options`]; invalid TOML surfaces the same two-line warning
+//! placeholder as the `clock_*` family so misconfigurations stay visible.
+
+use crate::payload::{Body, Payload, TextBlockData};
+
+pub fn parse_options<T: serde::de::DeserializeOwned + Default>(
+    raw: Option<&toml::Value>,
+) -> Result<T, String> {
+    match raw {
+        None => Ok(T::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+pub fn placeholder(msg: &str) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body: Body::TextBlock(TextBlockData {
+            lines: vec![
+                format!("⚠ {msg}"),
+                "check [widget.options] in config".into(),
+            ],
+        }),
+    }
+}
+
+pub fn bare(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}

--- a/src/fetcher/basic/entries.rs
+++ b/src/fetcher/basic/entries.rs
@@ -1,0 +1,157 @@
+//! `basic_entries` — key/value rows authored inline. The TOML twin of `grid_table`'s consumer
+//! shape, for project-facts panels (owner / language / license) or any small reference table.
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, EntriesData, Entry, Payload, Status};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Entries];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "entries",
+    type_hint: "list of {key, value?, status?}",
+    required: false,
+    default: Some("[]"),
+    description: "Key/value rows. `status` (ok / warn / error) tints the row in renderers that surface it.",
+}];
+
+pub struct BasicEntries;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub entries: Vec<EntryConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EntryConfig {
+    pub key: String,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub status: Option<Status>,
+}
+
+impl RealtimeFetcher for BasicEntries {
+    fn name(&self) -> &str {
+        "basic_entries"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders an `Entries` payload from inline `[widget.options].entries = [{key, value?, status?}]`. Right for project-facts panels (owner / language / license / docs-link) or any small reference table — the data is stable enough to live in TOML."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Entries).then(|| {
+            Body::Entries(EntriesData {
+                items: vec![
+                    Entry {
+                        key: "Owner".into(),
+                        value: Some("team-alpha".into()),
+                        status: None,
+                    },
+                    Entry {
+                        key: "Lang".into(),
+                        value: Some("Rust".into()),
+                        status: None,
+                    },
+                ],
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        common::bare(Body::Entries(EntriesData {
+            items: opts
+                .entries
+                .into_iter()
+                .map(|e| Entry {
+                    key: e.key,
+                    value: e.value,
+                    status: e.status,
+                })
+                .collect(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicEntries.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicEntries.name(), "basic_entries");
+        assert_eq!(BasicEntries.shapes(), &[Shape::Entries]);
+    }
+
+    #[test]
+    fn emits_entries_preserving_input_order() {
+        let p = compute(
+            r#"
+            [[entries]]
+            key = "Owner"
+            value = "team-alpha"
+            [[entries]]
+            key = "Lang"
+            value = "Rust"
+            status = "ok"
+            "#,
+        );
+        let Body::Entries(d) = p.body else {
+            panic!("expected Entries");
+        };
+        assert_eq!(d.items.len(), 2);
+        assert_eq!(d.items[0].key, "Owner");
+        assert_eq!(d.items[0].value.as_deref(), Some("team-alpha"));
+        assert_eq!(d.items[1].status, Some(Status::Ok));
+    }
+
+    #[test]
+    fn value_is_optional() {
+        let p = compute(
+            r#"
+            [[entries]]
+            key = "WIP"
+            "#,
+        );
+        let Body::Entries(d) = p.body else {
+            panic!("expected Entries");
+        };
+        assert_eq!(d.items[0].key, "WIP");
+        assert!(d.items[0].value.is_none());
+    }
+
+    #[test]
+    fn no_entries_yields_empty_payload() {
+        let p = BasicEntries.compute(&FetchContext::default());
+        let Body::Entries(d) = p.body else {
+            panic!("expected Entries");
+        };
+        assert!(d.items.is_empty());
+    }
+}

--- a/src/fetcher/basic/heatmap.rs
+++ b/src/fetcher/basic/heatmap.rs
@@ -1,0 +1,149 @@
+//! `basic_heatmap` — 2D intensity grid authored inline. Right for habit trackers, fixed
+//! sample heatmaps, and any small grid the user wants to ship in TOML rather than via the
+//! `basic_read_store` file-based variant.
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, HeatmapData, Payload};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Heatmap];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "cells",
+        type_hint: "2D list of u32, row-major",
+        required: false,
+        default: Some("[]"),
+        description: "Cell intensities. `cells[row][col]` — rows can be ragged but the renderer treats trailing missing cells as zeros.",
+    },
+    OptionSchema {
+        name: "thresholds",
+        type_hint: "list of u32",
+        required: false,
+        default: None,
+        description: "Explicit bucket boundaries. When omitted, `grid_heatmap` auto-quartiles from the data.",
+    },
+    OptionSchema {
+        name: "row_labels",
+        type_hint: "list of strings",
+        required: false,
+        default: None,
+        description: "One label per row. Renderers display these along the left edge when space allows.",
+    },
+    OptionSchema {
+        name: "col_labels",
+        type_hint: "list of strings",
+        required: false,
+        default: None,
+        description: "One label per column. Renderers display these along the top edge when space allows.",
+    },
+];
+
+pub struct BasicHeatmap;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub cells: Vec<Vec<u32>>,
+    #[serde(default)]
+    pub thresholds: Option<Vec<u32>>,
+    #[serde(default)]
+    pub row_labels: Option<Vec<String>>,
+    #[serde(default)]
+    pub col_labels: Option<Vec<String>>,
+}
+
+impl RealtimeFetcher for BasicHeatmap {
+    fn name(&self) -> &str {
+        "basic_heatmap"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a `Heatmap` payload from inline `[widget.options]`. `cells` is a row-major 2D grid of `u32` intensities; `thresholds` / `row_labels` / `col_labels` are optional. Right for habit trackers, sample / demo grids, or any small fixed heatmap the user wants to keep in TOML."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Heatmap).then(|| {
+            Body::Heatmap(HeatmapData {
+                cells: vec![vec![0, 1, 2], vec![1, 3, 1], vec![2, 2, 4]],
+                thresholds: None,
+                row_labels: None,
+                col_labels: None,
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        common::bare(Body::Heatmap(HeatmapData {
+            cells: opts.cells,
+            thresholds: opts.thresholds,
+            row_labels: opts.row_labels,
+            col_labels: opts.col_labels,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicHeatmap.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicHeatmap.name(), "basic_heatmap");
+        assert_eq!(BasicHeatmap.shapes(), &[Shape::Heatmap]);
+    }
+
+    #[test]
+    fn emits_grid_with_optional_labels_and_thresholds() {
+        let p = compute(
+            r#"
+            cells = [[0, 1, 2], [1, 3, 1]]
+            thresholds = [1, 2, 3]
+            row_labels = ["Mon", "Tue"]
+            col_labels = ["W1", "W2", "W3"]
+            "#,
+        );
+        let Body::Heatmap(d) = p.body else {
+            panic!("expected Heatmap");
+        };
+        assert_eq!(d.cells, vec![vec![0, 1, 2], vec![1, 3, 1]]);
+        assert_eq!(d.thresholds, Some(vec![1, 2, 3]));
+        assert_eq!(d.row_labels, Some(vec!["Mon".into(), "Tue".into()]));
+        assert_eq!(
+            d.col_labels,
+            Some(vec!["W1".into(), "W2".into(), "W3".into()])
+        );
+    }
+
+    #[test]
+    fn no_options_yields_empty_grid() {
+        let p = BasicHeatmap.compute(&FetchContext::default());
+        let Body::Heatmap(d) = p.body else {
+            panic!("expected Heatmap");
+        };
+        assert!(d.cells.is_empty());
+    }
+}

--- a/src/fetcher/basic/image.rs
+++ b/src/fetcher/basic/image.rs
@@ -1,0 +1,113 @@
+//! `basic_image` — render a file from disk as the splash image. The escape hatch for repo logos
+//! and per-directory branding without writing a fetcher.
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, ImageData, Payload};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Image];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "path",
+    type_hint: "string (file path)",
+    required: true,
+    default: None,
+    description: "Absolute or `~`-expanded path to a PNG / JPEG / GIF / WebP. Loaded by `media_image` at draw time; this fetcher only passes the string through.",
+}];
+
+pub struct BasicImage;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+impl RealtimeFetcher for BasicImage {
+    fn name(&self) -> &str {
+        "basic_image"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Emits a user-configured file path as an `Image` payload. Right for repo logos, per-directory branding, or any static image — the renderer (`media_image`) is what actually loads the bytes. Path expansion is deferred to the renderer so this fetcher is pure and infallible at compute time."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Image).then(|| {
+            Body::Image(ImageData {
+                path: "/path/to/logo.png".into(),
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        match opts.path.filter(|p| !p.trim().is_empty()) {
+            Some(path) => common::bare(Body::Image(ImageData { path })),
+            None => common::placeholder("basic_image: `path` is required"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract() {
+        let f = BasicImage;
+        assert_eq!(f.name(), "basic_image");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.shapes(), &[Shape::Image]);
+    }
+
+    #[test]
+    fn emits_image_body_with_supplied_path() {
+        let p = BasicImage.compute(&FetchContext {
+            options: Some(toml::from_str(r#"path = "/tmp/logo.png""#).unwrap()),
+            ..Default::default()
+        });
+        assert_eq!(
+            p.body,
+            Body::Image(ImageData {
+                path: "/tmp/logo.png".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn missing_path_renders_placeholder() {
+        let p = BasicImage.compute(&FetchContext::default());
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`path` is required"));
+    }
+
+    #[test]
+    fn blank_path_renders_placeholder() {
+        let p = BasicImage.compute(&FetchContext {
+            options: Some(toml::from_str(r#"path = "   ""#).unwrap()),
+            ..Default::default()
+        });
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`path` is required"));
+    }
+}

--- a/src/fetcher/basic/links.rs
+++ b/src/fetcher/basic/links.rs
@@ -253,6 +253,49 @@ mod tests {
     }
 
     #[test]
+    fn text_block_shape_lists_labels_without_urls() {
+        let p = BasicLinks.compute(&ctx(
+            opts(
+                r#"
+                [[links]]
+                label = "GitHub"
+                url = "https://github.com/"
+                [[links]]
+                label = "Docs"
+                "#,
+            ),
+            Some(Shape::TextBlock),
+        ));
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected TextBlock");
+        };
+        assert_eq!(d.lines, vec!["GitHub".to_string(), "Docs".to_string()]);
+    }
+
+    #[test]
+    fn entries_shape_maps_label_to_optional_url() {
+        let p = BasicLinks.compute(&ctx(
+            opts(
+                r#"
+                [[links]]
+                label = "GitHub"
+                url = "https://github.com/"
+                [[links]]
+                label = "Docs"
+                "#,
+            ),
+            Some(Shape::Entries),
+        ));
+        let Body::Entries(d) = p.body else {
+            panic!("expected Entries");
+        };
+        assert_eq!(d.items[0].key, "GitHub");
+        assert_eq!(d.items[0].value.as_deref(), Some("https://github.com/"));
+        assert_eq!(d.items[1].key, "Docs");
+        assert!(d.items[1].value.is_none());
+    }
+
+    #[test]
     fn missing_options_yields_empty_list() {
         let p = BasicLinks.compute(&FetchContext::default());
         let Body::LinkedTextBlock(d) = p.body else {

--- a/src/fetcher/basic/links.rs
+++ b/src/fetcher/basic/links.rs
@@ -1,0 +1,285 @@
+//! `basic_links` — user-authored bookmark list emitted as the row-shaped variants. Pairs with a
+//! per-directory `.splashboard/dashboard.toml` so a repo can ship pinned URLs (docs, CI,
+//! dashboards) that surface automatically on `cd`.
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, Payload, TextBlockData, TextData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::ImageLinkedList,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "links",
+    type_hint: "list of {label, url?, subtitle?, thumbnail?}",
+    required: false,
+    default: Some("[]"),
+    description: "Pinned links rendered as rows. `label` is required; `url` makes the row OSC8-clickable in `LinkedTextBlock` / `ImageLinkedList`; `thumbnail` (file path) lights up the `ImageLinkedList` variant.",
+}];
+
+pub struct BasicLinks;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub links: Vec<LinkConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LinkConfig {
+    pub label: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub thumbnail: Option<String>,
+}
+
+impl RealtimeFetcher for BasicLinks {
+    fn name(&self) -> &str {
+        "basic_links"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a user-authored list of pinned links from `[widget.options].links`. `LinkedTextBlock` (default) and `ImageLinkedList` wrap rows with a URL in OSC 8 escape sequences so terminals surface them as clickable; `Text` headlines the first label, `TextBlock` is plain labels, `MarkdownTextBlock` emits `- [label](url)` bullets, `Entries` is label → url rows. Right for per-directory bookmarks (repo docs, CI dashboard, deploy console)."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::LinkedTextBlock => samples::linked_text_block(&[
+                ("GitHub", Some("https://github.com/")),
+                ("Docs", Some("https://example.com/docs")),
+            ]),
+            Shape::Text => samples::text("GitHub"),
+            Shape::TextBlock => samples::text_block(&["GitHub", "Docs"]),
+            Shape::MarkdownTextBlock => samples::markdown(
+                "- [GitHub](https://github.com/)\n- [Docs](https://example.com/docs)",
+            ),
+            Shape::Entries => samples::entries(&[
+                ("GitHub", "https://github.com/"),
+                ("Docs", "https://example.com/docs"),
+            ]),
+            Shape::ImageLinkedList => samples::image_linked_list(&[
+                ("GitHub", Some("https://github.com/"), None, Some("source")),
+                (
+                    "Docs",
+                    Some("https://example.com/docs"),
+                    None,
+                    Some("reference"),
+                ),
+            ]),
+            _ => return None,
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        common::bare(body_for_shape(&opts.links, shape))
+    }
+}
+
+fn body_for_shape(links: &[LinkConfig], shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: links.first().map(|l| l.label.clone()).unwrap_or_default(),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: links.iter().map(|l| l.label.clone()).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: links.iter().map(markdown_bullet).collect::<Vec<_>>().join("\n"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: links
+                .iter()
+                .map(|l| Entry {
+                    key: l.label.clone(),
+                    value: l.url.clone(),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::ImageLinkedList => Body::ImageLinkedList(ImageLinkedListData {
+            items: links
+                .iter()
+                .map(|l| ImageLinkedItem {
+                    title: l.label.clone(),
+                    url: l.url.clone(),
+                    thumbnail_path: l.thumbnail.clone(),
+                    subtitle: l.subtitle.clone(),
+                })
+                .collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: links
+                .iter()
+                .map(|l| LinkedLine {
+                    text: l.label.clone(),
+                    url: l.url.clone(),
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn markdown_bullet(link: &LinkConfig) -> String {
+    match &link.url {
+        Some(url) => format!("- [{}]({})", link.label, url),
+        None => format!("- {}", link.label),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(options: toml::Value, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "x".into(),
+            options: Some(options),
+            shape,
+            ..Default::default()
+        }
+    }
+
+    fn opts(toml_src: &str) -> toml::Value {
+        toml::from_str(toml_src).unwrap()
+    }
+
+    #[test]
+    fn contract() {
+        let f = BasicLinks;
+        assert_eq!(f.name(), "basic_links");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(f.shapes(), SHAPES);
+    }
+
+    #[test]
+    fn linked_text_block_default_wraps_rows_with_optional_urls() {
+        let p = BasicLinks.compute(&ctx(
+            opts(
+                r#"
+                [[links]]
+                label = "GitHub"
+                url = "https://github.com/"
+                [[links]]
+                label = "Local Notes"
+                "#,
+            ),
+            None,
+        ));
+        let Body::LinkedTextBlock(d) = p.body else {
+            panic!("expected LinkedTextBlock");
+        };
+        assert_eq!(d.items.len(), 2);
+        assert_eq!(d.items[0].text, "GitHub");
+        assert_eq!(d.items[0].url.as_deref(), Some("https://github.com/"));
+        assert_eq!(d.items[1].text, "Local Notes");
+        assert!(d.items[1].url.is_none());
+    }
+
+    #[test]
+    fn text_shape_headlines_first_link() {
+        let p = BasicLinks.compute(&ctx(
+            opts(
+                r#"
+                [[links]]
+                label = "Docs"
+                [[links]]
+                label = "CI"
+                "#,
+            ),
+            Some(Shape::Text),
+        ));
+        assert_eq!(p.body, Body::Text(TextData { value: "Docs".into() }));
+    }
+
+    #[test]
+    fn markdown_bullets_use_link_syntax_only_when_url_set() {
+        let p = BasicLinks.compute(&ctx(
+            opts(
+                r#"
+                [[links]]
+                label = "GitHub"
+                url = "https://github.com/"
+                [[links]]
+                label = "TODO"
+                "#,
+            ),
+            Some(Shape::MarkdownTextBlock),
+        ));
+        let Body::MarkdownTextBlock(d) = p.body else {
+            panic!("expected markdown");
+        };
+        assert_eq!(d.value, "- [GitHub](https://github.com/)\n- TODO");
+    }
+
+    #[test]
+    fn missing_options_yields_empty_list() {
+        let p = BasicLinks.compute(&FetchContext::default());
+        let Body::LinkedTextBlock(d) = p.body else {
+            panic!("expected LinkedTextBlock");
+        };
+        assert!(d.items.is_empty());
+    }
+
+    #[test]
+    fn unknown_option_key_renders_placeholder() {
+        let p = BasicLinks.compute(&ctx(opts(r#"bogus = "x""#), None));
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder TextBlock");
+        };
+        assert!(d.lines[0].contains("invalid options"));
+    }
+
+    #[test]
+    fn image_linked_list_carries_thumbnails_and_subtitles() {
+        let p = BasicLinks.compute(&ctx(
+            opts(
+                r#"
+                [[links]]
+                label = "Logo"
+                url = "https://example.com/"
+                subtitle = "tagline"
+                thumbnail = "/tmp/logo.png"
+                "#,
+            ),
+            Some(Shape::ImageLinkedList),
+        ));
+        let Body::ImageLinkedList(d) = p.body else {
+            panic!("expected ImageLinkedList");
+        };
+        assert_eq!(d.items[0].title, "Logo");
+        assert_eq!(d.items[0].thumbnail_path.as_deref(), Some("/tmp/logo.png"));
+        assert_eq!(d.items[0].subtitle.as_deref(), Some("tagline"));
+    }
+}

--- a/src/fetcher/basic/links.rs
+++ b/src/fetcher/basic/links.rs
@@ -115,7 +115,11 @@ fn body_for_shape(links: &[LinkConfig], shape: Shape) -> Body {
             lines: links.iter().map(|l| l.label.clone()).collect(),
         }),
         Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
-            value: links.iter().map(markdown_bullet).collect::<Vec<_>>().join("\n"),
+            value: links
+                .iter()
+                .map(markdown_bullet)
+                .collect::<Vec<_>>()
+                .join("\n"),
         }),
         Shape::Entries => Body::Entries(EntriesData {
             items: links
@@ -220,7 +224,12 @@ mod tests {
             ),
             Some(Shape::Text),
         ));
-        assert_eq!(p.body, Body::Text(TextData { value: "Docs".into() }));
+        assert_eq!(
+            p.body,
+            Body::Text(TextData {
+                value: "Docs".into()
+            })
+        );
     }
 
     #[test]

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -10,6 +10,7 @@ use super::RealtimeFetcher;
 
 pub mod badge;
 pub mod bars;
+pub mod calendar;
 pub mod common;
 pub mod entries;
 pub mod image;
@@ -21,6 +22,7 @@ pub mod timeline;
 
 pub use badge::BasicBadge;
 pub use bars::BasicBars;
+pub use calendar::BasicCalendar;
 pub use entries::BasicEntries;
 pub use image::BasicImage;
 pub use links::BasicLinks;
@@ -40,5 +42,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicNumbers),
         Arc::new(BasicPoints),
         Arc::new(BasicTimeline),
+        Arc::new(BasicCalendar),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -48,3 +48,141 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicHeatmap),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fetcher::{FetchContext, Safety};
+    use crate::payload::Body;
+    use crate::render::{Shape, shape_of};
+
+    const ALL_SHAPES: &[Shape] = &[
+        Shape::Text,
+        Shape::TextBlock,
+        Shape::MarkdownTextBlock,
+        Shape::LinkedTextBlock,
+        Shape::ImageLinkedList,
+        Shape::Entries,
+        Shape::Ratio,
+        Shape::NumberSeries,
+        Shape::PointSeries,
+        Shape::Bars,
+        Shape::Image,
+        Shape::Calendar,
+        Shape::Heatmap,
+        Shape::Badge,
+        Shape::Timeline,
+        Shape::Error,
+    ];
+
+    /// The family exists to make every payload `Shape` emittable from config alone. The three
+    /// text shapes (`Text` / `TextBlock` / `MarkdownTextBlock`) are already owned by the shipped
+    /// `basic_static`, and `Error` is the placeholder pseudo-shape — every *other* shape must be
+    /// reachable through some fetcher's `shapes()` here. Note `ImageLinkedList` rides along on
+    /// `basic_links` (same "list of links" data, thumbnail variant) rather than getting its own
+    /// fetcher, so this checks `shapes()` membership, not `default_shape()`.
+    #[test]
+    fn family_makes_every_non_text_payload_shape_reachable() {
+        let fetchers = realtime_fetchers();
+        let names: Vec<&str> = fetchers.iter().map(|f| f.name()).collect();
+        for expected in [
+            "basic_links",
+            "basic_image",
+            "basic_badge",
+            "basic_ratio",
+            "basic_bars",
+            "basic_entries",
+            "basic_numbers",
+            "basic_points",
+            "basic_timeline",
+            "basic_calendar",
+            "basic_heatmap",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "{expected} missing from realtime_fetchers()"
+            );
+        }
+
+        let owned_by_basic_static = [
+            Shape::Text,
+            Shape::TextBlock,
+            Shape::MarkdownTextBlock,
+            Shape::Error,
+        ];
+        for &shape in ALL_SHAPES {
+            if owned_by_basic_static.contains(&shape) {
+                continue;
+            }
+            assert!(
+                fetchers.iter().any(|f| f.shapes().contains(&shape)),
+                "no basic_* fetcher can emit {shape:?}"
+            );
+        }
+    }
+
+    /// Contract sweep over the whole family: `Safe`, `basic_` prefix, `default_shape` is a
+    /// member of `shapes()`, and `sample_body` returns `Some` with a matching `Body` for every
+    /// declared shape and `None` for every undeclared one.
+    #[test]
+    fn every_fetcher_satisfies_the_realtime_contract() {
+        for f in realtime_fetchers() {
+            let name = f.name();
+            assert!(name.starts_with("basic_"), "{name} missing basic_ prefix");
+            assert_eq!(f.safety(), Safety::Safe, "{name} must be Safe");
+            assert!(!f.shapes().is_empty(), "{name} declares no shapes");
+            assert!(
+                f.shapes().contains(&f.default_shape()),
+                "{name} default_shape() not in shapes()"
+            );
+            for &shape in ALL_SHAPES {
+                let declared = f.shapes().contains(&shape);
+                match f.sample_body(shape) {
+                    Some(body) => {
+                        assert!(
+                            declared,
+                            "{name} sample_body({shape:?}) is Some for an undeclared shape"
+                        );
+                        assert_eq!(
+                            shape_of(&body),
+                            shape,
+                            "{name} sample_body({shape:?}) returned a mismatched Body"
+                        );
+                    }
+                    None => assert!(
+                        !declared,
+                        "{name} declares {shape:?} but sample_body returned None"
+                    ),
+                }
+            }
+        }
+    }
+
+    /// Every fetcher's `Options` struct is `#[serde(deny_unknown_fields)]`, so a typo'd key
+    /// must surface the shared two-line placeholder rather than being silently ignored.
+    #[test]
+    fn every_fetcher_rejects_unknown_option_keys() {
+        let bogus: toml::Value =
+            toml::from_str("definitely_not_a_real_option = true").expect("valid toml");
+        for f in realtime_fetchers() {
+            let ctx = FetchContext {
+                options: Some(bogus.clone()),
+                ..Default::default()
+            };
+            match f.compute(&ctx).body {
+                Body::TextBlock(d) => assert!(
+                    d.lines
+                        .first()
+                        .is_some_and(|line| line.contains("invalid options")),
+                    "{} unknown-key placeholder missing 'invalid options': {:?}",
+                    f.name(),
+                    d.lines
+                ),
+                other => panic!(
+                    "{} should render a placeholder on an unknown option key, got {other:?}",
+                    f.name()
+                ),
+            }
+        }
+    }
+}

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use super::RealtimeFetcher;
 
 pub mod badge;
+pub mod bars;
 pub mod common;
 pub mod image;
 pub mod links;
 pub mod ratio;
 
 pub use badge::BasicBadge;
+pub use bars::BasicBars;
 pub use image::BasicImage;
 pub use links::BasicLinks;
 pub use ratio::BasicRatio;
@@ -25,5 +27,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicImage),
         Arc::new(BasicBadge),
         Arc::new(BasicRatio),
+        Arc::new(BasicBars),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -12,15 +12,18 @@ pub mod badge;
 pub mod common;
 pub mod image;
 pub mod links;
+pub mod ratio;
 
 pub use badge::BasicBadge;
 pub use image::BasicImage;
 pub use links::BasicLinks;
+pub use ratio::BasicRatio;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
     vec![
         Arc::new(BasicLinks),
         Arc::new(BasicImage),
         Arc::new(BasicBadge),
+        Arc::new(BasicRatio),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -9,10 +9,12 @@ use std::sync::Arc;
 use super::RealtimeFetcher;
 
 pub mod common;
+pub mod image;
 pub mod links;
 
+pub use image::BasicImage;
 pub use links::BasicLinks;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
-    vec![Arc::new(BasicLinks)]
+    vec![Arc::new(BasicLinks), Arc::new(BasicImage)]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -13,6 +13,7 @@ pub mod bars;
 pub mod calendar;
 pub mod common;
 pub mod entries;
+pub mod heatmap;
 pub mod image;
 pub mod links;
 pub mod numbers;
@@ -24,6 +25,7 @@ pub use badge::BasicBadge;
 pub use bars::BasicBars;
 pub use calendar::BasicCalendar;
 pub use entries::BasicEntries;
+pub use heatmap::BasicHeatmap;
 pub use image::BasicImage;
 pub use links::BasicLinks;
 pub use numbers::BasicNumbers;
@@ -43,5 +45,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicPoints),
         Arc::new(BasicTimeline),
         Arc::new(BasicCalendar),
+        Arc::new(BasicHeatmap),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -11,12 +11,14 @@ use super::RealtimeFetcher;
 pub mod badge;
 pub mod bars;
 pub mod common;
+pub mod entries;
 pub mod image;
 pub mod links;
 pub mod ratio;
 
 pub use badge::BasicBadge;
 pub use bars::BasicBars;
+pub use entries::BasicEntries;
 pub use image::BasicImage;
 pub use links::BasicLinks;
 pub use ratio::BasicRatio;
@@ -28,5 +30,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicBadge),
         Arc::new(BasicRatio),
         Arc::new(BasicBars),
+        Arc::new(BasicEntries),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -14,6 +14,7 @@ pub mod common;
 pub mod entries;
 pub mod image;
 pub mod links;
+pub mod numbers;
 pub mod ratio;
 
 pub use badge::BasicBadge;
@@ -21,6 +22,7 @@ pub use bars::BasicBars;
 pub use entries::BasicEntries;
 pub use image::BasicImage;
 pub use links::BasicLinks;
+pub use numbers::BasicNumbers;
 pub use ratio::BasicRatio;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
@@ -31,5 +33,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicRatio),
         Arc::new(BasicBars),
         Arc::new(BasicEntries),
+        Arc::new(BasicNumbers),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -17,6 +17,7 @@ pub mod links;
 pub mod numbers;
 pub mod points;
 pub mod ratio;
+pub mod timeline;
 
 pub use badge::BasicBadge;
 pub use bars::BasicBars;
@@ -26,6 +27,7 @@ pub use links::BasicLinks;
 pub use numbers::BasicNumbers;
 pub use points::BasicPoints;
 pub use ratio::BasicRatio;
+pub use timeline::BasicTimeline;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
     vec![
@@ -37,5 +39,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicEntries),
         Arc::new(BasicNumbers),
         Arc::new(BasicPoints),
+        Arc::new(BasicTimeline),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -8,13 +8,19 @@ use std::sync::Arc;
 
 use super::RealtimeFetcher;
 
+pub mod badge;
 pub mod common;
 pub mod image;
 pub mod links;
 
+pub use badge::BasicBadge;
 pub use image::BasicImage;
 pub use links::BasicLinks;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
-    vec![Arc::new(BasicLinks), Arc::new(BasicImage)]
+    vec![
+        Arc::new(BasicLinks),
+        Arc::new(BasicImage),
+        Arc::new(BasicBadge),
+    ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -1,0 +1,15 @@
+//! `basic_*` family — config-only realtime fetchers, one per `Shape`. Each sibling lets users
+//! author the widget's payload inline in TOML (`[widget.options]`) without writing a fetcher.
+//! Pairs with `basic_static` (Text / TextBlock / MarkdownTextBlock, shipped) and
+//! `basic_read_store` (file-based escape hatch, shipped). All are `Safety::Safe` (no I/O) and
+//! `RealtimeFetcher` (pure config → payload, recomputed every frame).
+
+use std::sync::Arc;
+
+use super::RealtimeFetcher;
+
+pub mod common;
+
+pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
+    vec![]
+}

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -15,6 +15,7 @@ pub mod entries;
 pub mod image;
 pub mod links;
 pub mod numbers;
+pub mod points;
 pub mod ratio;
 
 pub use badge::BasicBadge;
@@ -23,6 +24,7 @@ pub use entries::BasicEntries;
 pub use image::BasicImage;
 pub use links::BasicLinks;
 pub use numbers::BasicNumbers;
+pub use points::BasicPoints;
 pub use ratio::BasicRatio;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
@@ -34,5 +36,6 @@ pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
         Arc::new(BasicBars),
         Arc::new(BasicEntries),
         Arc::new(BasicNumbers),
+        Arc::new(BasicPoints),
     ]
 }

--- a/src/fetcher/basic/mod.rs
+++ b/src/fetcher/basic/mod.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 use super::RealtimeFetcher;
 
 pub mod common;
+pub mod links;
+
+pub use links::BasicLinks;
 
 pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
-    vec![]
+    vec![Arc::new(BasicLinks)]
 }

--- a/src/fetcher/basic/numbers.rs
+++ b/src/fetcher/basic/numbers.rs
@@ -1,0 +1,102 @@
+//! `basic_numbers` — `NumberSeries` authored inline. Right for tiny static series the user
+//! wants to sparkline / histogram (manual weekly counts, learning curve "1 chapter / day").
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, NumberSeriesData, Payload};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::NumberSeries];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "values",
+    type_hint: "list of u64",
+    required: false,
+    default: Some("[]"),
+    description: "The series values in chronological / sequential order. Renderers like `chart_sparkline` consume this directly.",
+}];
+
+pub struct BasicNumbers;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub values: Vec<u64>,
+}
+
+impl RealtimeFetcher for BasicNumbers {
+    fn name(&self) -> &str {
+        "basic_numbers"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a `NumberSeries` from inline `[widget.options].values`. Right for tiny static series the user wants to sparkline or histogram without a dedicated fetcher (weekly tallies, manual progress curves)."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::NumberSeries).then(|| {
+            Body::NumberSeries(NumberSeriesData {
+                values: vec![3, 5, 8, 13, 21, 34],
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        common::bare(Body::NumberSeries(NumberSeriesData {
+            values: opts.values,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicNumbers.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicNumbers.name(), "basic_numbers");
+        assert_eq!(BasicNumbers.shapes(), &[Shape::NumberSeries]);
+    }
+
+    #[test]
+    fn emits_values_in_order() {
+        let p = compute(r#"values = [3, 5, 8, 13, 21]"#);
+        assert_eq!(
+            p.body,
+            Body::NumberSeries(NumberSeriesData {
+                values: vec![3, 5, 8, 13, 21],
+            })
+        );
+    }
+
+    #[test]
+    fn no_values_yields_empty_series() {
+        let p = BasicNumbers.compute(&FetchContext::default());
+        let Body::NumberSeries(d) = p.body else {
+            panic!("expected NumberSeries");
+        };
+        assert!(d.values.is_empty());
+    }
+}

--- a/src/fetcher/basic/points.rs
+++ b/src/fetcher/basic/points.rs
@@ -1,0 +1,130 @@
+//! `basic_points` — `PointSeries` authored inline. Supports multiple series for line / scatter
+//! charts where each series carries its own name + (x, y) pairs.
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload, PointSeries, PointSeriesData};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::PointSeries];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "series",
+    type_hint: "list of {name, points: [[x, y], ...]}",
+    required: false,
+    default: Some("[]"),
+    description: "One entry per line / cluster. Points are `[x, y]` float pairs. `chart_line` / `chart_scatter` consume this directly.",
+}];
+
+pub struct BasicPoints;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub series: Vec<SeriesConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SeriesConfig {
+    pub name: String,
+    #[serde(default)]
+    pub points: Vec<(f64, f64)>,
+}
+
+impl RealtimeFetcher for BasicPoints {
+    fn name(&self) -> &str {
+        "basic_points"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a `PointSeries` from inline `[widget.options].series = [{name, points: [[x, y], ...]}]`. Supports multiple series so a single widget can carry several lines / clusters."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::PointSeries).then(|| {
+            Body::PointSeries(PointSeriesData {
+                series: vec![PointSeries {
+                    name: "demo".into(),
+                    points: vec![(0.0, 1.0), (1.0, 2.5), (2.0, 1.8), (3.0, 3.0)],
+                }],
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        common::bare(Body::PointSeries(PointSeriesData {
+            series: opts
+                .series
+                .into_iter()
+                .map(|s| PointSeries {
+                    name: s.name,
+                    points: s.points,
+                })
+                .collect(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicPoints.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicPoints.name(), "basic_points");
+        assert_eq!(BasicPoints.shapes(), &[Shape::PointSeries]);
+    }
+
+    #[test]
+    fn emits_named_series_with_points() {
+        let p = compute(
+            r#"
+            [[series]]
+            name = "alpha"
+            points = [[0.0, 1.0], [1.0, 2.0]]
+            [[series]]
+            name = "beta"
+            points = [[0.0, 0.5]]
+            "#,
+        );
+        let Body::PointSeries(d) = p.body else {
+            panic!("expected PointSeries");
+        };
+        assert_eq!(d.series.len(), 2);
+        assert_eq!(d.series[0].name, "alpha");
+        assert_eq!(d.series[0].points, vec![(0.0, 1.0), (1.0, 2.0)]);
+        assert_eq!(d.series[1].points, vec![(0.0, 0.5)]);
+    }
+
+    #[test]
+    fn no_series_yields_empty_payload() {
+        let p = BasicPoints.compute(&FetchContext::default());
+        let Body::PointSeries(d) = p.body else {
+            panic!("expected PointSeries");
+        };
+        assert!(d.series.is_empty());
+    }
+}

--- a/src/fetcher/basic/ratio.rs
+++ b/src/fetcher/basic/ratio.rs
@@ -1,0 +1,152 @@
+//! `basic_ratio` — single 0..=1 progress reading authored inline. Right for manual progress
+//! displays (OKR, side-project completion %, "we've finished N of M chapters") where automating
+//! the source isn't worth a dedicated fetcher.
+
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload, RatioData};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Ratio];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "value",
+        type_hint: "float (clamped to 0.0..=1.0)",
+        required: true,
+        default: None,
+        description: "Progress as a fraction. Out-of-range values are clamped rather than rejected so a misconfig still renders.",
+    },
+    OptionSchema {
+        name: "label",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Optional caption shown beside the gauge.",
+    },
+    OptionSchema {
+        name: "denominator",
+        type_hint: "u64",
+        required: false,
+        default: None,
+        description: "Optional total the value is a fraction of (e.g. `denominator = 365` when value tracks day-of-year). Lets renderers print `N of M` instead of percent-only.",
+    },
+];
+
+pub struct BasicRatio;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub value: Option<f64>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub denominator: Option<u64>,
+}
+
+impl RealtimeFetcher for BasicRatio {
+    fn name(&self) -> &str {
+        "basic_ratio"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Single `Ratio` (0..=1) authored inline in config. Pairs with any gauge renderer. Clamps out-of-range values silently — the splash should never be unable to render because of one bad number."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Ratio).then(|| {
+            Body::Ratio(RatioData {
+                value: 0.6,
+                label: Some("Q2 OKR".into()),
+                denominator: None,
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        let Some(raw) = opts.value else {
+            return common::placeholder("basic_ratio: `value` is required");
+        };
+        common::bare(Body::Ratio(RatioData {
+            value: raw.clamp(0.0, 1.0),
+            label: opts.label,
+            denominator: opts.denominator,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicRatio.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicRatio.name(), "basic_ratio");
+        assert_eq!(BasicRatio.shapes(), &[Shape::Ratio]);
+    }
+
+    #[test]
+    fn emits_value_with_optional_fields() {
+        let p = compute(
+            r#"
+            value = 0.42
+            label = "Q2 OKR"
+            denominator = 100
+            "#,
+        );
+        assert_eq!(
+            p.body,
+            Body::Ratio(RatioData {
+                value: 0.42,
+                label: Some("Q2 OKR".into()),
+                denominator: Some(100),
+            })
+        );
+    }
+
+    #[test]
+    fn clamps_out_of_range_values() {
+        let high = compute(r#"value = 1.7"#);
+        let low = compute(r#"value = -0.3"#);
+        let Body::Ratio(h) = high.body else {
+            unreachable!()
+        };
+        let Body::Ratio(l) = low.body else {
+            unreachable!()
+        };
+        assert_eq!(h.value, 1.0);
+        assert_eq!(l.value, 0.0);
+    }
+
+    #[test]
+    fn missing_value_renders_placeholder() {
+        let p = BasicRatio.compute(&FetchContext::default());
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("`value` is required"));
+    }
+}

--- a/src/fetcher/basic/ratio.rs
+++ b/src/fetcher/basic/ratio.rs
@@ -149,4 +149,13 @@ mod tests {
         };
         assert!(d.lines[0].contains("`value` is required"));
     }
+
+    #[test]
+    fn non_numeric_value_renders_placeholder() {
+        let p = compute(r#"value = "not a number""#);
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("invalid options"));
+    }
 }

--- a/src/fetcher/basic/timeline.rs
+++ b/src/fetcher/basic/timeline.rs
@@ -1,0 +1,171 @@
+//! `basic_timeline` — chronological events authored inline. Right for fixed milestones
+//! (release history, project anniversaries) where the date is decided once and the splash just
+//! displays it forever.
+
+use chrono::DateTime;
+use serde::Deserialize;
+
+use crate::fetcher::{FetchContext, RealtimeFetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload, Status, TimelineData, TimelineEvent};
+use crate::render::Shape;
+
+use super::common;
+
+const SHAPES: &[Shape] = &[Shape::Timeline];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "events",
+    type_hint: "list of {at: RFC3339 string, title, detail?, status?}",
+    required: false,
+    default: Some("[]"),
+    description: "Timeline events. `at` accepts any RFC 3339 / ISO 8601 timestamp (e.g. `\"2024-06-01T00:00:00Z\"` or `\"2024-06-01T09:00:00+09:00\"`); the renderer formats the relative `\"3h ago\"` / `\"Jun 1\"` label at draw time.",
+}];
+
+pub struct BasicTimeline;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub events: Vec<EventConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventConfig {
+    pub at: String,
+    pub title: String,
+    #[serde(default)]
+    pub detail: Option<String>,
+    #[serde(default)]
+    pub status: Option<Status>,
+}
+
+impl RealtimeFetcher for BasicTimeline {
+    fn name(&self) -> &str {
+        "basic_timeline"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Renders a `Timeline` from inline `[widget.options].events`. Each event takes an RFC 3339 `at` timestamp plus a `title`; optional `detail` and `status` decorate the row. Right for fixed milestones (releases, anniversaries, planned freezes) where the dates don't change."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        (shape == Shape::Timeline).then(|| {
+            Body::Timeline(TimelineData {
+                events: vec![
+                    TimelineEvent {
+                        timestamp: 1_704_067_200,
+                        title: "v1.0 released".into(),
+                        detail: Some("first major release".into()),
+                        status: Some(Status::Ok),
+                    },
+                    TimelineEvent {
+                        timestamp: 1_706_745_600,
+                        title: "Feature freeze".into(),
+                        detail: None,
+                        status: None,
+                    },
+                ],
+            })
+        })
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let opts: Options = match common::parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return common::placeholder(&msg),
+        };
+        let events: Result<Vec<TimelineEvent>, String> =
+            opts.events.into_iter().map(parse_event).collect();
+        match events {
+            Ok(events) => common::bare(Body::Timeline(TimelineData { events })),
+            Err(msg) => common::placeholder(&msg),
+        }
+    }
+}
+
+fn parse_event(raw: EventConfig) -> Result<TimelineEvent, String> {
+    let timestamp = DateTime::parse_from_rfc3339(&raw.at)
+        .map(|dt| dt.timestamp())
+        .map_err(|e| format!("basic_timeline: invalid `at` value `{}`: {e}", raw.at))?;
+    Ok(TimelineEvent {
+        timestamp,
+        title: raw.title,
+        detail: raw.detail,
+        status: raw.status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compute(toml_src: &str) -> Payload {
+        BasicTimeline.compute(&FetchContext {
+            options: Some(toml::from_str(toml_src).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn contract() {
+        assert_eq!(BasicTimeline.name(), "basic_timeline");
+        assert_eq!(BasicTimeline.shapes(), &[Shape::Timeline]);
+    }
+
+    #[test]
+    fn parses_rfc3339_timestamps_to_unix_seconds() {
+        let p = compute(
+            r#"
+            [[events]]
+            at = "2024-01-01T00:00:00Z"
+            title = "v1.0"
+            [[events]]
+            at = "2024-02-01T09:00:00+09:00"
+            title = "Feature freeze"
+            detail = "no new features after this"
+            status = "warn"
+            "#,
+        );
+        let Body::Timeline(d) = p.body else {
+            panic!("expected Timeline");
+        };
+        assert_eq!(d.events.len(), 2);
+        assert_eq!(d.events[0].timestamp, 1_704_067_200);
+        assert_eq!(d.events[0].title, "v1.0");
+        assert_eq!(d.events[1].detail.as_deref(), Some("no new features after this"));
+        assert_eq!(d.events[1].status, Some(Status::Warn));
+    }
+
+    #[test]
+    fn invalid_timestamp_renders_placeholder() {
+        let p = compute(
+            r#"
+            [[events]]
+            at = "not-a-date"
+            title = "x"
+            "#,
+        );
+        let Body::TextBlock(d) = p.body else {
+            panic!("expected placeholder");
+        };
+        assert!(d.lines[0].contains("invalid `at` value"));
+    }
+
+    #[test]
+    fn no_events_yields_empty_timeline() {
+        let p = BasicTimeline.compute(&FetchContext::default());
+        let Body::Timeline(d) = p.body else {
+            panic!("expected Timeline");
+        };
+        assert!(d.events.is_empty());
+    }
+}

--- a/src/fetcher/basic/timeline.rs
+++ b/src/fetcher/basic/timeline.rs
@@ -141,7 +141,10 @@ mod tests {
         assert_eq!(d.events.len(), 2);
         assert_eq!(d.events[0].timestamp, 1_704_067_200);
         assert_eq!(d.events[0].title, "v1.0");
-        assert_eq!(d.events[1].detail.as_deref(), Some("no new features after this"));
+        assert_eq!(
+            d.events[1].detail.as_deref(),
+            Some("no new features after this")
+        );
         assert_eq!(d.events[1].status, Some(Status::Warn));
     }
 

--- a/src/fetcher/linear/client.rs
+++ b/src/fetcher/linear/client.rs
@@ -227,6 +227,14 @@ mod tests {
             let lock = crate::paths::TEST_ENV_LOCK
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
+            Self::set_inheriting(lock, value)
+        }
+
+        /// Same contract as [`Self::set`] but expects the caller to hand over an already-held
+        /// `TEST_ENV_LOCK` guard. Lets tests stage the env var under the lock and capture
+        /// `previous` inside the same critical section, instead of releasing + re-acquiring
+        /// (which lets a sibling test mutate `LINEAR_TOKEN` between setup and capture).
+        fn set_inheriting(lock: std::sync::MutexGuard<'static, ()>, value: Option<&str>) -> Self {
             let previous = std::env::var("LINEAR_TOKEN").ok();
             match value {
                 Some(value) => unsafe { std::env::set_var("LINEAR_TOKEN", value) },
@@ -445,19 +453,27 @@ mod tests {
 
     #[test]
     fn linear_token_guard_set_restores_outer_previous_value() {
-        let outer_previous = {
-            let _lock = crate::paths::TEST_ENV_LOCK
+        // Hold the lock continuously through `set` so a sibling test can't mutate
+        // `LINEAR_TOKEN` between the staged `"outer"` and `set`'s capture of `previous`.
+        // Previously this released the lock first and then called `LinearTokenGuard::set`,
+        // which re-acquired it — that gap was the Windows-only flake (sibling token tests
+        // would sneak in and `previous` would capture the wrong value).
+        let (outer_previous, captured_previous) = {
+            let lock = crate::paths::TEST_ENV_LOCK
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             let outer_previous = std::env::var("LINEAR_TOKEN").ok();
             unsafe { std::env::set_var("LINEAR_TOKEN", "outer") };
-            outer_previous
+            let guard = LinearTokenGuard::set_inheriting(lock, Some("inner"));
+            let captured_previous = guard.previous.clone();
+            drop(guard);
+            (outer_previous, captured_previous)
         };
 
-        let guard = LinearTokenGuard::set(Some("inner"));
-        drop(guard);
-
-        assert_eq!(std::env::var("LINEAR_TOKEN").ok().as_deref(), Some("outer"));
+        // The Drop-restores-previous contract is exercised by
+        // `linear_token_guard_restores_previous_value_on_drop`; here we only assert that
+        // `set` captures the value present at the call site.
+        assert_eq!(captured_previous.as_deref(), Some("outer"));
         restore_linear_token(outer_previous);
     }
 

--- a/src/fetcher/linear/client.rs
+++ b/src/fetcher/linear/client.rs
@@ -217,42 +217,44 @@ mod tests {
 
     use super::*;
 
+    /// Test-only RAII guard over the process-global `LINEAR_TOKEN`. Captures the current value,
+    /// applies a new one, and restores the captured value on drop.
+    ///
+    /// **The caller must hold [`crate::paths::TEST_ENV_LOCK`] for the guard's entire lifetime.**
+    /// The guard deliberately does *not* own the lock: an earlier design embedded the
+    /// `MutexGuard` here, but then `drop(guard)` released the lock *before* the test's trailing
+    /// assert / cleanup ran, so a sibling env-touching test could interleave and the cleanup's
+    /// `set_var` / `remove_var` would land in another test's critical section (the Windows-only
+    /// `LINEAR_TOKEN` flake). Keeping the lock in the test body and the guard lock-free means
+    /// every read, write, and restore happens inside one continuous critical section.
+    fn linear_token_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
     struct LinearTokenGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
         previous: Option<String>,
     }
 
     impl LinearTokenGuard {
         fn set(value: Option<&str>) -> Self {
-            let lock = crate::paths::TEST_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            Self::set_inheriting(lock, value)
-        }
-
-        /// Same contract as [`Self::set`] but expects the caller to hand over an already-held
-        /// `TEST_ENV_LOCK` guard. Lets tests stage the env var under the lock and capture
-        /// `previous` inside the same critical section, instead of releasing + re-acquiring
-        /// (which lets a sibling test mutate `LINEAR_TOKEN` between setup and capture).
-        fn set_inheriting(lock: std::sync::MutexGuard<'static, ()>, value: Option<&str>) -> Self {
             let previous = std::env::var("LINEAR_TOKEN").ok();
-            match value {
-                Some(value) => unsafe { std::env::set_var("LINEAR_TOKEN", value) },
-                None => unsafe { std::env::remove_var("LINEAR_TOKEN") },
-            }
-            Self {
-                _lock: lock,
-                previous,
-            }
+            apply_linear_token(value);
+            Self { previous }
         }
     }
 
     impl Drop for LinearTokenGuard {
         fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => unsafe { std::env::set_var("LINEAR_TOKEN", value) },
-                None => unsafe { std::env::remove_var("LINEAR_TOKEN") },
-            }
+            apply_linear_token(self.previous.as_deref());
+        }
+    }
+
+    fn apply_linear_token(value: Option<&str>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var("LINEAR_TOKEN", value) },
+            None => unsafe { std::env::remove_var("LINEAR_TOKEN") },
         }
     }
 
@@ -262,13 +264,6 @@ mod tests {
             .build()
             .unwrap()
             .block_on(future)
-    }
-
-    fn restore_linear_token(previous: Option<String>) {
-        match previous {
-            Some(value) => unsafe { std::env::set_var("LINEAR_TOKEN", value) },
-            None => unsafe { std::env::remove_var("LINEAR_TOKEN") },
-        }
     }
 
     fn unused_proxy_url() -> String {
@@ -305,6 +300,9 @@ mod tests {
 
     #[test]
     fn resolve_token_falls_back_to_env_value_when_config_is_blank() {
+        // `_lock` is declared before `_guard`, so it drops *after* the guard restores
+        // `LINEAR_TOKEN` — the whole test body is one critical section.
+        let _lock = linear_token_env_lock();
         let _guard = LinearTokenGuard::set(Some("  env-token  "));
         assert_eq!(resolve_token(Some("   ")).unwrap(), "env-token");
         assert_eq!(resolve_token(None).unwrap(), "env-token");
@@ -312,6 +310,7 @@ mod tests {
 
     #[test]
     fn resolve_token_errors_when_config_and_env_are_missing() {
+        let _lock = linear_token_env_lock();
         let _guard = LinearTokenGuard::set(None);
         assert!(matches!(
             resolve_token(None),
@@ -321,6 +320,7 @@ mod tests {
 
     #[test]
     fn resolve_token_rejects_blank_env_values() {
+        let _lock = linear_token_env_lock();
         let _guard = LinearTokenGuard::set(Some("   "));
         assert!(matches!(
             resolve_token(None),
@@ -365,6 +365,7 @@ mod tests {
 
     #[test]
     fn cache_extra_uses_empty_scope_when_no_token_is_available() {
+        let _lock = linear_token_env_lock();
         let _guard = LinearTokenGuard::set(None);
         assert_eq!(cache_extra(None, None), format!("{}|", token_scope("")));
     }
@@ -428,53 +429,44 @@ mod tests {
 
     #[test]
     fn linear_token_guard_restores_previous_value_on_drop() {
-        let (previous, guard) = {
-            let lock = crate::paths::TEST_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let previous = std::env::var("LINEAR_TOKEN").ok();
-            unsafe { std::env::set_var("LINEAR_TOKEN", "before") };
+        // The lock spans the whole test body — every `LINEAR_TOKEN` read, write, and the
+        // guard's restore-on-drop happen inside one critical section, so a sibling token
+        // test can never observe or clobber an intermediate value.
+        let _lock = linear_token_env_lock();
+        let original = std::env::var("LINEAR_TOKEN").ok();
+
+        unsafe { std::env::set_var("LINEAR_TOKEN", "before") };
+        {
             let guard = LinearTokenGuard {
-                _lock: lock,
                 previous: Some("before".into()),
             };
             unsafe { std::env::set_var("LINEAR_TOKEN", "during") };
-            (previous, guard)
-        };
-
-        drop(guard);
+            drop(guard);
+        }
         assert_eq!(
             std::env::var("LINEAR_TOKEN").ok().as_deref(),
             Some("before")
         );
 
-        restore_linear_token(previous);
+        apply_linear_token(original.as_deref());
     }
 
     #[test]
     fn linear_token_guard_set_restores_outer_previous_value() {
-        // Hold the lock continuously through `set` so a sibling test can't mutate
-        // `LINEAR_TOKEN` between the staged `"outer"` and `set`'s capture of `previous`.
-        // Previously this released the lock first and then called `LinearTokenGuard::set`,
-        // which re-acquired it — that gap was the Windows-only flake (sibling token tests
-        // would sneak in and `previous` would capture the wrong value).
-        let (outer_previous, captured_previous) = {
-            let lock = crate::paths::TEST_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let outer_previous = std::env::var("LINEAR_TOKEN").ok();
-            unsafe { std::env::set_var("LINEAR_TOKEN", "outer") };
-            let guard = LinearTokenGuard::set_inheriting(lock, Some("inner"));
-            let captured_previous = guard.previous.clone();
-            drop(guard);
-            (outer_previous, captured_previous)
-        };
+        // Same single-critical-section discipline: stage `"outer"`, let `set` capture it and
+        // swap in `"inner"`, then assert the guard's drop puts `"outer"` back — all under one
+        // continuously held `TEST_ENV_LOCK`.
+        let _lock = linear_token_env_lock();
+        let original = std::env::var("LINEAR_TOKEN").ok();
 
-        // The Drop-restores-previous contract is exercised by
-        // `linear_token_guard_restores_previous_value_on_drop`; here we only assert that
-        // `set` captures the value present at the call site.
-        assert_eq!(captured_previous.as_deref(), Some("outer"));
-        restore_linear_token(outer_previous);
+        unsafe { std::env::set_var("LINEAR_TOKEN", "outer") };
+        {
+            let _guard = LinearTokenGuard::set(Some("inner"));
+            assert_eq!(std::env::var("LINEAR_TOKEN").ok().as_deref(), Some("inner"));
+        }
+        assert_eq!(std::env::var("LINEAR_TOKEN").ok().as_deref(), Some("outer"));
+
+        apply_linear_token(original.as_deref());
     }
 
     #[test]

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -523,6 +523,32 @@ mod tests {
     }
 
     #[test]
+    fn with_builtins_registers_basic_family_as_realtime() {
+        let r = Registry::with_builtins();
+        for name in [
+            "basic_links",
+            "basic_image",
+            "basic_badge",
+            "basic_ratio",
+            "basic_bars",
+            "basic_entries",
+            "basic_numbers",
+            "basic_points",
+            "basic_timeline",
+            "basic_calendar",
+            "basic_heatmap",
+        ] {
+            let entry = r
+                .get(name)
+                .unwrap_or_else(|| panic!("{name} must be registered"));
+            assert!(
+                matches!(entry, RegisteredFetcher::Realtime(_)),
+                "{name} must be registered as realtime"
+            );
+        }
+    }
+
+    #[test]
     fn with_builtins_registers_clock_as_realtime() {
         let r = Registry::with_builtins();
         let entry = r.get("clock").expect("clock must be registered");

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -12,6 +12,7 @@ use crate::payload::{Body, ErrorData, ErrorKind, Payload, Status};
 use crate::render::Shape;
 use crate::samples;
 
+pub mod basic;
 pub mod calendar;
 pub mod clock;
 pub mod code;
@@ -376,6 +377,9 @@ impl Registry {
         }
         for f in code::fetchers() {
             r.register(f);
+        }
+        for f in basic::realtime_fetchers() {
+            r.register_realtime(f);
         }
         r
     }


### PR DESCRIPTION
## Summary

Closes the catalog gap for the `basic_*` family. Each new fetcher emits a single shape from inline `[widget.options]`, so users can author any widget literally in TOML without writing a fetcher. Pairs with the existing `basic_static` (Text / TextBlock / MarkdownTextBlock) and `basic_read_store` (file-based escape hatch).

All eleven are `RealtimeFetcher`, `Safety::Safe`, no I/O. Lives in `src/fetcher/basic/`.

| Fetcher | Default shape | Other shapes |
| --- | --- | --- |
| `basic_links` | `LinkedTextBlock` | `Text` / `TextBlock` / `MarkdownTextBlock` / `Entries` / `ImageLinkedList` |
| `basic_image` | `Image` | |
| `basic_badge` | `Badge` | |
| `basic_ratio` | `Ratio` | |
| `basic_bars` | `Bars` | |
| `basic_entries` | `Entries` | |
| `basic_numbers` | `NumberSeries` | |
| `basic_points` | `PointSeries` | |
| `basic_timeline` | `Timeline` | |
| `basic_calendar` | `Calendar` | |
| `basic_heatmap` | `Heatmap` | |

Full option schemas land in the auto-generated reference docs at `/reference/fetchers/basic/<name>/` after the docs site rebuilds.

## Highlights

- `basic_links` is the headliner: pairs with `list_links` for clickable per-repo bookmarks (`.splashboard/dashboard.toml` shipped in a repo surfaces its docs / CI / deploy URLs on `cd`).
- `basic_timeline` takes RFC 3339 `at` strings (e.g. `"2024-06-01T00:00:00Z"`) instead of raw epoch seconds and parses via `chrono::DateTime::parse_from_rfc3339`, so users don't have to compute unix timestamps by hand.
- `basic_calendar` defaults `year` / `month` / `day` to today in the resolved timezone, so a zero-config widget shows the current month with today highlighted; `events` lists extra days to mark.
- `basic_ratio` clamps out-of-range `value`s rather than erroring, so a misconfig never hides the gauge.
- Invalid TOML in any of them surfaces the same two-line `⚠ invalid options` / `check [widget.options] in config` placeholder used by the `clock_*` family.

Each fetcher carries its own `#[serde(deny_unknown_fields)]` `Options` struct plus an `OptionSchema` table consumed by the docs generator.

## Catalog

This sweep isn't currently tracked in any of #62–#68 — `basic_*` is a cross-cutting family. Suggest adding a new "## `basic_*` — inline config-only realtime fetchers" section to #41 (or #62) noting the 11 shipped entries; happy to do that in a follow-up doc PR if preferred.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (2182 passing, +44 new tests under `fetcher::basic`)
- [x] `cargo xtask` generates 11 new `docs-site/.../fetchers/basic/basic_*.md` reference pages cleanly
- [x] Manual `cargo run --bin splashboard` against a `.splashboard/dashboard.toml` exercising all 11 widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 11 built-in realtime fetchers for inline widget options: badge, bars, calendar, entries, heatmap, image, links, numbers, points, ratio, and timeline — all include option schemas, previews, and placeholder fallbacks.

* **Bug Fixes**
  * Fixed a race in token-handling tests by serializing environment access to avoid intermittent failures.

* **Chores**
  * CI workflow cache settings adjusted to avoid caching toolchain binaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/229)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->