### PR TITLE
feat(fetcher): add net_* fetcher family

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Shapes are the **only** coupling between fetchers and renderers. If you find you
 Produces a `Payload`. Two flavors:
 
 - **`Fetcher` (cached, async)** — disk cache with TTL, daemon refreshes in background, renderer reads from cache. Right for anything that does I/O: git2, HTTP, filesystem scans.
-- **`RealtimeFetcher` (sync, per-frame)** — recomputed on every draw tick, no cache at all. Right for "right now" values: `clock`, `system_cpu`, `system_uptime`, `clock_countdown`, `pomodoro`. Contract: < 1ms, infallible, no I/O. If you want to put `reqwest` in a `RealtimeFetcher`, it's not realtime — it's cached.
+- **`RealtimeFetcher` (sync, per-frame)** — recomputed on every draw tick, no cache at all. Right for "right now" values: `clock`, `system_cpu`, `system_uptime`, `clock_countdown`. Contract: < 1ms, infallible, no I/O. If you want to put `reqwest` in a `RealtimeFetcher`, it's not realtime — it's cached.
 
 Key invariants:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
 ]
 
@@ -933,6 +934,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -2872,6 +2884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3006,62 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "netdev"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
 ]
 
 [[package]]
@@ -3114,6 +3188,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,7 +3214,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3152,6 +3243,41 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -3273,6 +3399,12 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -4403,6 +4535,7 @@ dependencies = [
  "figlet-rs",
  "gix",
  "image",
+ "netdev",
  "ratatui",
  "ratatui-image",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 chrono-tz = { version = "0.10", default-features = false }
 sysinfo = "0.39.0"
 starship-battery = "0.11"
+netdev = "0.43"
 gix = { version = "0.83", default-features = false, features = ["revision", "status", "blob-diff", "max-performance-safe", "comfort", "sha1"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
 url = "2"

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -25,6 +25,7 @@ pub mod hackernews;
 pub mod linear;
 pub mod lobsters;
 pub mod nasa_apod;
+pub mod net;
 pub mod news;
 pub mod random_cat;
 pub mod random_dog;
@@ -370,6 +371,12 @@ impl Registry {
         }
         for f in system::cached_fetchers() {
             r.register(f);
+        }
+        for f in net::cached_fetchers() {
+            r.register(f);
+        }
+        for f in net::realtime_fetchers() {
+            r.register_realtime(f);
         }
         for f in git::fetchers() {
             r.register(f);

--- a/src/fetcher/net/gateway.rs
+++ b/src/fetcher/net/gateway.rs
@@ -1,0 +1,240 @@
+//! `net_gateway` — the host's default-route gateway.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, MarkdownTextBlockData, Payload, Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{
+    GatewayInfo, cache_key, default_gateway, entry, options_placeholder, parse_options, payload,
+};
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "kind",
+    type_hint: "\"gateway\" | \"interface\"",
+    required: false,
+    default: Some("\"gateway\""),
+    description: "Which field the `Text` shape shows — the gateway address or the interface it routes through. Ignored by the other shapes. (Route metric isn't exposed by the underlying platform APIs, so it isn't a `kind`.)",
+}];
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GatewayOptions {
+    #[serde(default)]
+    pub kind: Option<GatewayKind>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayKind {
+    #[default]
+    Gateway,
+    Interface,
+}
+
+pub struct NetGateway;
+
+#[async_trait]
+impl Fetcher for NetGateway {
+    fn name(&self) -> &str {
+        "net_gateway"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "The host's default-route gateway. `Text` (default) shows the gateway address — `kind = \"interface\"` shows the interface it routes through instead; `TextBlock` / `MarkdownTextBlock` / `Entries` roll up gateway + interface; `Badge` is a has-default-route / no-route pill."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_gateway(), shape, GatewayKind::Gateway)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: GatewayOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return Ok(options_placeholder(&msg)),
+        };
+        let gw = default_gateway();
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+        let kind = opts.kind.unwrap_or_default();
+        Ok(payload(body_for_shape(&gw, shape, kind).unwrap_or_else(
+            || {
+                Body::Text(TextData {
+                    value: text_value(&gw, kind),
+                })
+            },
+        )))
+    }
+}
+
+fn body_for_shape(gw: &GatewayInfo, shape: Shape, kind: GatewayKind) -> Option<Body> {
+    Some(match shape {
+        Shape::Text => Body::Text(TextData {
+            value: text_value(gw, kind),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: vec![
+                format!("gateway  {}", gateway_field(gw)),
+                format!("interface  {}", interface_field(gw)),
+            ],
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: format!(
+                "- **gateway** {}\n- **interface** {}",
+                gateway_field(gw),
+                interface_field(gw),
+            ),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("gateway", &gateway_field(gw)),
+                entry("interface", &interface_field(gw)),
+            ],
+        }),
+        Shape::Badge => Body::Badge(gateway_badge(gw)),
+        _ => return None,
+    })
+}
+
+fn text_value(gw: &GatewayInfo, kind: GatewayKind) -> String {
+    match kind {
+        GatewayKind::Gateway => gw
+            .ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| "no default route".into()),
+        GatewayKind::Interface => interface_field(gw),
+    }
+}
+
+fn gateway_field(gw: &GatewayInfo) -> String {
+    gw.ip
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| "n/a".into())
+}
+
+fn interface_field(gw: &GatewayInfo) -> String {
+    gw.interface.clone().unwrap_or_else(|| "n/a".into())
+}
+
+fn gateway_badge(gw: &GatewayInfo) -> BadgeData {
+    match gw.ip {
+        Some(ip) => BadgeData {
+            status: Status::Ok,
+            label: ip.to_string(),
+        },
+        None => BadgeData {
+            status: Status::Error,
+            label: "no default route".into(),
+        },
+    }
+}
+
+fn sample_gateway() -> GatewayInfo {
+    GatewayInfo {
+        ip: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+            192, 168, 1, 1,
+        ))),
+        interface: Some("eth0".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let gw = sample_gateway();
+        for &shape in SHAPES {
+            let body = body_for_shape(&gw, shape, GatewayKind::Gateway).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&gw, Shape::Ratio, GatewayKind::Gateway).is_none());
+    }
+
+    #[test]
+    fn text_value_honours_kind() {
+        let gw = sample_gateway();
+        assert_eq!(text_value(&gw, GatewayKind::Gateway), "192.168.1.1");
+        assert_eq!(text_value(&gw, GatewayKind::Interface), "eth0");
+
+        let empty = GatewayInfo::default();
+        assert_eq!(text_value(&empty, GatewayKind::Gateway), "no default route");
+        assert_eq!(text_value(&empty, GatewayKind::Interface), "n/a");
+    }
+
+    #[test]
+    fn badge_reflects_route_presence() {
+        assert_eq!(gateway_badge(&sample_gateway()).status, Status::Ok);
+        assert_eq!(gateway_badge(&GatewayInfo::default()).status, Status::Error);
+    }
+
+    #[test]
+    fn entries_always_carry_both_rows_even_when_unresolved() {
+        let Body::Entries(d) = body_for_shape(
+            &GatewayInfo::default(),
+            Shape::Entries,
+            GatewayKind::Gateway,
+        )
+        .unwrap() else {
+            panic!("expected entries");
+        };
+        assert_eq!(d.items.len(), 2);
+        assert_eq!(d.items[0].value.as_deref(), Some("n/a"));
+    }
+
+    #[test]
+    fn options_parse_and_reject_unknown_keys() {
+        let ok: toml::Value = toml::from_str("kind = \"interface\"").unwrap();
+        let parsed: GatewayOptions = parse_options(Some(&ok)).unwrap();
+        assert!(matches!(parsed.kind, Some(GatewayKind::Interface)));
+        let bad: toml::Value = toml::from_str("metric = 1").unwrap();
+        assert!(parse_options::<GatewayOptions>(Some(&bad)).is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_options_to_placeholder() {
+        let ctx = FetchContext {
+            shape: Some(Shape::Text),
+            options: Some(toml::from_str("kind = \"metric\"").unwrap()),
+            ..Default::default()
+        };
+        let Body::Text(t) = NetGateway.fetch(&ctx).await.unwrap().body else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("⚠"));
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetGateway.name(), "net_gateway");
+        assert_eq!(NetGateway.safety(), Safety::Safe);
+        assert_eq!(NetGateway.default_shape(), Shape::Text);
+        assert_eq!(NetGateway.option_schemas().len(), 1);
+        for &shape in SHAPES {
+            assert!(NetGateway.sample_body(shape).is_some());
+        }
+        assert!(NetGateway.sample_body(Shape::Bars).is_none());
+    }
+}

--- a/src/fetcher/net/interfaces.rs
+++ b/src/fetcher/net/interfaces.rs
@@ -1,0 +1,309 @@
+//! `net_interfaces` — every host network interface with its state, address, MTU and MAC.
+
+use async_trait::async_trait;
+
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, RatioData,
+    Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{NetIface, payload, primary_interface, snapshot};
+
+const SHAPES: &[Shape] = &[
+    Shape::Entries,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Ratio,
+    Shape::Bars,
+    Shape::Badge,
+];
+
+pub struct NetInterfaces;
+
+#[async_trait]
+impl Fetcher for NetInterfaces {
+    fn name(&self) -> &str {
+        "net_interfaces"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Every host network interface with its up/down state, primary IP, MTU and MAC. `Entries` (default) / `TextBlock` / `MarkdownTextBlock` list one row per interface; `Text` headlines the primary (default-route) interface; `Ratio` is the up-of-total fraction; `Bars` ranks interfaces by total bytes transferred; `Badge` is an online / offline pill."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_snapshot(), shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let ifaces = snapshot();
+        let shape = ctx.shape.unwrap_or(Shape::Entries);
+        Ok(payload(
+            body_for_shape(&ifaces, shape).unwrap_or_else(|| entries_body(&ifaces)),
+        ))
+    }
+}
+
+fn body_for_shape(ifaces: &[NetIface], shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::Entries => entries_body(ifaces),
+        Shape::Text => Body::Text(TextData {
+            value: headline(ifaces),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: ifaces.iter().map(row_line).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: ifaces
+                .iter()
+                .map(|i| format!("- **{}** {}", i.name, iface_summary(i)))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Ratio => Body::Ratio(up_ratio(ifaces)),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: ifaces
+                .iter()
+                .map(|i| Bar {
+                    label: i.name.clone(),
+                    value: i.rx_bytes.saturating_add(i.tx_bytes),
+                })
+                .collect(),
+        }),
+        Shape::Badge => Body::Badge(connectivity_badge(ifaces)),
+        _ => return None,
+    })
+}
+
+fn entries_body(ifaces: &[NetIface]) -> Body {
+    Body::Entries(EntriesData {
+        items: ifaces
+            .iter()
+            .map(|i| Entry {
+                key: i.name.clone(),
+                value: Some(iface_summary(i)),
+                status: Some(if i.up { Status::Ok } else { Status::Warn }),
+            })
+            .collect(),
+    })
+}
+
+/// Speaks for the primary interface ("what's my connection") rather than a bare count — the
+/// count is still the fallback when no interface is up.
+fn headline(ifaces: &[NetIface]) -> String {
+    match primary_interface(ifaces) {
+        Some(i) => format!("{} · {}", i.name, iface_summary(i)),
+        None => format!("{} interfaces", ifaces.len()),
+    }
+}
+
+fn row_line(i: &NetIface) -> String {
+    format!("{}  {}", i.name, iface_summary(i))
+}
+
+fn iface_summary(i: &NetIface) -> String {
+    let mut parts = vec![if i.up { "up" } else { "down" }.to_string()];
+    if let Some(addr) = primary_addr(i) {
+        parts.push(addr);
+    }
+    if let Some(mtu) = i.mtu {
+        parts.push(format!("mtu {mtu}"));
+    }
+    parts.join(" · ")
+}
+
+fn primary_addr(i: &NetIface) -> Option<String> {
+    i.ipv4
+        .first()
+        .map(ToString::to_string)
+        .or_else(|| i.ipv6.first().map(ToString::to_string))
+}
+
+fn up_ratio(ifaces: &[NetIface]) -> RatioData {
+    let total = ifaces.len() as u64;
+    let up = ifaces.iter().filter(|i| i.up).count() as u64;
+    RatioData {
+        value: if total == 0 {
+            0.0
+        } else {
+            up as f64 / total as f64
+        },
+        label: Some(format!("{up}/{total} up")),
+        denominator: Some(total),
+    }
+}
+
+/// Online when at least one non-loopback interface is up *and* carries an address — an `up`
+/// interface with no IP isn't actually reachable.
+fn connectivity_badge(ifaces: &[NetIface]) -> BadgeData {
+    let online = ifaces
+        .iter()
+        .any(|i| !i.loopback && i.up && (!i.ipv4.is_empty() || !i.ipv6.is_empty()));
+    if online {
+        BadgeData {
+            status: Status::Ok,
+            label: "online".into(),
+        }
+    } else {
+        BadgeData {
+            status: Status::Error,
+            label: "offline".into(),
+        }
+    }
+}
+
+fn sample_snapshot() -> Vec<NetIface> {
+    vec![
+        NetIface {
+            name: "lo".into(),
+            kind: "Loopback".into(),
+            mac: None,
+            ipv4: vec![std::net::Ipv4Addr::LOCALHOST],
+            ipv6: vec![],
+            up: true,
+            loopback: true,
+            is_default: false,
+            mtu: Some(65536),
+            rx_bytes: 4_096,
+            tx_bytes: 4_096,
+        },
+        NetIface {
+            name: "eth0".into(),
+            kind: "Ethernet".into(),
+            mac: Some("aa:bb:cc:dd:ee:ff".into()),
+            ipv4: vec![std::net::Ipv4Addr::new(192, 168, 1, 24)],
+            ipv6: vec![],
+            up: true,
+            loopback: false,
+            is_default: true,
+            mtu: Some(1500),
+            rx_bytes: 8_400_000,
+            tx_bytes: 1_200_000,
+        },
+        NetIface {
+            name: "wlan0".into(),
+            kind: "Wireless IEEE 802.11".into(),
+            mac: Some("11:22:33:44:55:66".into()),
+            ipv4: vec![],
+            ipv6: vec![],
+            up: false,
+            loopback: false,
+            is_default: false,
+            mtu: Some(1500),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::iface;
+    use super::*;
+
+    fn ctx(shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            shape,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let snap = sample_snapshot();
+        for &shape in SHAPES {
+            let body = body_for_shape(&snap, shape).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&snap, Shape::Image).is_none());
+        assert!(body_for_shape(&snap, Shape::Timeline).is_none());
+    }
+
+    #[test]
+    fn entries_mark_up_ok_and_down_warn() {
+        let snap = vec![
+            iface("eth0", &["10.0.0.2"], true),
+            iface("wlan0", &[], false),
+        ];
+        let Body::Entries(d) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        assert_eq!(d.items[0].status, Some(Status::Ok));
+        assert_eq!(d.items[1].status, Some(Status::Warn));
+        assert!(d.items[0].value.as_deref().unwrap().contains("10.0.0.2"));
+    }
+
+    #[test]
+    fn headline_names_primary_then_falls_back_to_count() {
+        let mut def = iface("eth0", &["10.0.0.2"], true);
+        def.is_default = true;
+        assert!(headline(&[def]).starts_with("eth0 · up"));
+        let down_only = vec![iface("lo", &["127.0.0.1"], true)];
+        assert_eq!(headline(&down_only), "1 interfaces");
+    }
+
+    #[test]
+    fn up_ratio_reports_fraction_with_denominator() {
+        let snap = vec![
+            iface("eth0", &["10.0.0.2"], true),
+            iface("wlan0", &[], false),
+        ];
+        let r = up_ratio(&snap);
+        assert_eq!(r.value, 0.5);
+        assert_eq!(r.denominator, Some(2));
+        assert_eq!(up_ratio(&[]).value, 0.0);
+    }
+
+    #[test]
+    fn connectivity_badge_needs_a_non_loopback_iface_with_an_address() {
+        let online = vec![
+            iface("lo", &["127.0.0.1"], true),
+            iface("eth0", &["10.0.0.2"], true),
+        ];
+        assert_eq!(connectivity_badge(&online).status, Status::Ok);
+
+        let up_but_no_ip = vec![iface("lo", &["127.0.0.1"], true), iface("eth0", &[], true)];
+        assert_eq!(connectivity_badge(&up_but_no_ip).status, Status::Error);
+
+        assert_eq!(connectivity_badge(&[]).label, "offline");
+    }
+
+    #[test]
+    fn bars_value_is_total_bytes_transferred() {
+        let snap = sample_snapshot();
+        let Body::Bars(d) = body_for_shape(&snap, Shape::Bars).unwrap() else {
+            panic!("expected bars");
+        };
+        assert_eq!(d.bars[1].label, "eth0");
+        assert_eq!(d.bars[1].value, 8_400_000 + 1_200_000);
+    }
+
+    #[tokio::test]
+    async fn fetch_emits_the_requested_shape() {
+        for &shape in SHAPES {
+            let body = NetInterfaces.fetch(&ctx(Some(shape))).await.unwrap().body;
+            // A host with no interfaces would empty-body some shapes; tolerate that, just never
+            // the wrong variant.
+            assert!(
+                matches!(crate::render::shape_of(&body), s if s == shape || matches!(body, Body::Entries(ref e) if e.items.is_empty()))
+            );
+        }
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetInterfaces.name(), "net_interfaces");
+        assert_eq!(NetInterfaces.safety(), Safety::Safe);
+        assert_eq!(NetInterfaces.default_shape(), Shape::Entries);
+        assert!(!NetInterfaces.description().is_empty());
+        for &shape in SHAPES {
+            assert!(NetInterfaces.sample_body(shape).is_some());
+        }
+        assert!(NetInterfaces.sample_body(Shape::Image).is_none());
+    }
+}

--- a/src/fetcher/net/ip.rs
+++ b/src/fetcher/net/ip.rs
@@ -1,0 +1,311 @@
+//! `net_ip` — the host's local IP addresses.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status, TextBlockData,
+    TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{
+    NetIface, cache_key, options_placeholder, parse_options, payload, primary_interface, snapshot,
+};
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "kind",
+    type_hint: "\"primary\" | \"v4\" | \"v6\"",
+    required: false,
+    default: Some("\"primary\""),
+    description: "Which address the `Text` shape shows for the primary interface. Ignored by `TextBlock` / `MarkdownTextBlock` / `Entries` (which always list every interface) and `Badge`.",
+}];
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IpOptions {
+    #[serde(default)]
+    pub kind: Option<IpKind>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IpKind {
+    #[default]
+    Primary,
+    V4,
+    V6,
+}
+
+pub struct NetIp;
+
+#[async_trait]
+impl Fetcher for NetIp {
+    fn name(&self) -> &str {
+        "net_ip"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "The host's own IPv4 / IPv6 addresses. `Text` (default) shows one address for the primary (default-route) interface — `kind` picks v4 / v6 / first-available; `TextBlock` / `MarkdownTextBlock` / `Entries` list every interface that has an address; `Badge` flags dual-stack / IPv4 / IPv6-only / no-address."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_snapshot(), shape, IpKind::Primary)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: IpOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return Ok(options_placeholder(&msg)),
+        };
+        let ifaces = snapshot();
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+        let kind = opts.kind.unwrap_or_default();
+        Ok(payload(
+            body_for_shape(&ifaces, shape, kind).unwrap_or_else(|| {
+                Body::Text(TextData {
+                    value: text_value(&ifaces, kind),
+                })
+            }),
+        ))
+    }
+}
+
+fn body_for_shape(ifaces: &[NetIface], shape: Shape, kind: IpKind) -> Option<Body> {
+    Some(match shape {
+        Shape::Text => Body::Text(TextData {
+            value: text_value(ifaces, kind),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: addressed(ifaces)
+                .map(|i| format!("{}  {}", i.name, addr_strings(i).join(", ")))
+                .collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: addressed(ifaces)
+                .map(|i| format!("- **{}** {}", i.name, addr_strings(i).join(" · ")))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: addressed(ifaces)
+                .map(|i| Entry {
+                    key: i.name.clone(),
+                    value: Some(addr_strings(i).join(", ")),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Badge => Body::Badge(ip_badge(ifaces)),
+        _ => return None,
+    })
+}
+
+fn text_value(ifaces: &[NetIface], kind: IpKind) -> String {
+    let Some(i) = primary_interface(ifaces) else {
+        return "no address".into();
+    };
+    match kind {
+        IpKind::V4 => first_v4(i).unwrap_or_else(|| "no IPv4".into()),
+        IpKind::V6 => first_v6(i).unwrap_or_else(|| "no IPv6".into()),
+        IpKind::Primary => first_v4(i)
+            .or_else(|| first_v6(i))
+            .unwrap_or_else(|| "no address".into()),
+    }
+}
+
+fn first_v4(i: &NetIface) -> Option<String> {
+    i.ipv4.first().map(ToString::to_string)
+}
+
+fn first_v6(i: &NetIface) -> Option<String> {
+    i.ipv6.first().map(ToString::to_string)
+}
+
+fn addr_strings(i: &NetIface) -> Vec<String> {
+    i.ipv4
+        .iter()
+        .map(ToString::to_string)
+        .chain(i.ipv6.iter().map(ToString::to_string))
+        .collect()
+}
+
+fn addressed(ifaces: &[NetIface]) -> impl Iterator<Item = &NetIface> {
+    ifaces
+        .iter()
+        .filter(|i| !i.ipv4.is_empty() || !i.ipv6.is_empty())
+}
+
+fn ip_badge(ifaces: &[NetIface]) -> BadgeData {
+    match primary_interface(ifaces) {
+        Some(i) if !i.ipv4.is_empty() && !i.ipv6.is_empty() => BadgeData {
+            status: Status::Ok,
+            label: "dual-stack".into(),
+        },
+        Some(i) if !i.ipv4.is_empty() => BadgeData {
+            status: Status::Ok,
+            label: format!("IPv4 {}", i.ipv4[0]),
+        },
+        Some(i) if !i.ipv6.is_empty() => BadgeData {
+            status: Status::Ok,
+            label: "IPv6 only".into(),
+        },
+        _ => BadgeData {
+            status: Status::Error,
+            label: "no address".into(),
+        },
+    }
+}
+
+fn sample_snapshot() -> Vec<NetIface> {
+    vec![
+        NetIface {
+            name: "lo".into(),
+            kind: "Loopback".into(),
+            mac: None,
+            ipv4: vec![std::net::Ipv4Addr::LOCALHOST],
+            ipv6: vec![],
+            up: true,
+            loopback: true,
+            is_default: false,
+            mtu: Some(65536),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+        NetIface {
+            name: "eth0".into(),
+            kind: "Ethernet".into(),
+            mac: Some("aa:bb:cc:dd:ee:ff".into()),
+            ipv4: vec![std::net::Ipv4Addr::new(192, 168, 1, 24)],
+            ipv6: vec!["fe80::1ab2".parse().unwrap()],
+            up: true,
+            loopback: false,
+            is_default: true,
+            mtu: Some(1500),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::iface;
+    use super::*;
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let snap = sample_snapshot();
+        for &shape in SHAPES {
+            let body = body_for_shape(&snap, shape, IpKind::Primary).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&snap, Shape::Ratio, IpKind::Primary).is_none());
+        assert!(body_for_shape(&snap, Shape::Bars, IpKind::Primary).is_none());
+    }
+
+    #[test]
+    fn text_value_honours_kind_and_falls_back() {
+        let snap = sample_snapshot();
+        assert_eq!(text_value(&snap, IpKind::Primary), "192.168.1.24");
+        assert_eq!(text_value(&snap, IpKind::V4), "192.168.1.24");
+        assert_eq!(text_value(&snap, IpKind::V6), "fe80::1ab2");
+
+        let v6_only = vec![{
+            let mut i = iface("eth0", &[], true);
+            i.is_default = true;
+            i.ipv6 = vec!["fe80::9".parse().unwrap()];
+            i
+        }];
+        assert_eq!(text_value(&v6_only, IpKind::Primary), "fe80::9");
+        assert_eq!(text_value(&v6_only, IpKind::V4), "no IPv4");
+        assert_eq!(text_value(&[], IpKind::Primary), "no address");
+    }
+
+    #[test]
+    fn entries_skip_interfaces_without_an_address() {
+        let snap = vec![
+            iface("eth0", &["10.0.0.2"], true),
+            iface("wlan0", &[], true),
+        ];
+        let Body::Entries(d) = body_for_shape(&snap, Shape::Entries, IpKind::Primary).unwrap()
+        else {
+            panic!("expected entries");
+        };
+        assert_eq!(d.items.len(), 1);
+        assert_eq!(d.items[0].key, "eth0");
+    }
+
+    #[test]
+    fn badge_classifies_stack() {
+        let dual = sample_snapshot();
+        assert_eq!(ip_badge(&dual).label, "dual-stack");
+
+        let mut v4 = iface("eth0", &["10.0.0.2"], true);
+        v4.is_default = true;
+        assert!(ip_badge(&[v4]).label.starts_with("IPv4"));
+        assert_eq!(ip_badge(&[]).status, Status::Error);
+    }
+
+    #[test]
+    fn options_parse_and_reject_unknown_keys() {
+        let ok: toml::Value = toml::from_str("kind = \"v6\"").unwrap();
+        let parsed: IpOptions = parse_options(Some(&ok)).unwrap();
+        assert!(matches!(parsed.kind, Some(IpKind::V6)));
+        let bad: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(parse_options::<IpOptions>(Some(&bad)).is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_options_to_placeholder() {
+        let ctx = FetchContext {
+            shape: Some(Shape::Text),
+            options: Some(toml::from_str("kind = \"bogus\"").unwrap()),
+            ..Default::default()
+        };
+        let Body::Text(t) = NetIp.fetch(&ctx).await.unwrap().body else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("⚠"));
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetIp.name(), "net_ip");
+        assert_eq!(NetIp.safety(), Safety::Safe);
+        assert_eq!(NetIp.default_shape(), Shape::Text);
+        assert_eq!(NetIp.option_schemas().len(), 1);
+        for &shape in SHAPES {
+            assert!(NetIp.sample_body(shape).is_some());
+        }
+        assert!(NetIp.sample_body(Shape::Ratio).is_none());
+        let base = FetchContext {
+            shape: Some(Shape::Text),
+            ..Default::default()
+        };
+        let other = FetchContext {
+            options: Some(toml::from_str("kind = \"v6\"").unwrap()),
+            ..base.clone()
+        };
+        assert_ne!(NetIp.cache_key(&base), NetIp.cache_key(&other));
+    }
+}

--- a/src/fetcher/net/mac.rs
+++ b/src/fetcher/net/mac.rs
@@ -1,0 +1,279 @@
+//! `net_mac` — link-layer (MAC) addresses per interface.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status, TextBlockData,
+    TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{
+    NetIface, cache_key, options_placeholder, parse_options, payload, primary_interface, snapshot,
+};
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "interface",
+    type_hint: "string (interface name)",
+    required: false,
+    default: Some("primary interface"),
+    description: "Interface the `Text` / `Badge` shapes speak for. Defaults to the primary (default-route) interface. Ignored by `TextBlock` / `MarkdownTextBlock` / `Entries`, which always list every interface with a MAC.",
+}];
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MacOptions {
+    #[serde(default)]
+    pub interface: Option<String>,
+}
+
+pub struct NetMac;
+
+#[async_trait]
+impl Fetcher for NetMac {
+    fn name(&self) -> &str {
+        "net_mac"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Link-layer (MAC) addresses. `Text` (default) shows the MAC of the `interface` option's target — the primary (default-route) interface by default; `TextBlock` / `MarkdownTextBlock` / `Entries` list every interface that has a MAC; `Badge` flags whether the selected MAC is universally administered or locally administered (i.e. randomized / spoofed)."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_snapshot(), shape, None)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: MacOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return Ok(options_placeholder(&msg)),
+        };
+        let ifaces = snapshot();
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+        let interface = opts.interface.as_deref();
+        Ok(payload(
+            body_for_shape(&ifaces, shape, interface).unwrap_or_else(|| {
+                Body::Text(TextData {
+                    value: text_value(&ifaces, interface),
+                })
+            }),
+        ))
+    }
+}
+
+fn body_for_shape(ifaces: &[NetIface], shape: Shape, interface: Option<&str>) -> Option<Body> {
+    Some(match shape {
+        Shape::Text => Body::Text(TextData {
+            value: text_value(ifaces, interface),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: with_mac(ifaces)
+                .map(|(name, mac)| format!("{name}  {mac}"))
+                .collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: with_mac(ifaces)
+                .map(|(name, mac)| format!("- **{name}** {mac}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: with_mac(ifaces)
+                .map(|(name, mac)| Entry {
+                    key: name.to_string(),
+                    value: Some(mac.to_string()),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Badge => Body::Badge(mac_badge(ifaces, interface)),
+        _ => return None,
+    })
+}
+
+fn text_value(ifaces: &[NetIface], interface: Option<&str>) -> String {
+    match interface {
+        Some(name) => match ifaces.iter().find(|i| i.name == name) {
+            Some(i) => i.mac.clone().unwrap_or_else(|| "n/a".into()),
+            None => format!("no interface {name}"),
+        },
+        None => primary_interface(ifaces)
+            .and_then(|i| i.mac.clone())
+            .unwrap_or_else(|| "n/a".into()),
+    }
+}
+
+fn with_mac(ifaces: &[NetIface]) -> impl Iterator<Item = (&str, &str)> {
+    ifaces
+        .iter()
+        .filter_map(|i| i.mac.as_deref().map(|m| (i.name.as_str(), m)))
+}
+
+fn mac_badge(ifaces: &[NetIface], interface: Option<&str>) -> BadgeData {
+    let selected = match interface {
+        Some(name) => ifaces.iter().find(|i| i.name == name),
+        None => primary_interface(ifaces),
+    };
+    match selected.and_then(|i| i.mac.as_deref()) {
+        Some(mac) => match is_locally_administered(mac) {
+            Some(true) => BadgeData {
+                status: Status::Warn,
+                label: "randomized".into(),
+            },
+            Some(false) => BadgeData {
+                status: Status::Ok,
+                label: "universal".into(),
+            },
+            None => BadgeData {
+                status: Status::Warn,
+                label: mac.to_string(),
+            },
+        },
+        None => BadgeData {
+            status: Status::Warn,
+            label: "no MAC".into(),
+        },
+    }
+}
+
+/// The U/L bit (bit `0x02` of the first octet) distinguishes a vendor-burned-in address from a
+/// locally administered one — the latter is what randomized / spoofed MACs use.
+fn is_locally_administered(mac: &str) -> Option<bool> {
+    let first = mac.split([':', '-']).next()?;
+    let octet = u8::from_str_radix(first, 16).ok()?;
+    Some(octet & 0x02 != 0)
+}
+
+fn sample_snapshot() -> Vec<NetIface> {
+    vec![
+        NetIface {
+            name: "eth0".into(),
+            kind: "Ethernet".into(),
+            mac: Some("3c:22:fb:8a:1d:04".into()),
+            ipv4: vec![std::net::Ipv4Addr::new(192, 168, 1, 24)],
+            ipv6: vec![],
+            up: true,
+            loopback: false,
+            is_default: true,
+            mtu: Some(1500),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+        NetIface {
+            name: "wlan0".into(),
+            kind: "Wireless IEEE 802.11".into(),
+            mac: Some("aa:bb:cc:dd:ee:ff".into()),
+            ipv4: vec![],
+            ipv6: vec![],
+            up: false,
+            loopback: false,
+            is_default: false,
+            mtu: Some(1500),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::iface;
+    use super::*;
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let snap = sample_snapshot();
+        for &shape in SHAPES {
+            let body = body_for_shape(&snap, shape, None).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&snap, Shape::Ratio, None).is_none());
+    }
+
+    #[test]
+    fn text_value_selects_by_interface_then_primary() {
+        let snap = sample_snapshot();
+        assert_eq!(text_value(&snap, None), "3c:22:fb:8a:1d:04");
+        assert_eq!(text_value(&snap, Some("wlan0")), "aa:bb:cc:dd:ee:ff");
+        assert_eq!(text_value(&snap, Some("ghost0")), "no interface ghost0");
+
+        let mut no_mac = iface("eth0", &["10.0.0.2"], true);
+        no_mac.mac = None;
+        no_mac.is_default = true;
+        assert_eq!(text_value(&[no_mac], None), "n/a");
+    }
+
+    #[test]
+    fn locally_administered_bit_detection() {
+        // 0x3c → bit 0x02 clear → universal; 0xaa → bit 0x02 set → local.
+        assert_eq!(is_locally_administered("3c:22:fb:8a:1d:04"), Some(false));
+        assert_eq!(is_locally_administered("aa:bb:cc:dd:ee:ff"), Some(true));
+        assert_eq!(is_locally_administered("02-00-00-00-00-00"), Some(true));
+        assert_eq!(is_locally_administered("zz:zz"), None);
+    }
+
+    #[test]
+    fn badge_classifies_universal_vs_randomized() {
+        let snap = sample_snapshot();
+        assert_eq!(mac_badge(&snap, None).label, "universal");
+        assert_eq!(mac_badge(&snap, Some("wlan0")).label, "randomized");
+        assert_eq!(mac_badge(&[], None).label, "no MAC");
+    }
+
+    #[test]
+    fn entries_and_blocks_skip_mac_less_interfaces() {
+        let mut no_mac = iface("lo", &["127.0.0.1"], true);
+        no_mac.mac = None;
+        let snap = vec![no_mac, iface("eth0", &["10.0.0.2"], true)];
+        let Body::Entries(d) = body_for_shape(&snap, Shape::Entries, None).unwrap() else {
+            panic!("expected entries");
+        };
+        assert_eq!(d.items.len(), 1);
+        assert_eq!(d.items[0].key, "eth0");
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_options_to_placeholder() {
+        let ctx = FetchContext {
+            shape: Some(Shape::Text),
+            options: Some(toml::from_str("bogus = true").unwrap()),
+            ..Default::default()
+        };
+        let Body::Text(t) = NetMac.fetch(&ctx).await.unwrap().body else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("⚠"));
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetMac.name(), "net_mac");
+        assert_eq!(NetMac.safety(), Safety::Safe);
+        assert_eq!(NetMac.default_shape(), Shape::Text);
+        assert_eq!(NetMac.option_schemas().len(), 1);
+        for &shape in SHAPES {
+            assert!(NetMac.sample_body(shape).is_some());
+        }
+        assert!(NetMac.sample_body(Shape::Bars).is_none());
+    }
+}

--- a/src/fetcher/net/mod.rs
+++ b/src/fetcher/net/mod.rs
@@ -1,0 +1,292 @@
+//! `net_*` family — local network interface / address state, plus a connection speed test.
+//!
+//! All `Safety::Safe`. The interface / address / gateway / proxy fetchers read only host-local
+//! state (the `netdev` interface table, the routing table, `$*_PROXY` env). `net_speedtest` does
+//! talk to the network, but only ever to the hardcoded `speed.cloudflare.com` — config can't
+//! redirect it, so it stays `Safe` under the host-fixed rule (same as `weather` → Open-Meteo).
+//!
+//! The four `netdev`-backed fetchers and `net_speedtest` are cache-backed — `get_interfaces()`
+//! walks every interface and isn't a `<1ms` read, and `net_speedtest` does multi-second network
+//! I/O. `net_proxy` is the one realtime fetcher: pure `std::env` reads, infallible, no I/O.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+
+use crate::payload::{Body, Entry, Payload, TextData};
+
+use super::{FetchContext, Fetcher, RealtimeFetcher};
+
+mod gateway;
+mod interfaces;
+mod ip;
+mod mac;
+mod proxy;
+mod speedtest;
+
+pub use gateway::NetGateway;
+pub use interfaces::NetInterfaces;
+pub use ip::NetIp;
+pub use mac::NetMac;
+pub use proxy::NetProxy;
+pub use speedtest::NetSpeedtest;
+
+pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        Arc::new(NetInterfaces),
+        Arc::new(NetIp),
+        Arc::new(NetMac),
+        Arc::new(NetGateway),
+        Arc::new(NetSpeedtest),
+    ]
+}
+
+pub fn realtime_fetchers() -> Vec<Arc<dyn RealtimeFetcher>> {
+    vec![Arc::new(NetProxy)]
+}
+
+/// Normalised view of one network interface, decoupled from `netdev`'s types so the per-fetcher
+/// modules — and, more importantly, their tests — never depend on the crate directly.
+#[derive(Debug, Clone)]
+pub(crate) struct NetIface {
+    pub name: String,
+    pub kind: String,
+    pub mac: Option<String>,
+    pub ipv4: Vec<Ipv4Addr>,
+    pub ipv6: Vec<Ipv6Addr>,
+    pub up: bool,
+    pub loopback: bool,
+    pub is_default: bool,
+    pub mtu: Option<u32>,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+}
+
+/// Resolved default-route gateway. `ip` / `interface` are independently optional because
+/// `netdev` can resolve a route without naming its interface (and vice versa).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct GatewayInfo {
+    pub ip: Option<IpAddr>,
+    pub interface: Option<String>,
+}
+
+pub(crate) fn snapshot() -> Vec<NetIface> {
+    netdev::get_interfaces()
+        .into_iter()
+        .map(|mut i| {
+            // `get_interfaces()` leaves `stats` unpopulated on Linux — it builds interfaces with
+            // `stats: None` and expects an explicit refresh. Without this, the byte counters are
+            // always zero and `net_interfaces`' byte-count `Bars` would be flat.
+            let _ = i.update_stats();
+            NetIface {
+                loopback: i.is_loopback(),
+                up: i.is_up(),
+                is_default: i.default,
+                kind: i.if_type.name(),
+                mac: i.mac_addr.map(|m| m.to_string()),
+                ipv4: i.ipv4.iter().map(|n| n.addr()).collect(),
+                ipv6: i.ipv6.iter().map(|n| n.addr()).collect(),
+                mtu: i.mtu,
+                rx_bytes: i.stats.as_ref().map(|s| s.rx_bytes).unwrap_or(0),
+                tx_bytes: i.stats.as_ref().map(|s| s.tx_bytes).unwrap_or(0),
+                name: i.name,
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn default_gateway() -> GatewayInfo {
+    // The interface `netdev` marks as the default route carries the resolved next-hop device,
+    // so we get the gateway IP *and* its interface name in one pass.
+    for iface in netdev::get_interfaces() {
+        if iface.default {
+            return GatewayInfo {
+                ip: iface.gateway.as_ref().and_then(gateway_ip),
+                interface: Some(iface.name),
+            };
+        }
+    }
+    // Fallback: the standalone route lookup has no interface name to offer.
+    GatewayInfo {
+        ip: netdev::get_default_gateway()
+            .ok()
+            .as_ref()
+            .and_then(gateway_ip),
+        interface: None,
+    }
+}
+
+fn gateway_ip(dev: &netdev::NetworkDevice) -> Option<IpAddr> {
+    dev.ipv4
+        .first()
+        .copied()
+        .map(IpAddr::V4)
+        .or_else(|| dev.ipv6.first().copied().map(IpAddr::V6))
+}
+
+/// The interface a single-value fetcher should speak for: the default-route interface, falling
+/// back to the first non-loopback interface that's up.
+pub(crate) fn primary_interface(ifaces: &[NetIface]) -> Option<&NetIface> {
+    ifaces
+        .iter()
+        .find(|i| i.is_default)
+        .or_else(|| ifaces.iter().find(|i| i.up && !i.loopback))
+}
+
+pub(crate) fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+pub(crate) fn entry(key: &str, value: &str) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.into()),
+        status: None,
+    }
+}
+
+pub(crate) fn parse_options<T: serde::de::DeserializeOwned + Default>(
+    raw: Option<&toml::Value>,
+) -> Result<T, String> {
+    match raw {
+        None => Ok(T::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+pub(crate) fn options_placeholder(msg: &str) -> Payload {
+    payload(Body::Text(TextData {
+        value: format!("⚠ {msg}"),
+    }))
+}
+
+/// Cache key that mixes in `ctx.options` on top of name + shape — the option-bearing `net_*`
+/// fetchers (`kind` / `interface`) branch their body on it, so two option sets must not collide
+/// on one cache entry. Mirrors [`crate::fetcher::default_cache_key`] otherwise.
+pub(crate) fn cache_key(name: &str, ctx: &FetchContext) -> String {
+    let shape = ctx.shape.map(|s| s.as_str()).unwrap_or("");
+    let opts = ctx
+        .options
+        .as_ref()
+        .and_then(|v| toml::to_string(v).ok())
+        .unwrap_or_default();
+    let raw = format!("{name}|{shape}|{opts}");
+    let digest = Sha256::digest(raw.as_bytes());
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{name}-{hex}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fetcher::Safety;
+    use crate::render::Shape;
+
+    pub(crate) fn iface(name: &str, ipv4: &[&str], up: bool) -> NetIface {
+        NetIface {
+            name: name.into(),
+            kind: "Ethernet".into(),
+            mac: Some("aa:bb:cc:dd:ee:ff".into()),
+            ipv4: ipv4.iter().map(|s| s.parse().unwrap()).collect(),
+            ipv6: vec![],
+            up,
+            loopback: name == "lo",
+            is_default: false,
+            mtu: Some(1500),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        }
+    }
+
+    #[test]
+    fn families_register_expected_names() {
+        let cached: Vec<_> = cached_fetchers()
+            .into_iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        let realtime: Vec<_> = realtime_fetchers()
+            .into_iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        assert_eq!(
+            cached,
+            vec![
+                "net_interfaces",
+                "net_ip",
+                "net_mac",
+                "net_gateway",
+                "net_speedtest",
+            ]
+        );
+        assert_eq!(realtime, vec!["net_proxy"]);
+        cached_fetchers()
+            .iter()
+            .for_each(|f| assert_eq!(f.safety(), Safety::Safe));
+        realtime_fetchers()
+            .iter()
+            .for_each(|f| assert_eq!(f.safety(), Safety::Safe));
+    }
+
+    #[test]
+    fn primary_interface_prefers_default_then_first_up_non_loopback() {
+        let mut def = iface("eth0", &["10.0.0.2"], true);
+        def.is_default = true;
+        let ifaces = vec![iface("lo", &["127.0.0.1"], true), def];
+        assert_eq!(primary_interface(&ifaces).unwrap().name, "eth0");
+
+        let no_default = vec![iface("lo", &["127.0.0.1"], true), iface("wlan0", &[], true)];
+        assert_eq!(primary_interface(&no_default).unwrap().name, "wlan0");
+
+        let all_down = vec![iface("lo", &["127.0.0.1"], true)];
+        assert!(primary_interface(&all_down).is_none());
+    }
+
+    #[test]
+    fn parse_options_defaults_on_none_and_rejects_unknown_keys() {
+        #[derive(Debug, Default, serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Opt {
+            #[serde(default)]
+            kind: Option<String>,
+        }
+        assert!(parse_options::<Opt>(None).unwrap().kind.is_none());
+        let ok: toml::Value = toml::from_str("kind = \"v4\"").unwrap();
+        assert_eq!(
+            parse_options::<Opt>(Some(&ok)).unwrap().kind.as_deref(),
+            Some("v4")
+        );
+        let bad: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(parse_options::<Opt>(Some(&bad)).is_err());
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_options_sensitive() {
+        let base = FetchContext {
+            shape: Some(Shape::Text),
+            ..Default::default()
+        };
+        let with_opts = FetchContext {
+            options: Some(toml::from_str("kind = \"v6\"").unwrap()),
+            ..base.clone()
+        };
+        assert!(cache_key("net_ip", &base).starts_with("net_ip-"));
+        assert_ne!(cache_key("net_ip", &base), cache_key("net_ip", &with_opts));
+    }
+
+    #[test]
+    fn options_placeholder_wraps_message_in_warning_text() {
+        let Body::Text(t) = options_placeholder("bad config").body else {
+            panic!("expected text body");
+        };
+        assert_eq!(t.value, "⚠ bad config");
+    }
+}

--- a/src/fetcher/net/proxy.rs
+++ b/src/fetcher/net/proxy.rs
@@ -217,6 +217,10 @@ mod tests {
         assert_eq!(proxy_badge(&direct).label, "direct");
     }
 
+    // Windows env vars are case-insensitive, so `https_proxy` and `HTTPS_PROXY` are the *same*
+    // variable there — the lowercase-vs-uppercase precedence this asserts only exists on Unix.
+    // `env_either` itself stays correct on Windows (it just reads the one variable twice).
+    #[cfg(not(windows))]
     #[test]
     fn compute_reads_live_env_lowercase_first() {
         let mut env = clear();

--- a/src/fetcher/net/proxy.rs
+++ b/src/fetcher/net/proxy.rs
@@ -1,0 +1,253 @@
+//! `net_proxy` — the `$*_PROXY` environment, i.e. whether this shell routes through a proxy.
+//!
+//! The one realtime fetcher in the family: pure `std::env` reads, infallible, no I/O.
+
+use crate::payload::{
+    BadgeData, Body, EntriesData, MarkdownTextBlockData, Payload, Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, RealtimeFetcher, Safety};
+use super::{entry, payload};
+
+const SHAPES: &[Shape] = &[
+    Shape::Entries,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Badge,
+];
+
+const DIRECT: &str = "(direct)";
+const UNSET: &str = "(unset)";
+
+pub struct NetProxy;
+
+/// Resolved proxy environment. Each field prefers the lowercase variable name (`http_proxy`)
+/// over the uppercase one (`HTTP_PROXY`), matching the de-facto precedence most CLIs use.
+struct ProxyState {
+    http: Option<String>,
+    https: Option<String>,
+    no_proxy: Option<String>,
+}
+
+impl ProxyState {
+    fn is_proxied(&self) -> bool {
+        self.http.is_some() || self.https.is_some()
+    }
+
+    /// The proxy that actually carries traffic — HTTPS first since nearly everything is TLS now.
+    fn active(&self) -> Option<&str> {
+        self.https.as_deref().or(self.http.as_deref())
+    }
+}
+
+impl RealtimeFetcher for NetProxy {
+    fn name(&self) -> &str {
+        "net_proxy"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "The shell's `$*_PROXY` environment. `Entries` (default) / `TextBlock` / `MarkdownTextBlock` roll up `http_proxy` / `https_proxy` / `no_proxy`; `Text` shows the proxy that actually carries traffic (HTTPS first), or `(direct)`; `Badge` is a proxied / direct pill."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_state(), shape)
+    }
+    fn compute(&self, ctx: &FetchContext) -> Payload {
+        let state = read_proxy_state();
+        let shape = ctx.shape.unwrap_or(Shape::Entries);
+        payload(body_for_shape(&state, shape).unwrap_or_else(|| entries_body(&state)))
+    }
+}
+
+fn read_proxy_state() -> ProxyState {
+    ProxyState {
+        http: env_either("http_proxy", "HTTP_PROXY"),
+        https: env_either("https_proxy", "HTTPS_PROXY"),
+        no_proxy: env_either("no_proxy", "NO_PROXY"),
+    }
+}
+
+fn env_either(lower: &str, upper: &str) -> Option<String> {
+    std::env::var(lower)
+        .ok()
+        .or_else(|| std::env::var(upper).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn body_for_shape(state: &ProxyState, shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::Entries => entries_body(state),
+        Shape::Text => Body::Text(TextData {
+            value: state.active().unwrap_or(DIRECT).to_string(),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: rows(state).map(|(k, v)| format!("{k}  {v}")).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: rows(state)
+                .map(|(k, v)| format!("- **{k}** {v}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Badge => Body::Badge(proxy_badge(state)),
+        _ => return None,
+    })
+}
+
+fn entries_body(state: &ProxyState) -> Body {
+    Body::Entries(EntriesData {
+        items: rows(state).map(|(k, v)| entry(k, &v)).collect(),
+    })
+}
+
+fn rows(state: &ProxyState) -> impl Iterator<Item = (&'static str, String)> {
+    [
+        ("http_proxy", state.http.clone()),
+        ("https_proxy", state.https.clone()),
+        ("no_proxy", state.no_proxy.clone()),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k, v.unwrap_or_else(|| UNSET.to_string())))
+}
+
+/// `Warn`, not `Error` — being proxied isn't broken, but it's worth a glance-level flag since it
+/// silently changes where every request goes.
+fn proxy_badge(state: &ProxyState) -> BadgeData {
+    if state.is_proxied() {
+        BadgeData {
+            status: Status::Warn,
+            label: "proxied".into(),
+        }
+    } else {
+        BadgeData {
+            status: Status::Ok,
+            label: "direct".into(),
+        }
+    }
+}
+
+fn sample_state() -> ProxyState {
+    ProxyState {
+        http: Some("http://proxy.corp:8080".into()),
+        https: Some("http://proxy.corp:8080".into()),
+        no_proxy: Some("localhost,127.0.0.1,.internal".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fetcher::system::test_helpers::{EnvGuard, ctx_with_shape};
+
+    const PROXY_KEYS: &[&str] = &[
+        "http_proxy",
+        "HTTP_PROXY",
+        "https_proxy",
+        "HTTPS_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ];
+
+    fn clear() -> Vec<(&'static str, Option<&'static str>)> {
+        PROXY_KEYS.iter().map(|k| (*k, None)).collect()
+    }
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let state = sample_state();
+        for &shape in SHAPES {
+            let body = body_for_shape(&state, shape).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&state, Shape::Ratio).is_none());
+        assert!(body_for_shape(&state, Shape::Bars).is_none());
+    }
+
+    #[test]
+    fn active_prefers_https_then_http_then_direct() {
+        let both = sample_state();
+        assert_eq!(both.active(), Some("http://proxy.corp:8080"));
+        let http_only = ProxyState {
+            http: Some("http://h:1".into()),
+            https: None,
+            no_proxy: None,
+        };
+        assert_eq!(http_only.active(), Some("http://h:1"));
+        let none = ProxyState {
+            http: None,
+            https: None,
+            no_proxy: None,
+        };
+        assert_eq!(none.active(), None);
+        assert!(!none.is_proxied());
+    }
+
+    #[test]
+    fn entries_fall_back_to_unset_marker() {
+        let partial = ProxyState {
+            http: None,
+            https: Some("http://h:1".into()),
+            no_proxy: None,
+        };
+        let Body::Entries(d) = entries_body(&partial) else {
+            panic!("expected entries");
+        };
+        assert_eq!(d.items.len(), 3);
+        assert_eq!(d.items[0].value.as_deref(), Some(UNSET));
+        assert_eq!(d.items[1].value.as_deref(), Some("http://h:1"));
+    }
+
+    #[test]
+    fn badge_distinguishes_proxied_from_direct() {
+        assert_eq!(proxy_badge(&sample_state()).status, Status::Warn);
+        let direct = ProxyState {
+            http: None,
+            https: None,
+            no_proxy: Some("localhost".into()),
+        };
+        // no_proxy alone is not "proxied".
+        assert_eq!(proxy_badge(&direct).status, Status::Ok);
+        assert_eq!(proxy_badge(&direct).label, "direct");
+    }
+
+    #[test]
+    fn compute_reads_live_env_lowercase_first() {
+        let mut env = clear();
+        env.push(("https_proxy", Some("http://low:8080")));
+        env.push(("HTTPS_PROXY", Some("http://up:9090")));
+        let _guard = EnvGuard::set(&env);
+        let Body::Text(t) = NetProxy.compute(&ctx_with_shape(Some(Shape::Text))).body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "http://low:8080");
+    }
+
+    #[test]
+    fn compute_reports_direct_when_env_is_clear() {
+        let _guard = EnvGuard::set(&clear());
+        let Body::Badge(b) = NetProxy.compute(&ctx_with_shape(Some(Shape::Badge))).body else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "direct");
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetProxy.name(), "net_proxy");
+        assert_eq!(NetProxy.safety(), Safety::Safe);
+        assert_eq!(NetProxy.default_shape(), Shape::Entries);
+        assert!(NetProxy.option_schemas().is_empty());
+        for &shape in SHAPES {
+            assert!(NetProxy.sample_body(shape).is_some());
+        }
+        assert!(NetProxy.sample_body(Shape::Ratio).is_none());
+    }
+}

--- a/src/fetcher/net/speedtest.rs
+++ b/src/fetcher/net/speedtest.rs
@@ -1,0 +1,385 @@
+//! `net_speedtest` — actual measured internet bandwidth (download / upload / latency).
+//!
+//! Unlike a throughput monitor (which only shows whatever happens to be flowing right now), this
+//! runs a real transfer test and reports the connection's *capacity* — the number people mean by
+//! "internet speed". The endpoint is the hardcoded `speed.cloudflare.com` (`__down` / `__up`,
+//! purpose-built, no API key, globally CDN'd); config can't redirect it, so the fetcher is
+//! `Safety::Safe` under the host-fixed rule.
+//!
+//! The download is *time-boxed*: it pulls fixed-size chunks back-to-back and stops once
+//! [`DOWNLOAD_BUDGET`] has elapsed, so a fast link gets an accurate sample and a slow one stays
+//! bounded. Upload posts a single modest fixed payload. The whole thing takes a few seconds —
+//! the background fetch daemon (30s budget) absorbs that; a `--wait` invocation on a slow link
+//! may fall back to the cached value.
+
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, MarkdownTextBlockData, Payload, Status,
+    TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{entry, payload};
+
+const DOWN_URL: &str = "https://speed.cloudflare.com/__down";
+const UP_URL: &str = "https://speed.cloudflare.com/__up";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+/// Per-request ceiling so one slow chunk can't hang the whole test.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// Wall-clock cap on the download phase — chunks are pulled until this elapses.
+const DOWNLOAD_BUDGET: Duration = Duration::from_secs(3);
+/// Bytes per download request. Small enough that a single slow chunk overruns the budget only
+/// marginally, large enough to measure a fast link without HTTP overhead dominating.
+const CHUNK_BYTES: u64 = 2_000_000;
+/// Single upload payload size. Modest so a typical link finishes well inside the daemon budget.
+const UPLOAD_BYTES: usize = 2_000_000;
+
+/// Download Mbps below this flips the `Badge` to `Warn`; below [`SLOW_MBPS`] to `Error`. Rough
+/// "usable broadband" / "barely working" lines — not lab thresholds, just a glance-level tier.
+const OK_MBPS: f64 = 25.0;
+const SLOW_MBPS: f64 = 5.0;
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Badge,
+];
+
+pub struct NetSpeedtest;
+
+/// One speed-test result. `latency_ms` is optional because a failed latency probe shouldn't sink
+/// an otherwise-good download / upload measurement.
+#[derive(Debug, Clone, Copy)]
+struct Speedtest {
+    download_mbps: f64,
+    upload_mbps: f64,
+    latency_ms: Option<u64>,
+}
+
+#[async_trait]
+impl Fetcher for NetSpeedtest {
+    fn name(&self) -> &str {
+        "net_speedtest"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Measured internet bandwidth — runs a real download / upload test against the fixed `speed.cloudflare.com` endpoint and reports connection capacity (not whatever happens to be flowing now). `Text` (default) headlines down + up; `TextBlock` / `MarkdownTextBlock` / `Entries` roll up download / upload / latency; `Bars` is download vs upload; `Badge` tiers the connection by download speed. No API key required."
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_speedtest(), shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let client = http();
+        let latency_ms = measure_latency(client).await;
+        let download_mbps = measure_download(client).await?;
+        // A blocked POST shouldn't sink the whole reading — report download with upload as 0.
+        let upload_mbps = measure_upload(client).await.unwrap_or(0.0);
+        let result = Speedtest {
+            download_mbps,
+            upload_mbps,
+            latency_ms,
+        };
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+        Ok(payload(body_for_shape(&result, shape).unwrap_or_else(
+            || {
+                Body::Text(TextData {
+                    value: text_value(&result),
+                })
+            },
+        )))
+    }
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            // No transparent decompression — a throughput test must measure wire bytes, not the
+            // inflated size of a decompressed body.
+            .gzip(false)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+/// Pulls `CHUNK_BYTES` chunks back-to-back until [`DOWNLOAD_BUDGET`] elapses, then divides total
+/// bytes by actual elapsed time. A chunk error ends the loop early; a run that moved no bytes at
+/// all is a hard error (nothing to report).
+async fn measure_download(client: &Client) -> Result<f64, FetchError> {
+    let start = Instant::now();
+    let mut total: u64 = 0;
+    while start.elapsed() < DOWNLOAD_BUDGET {
+        match download_chunk(client).await {
+            Ok(n) => total += n,
+            Err(_) => break,
+        }
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    if total == 0 {
+        return Err(FetchError::Failed(
+            "net_speedtest: download produced no data".into(),
+        ));
+    }
+    Ok(bytes_to_mbps(total, elapsed))
+}
+
+async fn download_chunk(client: &Client) -> Result<u64, FetchError> {
+    let url = format!("{DOWN_URL}?bytes={CHUNK_BYTES}");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("net_speedtest download: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(FetchError::Failed(format!(
+            "net_speedtest download: {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("net_speedtest download body: {e}")))?;
+    Ok(bytes.len() as u64)
+}
+
+async fn measure_upload(client: &Client) -> Result<f64, FetchError> {
+    let body = vec![0u8; UPLOAD_BYTES];
+    let start = Instant::now();
+    let resp = client
+        .post(UP_URL)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("net_speedtest upload: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(FetchError::Failed(format!(
+            "net_speedtest upload: {}",
+            resp.status()
+        )));
+    }
+    let _ = resp.bytes().await;
+    Ok(bytes_to_mbps(
+        UPLOAD_BYTES as u64,
+        start.elapsed().as_secs_f64(),
+    ))
+}
+
+/// Round-trip time of a near-empty request — close enough to a latency figure for a glance.
+async fn measure_latency(client: &Client) -> Option<u64> {
+    let url = format!("{DOWN_URL}?bytes=0");
+    let start = Instant::now();
+    let resp = client.get(&url).send().await.ok()?;
+    let _ = resp.bytes().await.ok()?;
+    Some(start.elapsed().as_millis() as u64)
+}
+
+fn bytes_to_mbps(bytes: u64, secs: f64) -> f64 {
+    if secs <= 0.0 {
+        return 0.0;
+    }
+    (bytes as f64 * 8.0) / secs / 1_000_000.0
+}
+
+fn body_for_shape(s: &Speedtest, shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::Text => Body::Text(TextData {
+            value: text_value(s),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: vec![
+                format!("download  {}", format_mbps(s.download_mbps)),
+                format!("upload  {}", format_mbps(s.upload_mbps)),
+                format!("latency  {}", format_latency(s.latency_ms)),
+            ],
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: format!(
+                "- **download** {}\n- **upload** {}\n- **latency** {}",
+                format_mbps(s.download_mbps),
+                format_mbps(s.upload_mbps),
+                format_latency(s.latency_ms),
+            ),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("download", &format_mbps(s.download_mbps)),
+                entry("upload", &format_mbps(s.upload_mbps)),
+                entry("latency", &format_latency(s.latency_ms)),
+            ],
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "↓ download".into(),
+                    value: s.download_mbps.round() as u64,
+                },
+                Bar {
+                    label: "↑ upload".into(),
+                    value: s.upload_mbps.round() as u64,
+                },
+            ],
+        }),
+        Shape::Badge => Body::Badge(speedtest_badge(s)),
+        _ => return None,
+    })
+}
+
+fn text_value(s: &Speedtest) -> String {
+    format!(
+        "↓ {}  ↑ {}",
+        format_mbps(s.download_mbps),
+        format_mbps(s.upload_mbps)
+    )
+}
+
+/// Tiers the connection by *download* speed — the figure that gates everyday use. Direction is
+/// one number here (it's a capacity reading, not long/short sentiment), so the colour can carry
+/// quality honestly.
+fn speedtest_badge(s: &Speedtest) -> BadgeData {
+    let status = if s.download_mbps >= OK_MBPS {
+        Status::Ok
+    } else if s.download_mbps >= SLOW_MBPS {
+        Status::Warn
+    } else {
+        Status::Error
+    };
+    BadgeData {
+        status,
+        label: format!("↓ {}", format_mbps(s.download_mbps)),
+    }
+}
+
+fn format_mbps(mbps: f64) -> String {
+    if mbps >= 10.0 {
+        format!("{mbps:.0} Mbps")
+    } else {
+        format!("{mbps:.1} Mbps")
+    }
+}
+
+fn format_latency(ms: Option<u64>) -> String {
+    ms.map(|m| format!("{m} ms")).unwrap_or_else(|| "—".into())
+}
+
+fn sample_speedtest() -> Speedtest {
+    Speedtest {
+        download_mbps: 487.0,
+        upload_mbps: 42.0,
+        latency_ms: Some(12),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let s = sample_speedtest();
+        for &shape in SHAPES {
+            let body = body_for_shape(&s, shape).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&s, Shape::Ratio).is_none());
+        assert!(body_for_shape(&s, Shape::Timeline).is_none());
+        assert!(body_for_shape(&s, Shape::NumberSeries).is_none());
+    }
+
+    #[test]
+    fn bytes_to_mbps_converts_bytes_and_seconds_to_megabits() {
+        // 1_000_000 bytes in 1s = 8 Mbps.
+        assert_eq!(bytes_to_mbps(1_000_000, 1.0), 8.0);
+        // 12_500_000 bytes in 2s = 50 Mbps.
+        assert_eq!(bytes_to_mbps(12_500_000, 2.0), 50.0);
+        assert_eq!(bytes_to_mbps(1_000_000, 0.0), 0.0);
+    }
+
+    #[test]
+    fn format_mbps_drops_decimals_above_ten() {
+        assert_eq!(format_mbps(487.3), "487 Mbps");
+        assert_eq!(format_mbps(42.0), "42 Mbps");
+        assert_eq!(format_mbps(4.27), "4.3 Mbps");
+        assert_eq!(format_mbps(0.0), "0.0 Mbps");
+    }
+
+    #[test]
+    fn format_latency_falls_back_to_dash() {
+        assert_eq!(format_latency(Some(12)), "12 ms");
+        assert_eq!(format_latency(None), "—");
+    }
+
+    #[test]
+    fn badge_tiers_by_download_speed() {
+        let tier = |down: f64| {
+            speedtest_badge(&Speedtest {
+                download_mbps: down,
+                upload_mbps: 10.0,
+                latency_ms: None,
+            })
+            .status
+        };
+        assert_eq!(tier(500.0), Status::Ok);
+        assert_eq!(tier(OK_MBPS), Status::Ok);
+        assert_eq!(tier(12.0), Status::Warn);
+        assert_eq!(tier(SLOW_MBPS), Status::Warn);
+        assert_eq!(tier(1.0), Status::Error);
+    }
+
+    #[test]
+    fn text_and_entries_carry_both_directions() {
+        let s = sample_speedtest();
+        assert_eq!(text_value(&s), "↓ 487 Mbps  ↑ 42 Mbps");
+        let Body::Entries(d) = body_for_shape(&s, Shape::Entries).unwrap() else {
+            panic!("expected entries");
+        };
+        assert_eq!(d.items.len(), 3);
+        assert_eq!(d.items[2].key, "latency");
+        assert_eq!(d.items[2].value.as_deref(), Some("12 ms"));
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetSpeedtest.name(), "net_speedtest");
+        assert_eq!(NetSpeedtest.safety(), Safety::Safe);
+        assert_eq!(NetSpeedtest.default_shape(), Shape::Text);
+        assert!(NetSpeedtest.option_schemas().is_empty());
+        for &shape in SHAPES {
+            assert!(NetSpeedtest.sample_body(shape).is_some());
+        }
+        assert!(NetSpeedtest.sample_body(Shape::Ratio).is_none());
+    }
+
+    /// Live smoke test — hits Cloudflare. `#[ignore]` keeps CI offline-safe; run with
+    /// `cargo test -- --ignored fetcher::net::speedtest::tests::live` to verify the real path.
+    #[tokio::test]
+    #[ignore]
+    async fn live_speedtest_returns_a_reading() {
+        let ctx = FetchContext {
+            shape: Some(Shape::Text),
+            ..Default::default()
+        };
+        let p = NetSpeedtest.fetch(&ctx).await.unwrap();
+        let Body::Text(t) = p.body else {
+            panic!("expected text");
+        };
+        eprintln!("net_speedtest → {}", t.value);
+        assert!(t.value.contains("Mbps"));
+    }
+}


### PR DESCRIPTION
## Summary

New `net_*` fetcher family — 6 fetchers covering local network state plus a measured-bandwidth test. All `Safety::Safe`.

| fetcher | what it shows | shapes |
|---|---|---|
| `net_interfaces` | every interface: up/down · IP · MTU · MAC | Text · TextBlock · MarkdownTextBlock · Entries · Ratio · Bars · Badge |
| `net_ip` | local IPv4 / IPv6 (`kind` = primary/v4/v6) | Text · TextBlock · MarkdownTextBlock · Entries · Badge |
| `net_mac` | link-layer addresses; Badge flags universal vs randomized | Text · TextBlock · MarkdownTextBlock · Entries · Badge |
| `net_gateway` | default-route gateway + interface (`kind` = gateway/interface) | Text · TextBlock · MarkdownTextBlock · Entries · Badge |
| `net_proxy` | `$*_PROXY` env (realtime) | Entries · Text · TextBlock · MarkdownTextBlock · Badge |
| `net_speedtest` | measured download / upload / latency | Text · TextBlock · MarkdownTextBlock · Entries · Bars · Badge |

### Design notes
- Shared `netdev`-backed interface snapshot in `net/mod.rs` (new dep: `netdev` 0.43). `get_interfaces()` leaves `stats` unpopulated on Linux, so `snapshot()` calls `update_stats()` — otherwise byte counters read flat zero.
- `net_proxy` is the one realtime fetcher (pure env reads); the four `netdev` fetchers and `net_speedtest` are cached.
- `net_speedtest` hits the hardcoded `speed.cloudflare.com` (`__down` / `__up`) — config can't redirect it, so it stays `Safe` under the host-fixed rule (same as `weather` → Open-Meteo). The download phase is time-boxed so a slow link stays bounded within the daemon's 30s budget.
- An instantaneous-throughput `net_speed` was prototyped and dropped: a single ~500ms sample frozen for the cache TTL is noise on a one-shot splash. `net_speedtest` measures connection *capacity* — the splash-appropriate "network speed".

Ticks `net_interfaces` / `net_ip` / `net_mac` / `net_gateway` / `net_proxy` on #62 and adds `net_speedtest` as a new entry. Refs #41.

## Test plan
- [x] `cargo test` — 2299 passing; every fetcher's shape branches + option parsing covered
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] live `net_speedtest` against Cloudflare: `↓ 246 Mbps  ↑ 189 Mbps`
- [x] tty smoke test via a throwaway `.splashboard/dashboard.toml` exercising all 6 fetchers across shapes/options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive network monitoring: view active network interfaces with status, display IPv4/IPv6 addresses, check MAC addresses, identify default gateway and routing information, and detect proxy configuration.
  * Added internet speed testing to measure download and upload bandwidth.

* **Documentation**
  * Updated fetcher reference documentation to reflect real-time capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/234)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->