### PR TITLE
feat(runtime): add persistent watch mode (splashboard watch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ The themes page renders one "demo dashboard" (currently `home_daily`) under ever
 
 - **Plugin protocol (#5)** — closed. Splashboard is a curated splash renderer, not a dashboard framework. Subprocess plugins can't be bounded in blast radius (a generic `http_fetch` plugin breaks every mitigation). Custom widgets land as built-in PRs or use ReadStore.
 - **Command widget (#20)** — closed. No `command = "..."` fetcher, in any config scope. Local-vs-global rule carve-outs are not worth the footgun potential or the threat-model complexity.
-- **Screensaver sub-mode** — out of scope. Animation lives within the existing 2-second ANIMATION_WINDOW; a persistent idle loop is a different product.
+- **Screensaver / idle eye-candy loop** — out of scope. `splashboard watch` (#232) is a persistent *functional* dashboard mode (the data updates, the user is watching the data); that's fine and shipped. What stays rejected is a persistent loop that exists purely to animate — intro animations still live within the one-shot 2-second ANIMATION_WINDOW and play once at `watch` startup, they do not replay on every data update.
 - **XDG paths via the `dirs` crate** — migrated away. One user-visible `$HOME/.splashboard/` for all platforms, because `~/Library/Application Support/splashboard/` is a surprising place for a CLI tool's state.
 
 ## When in doubt

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ echo 'Invoke-Expression (& splashboard init powershell | Out-String)' >> $PROFIL
 - [Configuration](https://splashboard.unhappychoice.com/guides/configuration/) — the full TOML schema
 - [Presets](https://splashboard.unhappychoice.com/guides/presets/) & [Themes](https://splashboard.unhappychoice.com/guides/themes/) — curated dashboards and palettes
 - [Trust model](https://splashboard.unhappychoice.com/guides/trust/) — how per-directory configs are sandboxed
+- [Watch mode](https://splashboard.unhappychoice.com/guides/watch/) — persistent foreground dashboard via `splashboard watch`
 - [Reference](https://splashboard.unhappychoice.com/reference/matrix/) — every fetcher and renderer with options and compatible shapes
 
 ## Status

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig({
             { label: 'Themes', link: '/guides/themes/' },
             { label: 'ReadStore', link: '/guides/read-store/' },
             { label: 'Trust model', link: '/guides/trust/' },
+            { label: 'Watch mode', link: '/guides/watch/' },
             { label: 'Cookbook', link: '/guides/cookbook/' },
           ],
         },

--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -167,6 +167,8 @@ From here:
   adopt verbatim.
 - [Themes](/guides/themes/) — 26 built-in palettes plus
   per-token overrides.
+- [Watch mode](/guides/watch/) — `splashboard watch` keeps the
+  dashboard live in the foreground instead of painting once.
 - The [reference](/reference/matrix/) — the complete list of
   fetchers and renderers with their options and compatible shapes.
 

--- a/docs-site/src/content/docs/guides/watch.md
+++ b/docs-site/src/content/docs/guides/watch.md
@@ -1,0 +1,108 @@
+---
+title: Watch mode
+description: Run splashboard as a persistent foreground dashboard instead of a one-shot splash.
+---
+
+The default splash paints once on shell startup or `cd` and hands the
+terminal straight back to your prompt. `splashboard watch` does the opposite:
+it holds the alternate screen and keeps the dashboard live until you exit.
+
+## When to use it
+
+- You want a glance-able dashboard on a second monitor or tmux pane.
+- You're tuning a config and want to see the result update as you save.
+- You want to watch CI / weather / heatmaps refresh in real time.
+
+The shell-hook splash stays splashboard's identity — `watch` is a
+deliberate foreground invocation, not the default. It is not the
+splash; it's a different mode that reuses the same widgets.
+
+## Running it
+
+```bash
+splashboard watch
+```
+
+The config is resolved exactly like the splash: a project-local
+`./.splashboard/dashboard.toml` (walked up from `cwd`) wins; otherwise
+the home / project dashboard under `$HOME/.splashboard/` is used. Unlike
+the shell-hook splash, `watch` ignores the `auto_home` / `auto_on_cd`
+opt-outs — you typed the command, so it runs.
+
+`q` or Ctrl-C exits. The alternate screen is restored on clean exit,
+panic, or `?`-bubbled errors via a `Drop` guard plus a panic hook.
+
+## What's live
+
+Inside the watch loop:
+
+- **Realtime fetchers** (`clock`, `system_*`, `clock_*`) are recomputed
+  on a ~200 ms throttle. The seconds digit on a `clock` widget ticks
+  once per second; CPU / memory gauges fluctuate as you load the system.
+- **Cached fetchers** (`git_*`, `github_*`, `rss`, `*_watchlist`, …)
+  are refreshed on their own TTL by an in-process fetch loop, not via
+  the detached daemon the splash uses. The foreground reads only from
+  memory; disk is touched once at the top (warm-start) and once at the
+  bottom (best-effort flush).
+- **Animated renderers** play once during the 2-second startup window
+  and then sit static. They do not replay on data updates — the
+  one-shot animation contract still applies. The data-update channel is
+  the cached / realtime refresh itself, not a re-played reveal.
+- **Redraw-on-change**: an idle dashboard does not redraw at the frame
+  rate. A repaint happens only when a payload changed, a cache TTL
+  expired, the terminal resized, or the footer countdown advanced — so
+  watch idles at roughly 1–5 redraws / second.
+
+## Status footer
+
+The bottom row is reserved for chrome:
+
+```
+ ⟳ next refresh in 45s                              q / Ctrl-C  quit
+```
+
+The left segment is a priority status line:
+
+| When | The footer shows |
+|---|---|
+| Any cached widget still loading | `loading N widgets…` |
+| Anything stale right now | `refreshing…` |
+| Steady state with cached widgets | `next refresh in <duration>` (the soonest TTL expiry) |
+| Realtime-only dashboard | `realtime` |
+
+The right segment lists the active key bindings. The whole footer is
+painted on the theme's `bg_subtle` surface so it reads as chrome
+separate from the dashboard band.
+
+## Trust still applies
+
+The trust model (see [Trust model](/guides/trust/)) is unchanged: a
+project-local dashboard that hasn't been
+[`splashboard trust`](/guides/trust/#granting-trust)-ed still renders
+Network widgets as `🔒 requires trust` placeholders. The gate is
+evaluated once at startup, same as the splash.
+
+## Cache lifecycle
+
+`watch` is single-process, so the disk cache that exists for splash ↔
+daemon IPC is unnecessary on the hot path. The watch loop:
+
+1. **Boots warm**: existing entries for the configured widgets are
+   copied from `$HOME/.splashboard/cache/` into an in-memory map.
+2. **Runs in-memory**: every read and write during the session is a
+   HashMap operation. No disk I/O on the hot path; no `.lock` files
+   created.
+3. **Flushes on clean exit**: the in-memory state is written back so
+   the next splash or watch warm-starts from the latest values. A
+   `SIGKILL` skips the flush, but the next session simply refetches on
+   TTL — nothing breaks.
+
+## Limits
+
+- `watch` is not wired into the shell hook. It is a deliberate
+  foreground command; do not source it from your rc.
+- `watch` is not an idle screensaver loop. The animation contract from
+  the one-shot splash still holds: animations play once, then settle.
+- Concurrent `splashboard` invocations (a splash running while `watch`
+  is up) read the disk cache as it was at the last flush. The in-memory
+  state is not visible across processes.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -129,11 +129,21 @@ impl CacheBackend for Cache {
 pub struct MemCache {
     entries: Arc<RwLock<HashMap<String, CacheEntry>>>,
     in_flight: Arc<Mutex<HashSet<String>>>,
+    /// Monotonic counter bumped on every successful `store`. Watch's foreground reads it to
+    /// decide whether to re-walk the entries map at all — when it hasn't advanced since last
+    /// check, nothing has been written, and the per-frame cache read can be skipped.
+    generation: Arc<AtomicU64>,
 }
 
 impl MemCache {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Current write generation. Use this to short-circuit redundant `load` walks when the
+    /// memory map hasn't been mutated since last check.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
     }
 
     /// Copy entries matching `keys` from `disk` into a fresh `MemCache`. Missing keys are
@@ -170,9 +180,12 @@ impl CacheBackend for MemCache {
         self.entries.read().ok()?.get(key).cloned()
     }
     fn store(&self, key: &str, entry: &CacheEntry) -> std::io::Result<()> {
-        if let Ok(mut e) = self.entries.write() {
-            e.insert(key.to_string(), entry.clone());
-        }
+        let Ok(mut e) = self.entries.write() else {
+            return Ok(());
+        };
+        e.insert(key.to_string(), entry.clone());
+        drop(e);
+        self.generation.fetch_add(1, Ordering::Release);
         Ok(())
     }
     fn try_lock(&self, key: &str) -> Option<CacheLockGuard> {
@@ -529,6 +542,20 @@ mod tests {
             Some(entry)
         );
         assert!(<MemCache as CacheBackend>::load(&mem, "absent").is_none());
+    }
+
+    #[test]
+    fn mem_cache_generation_bumps_only_on_store() {
+        let mem = MemCache::new();
+        let gen0 = mem.generation();
+        let backend: &dyn CacheBackend = &mem;
+        // Pure reads / lock acquires must not advance the generation — readers gate per-frame
+        // work on this, so a spurious bump would cause unnecessary redraws.
+        let _ = backend.load("absent");
+        let _held = backend.try_lock("k");
+        assert_eq!(mem.generation(), gen0);
+        backend.store("k", &CacheEntry::new(sample(), 60)).unwrap();
+        assert_eq!(mem.generation(), gen0 + 1);
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
 
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -86,11 +88,116 @@ impl Cache {
     pub fn path_for(&self, widget_id: &str) -> PathBuf {
         self.dir.join(format!("{}.json", sanitize(widget_id)))
     }
+}
 
-    /// Non-blocking: returns None if another process already holds the lock for this key. Locks
-    /// older than `STALE_LOCK_THRESHOLD` are stolen (assumed crashed).
-    pub fn try_lock(&self, key: &str) -> Option<Lock> {
-        Lock::try_acquire(&self.dir, key)
+/// Abstraction over the storage backend used by `fetch_all` / `load_entries`. The one-shot
+/// splash uses the disk-backed `Cache`; `watch` runs against `MemCache` because the disk is
+/// only justified as IPC between the splash parent and the detached fetch daemon — `watch`
+/// has no child process, so a write-through to disk on every refresh is pure waste.
+pub trait CacheBackend: Send + Sync {
+    fn load(&self, key: &str) -> Option<CacheEntry>;
+    fn store(&self, key: &str, entry: &CacheEntry) -> std::io::Result<()>;
+    /// Non-blocking. `None` if a parallel fetch already holds the slot. Held across the fetch
+    /// await so the same widget can't be refetched twice in one pass.
+    fn try_lock(&self, key: &str) -> Option<CacheLockGuard>;
+}
+
+/// Token returned by [`CacheBackend::try_lock`]. Dropping it releases the lock — removes the
+/// `.lock` file for the disk path, takes the key out of the in-flight set for the in-memory one.
+pub enum CacheLockGuard {
+    File(Lock),
+    Memory(MemLockGuard),
+}
+
+impl CacheBackend for Cache {
+    fn load(&self, key: &str) -> Option<CacheEntry> {
+        Cache::load(self, key)
+    }
+    fn store(&self, key: &str, entry: &CacheEntry) -> std::io::Result<()> {
+        Cache::store(self, key, entry)
+    }
+    fn try_lock(&self, key: &str) -> Option<CacheLockGuard> {
+        Lock::try_acquire(&self.dir, key).map(CacheLockGuard::File)
+    }
+}
+
+/// In-memory cache backend for `watch`. Same TTL semantics as the disk `Cache` (entries carry
+/// `refreshed_at` + `ttl_seconds`), but all reads and writes are HashMap operations and the
+/// per-key locks are a HashSet of in-flight keys. The disk `Cache` is only touched for
+/// warm-start at the top of `watch` and best-effort flush at the bottom.
+#[derive(Clone, Default)]
+pub struct MemCache {
+    entries: Arc<RwLock<HashMap<String, CacheEntry>>>,
+    in_flight: Arc<Mutex<HashSet<String>>>,
+}
+
+impl MemCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Copy entries matching `keys` from `disk` into a fresh `MemCache`. Missing keys are
+    /// skipped — the watch fetch loop will populate them on its first pass.
+    pub fn warm_from<'a>(disk: Option<&Cache>, keys: impl IntoIterator<Item = &'a str>) -> Self {
+        let mem = Self::new();
+        let Some(d) = disk else {
+            return mem;
+        };
+        if let Ok(mut entries) = mem.entries.write() {
+            for key in keys {
+                if let Some(e) = d.load(key) {
+                    entries.insert(key.to_string(), e);
+                }
+            }
+        }
+        mem
+    }
+
+    /// Write every in-memory entry back to disk. Errors per-key are swallowed — losing one
+    /// write on shutdown only forces a refetch next session.
+    pub fn flush_to(&self, disk: &Cache) {
+        let Ok(entries) = self.entries.read() else {
+            return;
+        };
+        for (key, entry) in entries.iter() {
+            let _ = disk.store(key, entry);
+        }
+    }
+}
+
+impl CacheBackend for MemCache {
+    fn load(&self, key: &str) -> Option<CacheEntry> {
+        self.entries.read().ok()?.get(key).cloned()
+    }
+    fn store(&self, key: &str, entry: &CacheEntry) -> std::io::Result<()> {
+        if let Ok(mut e) = self.entries.write() {
+            e.insert(key.to_string(), entry.clone());
+        }
+        Ok(())
+    }
+    fn try_lock(&self, key: &str) -> Option<CacheLockGuard> {
+        let mut set = self.in_flight.lock().ok()?;
+        if set.contains(key) {
+            return None;
+        }
+        set.insert(key.to_string());
+        Some(CacheLockGuard::Memory(MemLockGuard {
+            key: key.to_string(),
+            in_flight: Arc::clone(&self.in_flight),
+        }))
+    }
+}
+
+pub struct MemLockGuard {
+    key: String,
+    in_flight: Arc<Mutex<HashSet<String>>>,
+}
+
+impl Drop for MemLockGuard {
+    fn drop(&mut self) {
+        if let Ok(mut set) = self.in_flight.lock() {
+            set.remove(&self.key);
+        }
     }
 }
 
@@ -375,6 +482,68 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let _a = Lock::try_acquire(dir.path(), "a").unwrap();
         let _b = Lock::try_acquire(dir.path(), "b").unwrap();
+    }
+
+    #[test]
+    fn mem_cache_round_trips_through_the_trait() {
+        let mem = MemCache::new();
+        let entry = CacheEntry::new(sample(), 60);
+        let backend: &dyn CacheBackend = &mem;
+        backend.store("k", &entry).unwrap();
+        assert_eq!(backend.load("k"), Some(entry));
+    }
+
+    #[test]
+    fn mem_cache_try_lock_is_exclusive_until_dropped() {
+        let mem = MemCache::new();
+        let backend: &dyn CacheBackend = &mem;
+        let held = backend.try_lock("k").expect("first acquire succeeds");
+        assert!(
+            backend.try_lock("k").is_none(),
+            "second acquire must fail while held"
+        );
+        drop(held);
+        assert!(
+            backend.try_lock("k").is_some(),
+            "acquire succeeds after drop"
+        );
+    }
+
+    #[test]
+    fn mem_cache_try_lock_separates_keys() {
+        let mem = MemCache::new();
+        let _a = mem.try_lock("a").unwrap();
+        let _b = mem.try_lock("b").unwrap();
+    }
+
+    #[test]
+    fn mem_cache_warm_from_copies_matching_disk_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let disk = Cache::open(dir.path().to_path_buf()).unwrap();
+        let entry = CacheEntry::new(sample(), 60);
+        disk.store("present", &entry).unwrap();
+
+        let mem = MemCache::warm_from(Some(&disk), ["present", "absent"]);
+        assert_eq!(
+            <MemCache as CacheBackend>::load(&mem, "present"),
+            Some(entry)
+        );
+        assert!(<MemCache as CacheBackend>::load(&mem, "absent").is_none());
+    }
+
+    #[test]
+    fn mem_cache_flush_to_writes_every_entry_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let disk = Cache::open(dir.path().to_path_buf()).unwrap();
+        let mem = MemCache::new();
+        let a = CacheEntry::new(sample(), 60);
+        let b = CacheEntry::new(sample(), 120);
+        <MemCache as CacheBackend>::store(&mem, "a", &a).unwrap();
+        <MemCache as CacheBackend>::store(&mem, "b", &b).unwrap();
+
+        mem.flush_to(&disk);
+        assert_eq!(disk.load("a"), Some(a));
+        assert_eq!(disk.load("b"), Some(b));
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -150,15 +150,11 @@ impl MemCache {
     /// skipped — the watch fetch loop will populate them on its first pass.
     pub fn warm_from<'a>(disk: Option<&Cache>, keys: impl IntoIterator<Item = &'a str>) -> Self {
         let mem = Self::new();
-        let Some(d) = disk else {
-            return mem;
-        };
-        if let Ok(mut entries) = mem.entries.write() {
-            for key in keys {
-                if let Some(e) = d.load(key) {
-                    entries.insert(key.to_string(), e);
-                }
-            }
+        if let (Some(d), Ok(mut entries)) = (disk, mem.entries.write()) {
+            entries.extend(
+                keys.into_iter()
+                    .filter_map(|k| d.load(k).map(|e| (k.to_string(), e))),
+            );
         }
         mem
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -44,7 +44,9 @@ pub async fn run_fetch_only(kind: DashboardKind, path: Option<&Path>) -> io::Res
     let settings = load_settings_or_default();
     let config = Config::from_parts(settings, dashboard);
     let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
-    runtime::fetch_and_persist(&config, ident_ref).await;
+    let cache = crate::cache::Cache::open_default();
+    let backend = cache.as_ref().map(|c| c as &dyn crate::cache::CacheBackend);
+    runtime::fetch_and_persist(&config, ident_ref, backend).await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,11 @@ enum Command {
         #[command(subcommand)]
         subcommand: CacheSubcommand,
     },
+    /// Persistent dashboard mode: render the splash full-screen and keep it live — realtime
+    /// widgets tick, cached widgets refresh on their TTL, and the screen repaints as data
+    /// lands. Press `q` or Ctrl-C to exit. Unlike the shell-hook splash this is a deliberate
+    /// foreground invocation and ignores `auto_home` / `auto_on_cd`.
+    Watch,
 }
 
 #[derive(Subcommand)]
@@ -217,6 +222,11 @@ fn main() -> io::Result<()> {
         Some(Command::Catalog { target }) => run_catalog(target),
         Some(Command::License { own }) => run_license(own),
         Some(Command::Cache { subcommand }) => run_cache(subcommand),
+        Some(Command::Watch) => run_async({
+            logging::init();
+            apply_secrets();
+            run_watch()
+        }),
         None => {
             if !should_render() {
                 return Ok(());
@@ -271,6 +281,20 @@ async fn render_for_cd(wait: bool) -> io::Result<()> {
     }
     let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
     runtime::run(&config, &source, ident_ref, wait).await
+}
+
+/// Entry point for `splashboard watch`. A deliberate foreground invocation, so it skips the
+/// `auto_home` / `auto_on_cd` opt-out gates the shell-hook splash honours — but still needs an
+/// interactive terminal for raw mode and the alternate screen.
+async fn run_watch() -> io::Result<()> {
+    if !stdout().is_terminal() || !stdin().is_terminal() {
+        eprintln!("splashboard watch requires an interactive terminal");
+        return Ok(());
+    }
+    let source = config::resolve_dashboard_source();
+    let (config, ident) = load_full_config(&source)?;
+    let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
+    runtime::watch(&config, ident_ref).await
 }
 
 fn should_render() -> bool {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,7 +20,7 @@ use ratatui::{
 };
 use tokio::task::JoinSet;
 
-use crate::cache::{Cache, CacheEntry, CacheEntryKind};
+use crate::cache::{Cache, CacheBackend, CacheEntry, CacheEntryKind, MemCache};
 use crate::config::{Config, General, WidgetConfig};
 use crate::daemon;
 use crate::fetcher::{self, FetchContext, Registry, ShapeMismatch};
@@ -273,7 +273,7 @@ pub async fn run(
     let (cached_widgets, realtime_widgets) = split_by_fetcher_kind(&fetchable, &registry);
 
     let entries = load_entries(
-        cache.as_ref(),
+        as_backend(&cache),
         &registry,
         &cached_widgets,
         &config.general,
@@ -393,7 +393,7 @@ pub async fn run(
             let mut daemon_done = !wait;
             loop {
                 let entries = refresh_payloads(
-                    &cache,
+                    as_backend(&cache),
                     &registry,
                     &buckets,
                     &config.general,
@@ -445,7 +445,7 @@ pub async fn run(
                 }
             }
             let entries = refresh_payloads(
-                &cache,
+                as_backend(&cache),
                 &registry,
                 &buckets,
                 &config.general,
@@ -473,7 +473,7 @@ pub async fn run(
             let fetch_deadline = if wait { WAIT_DEADLINE } else { FAST_DEADLINE };
             let fresh = fetch_all(
                 &registry,
-                cache.as_ref(),
+                as_backend(&cache),
                 &cached_widgets,
                 &entries,
                 &config.general,
@@ -525,7 +525,10 @@ const WATCH_FETCH_TICK: Duration = Duration::from_secs(2);
 /// screen repaints as data lands. Exits on `q` or Ctrl-C.
 pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::Result<()> {
     let layout = config.to_layout();
-    let cache = Cache::open_default();
+    // Disk is only touched at the boundaries: warm `mem_cache` from disk at the top, flush back
+    // at the bottom. The hot path (foreground reads + fetch-task writes) lives entirely in
+    // memory — the disk cache exists for the splash/daemon IPC and watch has no daemon.
+    let disk_cache = Cache::open_default();
     let registry = Registry::with_builtins();
     let render_registry = render::Registry::with_builtins();
     let specs = render_specs(&config.widgets);
@@ -541,8 +544,13 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
     let (fetchable, shape_invalid) = partition_by_shape_support(&fetchable, &shapes, &registry);
     let (cached_widgets, realtime_widgets) = split_by_fetcher_kind(&fetchable, &registry);
 
+    // Warm the in-memory cache from disk for the cached widgets we know about. Anything
+    // missing on disk simply starts as `loading` and the fetch loop populates it.
+    let cache_keys = cache_keys_for(&cached_widgets, &registry, &config.general, &shapes);
+    let mem_cache = MemCache::warm_from(disk_cache.as_ref(), cache_keys.iter().map(String::as_str));
+
     let entries = load_entries(
-        cache.as_ref(),
+        Some(&mem_cache),
         &registry,
         &cached_widgets,
         &config.general,
@@ -569,10 +577,14 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
     }
 
     // In-process replacement for the detached fetch daemon: re-runs the cached fetchers on a
-    // loop so the foreground only ever reads from cache. Owned clones because the task outlives
-    // this stack frame; aborted on exit.
+    // loop so the foreground only ever reads from `mem_cache`. Owned clones because the task
+    // outlives this stack frame; aborted on exit.
     let fetch_ident = config_ident.map(|(p, h)| (p.to_path_buf(), h.to_string()));
-    let fetch_loop = tokio::spawn(watch_fetch_loop(config.clone(), fetch_ident));
+    let fetch_loop = tokio::spawn(watch_fetch_loop(
+        config.clone(),
+        fetch_ident,
+        mem_cache.clone(),
+    ));
 
     let buckets = WidgetBuckets {
         cached: &cached_widgets,
@@ -624,7 +636,7 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
         }
 
         let entries = refresh_payloads(
-            &cache,
+            Some(&mem_cache),
             &registry,
             &buckets,
             &config.general,
@@ -668,6 +680,12 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
 
     fetch_loop.abort();
     drop(terminal);
+    // Best-effort flush. Losing the most recent fetch on a SIGKILL just forces a refetch next
+    // session; for clean exits (`q`, Ctrl-C, `?` bail) the disk reflects the latest values so
+    // the next splash / watch warm-starts.
+    if let Some(disk) = disk_cache.as_ref() {
+        mem_cache.flush_to(disk);
+    }
     result
 }
 
@@ -675,10 +693,10 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
 /// the cached fetchers and writes the cache, then sleeps. `fetch_and_persist` only refetches
 /// widgets whose cache entry is stale, so widget TTLs — not `WATCH_FETCH_TICK` — set the real
 /// refresh cadence.
-async fn watch_fetch_loop(config: Config, ident: Option<(PathBuf, String)>) {
+async fn watch_fetch_loop(config: Config, ident: Option<(PathBuf, String)>, cache: MemCache) {
     loop {
         let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
-        fetch_and_persist(&config, ident_ref).await;
+        fetch_and_persist(&config, ident_ref, Some(&cache as &dyn CacheBackend)).await;
         tokio::time::sleep(WATCH_FETCH_TICK).await;
     }
 }
@@ -739,8 +757,11 @@ fn install_watch_panic_hook() {
 /// nowhere (daemon has no stdio) and simply leave stale cache in place. The daemon re-checks
 /// trust itself because it loads config via its own command-line argument, not from shared
 /// state.
-pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &str)>) {
-    let cache = Cache::open_default();
+pub async fn fetch_and_persist(
+    config: &Config,
+    config_ident: Option<(&Path, &str)>,
+    cache: Option<&dyn CacheBackend>,
+) {
     let registry = Registry::with_builtins();
     let render_registry = render::Registry::with_builtins();
     let decision = TrustStore::load().decide(config_ident);
@@ -754,16 +775,10 @@ pub async fn fetch_and_persist(config: &Config, config_ident: Option<(&Path, &st
     let (fetchable, _shape_invalid) = partition_by_shape_support(&fetchable, &shapes, &registry);
     // Daemon only persists cached-fetcher output. Realtime widgets have no disk representation.
     let (cached_widgets, _realtime) = split_by_fetcher_kind(&fetchable, &registry);
-    let entries = load_entries(
-        cache.as_ref(),
-        &registry,
-        &cached_widgets,
-        &config.general,
-        &shapes,
-    );
+    let entries = load_entries(cache, &registry, &cached_widgets, &config.general, &shapes);
     let _ = fetch_all(
         &registry,
-        cache.as_ref(),
+        cache,
         &cached_widgets,
         &entries,
         &config.general,
@@ -789,14 +804,14 @@ struct WidgetBuckets<'a> {
 /// scale badly. Trust-gate and shape-mismatch placeholders are re-applied defensively so a
 /// daemon-written entry can't leak into a gated slot.
 fn refresh_payloads(
-    cache: &Option<Cache>,
+    cache: Option<&dyn CacheBackend>,
     registry: &Registry,
     buckets: &WidgetBuckets<'_>,
     general: &General,
     shapes: &HashMap<WidgetId, Shape>,
     payloads: &mut HashMap<WidgetId, Payload>,
 ) -> HashMap<WidgetId, CacheEntry> {
-    let entries = load_entries(cache.as_ref(), registry, buckets.cached, general, shapes);
+    let entries = load_entries(cache, registry, buckets.cached, general, shapes);
     for (id, payload) in entries_to_payloads(&entries) {
         payloads.insert(id, payload);
     }
@@ -833,8 +848,37 @@ fn fetch_context(
     }
 }
 
+/// Coerces the owned `Option<Cache>` callers carry into the trait-object form the cache
+/// plumbing accepts. One liner, but kept named so call sites don't repeat the cast.
+fn as_backend(cache: &Option<Cache>) -> Option<&dyn CacheBackend> {
+    cache.as_ref().map(|c| c as &dyn CacheBackend)
+}
+
+/// Derives the on-disk cache key for every cached widget. Used by `watch` to know which disk
+/// entries to copy into its `MemCache` at start-up.
+fn cache_keys_for(
+    widgets: &[WidgetConfig],
+    registry: &Registry,
+    general: &General,
+    shapes: &HashMap<WidgetId, Shape>,
+) -> Vec<String> {
+    widgets
+        .iter()
+        .filter_map(|w| {
+            let fetcher = registry.get_cached(&w.fetcher)?;
+            let ctx = fetch_context(
+                w,
+                general,
+                shapes.get(&w.id).copied(),
+                Duration::from_secs(0),
+            );
+            Some(fetcher.cache_key(&ctx))
+        })
+        .collect()
+}
+
 fn load_entries(
-    cache: Option<&Cache>,
+    cache: Option<&dyn CacheBackend>,
     registry: &Registry,
     widgets: &[WidgetConfig],
     general: &General,
@@ -876,7 +920,7 @@ fn resolve_refresh_interval(w: &WidgetConfig, fetcher: &dyn fetcher::Fetcher) ->
 
 async fn fetch_all(
     registry: &Registry,
-    cache: Option<&Cache>,
+    cache: Option<&dyn CacheBackend>,
     widgets: &[WidgetConfig],
     cached: &HashMap<WidgetId, CacheEntry>,
     general: &General,
@@ -2446,11 +2490,17 @@ mod tests {
             ..Default::default()
         };
 
+        let disk = Cache::open_default();
+        let backend = disk.as_ref().map(|c| c as &dyn CacheBackend);
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap()
-            .block_on(fetch_and_persist(&config, Some((&config_path, &hash))));
+            .block_on(fetch_and_persist(
+                &config,
+                Some((&config_path, &hash)),
+                backend,
+            ));
 
         let cache = Cache::open_default().unwrap();
         let registry = Registry::with_builtins();
@@ -2633,7 +2683,7 @@ mod tests {
         };
         let mut payloads: HashMap<WidgetId, Payload> = HashMap::new();
         let _ = refresh_payloads(
-            &None,
+            None,
             &registry,
             &buckets,
             &General::default(),
@@ -2692,7 +2742,7 @@ mod tests {
         ]);
 
         let entries = refresh_payloads(
-            &cache,
+            as_backend(&cache),
             &registry,
             &buckets,
             &General::default(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -997,7 +997,8 @@ fn draw<B: Backend>(
 /// natural `requested_height`, top-anchored — `draw_frame` distributes the layout's rows across
 /// whatever area it's handed, so a fullscreen area would stretch the dashboard down to fill the
 /// terminal. The whole screen is painted with the theme bg first so the band below the
-/// dashboard isn't a bare terminal-coloured strip.
+/// dashboard isn't a bare terminal-coloured strip, and the bottom row is reserved for the
+/// key-binding footer.
 #[allow(clippy::too_many_arguments)]
 fn draw_watch<B: Backend>(
     terminal: &mut Terminal<B>,
@@ -1014,15 +1015,33 @@ fn draw_watch<B: Backend>(
     terminal.draw(|frame| {
         let full = frame.area();
         paint_viewport_bg(frame, full, theme);
-        let area = Rect {
-            height: requested_height.min(full.height),
+        let footer_height = u16::from(full.height >= 2);
+        let body = Rect {
+            height: requested_height.min(full.height - footer_height),
             ..full
         };
         draw_frame(
-            frame, area, root, payloads, specs, registry, theme, general, padding, 0, loading,
+            frame, body, root, payloads, specs, registry, theme, general, padding, 0, loading,
         );
+        if footer_height > 0 {
+            let footer = Rect {
+                y: full.y + full.height - 1,
+                height: 1,
+                ..full
+            };
+            render_watch_footer(frame, footer, theme);
+        }
     })?;
     Ok(())
+}
+
+/// One-line key-binding footer pinned to the bottom of the `watch` alternate screen, painted on
+/// the theme's subtle surface so it reads as chrome separate from the dashboard band.
+fn render_watch_footer(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let style = Style::default().bg(theme.bg_subtle).fg(theme.text_dim);
+    frame.render_widget(Block::default().style(style), area);
+    let hint = Paragraph::new(Line::from(" q / Ctrl-C  quit").style(style));
+    frame.render_widget(hint, area);
 }
 
 /// Same as [`draw`] but parks the cursor at the bottom-left of the inline area afterwards, so
@@ -1414,6 +1433,44 @@ mod tests {
         crate::paths::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn draw_watch_pins_footer_to_bottom_row_and_keeps_dashboard_top_anchored() {
+        let root = single_widget_tree("x");
+        let mut payloads = HashMap::new();
+        payloads.insert("x".into(), text_payload("hello"));
+        let specs = HashMap::new();
+        let registry = render::Registry::with_builtins();
+        let backend = TestBackend::new(50, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::default();
+        let loading = HashMap::new();
+        draw_watch(
+            &mut terminal,
+            &root,
+            &payloads,
+            &specs,
+            &registry,
+            &theme,
+            &General::default(),
+            (0, 0),
+            3,
+            &loading,
+        )
+        .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert!(
+            row_text(&buf, 0).contains("hello"),
+            "dashboard top-anchored"
+        );
+        let footer = row_text(&buf, 19);
+        assert!(footer.contains("quit"), "footer in bottom row: {footer:?}");
+        assert_eq!(
+            buf.cell((0, 19)).unwrap().bg,
+            theme.bg_subtle,
+            "footer painted on the subtle surface"
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -624,17 +624,26 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
     let mut cache_gen = mem_cache.generation();
     let mut prev_status: Option<WatchStatus> = None;
 
-    let result = loop {
+    // Loop body errors are funnelled through `break Err(...)` rather than `?` so the teardown
+    // below (`fetch_loop.abort()` + `mem_cache.flush_to(disk)`) always runs. A transient
+    // terminal I/O error should still flush, otherwise this session's fetches would be lost.
+    let result: io::Result<()> = loop {
         // Drain pending input. `q` / Ctrl-C quit; a resize forces a repaint (ratatui picks up
         // the new size on the next `draw`).
         let mut resized = false;
         let mut quit = false;
-        while event::poll(Duration::ZERO)? {
-            match event::read()? {
-                Event::Key(k) if k.kind == KeyEventKind::Press => quit |= is_quit_key(&k),
-                Event::Resize(_, _) => resized = true,
-                _ => {}
+        let drain: io::Result<()> = (|| {
+            while event::poll(Duration::ZERO)? {
+                match event::read()? {
+                    Event::Key(k) if k.kind == KeyEventKind::Press => quit |= is_quit_key(&k),
+                    Event::Resize(_, _) => resized = true,
+                    _ => {}
+                }
             }
+            Ok(())
+        })();
+        if let Err(e) = drain {
+            break Err(e);
         }
         if quit {
             break Ok(());
@@ -684,7 +693,7 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
             animating,
             !loading.is_empty(),
         ) {
-            draw_watch(
+            if let Err(e) = draw_watch(
                 &mut terminal.inner,
                 &layout,
                 &payloads,
@@ -696,7 +705,9 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
                 requested_height,
                 &loading,
                 &status,
-            )?;
+            ) {
+                break Err(e);
+            }
             prev_status = Some(status);
         }
 
@@ -705,9 +716,10 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
 
     fetch_loop.abort();
     drop(terminal);
-    // Best-effort flush. Losing the most recent fetch on a SIGKILL just forces a refetch next
-    // session; for clean exits (`q`, Ctrl-C, `?` bail) the disk reflects the latest values so
-    // the next splash / watch warm-starts.
+    // Best-effort flush. Runs on every exit path that reaches here (`q`, Ctrl-C, panic
+    // unwinding past `Drop`, or a terminal I/O error funneled through the loop's `break`).
+    // SIGKILL is the only path that skips this, and the cost there is just a refetch next
+    // session.
     if let Some(disk) = disk_cache.as_ref() {
         mem_cache.flush_to(disk);
     }
@@ -750,10 +762,22 @@ struct WatchTerminal {
 
 impl WatchTerminal {
     fn enter() -> io::Result<Self> {
+        // Stepwise so a failure after we've already mutated terminal state rolls each previous
+        // step back. `Drop` only fires on a constructed `Self`, so a `?` on the final step
+        // would otherwise leave the user in raw mode on the alternate screen with no recovery.
         enable_raw_mode()?;
-        execute!(stdout(), EnterAlternateScreen, Hide)?;
-        let inner = Terminal::new(CrosstermBackend::new(stdout()))?;
-        Ok(Self { inner })
+        if let Err(e) = execute!(stdout(), EnterAlternateScreen, Hide) {
+            let _ = disable_raw_mode();
+            return Err(e);
+        }
+        match Terminal::new(CrosstermBackend::new(stdout())) {
+            Ok(inner) => Ok(Self { inner }),
+            Err(e) => {
+                let _ = execute!(stdout(), LeaveAlternateScreen, Show);
+                let _ = disable_raw_mode();
+                Err(e)
+            }
+        }
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,12 +1,18 @@
 use std::collections::HashMap;
-use std::io::{self, stdout};
-use std::path::Path;
-use std::time::Duration;
+use std::io::{self, Stdout, stdout};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use ratatui::{
     Frame, Terminal, TerminalOptions, Viewport,
     backend::{Backend, CrosstermBackend, TestBackend},
     buffer::Buffer,
+    crossterm::{
+        cursor::{Hide, Show},
+        event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+        execute,
+        terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    },
     layout::{Alignment, Position, Rect},
     style::{Color, Modifier, Style},
     text::Line,
@@ -499,6 +505,216 @@ pub async fn run(
 
     finalize_splash(&mut terminal);
     Ok(())
+}
+
+/// Frame cadence for `watch` mode — the same 50ms as the splash animation loop. Drives input
+/// polling and the redraw check; actual repaints are gated by [`watch_should_draw`].
+const WATCH_FRAME_TICK: Duration = Duration::from_millis(50);
+/// How often realtime fetchers are recomputed inside `watch`. Realtime fetchers run per-frame
+/// in the one-shot splash, but a 50ms recompute loop is wasteful for a persistent dashboard —
+/// 200ms keeps `clock` / `system_*` visibly live without a frame-rate fetch loop.
+const WATCH_REALTIME_TICK: Duration = Duration::from_millis(200);
+/// How often the in-process fetch loop checks cached widgets. Each pass only refetches widgets
+/// whose cache entry is stale (see `should_refresh`), so this is a poll interval, not a fetch
+/// interval — each fetcher's TTL sets the real cadence.
+const WATCH_FETCH_TICK: Duration = Duration::from_secs(2);
+
+/// Persistent dashboard mode. Unlike [`run`], which paints once and hands the terminal back to
+/// the shell, `watch` holds the alternate screen and keeps the dashboard live: realtime
+/// fetchers tick, cached fetchers refresh on their TTL via an in-process fetch loop, and the
+/// screen repaints as data lands. Exits on `q` or Ctrl-C.
+pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::Result<()> {
+    let layout = config.to_layout();
+    let cache = Cache::open_default();
+    let registry = Registry::with_builtins();
+    let render_registry = render::Registry::with_builtins();
+    let specs = render_specs(&config.widgets);
+    let theme = Theme::from_config(&config.theme);
+    let padding = config.general.padding.map(|p| p.xy()).unwrap_or((0, 0));
+
+    // Same widget partitioning as `run`: trust gate, unknown-fetcher divert, shape validation,
+    // then split cached vs realtime.
+    let decision = TrustStore::load().decide(config_ident);
+    let (fetchable, gated) = trust::partition_by_trust(&config.widgets, &registry, decision);
+    let (fetchable, unknown) = partition_by_known_fetcher(&fetchable, &registry);
+    let shapes = derive_shapes(&config.widgets, &registry, &render_registry);
+    let (fetchable, shape_invalid) = partition_by_shape_support(&fetchable, &shapes, &registry);
+    let (cached_widgets, realtime_widgets) = split_by_fetcher_kind(&fetchable, &registry);
+
+    let entries = load_entries(
+        cache.as_ref(),
+        &registry,
+        &cached_widgets,
+        &config.general,
+        &shapes,
+    );
+    let mut payloads = entries_to_payloads(&entries);
+    payloads.extend(compute_realtime_payloads(
+        &registry,
+        &realtime_widgets,
+        &config.general,
+        &shapes,
+    ));
+    for w in &gated {
+        payloads.insert(w.id.clone(), trust::requires_trust_placeholder());
+    }
+    for w in &unknown {
+        payloads.insert(
+            w.id.clone(),
+            fetcher::unknown_fetcher_placeholder(&w.fetcher),
+        );
+    }
+    for (w, err) in &shape_invalid {
+        payloads.insert(w.id.clone(), fetcher::shape_mismatch_placeholder(err));
+    }
+
+    // In-process replacement for the detached fetch daemon: re-runs the cached fetchers on a
+    // loop so the foreground only ever reads from cache. Owned clones because the task outlives
+    // this stack frame; aborted on exit.
+    let fetch_ident = config_ident.map(|(p, h)| (p.to_path_buf(), h.to_string()));
+    let fetch_loop = tokio::spawn(watch_fetch_loop(config.clone(), fetch_ident));
+
+    let buckets = WidgetBuckets {
+        cached: &cached_widgets,
+        gated: &gated,
+        unknown: &unknown,
+        shape_invalid: &shape_invalid,
+    };
+    let real_animated = render::any_widget_animates(&config.widgets, &render_registry);
+
+    install_watch_panic_hook();
+    let mut terminal = WatchTerminal::enter()?;
+    let start = Instant::now();
+    let mut last_realtime = Instant::now();
+    // Snapshot of the last-drawn state, used to skip repaints when nothing changed.
+    let mut prev: Option<(HashMap<WidgetId, Payload>, HashMap<WidgetId, Shape>)> = None;
+
+    let result = loop {
+        // Drain pending input. `q` / Ctrl-C quit; a resize forces a repaint (ratatui picks up
+        // the new size on the next `draw`).
+        let mut resized = false;
+        let mut quit = false;
+        while event::poll(Duration::ZERO)? {
+            match event::read()? {
+                Event::Key(k) if k.kind == KeyEventKind::Press => quit |= is_quit_key(&k),
+                Event::Resize(_, _) => resized = true,
+                _ => {}
+            }
+        }
+        if quit {
+            break Ok(());
+        }
+
+        if last_realtime.elapsed() >= WATCH_REALTIME_TICK {
+            payloads.extend(compute_realtime_payloads(
+                &registry,
+                &realtime_widgets,
+                &config.general,
+                &shapes,
+            ));
+            last_realtime = Instant::now();
+        }
+
+        let entries = refresh_payloads(
+            &cache,
+            &registry,
+            &buckets,
+            &config.general,
+            &shapes,
+            &mut payloads,
+        );
+        let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, false);
+
+        let animating = real_animated && start.elapsed() < ANIMATION_WINDOW;
+        let changed = match &prev {
+            Some((p, l)) => p != &payloads || l != &loading,
+            None => true,
+        };
+        if watch_should_draw(resized, changed, animating, !loading.is_empty()) {
+            draw(
+                &mut terminal.inner,
+                &layout,
+                &payloads,
+                &specs,
+                &render_registry,
+                &theme,
+                &config.general,
+                padding,
+                0,
+                &loading,
+            )?;
+            prev = Some((payloads.clone(), loading));
+        }
+
+        tokio::time::sleep(WATCH_FRAME_TICK).await;
+    };
+
+    fetch_loop.abort();
+    drop(terminal);
+    result
+}
+
+/// In-process fetch loop for `watch`. Mirrors the detached `fetch-only` daemon: each pass runs
+/// the cached fetchers and writes the cache, then sleeps. `fetch_and_persist` only refetches
+/// widgets whose cache entry is stale, so widget TTLs — not `WATCH_FETCH_TICK` — set the real
+/// refresh cadence.
+async fn watch_fetch_loop(config: Config, ident: Option<(PathBuf, String)>) {
+    loop {
+        let ident_ref = ident.as_ref().map(|(p, h)| (p.as_path(), h.as_str()));
+        fetch_and_persist(&config, ident_ref).await;
+        tokio::time::sleep(WATCH_FETCH_TICK).await;
+    }
+}
+
+/// Whether the `watch` loop should repaint this frame. A persistent dashboard on an idle laptop
+/// should not redraw 20x/s for nothing, so a repaint happens only when there is a reason: the
+/// terminal resized, a payload or loading-set changed, the intro animation is still playing, or
+/// a widget is still showing its loading spinner.
+fn watch_should_draw(resized: bool, changed: bool, animating: bool, loading_active: bool) -> bool {
+    resized || changed || animating || loading_active
+}
+
+/// `q` or Ctrl-C exit `watch`. Ctrl-C arrives as a key event rather than SIGINT because raw
+/// mode is enabled, so both quit paths are handled here.
+fn is_quit_key(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char('q'))
+        || (matches!(key.code, KeyCode::Char('c')) && key.modifiers.contains(KeyModifiers::CONTROL))
+}
+
+/// RAII wrapper for the alternate-screen session `watch` runs in. `enter` enables raw mode and
+/// switches to the alternate screen; `Drop` restores both, so the terminal is left sane whether
+/// `watch` returns normally, bails on a `?`, or unwinds on a panic.
+struct WatchTerminal {
+    inner: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl WatchTerminal {
+    fn enter() -> io::Result<Self> {
+        enable_raw_mode()?;
+        execute!(stdout(), EnterAlternateScreen, Hide)?;
+        let inner = Terminal::new(CrosstermBackend::new(stdout()))?;
+        Ok(Self { inner })
+    }
+}
+
+impl Drop for WatchTerminal {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout(), LeaveAlternateScreen, Show);
+    }
+}
+
+/// Restores the terminal from the panic hook so a panic inside the `watch` loop doesn't leave
+/// the user in raw mode on the alternate screen. `WatchTerminal`'s `Drop` also restores during
+/// unwind, but the default hook prints the panic message first — this runs before that so the
+/// message lands on the normal screen.
+fn install_watch_panic_hook() {
+    let original = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout(), LeaveAlternateScreen, Show);
+        original(info);
+    }));
 }
 
 /// Runs fetchers and persists the results. Called by the detached `fetch-only` subcommand so the
@@ -2389,6 +2605,48 @@ mod tests {
             loop_should_exit(true, true, true),
             "hard deadline always wins"
         );
+    }
+
+    #[test]
+    fn watch_should_draw_only_when_there_is_a_reason() {
+        // Idle steady state: nothing changed, no animation, no spinner → skip the repaint so a
+        // persistent dashboard doesn't burn CPU at the frame rate.
+        assert!(!watch_should_draw(false, false, false, false));
+        assert!(watch_should_draw(true, false, false, false), "resized");
+        assert!(watch_should_draw(false, true, false, false), "data changed");
+        assert!(
+            watch_should_draw(false, false, true, false),
+            "intro animation playing"
+        );
+        assert!(
+            watch_should_draw(false, false, false, true),
+            "loading spinner active"
+        );
+    }
+
+    #[test]
+    fn is_quit_key_matches_q_and_ctrl_c_only() {
+        assert!(is_quit_key(&KeyEvent::new(
+            KeyCode::Char('q'),
+            KeyModifiers::NONE
+        )));
+        assert!(is_quit_key(&KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL
+        )));
+        // Bare `c` is just a keystroke, not a quit — only Ctrl-C is.
+        assert!(!is_quit_key(&KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::NONE
+        )));
+        assert!(!is_quit_key(&KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE
+        )));
+        assert!(!is_quit_key(&KeyEvent::new(
+            KeyCode::Esc,
+            KeyModifiers::NONE
+        )));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -143,19 +143,33 @@ fn compute_realtime_payloads(
     general: &General,
     shapes: &HashMap<WidgetId, Shape>,
 ) -> HashMap<WidgetId, Payload> {
-    widgets
-        .iter()
-        .filter_map(|w| {
-            let fetcher = registry.get_realtime(&w.fetcher)?;
-            let ctx = fetch_context(
-                w,
-                general,
-                shapes.get(&w.id).copied(),
-                Duration::from_secs(0),
-            );
-            Some((w.id.clone(), fetcher.compute(&ctx)))
-        })
-        .collect()
+    let mut out = HashMap::new();
+    compute_realtime_payloads_into(registry, widgets, general, shapes, &mut out);
+    out
+}
+
+/// Recomputes every realtime widget directly into `out`, overwriting existing keys. The
+/// allocation-free variant `watch` uses on every realtime tick — building a fresh `HashMap`
+/// every 200ms and `extend`-ing it into `payloads` was wasted work.
+fn compute_realtime_payloads_into(
+    registry: &Registry,
+    widgets: &[WidgetConfig],
+    general: &General,
+    shapes: &HashMap<WidgetId, Shape>,
+    out: &mut HashMap<WidgetId, Payload>,
+) {
+    for w in widgets {
+        let Some(fetcher) = registry.get_realtime(&w.fetcher) else {
+            continue;
+        };
+        let ctx = fetch_context(
+            w,
+            general,
+            shapes.get(&w.id).copied(),
+            Duration::from_secs(0),
+        );
+        out.insert(w.id.clone(), fetcher.compute(&ctx));
+    }
 }
 
 /// Widgets whose data we're still waiting on. Two cases are both treated as "loading":
@@ -586,12 +600,10 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
         mem_cache.clone(),
     ));
 
-    let buckets = WidgetBuckets {
-        cached: &cached_widgets,
-        gated: &gated,
-        unknown: &unknown,
-        shape_invalid: &shape_invalid,
-    };
+    // Placeholders for gated / unknown / shape-invalid widgets are inserted into `payloads`
+    // above and never change after startup in watch mode (the fetch loop excludes them by
+    // construction), so the splash's per-frame re-application via `refresh_payloads` would be
+    // wasted work here.
     let real_animated = render::any_widget_animates(&config.widgets, &render_registry);
     // The dashboard is drawn at its natural height, top-anchored on the alternate screen —
     // handing the layout the whole fullscreen area would stretch its rows down to fill the
@@ -605,9 +617,12 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
     let mut terminal = WatchTerminal::enter()?;
     let start = Instant::now();
     let mut last_realtime = Instant::now();
-    // Snapshot of the last-drawn state, used to skip repaints when nothing changed. The footer
-    // is part of it so its countdown still ticks when widget data is otherwise idle.
-    let mut prev: Option<WatchSnapshot> = None;
+    // Cached entries are carried across iterations and only re-pulled from `mem_cache` when its
+    // generation advances. The footer's `next refresh in N` countdown reads from this every
+    // frame, so we have to keep it around — but the per-frame work was the wasteful part.
+    let mut cached_entries = entries;
+    let mut cache_gen = mem_cache.generation();
+    let mut prev_status: Option<WatchStatus> = None;
 
     let result = loop {
         // Drain pending input. `q` / Ctrl-C quit; a resize forces a repaint (ratatui picks up
@@ -625,36 +640,50 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
             break Ok(());
         }
 
-        if last_realtime.elapsed() >= WATCH_REALTIME_TICK {
-            payloads.extend(compute_realtime_payloads(
+        let realtime_recomputed = last_realtime.elapsed() >= WATCH_REALTIME_TICK;
+        if realtime_recomputed {
+            compute_realtime_payloads_into(
                 &registry,
                 &realtime_widgets,
                 &config.general,
                 &shapes,
-            ));
+                &mut payloads,
+            );
             last_realtime = Instant::now();
         }
 
-        let entries = refresh_payloads(
-            Some(&mem_cache),
-            &registry,
-            &buckets,
-            &config.general,
-            &shapes,
-            &mut payloads,
-        );
-        let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, false);
+        // Re-pull cached entries only when the fetch task has actually written something. In
+        // steady state this branch is taken once every widget TTL, not once per frame.
+        let cur_gen = mem_cache.generation();
+        let cache_changed = cur_gen != cache_gen;
+        if cache_changed {
+            cached_entries = load_entries(
+                Some(&mem_cache),
+                &registry,
+                &cached_widgets,
+                &config.general,
+                &shapes,
+            );
+            for (id, entry) in &cached_entries {
+                payloads.insert(id.clone(), entry.payload.clone());
+            }
+            cache_gen = cur_gen;
+        }
+
+        let loading = compute_loading(&cached_widgets, &payloads, &cached_entries, &shapes, false);
         let status = WatchStatus {
-            next_refresh_secs: next_refresh_secs(&entries),
+            next_refresh_secs: next_refresh_secs(&cached_entries),
             loading: loading.len(),
         };
 
         let animating = real_animated && start.elapsed() < ANIMATION_WINDOW;
-        let changed = match &prev {
-            Some(p) => p.payloads != payloads || p.loading != loading || p.status != status,
-            None => true,
-        };
-        if watch_should_draw(resized, changed, animating, !loading.is_empty()) {
+        let status_changed = prev_status != Some(status);
+        if watch_should_draw(
+            resized,
+            cache_changed || realtime_recomputed || status_changed,
+            animating,
+            !loading.is_empty(),
+        ) {
             draw_watch(
                 &mut terminal.inner,
                 &layout,
@@ -668,11 +697,7 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
                 &loading,
                 &status,
             )?;
-            prev = Some(WatchSnapshot {
-                payloads: payloads.clone(),
-                loading,
-                status,
-            });
+            prev_status = Some(status);
         }
 
         tokio::time::sleep(WATCH_FRAME_TICK).await;
@@ -1090,17 +1115,10 @@ fn draw_watch<B: Backend>(
     Ok(())
 }
 
-/// The last-drawn state of the `watch` loop. Compared against the current frame's state to
-/// skip redundant repaints — an idle dashboard shouldn't redraw at the frame rate.
-struct WatchSnapshot {
-    payloads: HashMap<WidgetId, Payload>,
-    loading: HashMap<WidgetId, Shape>,
-    status: WatchStatus,
-}
-
-/// Footer status shown by `watch`, kept in the redraw snapshot so its countdown still ticks
-/// when widget data is otherwise idle.
-#[derive(Debug, Clone, PartialEq)]
+/// Footer status shown by `watch`. The loop tracks the last-drawn copy of this so the
+/// countdown still ticks when widget data is otherwise idle. `Copy` so change detection is a
+/// trivial value comparison, no clone needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WatchStatus {
     /// Seconds until the soonest cached widget goes stale — when `watch` next has new data.
     /// `None` for a realtime-only dashboard (no cached widgets).

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -581,6 +581,13 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
         shape_invalid: &shape_invalid,
     };
     let real_animated = render::any_widget_animates(&config.widgets, &render_registry);
+    // The dashboard is drawn at its natural height, top-anchored on the alternate screen —
+    // handing the layout the whole fullscreen area would stretch its rows down to fill the
+    // terminal. Same height resolution as the inline splash in `run`.
+    let requested_height = config
+        .general
+        .height
+        .unwrap_or_else(|| config.computed_height().max(DEFAULT_VIEWPORT_LINES));
 
     install_watch_panic_hook();
     let mut terminal = WatchTerminal::enter()?;
@@ -631,7 +638,7 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
             None => true,
         };
         if watch_should_draw(resized, changed, animating, !loading.is_empty()) {
-            draw(
+            draw_watch(
                 &mut terminal.inner,
                 &layout,
                 &payloads,
@@ -640,7 +647,7 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
                 &theme,
                 &config.general,
                 padding,
-                0,
+                requested_height,
                 &loading,
             )?;
             prev = Some((payloads.clone(), loading));
@@ -982,6 +989,38 @@ fn draw<B: Backend>(
             hidden_rows,
             loading,
         )
+    })?;
+    Ok(())
+}
+
+/// Draw used by `watch`. The alternate screen is fullscreen, but the dashboard is drawn at its
+/// natural `requested_height`, top-anchored — `draw_frame` distributes the layout's rows across
+/// whatever area it's handed, so a fullscreen area would stretch the dashboard down to fill the
+/// terminal. The whole screen is painted with the theme bg first so the band below the
+/// dashboard isn't a bare terminal-coloured strip.
+#[allow(clippy::too_many_arguments)]
+fn draw_watch<B: Backend>(
+    terminal: &mut Terminal<B>,
+    root: &Layout,
+    payloads: &HashMap<WidgetId, Payload>,
+    specs: &HashMap<WidgetId, RenderSpec>,
+    registry: &render::Registry,
+    theme: &Theme,
+    general: &General,
+    padding: (u16, u16),
+    requested_height: u16,
+    loading: &HashMap<WidgetId, Shape>,
+) -> Result<(), B::Error> {
+    terminal.draw(|frame| {
+        let full = frame.area();
+        paint_viewport_bg(frame, full, theme);
+        let area = Rect {
+            height: requested_height.min(full.height),
+            ..full
+        };
+        draw_frame(
+            frame, area, root, payloads, specs, registry, theme, general, padding, 0, loading,
+        );
     })?;
     Ok(())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::{self, Stdout, stdout};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use ratatui::{
     Frame, Terminal, TerminalOptions, Viewport,
@@ -15,7 +15,7 @@ use ratatui::{
     },
     layout::{Alignment, Position, Rect},
     style::{Color, Modifier, Style},
-    text::Line,
+    text::{Line, Span},
     widgets::{Block, Paragraph},
 };
 use tokio::task::JoinSet;
@@ -593,8 +593,9 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
     let mut terminal = WatchTerminal::enter()?;
     let start = Instant::now();
     let mut last_realtime = Instant::now();
-    // Snapshot of the last-drawn state, used to skip repaints when nothing changed.
-    let mut prev: Option<(HashMap<WidgetId, Payload>, HashMap<WidgetId, Shape>)> = None;
+    // Snapshot of the last-drawn state, used to skip repaints when nothing changed. The footer
+    // is part of it so its countdown still ticks when widget data is otherwise idle.
+    let mut prev: Option<WatchSnapshot> = None;
 
     let result = loop {
         // Drain pending input. `q` / Ctrl-C quit; a resize forces a repaint (ratatui picks up
@@ -631,10 +632,14 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
             &mut payloads,
         );
         let loading = compute_loading(&cached_widgets, &payloads, &entries, &shapes, false);
+        let status = WatchStatus {
+            next_refresh_secs: next_refresh_secs(&entries),
+            loading: loading.len(),
+        };
 
         let animating = real_animated && start.elapsed() < ANIMATION_WINDOW;
         let changed = match &prev {
-            Some((p, l)) => p != &payloads || l != &loading,
+            Some(p) => p.payloads != payloads || p.loading != loading || p.status != status,
             None => true,
         };
         if watch_should_draw(resized, changed, animating, !loading.is_empty()) {
@@ -649,8 +654,13 @@ pub async fn watch(config: &Config, config_ident: Option<(&Path, &str)>) -> io::
                 padding,
                 requested_height,
                 &loading,
+                &status,
             )?;
-            prev = Some((payloads.clone(), loading));
+            prev = Some(WatchSnapshot {
+                payloads: payloads.clone(),
+                loading,
+                status,
+            });
         }
 
         tokio::time::sleep(WATCH_FRAME_TICK).await;
@@ -1011,6 +1021,7 @@ fn draw_watch<B: Backend>(
     padding: (u16, u16),
     requested_height: u16,
     loading: &HashMap<WidgetId, Shape>,
+    status: &WatchStatus,
 ) -> Result<(), B::Error> {
     terminal.draw(|frame| {
         let full = frame.area();
@@ -1029,19 +1040,95 @@ fn draw_watch<B: Backend>(
                 height: 1,
                 ..full
             };
-            render_watch_footer(frame, footer, theme);
+            render_watch_footer(frame, footer, status, theme);
         }
     })?;
     Ok(())
 }
 
-/// One-line key-binding footer pinned to the bottom of the `watch` alternate screen, painted on
-/// the theme's subtle surface so it reads as chrome separate from the dashboard band.
-fn render_watch_footer(frame: &mut Frame, area: Rect, theme: &Theme) {
-    let style = Style::default().bg(theme.bg_subtle).fg(theme.text_dim);
-    frame.render_widget(Block::default().style(style), area);
-    let hint = Paragraph::new(Line::from(" q / Ctrl-C  quit").style(style));
-    frame.render_widget(hint, area);
+/// The last-drawn state of the `watch` loop. Compared against the current frame's state to
+/// skip redundant repaints — an idle dashboard shouldn't redraw at the frame rate.
+struct WatchSnapshot {
+    payloads: HashMap<WidgetId, Payload>,
+    loading: HashMap<WidgetId, Shape>,
+    status: WatchStatus,
+}
+
+/// Footer status shown by `watch`, kept in the redraw snapshot so its countdown still ticks
+/// when widget data is otherwise idle.
+#[derive(Debug, Clone, PartialEq)]
+struct WatchStatus {
+    /// Seconds until the soonest cached widget goes stale — when `watch` next has new data.
+    /// `None` for a realtime-only dashboard (no cached widgets).
+    next_refresh_secs: Option<u64>,
+    /// Cached widgets still waiting on their first payload.
+    loading: usize,
+}
+
+/// Seconds until the soonest cached widget goes stale. `None` when there are no cached widgets.
+fn next_refresh_secs(entries: &HashMap<WidgetId, CacheEntry>) -> Option<u64> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    entries
+        .values()
+        .map(|e| {
+            e.refreshed_at
+                .saturating_add(e.ttl_seconds)
+                .saturating_sub(now)
+        })
+        .min()
+}
+
+/// The left-hand meta segment of the watch footer: what the dashboard is doing right now.
+fn watch_footer_meta(status: &WatchStatus) -> String {
+    if status.loading > 0 {
+        let plural = if status.loading == 1 { "" } else { "s" };
+        return format!("loading {} widget{plural}…", status.loading);
+    }
+    match status.next_refresh_secs {
+        None => "realtime".to_string(),
+        Some(0) => "refreshing…".to_string(),
+        Some(secs) => format!("next refresh in {}", fmt_duration_compact(secs)),
+    }
+}
+
+/// Compact duration for the footer: `45s`, `3m`, `2h`. Status-bar granularity, not precise.
+fn fmt_duration_compact(secs: u64) -> String {
+    match secs {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s => format!("{}h", s / 3600),
+    }
+}
+
+/// One-line status footer pinned to the bottom of the `watch` alternate screen: live meta info
+/// on the left, key bindings on the right, on the theme's subtle surface so it reads as chrome
+/// separate from the dashboard band.
+fn render_watch_footer(frame: &mut Frame, area: Rect, status: &WatchStatus, theme: &Theme) {
+    let bg = theme.bg_subtle;
+    let label = Style::default().bg(bg).fg(theme.text_secondary);
+    let key = Style::default()
+        .bg(bg)
+        .fg(theme.text)
+        .add_modifier(Modifier::BOLD);
+
+    frame.render_widget(Block::default().style(Style::default().bg(bg)), area);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!(" ⟳ {}", watch_footer_meta(status)),
+            label,
+        ))),
+        area,
+    );
+    let controls = Line::from(vec![
+        Span::styled("q", key),
+        Span::styled(" / ", label),
+        Span::styled("Ctrl-C", key),
+        Span::styled(" quit ", label),
+    ]);
+    frame.render_widget(Paragraph::new(controls).alignment(Alignment::Right), area);
 }
 
 /// Same as [`draw`] but parks the cursor at the bottom-left of the inline area afterwards, so
@@ -1446,6 +1533,10 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let theme = Theme::default();
         let loading = HashMap::new();
+        let status = WatchStatus {
+            next_refresh_secs: Some(45),
+            loading: 0,
+        };
         draw_watch(
             &mut terminal,
             &root,
@@ -1457,6 +1548,7 @@ mod tests {
             (0, 0),
             3,
             &loading,
+            &status,
         )
         .unwrap();
         let buf = terminal.backend().buffer().clone();
@@ -1465,11 +1557,56 @@ mod tests {
             "dashboard top-anchored"
         );
         let footer = row_text(&buf, 19);
-        assert!(footer.contains("quit"), "footer in bottom row: {footer:?}");
+        assert!(footer.contains("quit"), "key binding in footer: {footer:?}");
+        assert!(
+            footer.contains("next refresh in 45s"),
+            "meta info in footer: {footer:?}"
+        );
         assert_eq!(
             buf.cell((0, 19)).unwrap().bg,
             theme.bg_subtle,
             "footer painted on the subtle surface"
+        );
+    }
+
+    #[test]
+    fn watch_footer_meta_prioritises_loading_then_refresh_countdown() {
+        assert_eq!(
+            watch_footer_meta(&WatchStatus {
+                next_refresh_secs: Some(10),
+                loading: 2,
+            }),
+            "loading 2 widgets…",
+            "loading wins over the countdown"
+        );
+        assert_eq!(
+            watch_footer_meta(&WatchStatus {
+                next_refresh_secs: Some(1),
+                loading: 1,
+            }),
+            "loading 1 widget…"
+        );
+        assert_eq!(
+            watch_footer_meta(&WatchStatus {
+                next_refresh_secs: Some(90),
+                loading: 0,
+            }),
+            "next refresh in 1m"
+        );
+        assert_eq!(
+            watch_footer_meta(&WatchStatus {
+                next_refresh_secs: Some(0),
+                loading: 0,
+            }),
+            "refreshing…"
+        );
+        assert_eq!(
+            watch_footer_meta(&WatchStatus {
+                next_refresh_secs: None,
+                loading: 0,
+            }),
+            "realtime",
+            "no cached widgets → realtime-only dashboard"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds `splashboard watch`, a persistent foreground dashboard mode (#232). The one-shot splash paints once and hands the terminal back to the shell; `watch` holds the alternate screen and keeps the dashboard live:

- realtime fetchers (`clock`, `system_*`) tick on a 200ms throttle
- cached fetchers refresh on their own TTL via an in-process fetch loop that reuses `fetch_and_persist` (so per-widget `refresh_interval` already works)
- the screen repaints as data lands
- `q` or Ctrl-C exits

It is a deliberate foreground invocation, so it ignores the `auto_home` / `auto_on_cd` opt-out gates the shell-hook splash honours, but still requires a TTY.

## Design

The core loop reuses existing machinery (widget partitioning, `refresh_payloads`, `draw`), so the new surface is small:

- **`runtime::watch()`** — setup mirrors `run()`, then an input + redraw loop.
- **`WatchTerminal`** — RAII guard for raw mode + alternate screen, restored on normal return, `?` bail, or panic. A panic hook restores before the default hook prints, so a panic message lands on the normal screen.
- **In-process fetch loop** — a spawned task runs `fetch_and_persist` every 2s; `should_refresh` means only stale widgets actually refetch, so widget TTLs set the real cadence. No detached daemon is spawned in watch mode.
- **Redraw-on-change** — a frame is painted only when there is a reason (resize, payload/loading diff, intro animation still in its window, or a loading spinner active), so an idle dashboard does not burn CPU at the frame rate.
- **Animations** — intro animations play once at startup via the existing process-global `ANIMATION_WINDOW` and then sit static. They intentionally do not replay on data updates (replaying a reveal effect on every refresh would be noise, not delight).

`AGENTS.md`: the rejected "Screensaver sub-mode" entry is re-scoped to "idle eye-candy loop" now that a functional persistent mode exists, as the issue asked.

## Test plan

- `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check` all green.
- New unit tests for the two factored pure helpers: `watch_should_draw` (redraw gate) and `is_quit_key` (`q` / Ctrl-C only).
- Non-TTY smoke test: `splashboard watch` outside a terminal prints a friendly message and exits 0.
- **Interactive smoke test still needed** (cannot be automated without a TTY): run `splashboard watch` in a real terminal, confirm the dashboard renders full-screen, the clock ticks, cached widgets refresh, resize reflows, and `q` / Ctrl-C restore the terminal cleanly.

Catalog: #232 is a cross-cutting feature with its own issue, not a #41 checkbox.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent interactive "watch" mode/subcommand for live dashboard rendering with efficient redraws, resize handling, and quit via 'q' or Ctrl‑C.
  * Added an in‑memory cache backend to speed live updates and support warm‑start/flush semantics.

* **Bug Fixes / Reliability**
  * Improved terminal safety and restore behavior on errors/panics.
  * Fetch-only flow now explicitly uses the cache backend.

* **Tests**
  * Added coverage for watch behavior and cache semantics.

* **Documentation**
  * Clarified screensaver/idle animation guidance and allowed short startup intro animations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/238)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->