### PR TITLE
feat(fetcher): add deal_* family for gaming deal aggregators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1298,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2585,11 +2601,24 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -3707,6 +3736,12 @@ dependencies = [
  "ref-cast",
  "wide",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5602,6 +5637,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tui-big-text = "0.8"
 tui-piechart = "0.3"
 tachyonfx = { version = "0.25", default-features = false, features = ["std"] }
 ratatui-image = { version = "11", default-features = false, features = ["crossterm"] }
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "gif"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process"] }
 async-trait = "0.1"
 sha2 = "0.11"

--- a/src/fetcher/deal/common.rs
+++ b/src/fetcher/deal/common.rs
@@ -1,0 +1,350 @@
+//! Shared row model + shape builders for the `deal_*` family.
+//!
+//! Each sibling (`deal_free_games`, `deal_steam_daily`, `deal_games`) parses its upstream
+//! into a `Vec<DealRow>` and dispatches by shape through the builders below. Keeping the
+//! row vocabulary uniform means a renderer swapping between siblings sees consistent
+//! `[Store] Title  $price (X% off)` output regardless of source.
+
+use chrono::{DateTime, Utc};
+
+use crate::fetcher::thumbnails;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData,
+    LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, Status, TextBlockData, TextData,
+    TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+
+/// Cap multi-row shapes so a runaway upstream can't swamp a single widget slot.
+pub(super) const MAX_ROWS: usize = 20;
+/// Bars / entries labels longer than this get an ellipsis. Picked to fit a typical sidebar.
+const LABEL_MAX_CHARS: usize = 40;
+
+#[derive(Debug, Clone)]
+pub(super) struct DealRow {
+    pub title: String,
+    pub image_url: Option<String>,
+    pub sale_price: Option<String>,
+    pub original_price: Option<String>,
+    pub discount_pct: Option<u32>,
+    pub store: Option<String>,
+    pub link: String,
+    pub published: Option<DateTime<Utc>>,
+}
+
+impl DealRow {
+    /// `"Title  $4.99 (50% off from $9.99)"`, with each piece dropping out when absent.
+    pub(super) fn label(&self) -> String {
+        let mut s = self.title.clone();
+        match (&self.sale_price, &self.original_price, self.discount_pct) {
+            (Some(price), Some(orig), Some(pct)) => {
+                s.push_str(&format!("  {price} ({pct}% off from {orig})"));
+            }
+            (Some(price), _, Some(pct)) => s.push_str(&format!("  {price} ({pct}% off)")),
+            (Some(price), _, None) => s.push_str(&format!("  {price}")),
+            (None, _, Some(pct)) => s.push_str(&format!("  {pct}% off")),
+            (None, _, None) => {}
+        }
+        s
+    }
+
+    /// Same as [`label`](Self::label) but prefixed with `[Store]` when known.
+    pub(super) fn label_with_store(&self) -> String {
+        match &self.store {
+            Some(store) => format!("[{store}] {}", self.label()),
+            None => self.label(),
+        }
+    }
+
+    /// Short subtitle for `Timeline` / `ImageLinkedList` rows: `"Store · $X · 50% off"`.
+    fn subtitle(&self) -> Option<String> {
+        let pieces: Vec<String> = [
+            self.store.clone(),
+            self.sale_price.clone(),
+            self.discount_pct.map(|p| format!("{p}% off")),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        (!pieces.is_empty()).then(|| pieces.join(" · "))
+    }
+}
+
+/// Dispatch a non-image shape to its body builder. `ImageLinkedList` and `Image` are
+/// handled separately because they need to download thumbnails async.
+pub(super) fn body_for_shape(rows: &[DealRow], shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => linked_text_block_body(rows),
+        Shape::TextBlock => text_block_body(rows),
+        Shape::MarkdownTextBlock => markdown_body(rows),
+        Shape::Text => text_body(rows),
+        Shape::Entries => entries_body(rows),
+        Shape::Bars => bars_body(rows),
+        Shape::Badge => badge_body(rows),
+        Shape::Timeline => timeline_body(rows),
+        _ => return None,
+    })
+}
+
+pub(super) fn linked_text_block_body(rows: &[DealRow]) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: rows
+            .iter()
+            .map(|r| LinkedLine {
+                text: r.label_with_store(),
+                url: Some(r.link.clone()),
+            })
+            .collect(),
+    })
+}
+
+pub(super) fn text_block_body(rows: &[DealRow]) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: rows.iter().map(|r| r.label_with_store()).collect(),
+    })
+}
+
+pub(super) fn markdown_body(rows: &[DealRow]) -> Body {
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: rows
+            .iter()
+            .map(|r| format!("- [{}]({})", r.label_with_store(), r.link))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    })
+}
+
+pub(super) fn text_body(rows: &[DealRow]) -> Body {
+    let value = top_row(rows)
+        .map(|r| r.label_with_store())
+        .unwrap_or_default();
+    Body::Text(TextData { value })
+}
+
+pub(super) fn entries_body(rows: &[DealRow]) -> Body {
+    Body::Entries(EntriesData {
+        items: rows
+            .iter()
+            .map(|r| Entry {
+                key: truncate(&r.title, LABEL_MAX_CHARS),
+                value: Some(entry_value(r)),
+                status: Some(status_for_pct(r.discount_pct.unwrap_or(0))),
+            })
+            .collect(),
+    })
+}
+
+pub(super) fn bars_body(rows: &[DealRow]) -> Body {
+    let mut sorted: Vec<&DealRow> = rows.iter().collect();
+    sorted.sort_by_key(|r| std::cmp::Reverse(r.discount_pct.unwrap_or(0)));
+    Body::Bars(BarsData {
+        bars: sorted
+            .into_iter()
+            .map(|r| Bar {
+                label: truncate(&r.title, LABEL_MAX_CHARS),
+                value: r.discount_pct.unwrap_or(0) as u64,
+            })
+            .collect(),
+    })
+}
+
+pub(super) fn badge_body(rows: &[DealRow]) -> Body {
+    let best = top_row(rows).and_then(|r| r.discount_pct).unwrap_or(0);
+    let (status, label) = match best {
+        100 => (Status::Ok, "free this week".to_string()),
+        n if n >= 50 => (Status::Ok, format!("{n}% off")),
+        n if n > 0 => (Status::Warn, format!("{n}% off")),
+        _ => (Status::Warn, "no deals".to_string()),
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+pub(super) fn timeline_body(rows: &[DealRow]) -> Body {
+    Body::Timeline(TimelineData {
+        events: rows
+            .iter()
+            .map(|r| TimelineEvent {
+                timestamp: r.published.map(|d| d.timestamp()).unwrap_or(0),
+                title: r.title.clone(),
+                detail: r.subtitle(),
+                status: Some(status_for_pct(r.discount_pct.unwrap_or(0))),
+            })
+            .collect(),
+    })
+}
+
+pub(super) async fn image_linked_body(rows: &[DealRow]) -> Body {
+    let urls: Vec<Option<String>> = rows.iter().map(|r| r.image_url.clone()).collect();
+    let paths = thumbnails::download_many(&urls).await;
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: rows
+            .iter()
+            .zip(paths)
+            .map(|(r, path)| ImageLinkedItem {
+                title: r.title.clone(),
+                url: Some(r.link.clone()),
+                thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
+                subtitle: r.subtitle(),
+            })
+            .collect(),
+    })
+}
+
+fn entry_value(r: &DealRow) -> String {
+    match (&r.sale_price, r.discount_pct) {
+        (Some(price), Some(pct)) => format!("{price} ({pct}% off)"),
+        (Some(price), None) => price.clone(),
+        (None, Some(pct)) => format!("{pct}% off"),
+        (None, None) => "—".into(),
+    }
+}
+
+fn top_row(rows: &[DealRow]) -> Option<&DealRow> {
+    rows.iter().max_by_key(|r| r.discount_pct.unwrap_or(0))
+}
+
+fn status_for_pct(pct: u32) -> Status {
+    if pct >= 50 { Status::Ok } else { Status::Warn }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars()
+            .take(max - 1)
+            .chain(std::iter::once('…'))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(title: &str, pct: Option<u32>, store: Option<&str>) -> DealRow {
+        DealRow {
+            title: title.into(),
+            image_url: None,
+            sale_price: pct.map(|_| "$4.99".into()),
+            original_price: pct.map(|_| "$9.99".into()),
+            discount_pct: pct,
+            store: store.map(str::to_string),
+            link: "https://example.com/deal".into(),
+            published: None,
+        }
+    }
+
+    #[test]
+    fn label_omits_missing_fields() {
+        let bare = row("Bare", None, None);
+        assert_eq!(bare.label(), "Bare");
+    }
+
+    #[test]
+    fn label_with_full_pricing_includes_all_pieces() {
+        let r = row("Half Life", Some(50), None);
+        assert!(r.label().contains("Half Life"));
+        assert!(r.label().contains("$4.99"));
+        assert!(r.label().contains("50% off"));
+        assert!(r.label().contains("$9.99"));
+    }
+
+    #[test]
+    fn label_with_store_prefixes_when_known() {
+        let r = row("X", Some(40), Some("Steam"));
+        assert!(r.label_with_store().starts_with("[Steam]"));
+    }
+
+    #[test]
+    fn entries_body_carries_discount_status() {
+        let rows = vec![row("A", Some(80), Some("Steam")), row("B", Some(20), None)];
+        let Body::Entries(data) = entries_body(&rows) else {
+            panic!("expected entries");
+        };
+        assert_eq!(data.items[0].status, Some(Status::Ok));
+        assert_eq!(data.items[1].status, Some(Status::Warn));
+    }
+
+    #[test]
+    fn bars_body_sorts_descending_by_discount() {
+        let rows = vec![row("low", Some(20), None), row("high", Some(80), None)];
+        let Body::Bars(data) = bars_body(&rows) else {
+            panic!("expected bars");
+        };
+        assert_eq!(data.bars[0].label, "high");
+        assert_eq!(data.bars[0].value, 80);
+    }
+
+    #[test]
+    fn badge_flags_free_with_dedicated_label() {
+        let rows = vec![row("g", Some(100), None)];
+        let Body::Badge(data) = badge_body(&rows) else {
+            panic!("expected badge");
+        };
+        assert_eq!(data.status, Status::Ok);
+        assert!(data.label.contains("free"));
+    }
+
+    #[test]
+    fn badge_warns_when_only_small_discounts_present() {
+        let rows = vec![row("g", Some(10), None)];
+        let Body::Badge(data) = badge_body(&rows) else {
+            panic!("expected badge");
+        };
+        assert_eq!(data.status, Status::Warn);
+    }
+
+    #[test]
+    fn badge_empty_rows_reports_no_deals() {
+        let Body::Badge(data) = badge_body(&[]) else {
+            panic!("expected badge");
+        };
+        assert!(data.label.contains("no deals"));
+    }
+
+    #[test]
+    fn text_body_picks_largest_discount_as_headline() {
+        let rows = vec![row("small", Some(10), None), row("big", Some(70), None)];
+        let Body::Text(data) = text_body(&rows) else {
+            panic!("expected text");
+        };
+        assert!(data.value.contains("big"));
+    }
+
+    #[test]
+    fn timeline_uses_publish_timestamp() {
+        let mut r = row("g", Some(50), Some("Epic"));
+        r.published = Some(chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 5, 1, 12, 0, 0).unwrap());
+        let Body::Timeline(data) = timeline_body(&[r]) else {
+            panic!("expected timeline");
+        };
+        assert!(data.events[0].timestamp > 0);
+        assert!(data.events[0].detail.as_ref().unwrap().contains("Epic"));
+    }
+
+    #[test]
+    fn markdown_body_emits_bullet_list_with_links() {
+        let r = row("g", Some(60), None);
+        let Body::MarkdownTextBlock(data) = markdown_body(&[r]) else {
+            panic!("expected markdown");
+        };
+        assert!(data.value.starts_with("- ["));
+        assert!(data.value.contains("(https://example.com/deal)"));
+    }
+
+    #[test]
+    fn truncate_appends_ellipsis_when_over_limit() {
+        let long = "x".repeat(LABEL_MAX_CHARS + 5);
+        let t = truncate(&long, LABEL_MAX_CHARS);
+        assert_eq!(t.chars().count(), LABEL_MAX_CHARS);
+        assert!(t.ends_with('…'));
+    }
+
+    #[test]
+    fn body_for_shape_returns_none_for_unsupported_shapes() {
+        assert!(body_for_shape(&[], Shape::Heatmap).is_none());
+        assert!(body_for_shape(&[], Shape::Calendar).is_none());
+        assert!(body_for_shape(&[], Shape::Ratio).is_none());
+    }
+}

--- a/src/fetcher/deal/free_games.rs
+++ b/src/fetcher/deal/free_games.rs
@@ -1,0 +1,490 @@
+//! `deal_free_games` — free games / loot offers across 8 storefronts via the LootScraper
+//! aggregator (`feed.eikowagenknecht.com`).
+//!
+//! Safety::Safe — host is hardcoded and `platform` / `kind` pick among a closed enum, so config
+//! cannot redirect the request off-host. LootScraper is third-party but the public instance has
+//! shipped continuously since 2019 and absorbs the per-platform scraping complexity (Epic
+//! GraphQL, Amazon Luna OAuth, Steam giveaway events, GOG/Humble/itch.io homepage scrapes)
+//! that would otherwise sprawl into eight separate fetchers here.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use feed_rs::model::Entry;
+use regex::Regex;
+use serde::Deserialize;
+use url::Url;
+
+use super::common::{self, DealRow, MAX_ROWS};
+use crate::fetcher::feed;
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+const FEED_BASE: &str = "https://feed.eikowagenknecht.com";
+const NAME: &str = "deal_free_games";
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::ImageLinkedList,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "platform",
+        type_hint: "\"all\" | \"epic\" | \"steam\" | \"amazon\" | \"gog\" | \"humble\" | \"itch\" | \"apple\" | \"google\"",
+        required: false,
+        default: Some("\"all\""),
+        description: "Storefront to subscribe to. `all` merges every platform via LootScraper's aggregate feed.",
+    },
+    OptionSchema {
+        name: "kind",
+        type_hint: "\"game\" | \"loot\"",
+        required: false,
+        default: Some("\"game\""),
+        description: "`game` = full game giveaways; `loot` = in-game items / Twitch drops. Only `amazon` and `steam` expose a `loot` feed; other platforms reject it.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of offers to display.",
+    },
+];
+
+pub struct FreeGamesFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    platform: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for FreeGamesFetcher {
+    fn name(&self) -> &str {
+        NAME
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Free games and loot offers aggregated across Epic Games, Steam, Amazon Prime Gaming, GOG, Humble, itch.io, Apple App Store, and Google Play via the LootScraper feed. `platform = \"all\"` (default) merges every source; pick a specific platform to filter. `kind = \"loot\"` switches to the Twitch-drops / in-game-item variant (Amazon and Steam only)."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(NAME, ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body_for(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let platform = parse_platform(opts.platform.as_deref())?;
+        let kind = parse_kind(opts.kind.as_deref())?;
+        if kind == Kind::Loot && !platform.supports_loot() {
+            return Err(FetchError::Failed(format!(
+                "deal_free_games: `kind = \"loot\"` is only supported on `amazon` and `steam` (got `{}`)",
+                platform.config_value()
+            )));
+        }
+        let url = Url::parse(&platform.feed_url(kind))
+            .map_err(|e| FetchError::Failed(format!("deal_free_games: bad feed url: {e}")))?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_ROWS as u32) as usize;
+        let bytes = feed::fetch_bytes(&url, NAME).await?;
+        let parsed = feed::parse_feed(&bytes, NAME)?;
+        let rows: Vec<DealRow> = parsed
+            .entries
+            .iter()
+            .take(count)
+            .map(entry_to_row)
+            .collect();
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = match shape {
+            Shape::ImageLinkedList => common::image_linked_body(&rows).await,
+            other => common::body_for_shape(&rows, other)
+                .unwrap_or_else(|| common::linked_text_block_body(&rows)),
+        };
+        Ok(payload(body))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Platform {
+    All,
+    Epic,
+    Steam,
+    Amazon,
+    Gog,
+    Humble,
+    Itch,
+    Apple,
+    Google,
+}
+
+impl Platform {
+    fn config_value(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Epic => "epic",
+            Self::Steam => "steam",
+            Self::Amazon => "amazon",
+            Self::Gog => "gog",
+            Self::Humble => "humble",
+            Self::Itch => "itch",
+            Self::Apple => "apple",
+            Self::Google => "google",
+        }
+    }
+
+    fn url_slug(self) -> &'static str {
+        // LootScraper's per-platform feeds use slightly different short codes from our config
+        // value. Map explicitly so a config refactor can't silently break URL construction.
+        match self {
+            Self::All => "",
+            Self::Epic => "epic",
+            Self::Steam => "steam",
+            Self::Amazon => "amazon",
+            Self::Gog => "gog",
+            Self::Humble => "humble",
+            Self::Itch => "itch",
+            Self::Apple => "apple",
+            Self::Google => "google",
+        }
+    }
+
+    fn supports_loot(self) -> bool {
+        matches!(self, Self::Amazon | Self::Steam)
+    }
+
+    fn feed_url(self, kind: Kind) -> String {
+        if matches!(self, Self::All) {
+            format!("{FEED_BASE}/lootscraper.xml")
+        } else {
+            format!(
+                "{FEED_BASE}/lootscraper_{slug}_{kind}.xml",
+                slug = self.url_slug(),
+                kind = kind.url_slug(),
+            )
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Game,
+    Loot,
+}
+
+impl Kind {
+    fn url_slug(self) -> &'static str {
+        match self {
+            Self::Game => "game",
+            Self::Loot => "loot",
+        }
+    }
+}
+
+fn parse_platform(raw: Option<&str>) -> Result<Platform, FetchError> {
+    match raw.map(str::trim).filter(|s| !s.is_empty()) {
+        None => Ok(Platform::All),
+        Some(p) => match p.to_lowercase().as_str() {
+            "all" => Ok(Platform::All),
+            "epic" => Ok(Platform::Epic),
+            "steam" => Ok(Platform::Steam),
+            "amazon" => Ok(Platform::Amazon),
+            "gog" => Ok(Platform::Gog),
+            "humble" => Ok(Platform::Humble),
+            "itch" => Ok(Platform::Itch),
+            "apple" => Ok(Platform::Apple),
+            "google" => Ok(Platform::Google),
+            other => Err(FetchError::Failed(format!(
+                "deal_free_games: unknown platform `{other}` (expected all/epic/steam/amazon/gog/humble/itch/apple/google)"
+            ))),
+        },
+    }
+}
+
+fn parse_kind(raw: Option<&str>) -> Result<Kind, FetchError> {
+    match raw.map(str::trim).filter(|s| !s.is_empty()) {
+        None => Ok(Kind::Game),
+        Some(k) => match k.to_lowercase().as_str() {
+            "game" => Ok(Kind::Game),
+            "loot" => Ok(Kind::Loot),
+            other => Err(FetchError::Failed(format!(
+                "deal_free_games: unknown kind `{other}` (expected game/loot)"
+            ))),
+        },
+    }
+}
+
+/// LootScraper entry titles follow `"<Store> (<Kind>) - <Game>"` (e.g.
+/// `"Amazon Prime (Game) - Captain Blood"`). The store / game split survives even on the
+/// aggregate feed because every entry carries it. When the pattern doesn't match (older
+/// item, future variation) we fall back to the raw title with no store.
+fn entry_to_row(entry: &Entry) -> DealRow {
+    let raw_title = entry
+        .title
+        .as_ref()
+        .map(|t| feed::collapse_whitespace(&t.content))
+        .unwrap_or_default();
+    let (store, title) = split_store_and_title(&raw_title);
+    let link = feed::link_for(entry).unwrap_or_else(|| String::from("https://example.com/"));
+    DealRow {
+        title: if title.is_empty() {
+            "(unnamed offer)".into()
+        } else {
+            title
+        },
+        image_url: feed::thumbnail_url_for(entry),
+        sale_price: Some("Free".into()),
+        original_price: None,
+        discount_pct: Some(100),
+        store,
+        link,
+        published: entry.published.or(entry.updated),
+    }
+}
+
+fn split_store_and_title(raw: &str) -> (Option<String>, String) {
+    static SPLIT_RE: OnceLock<Regex> = OnceLock::new();
+    let re = SPLIT_RE.get_or_init(|| {
+        Regex::new(r"^(?P<store>[^(]+?)\s*\((?:Game|Loot)\)\s*-\s*(?P<title>.+)$").unwrap()
+    });
+    match re.captures(raw) {
+        Some(c) => (
+            Some(c["store"].trim().to_string()),
+            c["title"].trim().to_string(),
+        ),
+        None => (None, raw.to_string()),
+    }
+}
+
+fn sample_body_for(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "[Epic Games] Subnautica  Free (100% off)",
+                Some("https://store.epicgames.com/p/subnautica"),
+            ),
+            (
+                "[Amazon Prime] Star Wars Battlefront II  Free (100% off)",
+                Some("https://gaming.amazon.com/loot/star-wars-battlefront-2"),
+            ),
+            (
+                "[GOG] Galactic Civilizations III  Free (100% off)",
+                Some("https://www.gog.com/giveaway"),
+            ),
+        ]),
+        Shape::TextBlock => samples::text_block(&[
+            "[Epic Games] Subnautica  Free (100% off)",
+            "[Amazon Prime] Star Wars Battlefront II  Free (100% off)",
+            "[GOG] Galactic Civilizations III  Free (100% off)",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- [[Epic Games] Subnautica  Free (100% off)](https://store.epicgames.com/p/subnautica)\n- [[Amazon Prime] Star Wars Battlefront II  Free (100% off)](https://gaming.amazon.com/loot/star-wars-battlefront-2)",
+        ),
+        Shape::Text => samples::text("[Epic Games] Subnautica  Free (100% off)"),
+        Shape::Entries => samples::entries(&[
+            ("Subnautica", "Free (100% off)"),
+            ("Star Wars Battlefront II", "Free (100% off)"),
+            ("Galactic Civilizations III", "Free (100% off)"),
+        ]),
+        Shape::Bars => samples::bars(&[
+            ("Subnautica", 100),
+            ("Star Wars Battlefront II", 100),
+            ("Galactic Civilizations III", 100),
+        ]),
+        Shape::Badge => samples::badge(crate::payload::Status::Ok, "free this week"),
+        Shape::Timeline => samples::timeline(&[
+            (
+                1_745_625_600,
+                "Subnautica",
+                Some("Epic Games · Free · 100% off"),
+            ),
+            (
+                1_745_539_200,
+                "Star Wars Battlefront II",
+                Some("Amazon Prime · Free · 100% off"),
+            ),
+        ]),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts(raw: &str) -> toml::Value {
+        toml::from_str(raw).expect("test toml must parse")
+    }
+
+    #[test]
+    fn parse_platform_defaults_to_all() {
+        assert_eq!(parse_platform(None).unwrap(), Platform::All);
+        assert_eq!(parse_platform(Some("  ")).unwrap(), Platform::All);
+    }
+
+    #[test]
+    fn parse_platform_case_insensitive() {
+        assert_eq!(parse_platform(Some("Epic")).unwrap(), Platform::Epic);
+        assert_eq!(parse_platform(Some("STEAM")).unwrap(), Platform::Steam);
+    }
+
+    #[test]
+    fn parse_platform_rejects_unknown() {
+        let err = parse_platform(Some("origin")).unwrap_err();
+        let FetchError::Failed(msg) = err else {
+            panic!("expected Failed");
+        };
+        assert!(msg.contains("origin"));
+        assert!(msg.contains("expected"));
+    }
+
+    #[test]
+    fn parse_kind_defaults_to_game_and_rejects_unknown() {
+        assert_eq!(parse_kind(None).unwrap(), Kind::Game);
+        assert_eq!(parse_kind(Some("loot")).unwrap(), Kind::Loot);
+        assert!(parse_kind(Some("bundle")).is_err());
+    }
+
+    #[test]
+    fn feed_url_for_all_uses_aggregate_endpoint() {
+        let url = Platform::All.feed_url(Kind::Game);
+        assert_eq!(url, format!("{FEED_BASE}/lootscraper.xml"));
+    }
+
+    #[test]
+    fn feed_url_for_specific_platform_includes_kind_slug() {
+        assert_eq!(
+            Platform::Epic.feed_url(Kind::Game),
+            format!("{FEED_BASE}/lootscraper_epic_game.xml")
+        );
+        assert_eq!(
+            Platform::Amazon.feed_url(Kind::Loot),
+            format!("{FEED_BASE}/lootscraper_amazon_loot.xml")
+        );
+    }
+
+    #[test]
+    fn supports_loot_is_amazon_and_steam_only() {
+        assert!(Platform::Amazon.supports_loot());
+        assert!(Platform::Steam.supports_loot());
+        for p in [
+            Platform::Epic,
+            Platform::Gog,
+            Platform::Humble,
+            Platform::Itch,
+            Platform::Apple,
+            Platform::Google,
+        ] {
+            assert!(!p.supports_loot(), "{:?} should not support loot", p);
+        }
+    }
+
+    #[test]
+    fn split_store_extracts_prefix_when_present() {
+        let (store, title) = split_store_and_title("Amazon Prime (Game) - Captain Blood");
+        assert_eq!(store.as_deref(), Some("Amazon Prime"));
+        assert_eq!(title, "Captain Blood");
+    }
+
+    #[test]
+    fn split_store_handles_loot_variant() {
+        let (store, title) = split_store_and_title("Steam (Loot) - Some Cosmetic");
+        assert_eq!(store.as_deref(), Some("Steam"));
+        assert_eq!(title, "Some Cosmetic");
+    }
+
+    #[test]
+    fn split_store_falls_back_for_unrecognised_titles() {
+        let (store, title) = split_store_and_title("just a title");
+        assert!(store.is_none());
+        assert_eq!(title, "just a title");
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw = opts("platform = \"epic\"\nbogus = 1");
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_exposes_safety_safe_and_default_linked_shape() {
+        let f = FreeGamesFetcher;
+        assert_eq!(f.name(), NAME);
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(f.shapes(), SHAPES);
+    }
+
+    #[test]
+    fn sample_body_covers_every_supported_shape() {
+        let f = FreeGamesFetcher;
+        for shape in [
+            Shape::LinkedTextBlock,
+            Shape::TextBlock,
+            Shape::MarkdownTextBlock,
+            Shape::Text,
+            Shape::Entries,
+            Shape::Bars,
+            Shape::Badge,
+            Shape::Timeline,
+        ] {
+            assert!(
+                f.sample_body(shape).is_some(),
+                "sample missing for {shape:?}"
+            );
+        }
+        // ImageLinkedList needs a real on-disk thumbnail path, skipped like rss.
+        assert!(f.sample_body(Shape::ImageLinkedList).is_none());
+        assert!(f.sample_body(Shape::Heatmap).is_none());
+    }
+
+    #[test]
+    fn cache_key_varies_with_platform_option() {
+        let f = FreeGamesFetcher;
+        let base = FetchContext::default();
+        let mut a = base.clone();
+        let mut b = base.clone();
+        a.options = Some(opts("platform = \"epic\""));
+        b.options = Some(opts("platform = \"steam\""));
+        assert_ne!(f.cache_key(&a), f.cache_key(&b));
+    }
+}

--- a/src/fetcher/deal/games.rs
+++ b/src/fetcher/deal/games.rs
@@ -1,0 +1,436 @@
+//! `deal_games` — CheapShark cross-store gaming deals via the public JSON API.
+//!
+//! Safety::Safe — host hardcoded at `www.cheapshark.com`. Config picks the discount floor /
+//! row cap / optional store IDs; the URL stays on-host regardless. No API key needed.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+use super::common::{self, DealRow, MAX_ROWS};
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+const API_BASE: &str = "https://www.cheapshark.com/api/1.0/deals";
+const REDIRECT_BASE: &str = "https://www.cheapshark.com/redirect";
+const NAME: &str = "deal_games";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_BYTES: usize = 5 * 1024 * 1024;
+
+const DEFAULT_MIN_DISCOUNT: u32 = 50;
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::ImageLinkedList,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "min_discount",
+        type_hint: "integer (0..=100)",
+        required: false,
+        default: Some("50"),
+        description: "Discount-percent floor. Deals below this percent off are filtered out.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of deals to display.",
+    },
+    OptionSchema {
+        name: "stores",
+        type_hint: "list of integers (CheapShark store IDs)",
+        required: false,
+        default: None,
+        description: "Restrict to specific stores (CheapShark IDs: 1=Steam, 7=GOG, 11=Humble, 25=Epic, …). Omit for every store.",
+    },
+];
+
+pub struct GamesFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    min_discount: Option<u32>,
+    #[serde(default)]
+    limit: Option<u32>,
+    #[serde(default)]
+    stores: Option<Vec<u32>>,
+}
+
+#[async_trait]
+impl Fetcher for GamesFetcher {
+    fn name(&self) -> &str {
+        NAME
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Cross-store gaming deals via the public CheapShark API. Spans Steam, GOG, Epic, Humble, Fanatical, GreenManGaming, and more (filter via `stores`). Sorted by savings; the `min_discount` floor keeps the list focused on actually-meaningful discounts. No API key required."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(NAME, ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body_for(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let min_discount = opts.min_discount.unwrap_or(DEFAULT_MIN_DISCOUNT).min(100);
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_ROWS as u32);
+        let url = build_url(min_discount, limit, opts.stores.as_deref());
+        let raw = fetch_deals(&url).await?;
+        let rows: Vec<DealRow> = raw.into_iter().map(api_to_row).collect();
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = match shape {
+            Shape::ImageLinkedList => common::image_linked_body(&rows).await,
+            other => common::body_for_shape(&rows, other)
+                .unwrap_or_else(|| common::linked_text_block_body(&rows)),
+        };
+        Ok(payload(body))
+    }
+}
+
+fn build_url(min_discount: u32, limit: u32, stores: Option<&[u32]>) -> String {
+    let mut url =
+        format!("{API_BASE}?sortBy=Savings&desc=1&onSale=1&pageSize={limit}&lowerPrice=0");
+    if min_discount > 0 {
+        url.push_str(&format!("&minDiscount={min_discount}"));
+    }
+    if let Some(ids) = stores.filter(|s| !s.is_empty()) {
+        let csv = ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        url.push_str(&format!("&storeID={csv}"));
+    }
+    url
+}
+
+async fn fetch_deals(url: &str) -> Result<Vec<ApiDeal>, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("{NAME} request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("{NAME} {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("{NAME} read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "{NAME} response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("{NAME} json parse: {e}")))
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiDeal {
+    title: String,
+    #[serde(rename = "dealID")]
+    deal_id: String,
+    #[serde(rename = "storeID")]
+    store_id: String,
+    #[serde(rename = "salePrice")]
+    sale_price: String,
+    #[serde(rename = "normalPrice")]
+    normal_price: String,
+    savings: String,
+    thumb: Option<String>,
+}
+
+fn api_to_row(deal: ApiDeal) -> DealRow {
+    let pct = deal
+        .savings
+        .parse::<f64>()
+        .ok()
+        .map(|f| f.round() as u32)
+        .map(|p| p.min(100));
+    DealRow {
+        title: deal.title,
+        image_url: deal.thumb.filter(|s| !s.is_empty()),
+        sale_price: Some(format_price(&deal.sale_price)),
+        original_price: Some(format_price(&deal.normal_price)),
+        discount_pct: pct,
+        store: Some(store_name(&deal.store_id).to_string()),
+        link: format!("{REDIRECT_BASE}?dealID={}", deal.deal_id),
+        published: None,
+    }
+}
+
+fn format_price(raw: &str) -> String {
+    match raw.parse::<f64>() {
+        Ok(0.0) => "Free".into(),
+        Ok(v) => format!("${v:.2}"),
+        Err(_) => raw.to_string(),
+    }
+}
+
+/// CheapShark store IDs we surface a friendly name for. Anything else falls through to
+/// `"Store <id>"` so a new store doesn't trigger a release; the catalog can be backfilled
+/// from the docs when it next changes.
+fn store_name(id: &str) -> &'static str {
+    match id {
+        "1" => "Steam",
+        "2" => "GamersGate",
+        "3" => "GreenManGaming",
+        "4" => "Amazon",
+        "5" => "GameStop",
+        "7" => "GOG",
+        "8" => "Origin",
+        "11" => "Humble Store",
+        "13" => "Ubisoft Store",
+        "15" => "Fanatical",
+        "21" => "WinGameStore",
+        "23" => "GameBillet",
+        "24" => "Voidu",
+        "25" => "Epic Games Store",
+        "27" => "Gamesplanet",
+        "29" => "2Game",
+        "30" => "IndieGala",
+        "31" => "Blizzard Shop",
+        "33" => "DLGamer",
+        _ => "Other store",
+    }
+}
+
+fn sample_body_for(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "[Steam] Disco Elysium  $9.99 (75% off from $39.99)",
+                Some("https://www.cheapshark.com/redirect?dealID=sample-1"),
+            ),
+            (
+                "[Epic Games Store] Cyberpunk 2077  $29.99 (50% off from $59.99)",
+                Some("https://www.cheapshark.com/redirect?dealID=sample-2"),
+            ),
+            (
+                "[GOG] The Witcher 3  $4.99 (75% off from $19.99)",
+                Some("https://www.cheapshark.com/redirect?dealID=sample-3"),
+            ),
+        ]),
+        Shape::TextBlock => samples::text_block(&[
+            "[Steam] Disco Elysium  $9.99 (75% off from $39.99)",
+            "[Epic Games Store] Cyberpunk 2077  $29.99 (50% off from $59.99)",
+            "[GOG] The Witcher 3  $4.99 (75% off from $19.99)",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- [[Steam] Disco Elysium  $9.99 (75% off)](https://www.cheapshark.com/redirect?dealID=sample-1)\n- [[GOG] The Witcher 3  $4.99 (75% off)](https://www.cheapshark.com/redirect?dealID=sample-3)",
+        ),
+        Shape::Text => samples::text("[Steam] Disco Elysium  $9.99 (75% off from $39.99)"),
+        Shape::Entries => samples::entries(&[
+            ("Disco Elysium", "$9.99 (75% off)"),
+            ("Cyberpunk 2077", "$29.99 (50% off)"),
+            ("The Witcher 3", "$4.99 (75% off)"),
+        ]),
+        Shape::Bars => samples::bars(&[
+            ("Disco Elysium", 75),
+            ("The Witcher 3", 75),
+            ("Cyberpunk 2077", 50),
+        ]),
+        Shape::Badge => samples::badge(crate::payload::Status::Ok, "75% off"),
+        Shape::Timeline => samples::timeline(&[
+            (
+                1_745_625_600,
+                "Disco Elysium",
+                Some("Steam · $9.99 · 75% off"),
+            ),
+            (
+                1_745_539_200,
+                "Cyberpunk 2077",
+                Some("Epic Games Store · $29.99 · 50% off"),
+            ),
+        ]),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_url_emits_default_params() {
+        let url = build_url(50, 10, None);
+        assert!(url.contains("sortBy=Savings"));
+        assert!(url.contains("onSale=1"));
+        assert!(url.contains("pageSize=10"));
+        assert!(url.contains("minDiscount=50"));
+        assert!(!url.contains("storeID="));
+    }
+
+    #[test]
+    fn build_url_appends_store_filter_csv() {
+        let url = build_url(40, 5, Some(&[1, 7, 25]));
+        assert!(url.contains("storeID=1,7,25"));
+    }
+
+    #[test]
+    fn build_url_drops_min_discount_when_zero() {
+        let url = build_url(0, 5, None);
+        assert!(!url.contains("minDiscount"));
+    }
+
+    #[test]
+    fn format_price_handles_zero_as_free() {
+        assert_eq!(format_price("0.00"), "Free");
+        assert_eq!(format_price("9.99"), "$9.99");
+        assert_eq!(format_price("garbage"), "garbage");
+    }
+
+    #[test]
+    fn store_name_falls_back_for_unknown_ids() {
+        assert_eq!(store_name("1"), "Steam");
+        assert_eq!(store_name("25"), "Epic Games Store");
+        assert_eq!(store_name("999"), "Other store");
+    }
+
+    #[test]
+    fn api_to_row_parses_realistic_payload() {
+        let deal = ApiDeal {
+            title: "Vaudeville".into(),
+            deal_id: "abc%3D".into(),
+            store_id: "25".into(),
+            sale_price: "0.00".into(),
+            normal_price: "19.99".into(),
+            savings: "100.000000".into(),
+            thumb: Some("https://example.com/thumb.jpg".into()),
+        };
+        let row = api_to_row(deal);
+        assert_eq!(row.title, "Vaudeville");
+        assert_eq!(row.store.as_deref(), Some("Epic Games Store"));
+        assert_eq!(row.sale_price.as_deref(), Some("Free"));
+        assert_eq!(row.original_price.as_deref(), Some("$19.99"));
+        assert_eq!(row.discount_pct, Some(100));
+        assert!(row.link.contains("dealID=abc%3D"));
+    }
+
+    #[test]
+    fn api_to_row_clamps_implausible_savings() {
+        let deal = ApiDeal {
+            title: "Bug".into(),
+            deal_id: "d".into(),
+            store_id: "1".into(),
+            sale_price: "5.00".into(),
+            normal_price: "10.00".into(),
+            savings: "250".into(),
+            thumb: None,
+        };
+        let row = api_to_row(deal);
+        assert_eq!(row.discount_pct, Some(100));
+        assert!(row.image_url.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("min_discount = 60\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn options_parse_stores_list() {
+        let raw: toml::Value = toml::from_str("stores = [1, 7, 25]").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.stores, Some(vec![1, 7, 25]));
+    }
+
+    #[test]
+    fn fetcher_exposes_safety_safe_and_default_linked_shape() {
+        let f = GamesFetcher;
+        assert_eq!(f.name(), NAME);
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.default_shape(), Shape::LinkedTextBlock);
+    }
+
+    #[test]
+    fn sample_body_covers_every_supported_shape() {
+        let f = GamesFetcher;
+        for shape in [
+            Shape::LinkedTextBlock,
+            Shape::TextBlock,
+            Shape::MarkdownTextBlock,
+            Shape::Text,
+            Shape::Entries,
+            Shape::Bars,
+            Shape::Badge,
+            Shape::Timeline,
+        ] {
+            assert!(
+                f.sample_body(shape).is_some(),
+                "sample missing for {shape:?}"
+            );
+        }
+        assert!(f.sample_body(Shape::ImageLinkedList).is_none());
+        assert!(f.sample_body(Shape::Heatmap).is_none());
+    }
+
+    #[test]
+    fn cache_key_varies_with_min_discount() {
+        let f = GamesFetcher;
+        let base = FetchContext::default();
+        let mut a = base.clone();
+        let mut b = base.clone();
+        a.options = Some(toml::from_str("min_discount = 50").unwrap());
+        b.options = Some(toml::from_str("min_discount = 80").unwrap());
+        assert_ne!(f.cache_key(&a), f.cache_key(&b));
+    }
+}

--- a/src/fetcher/deal/mod.rs
+++ b/src/fetcher/deal/mod.rs
@@ -1,0 +1,42 @@
+//! `deal_*` family — gaming and (future) retail deal feeds.
+//!
+//! Each sibling normalises its upstream into the shared [`common::DealRow`] vocabulary so the
+//! same renderer chain (`list_links`, `list_cards`, `chart_bar`, `status_badge`, …) handles
+//! every variant. Batch 1 ships three gaming-focused sources; the `deal_*` prefix leaves room
+//! for non-gaming retail siblings without further renaming.
+
+mod common;
+mod free_games;
+mod games;
+mod steam_daily;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![
+        Arc::new(free_games::FreeGamesFetcher),
+        Arc::new(steam_daily::SteamDailyFetcher),
+        Arc::new(games::GamesFetcher),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetchers_entry_point_registers_the_batch_under_deal_prefix() {
+        let names: Vec<String> = fetchers().iter().map(|f| f.name().to_string()).collect();
+        assert!(names.contains(&"deal_free_games".to_string()));
+        assert!(names.contains(&"deal_steam_daily".to_string()));
+        assert!(names.contains(&"deal_games".to_string()));
+        for name in &names {
+            assert!(
+                name.starts_with("deal_"),
+                "{name} must use the `deal_` family prefix"
+            );
+        }
+    }
+}

--- a/src/fetcher/deal/steam_daily.rs
+++ b/src/fetcher/deal/steam_daily.rs
@@ -1,0 +1,283 @@
+//! `deal_steam_daily` — Steam's official daily / weekend / midweek deal RSS feed.
+//!
+//! Safety::Safe — host hardcoded at `store.steampowered.com`. The discount percent is parsed
+//! out of the entry title (`"Daily Deal - The Beast Inside, 25% Off"`); titles that don't
+//! match the canonical pattern still render but without a `discount_pct` populated.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use feed_rs::model::Entry;
+use regex::Regex;
+use serde::Deserialize;
+use url::Url;
+
+use super::common::{self, DealRow, MAX_ROWS};
+use crate::fetcher::feed;
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+use crate::samples;
+
+const FEED_URL: &str = "https://store.steampowered.com/feeds/daily_deals.xml";
+const NAME: &str = "deal_steam_daily";
+const STORE: &str = "Steam";
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Text,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::ImageLinkedList,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "count",
+    type_hint: "integer (1..=20)",
+    required: false,
+    default: Some("10"),
+    description: "Maximum number of deals to display.",
+}];
+
+pub struct SteamDailyFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for SteamDailyFetcher {
+    fn name(&self) -> &str {
+        NAME
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Steam's official daily deals RSS feed — currently-running individual game discounts curated by Valve. Each entry parses into `[Steam] <Game>  <N>% off`. Complements `deal_games` (CheapShark) which spans every store; this one mirrors Steam's storefront priority order."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(NAME, ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body_for(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_ROWS as u32) as usize;
+        let url = Url::parse(FEED_URL)
+            .map_err(|e| FetchError::Failed(format!("deal_steam_daily: bad feed url: {e}")))?;
+        let bytes = feed::fetch_bytes(&url, NAME).await?;
+        let parsed = feed::parse_feed(&bytes, NAME)?;
+        let rows: Vec<DealRow> = parsed
+            .entries
+            .iter()
+            .take(count)
+            .map(entry_to_row)
+            .collect();
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = match shape {
+            Shape::ImageLinkedList => common::image_linked_body(&rows).await,
+            other => common::body_for_shape(&rows, other)
+                .unwrap_or_else(|| common::linked_text_block_body(&rows)),
+        };
+        Ok(payload(body))
+    }
+}
+
+fn entry_to_row(entry: &Entry) -> DealRow {
+    let raw_title = entry
+        .title
+        .as_ref()
+        .map(|t| feed::collapse_whitespace(&t.content))
+        .unwrap_or_default();
+    let (title, discount_pct) = parse_title(&raw_title);
+    let link =
+        feed::link_for(entry).unwrap_or_else(|| String::from("https://store.steampowered.com"));
+    DealRow {
+        title: if title.is_empty() {
+            "(unnamed deal)".into()
+        } else {
+            title
+        },
+        image_url: feed::thumbnail_url_for(entry),
+        sale_price: None,
+        original_price: None,
+        discount_pct,
+        store: Some(STORE.into()),
+        link,
+        published: entry.published.or(entry.updated),
+    }
+}
+
+/// Steam titles use a handful of marketing prefixes (`Daily Deal`, `Weekend Deal`,
+/// `Midweek Madness`, `Weeklong Deal`, `Free Weekend`, `Special Promotion`, `Publisher Sale`).
+/// We strip whichever prefix matches and pull the trailing `, X% Off` clause when present.
+fn parse_title(raw: &str) -> (String, Option<u32>) {
+    static TITLE_RE: OnceLock<Regex> = OnceLock::new();
+    let re = TITLE_RE.get_or_init(|| {
+        Regex::new(
+            r"^(?P<prefix>[A-Za-z][A-Za-z ]+?)\s*-\s*(?P<title>.+?)(?:,\s*(?P<pct>\d{1,3})% Off!?)?$",
+        )
+        .unwrap()
+    });
+    match re.captures(raw) {
+        Some(c) => {
+            let title = c["title"].trim().to_string();
+            let pct = c.name("pct").and_then(|m| m.as_str().parse::<u32>().ok());
+            (title, pct.map(|p| p.min(100)))
+        }
+        None => (raw.to_string(), None),
+    }
+}
+
+fn sample_body_for(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "[Steam] Portal 2  75% off",
+                Some("https://store.steampowered.com/app/620/Portal_2/"),
+            ),
+            (
+                "[Steam] Hades  50% off",
+                Some("https://store.steampowered.com/app/1145360/Hades/"),
+            ),
+            (
+                "[Steam] Stardew Valley  40% off",
+                Some("https://store.steampowered.com/app/413150/Stardew_Valley/"),
+            ),
+        ]),
+        Shape::TextBlock => samples::text_block(&[
+            "[Steam] Portal 2  75% off",
+            "[Steam] Hades  50% off",
+            "[Steam] Stardew Valley  40% off",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- [[Steam] Portal 2  75% off](https://store.steampowered.com/app/620/Portal_2/)\n- [[Steam] Hades  50% off](https://store.steampowered.com/app/1145360/Hades/)",
+        ),
+        Shape::Text => samples::text("[Steam] Portal 2  75% off"),
+        Shape::Entries => samples::entries(&[
+            ("Portal 2", "75% off"),
+            ("Hades", "50% off"),
+            ("Stardew Valley", "40% off"),
+        ]),
+        Shape::Bars => samples::bars(&[("Portal 2", 75), ("Hades", 50), ("Stardew Valley", 40)]),
+        Shape::Badge => samples::badge(crate::payload::Status::Ok, "75% off"),
+        Shape::Timeline => samples::timeline(&[
+            (1_745_625_600, "Portal 2", Some("Steam · 75% off")),
+            (1_745_539_200, "Hades", Some("Steam · 50% off")),
+        ]),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_title_extracts_daily_deal_discount() {
+        let (title, pct) = parse_title("Daily Deal - The Beast Inside, 25% Off");
+        assert_eq!(title, "The Beast Inside");
+        assert_eq!(pct, Some(25));
+    }
+
+    #[test]
+    fn parse_title_handles_weekend_deal_with_exclamation() {
+        let (title, pct) = parse_title("Weekend Deal - Portal 2, 75% Off!");
+        assert_eq!(title, "Portal 2");
+        assert_eq!(pct, Some(75));
+    }
+
+    #[test]
+    fn parse_title_handles_midweek_madness_three_word_prefix() {
+        let (title, pct) = parse_title("Midweek Madness - Game Of The Year, 50% Off");
+        assert_eq!(title, "Game Of The Year");
+        assert_eq!(pct, Some(50));
+    }
+
+    #[test]
+    fn parse_title_returns_none_pct_when_clause_absent() {
+        let (title, pct) = parse_title("Free Weekend - Some Multiplayer Game");
+        assert_eq!(title, "Some Multiplayer Game");
+        assert!(pct.is_none());
+    }
+
+    #[test]
+    fn parse_title_clamps_implausible_percentages() {
+        let (_title, pct) = parse_title("Daily Deal - Bug, 250% Off");
+        assert_eq!(pct, Some(100));
+    }
+
+    #[test]
+    fn parse_title_falls_back_to_raw_when_pattern_misses() {
+        let (title, pct) = parse_title("just a random string");
+        assert_eq!(title, "just a random string");
+        assert!(pct.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("count = 5\nbogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_exposes_safety_safe_and_steam_store_attribution() {
+        let f = SteamDailyFetcher;
+        assert_eq!(f.name(), NAME);
+        assert_eq!(f.safety(), Safety::Safe);
+        assert_eq!(f.default_shape(), Shape::LinkedTextBlock);
+    }
+
+    #[test]
+    fn sample_body_covers_every_supported_shape() {
+        let f = SteamDailyFetcher;
+        for shape in [
+            Shape::LinkedTextBlock,
+            Shape::TextBlock,
+            Shape::MarkdownTextBlock,
+            Shape::Text,
+            Shape::Entries,
+            Shape::Bars,
+            Shape::Badge,
+            Shape::Timeline,
+        ] {
+            assert!(
+                f.sample_body(shape).is_some(),
+                "sample missing for {shape:?}"
+            );
+        }
+        assert!(f.sample_body(Shape::ImageLinkedList).is_none());
+        assert!(f.sample_body(Shape::Heatmap).is_none());
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -17,6 +17,7 @@ pub mod calendar;
 pub mod clock;
 pub mod code;
 pub mod crypto_watchlist;
+pub mod deal;
 pub mod deariary;
 pub mod feed;
 pub mod git;
@@ -338,6 +339,9 @@ impl Registry {
         r.register(Arc::new(nasa_apod::NasaApodFetcher));
         r.register(Arc::new(youtube::YoutubeChannelFetcher));
         for f in calendar::fetchers() {
+            r.register(f);
+        }
+        for f in deal::fetchers() {
             r.register(f);
         }
         for f in deariary::fetchers() {


### PR DESCRIPTION
## Summary

New `deal_*` fetcher family — three siblings sharing a `DealRow` model and shape pipeline so renderers swapping between them see consistent `[Store] Title  $price (X% off)` output regardless of source. All three are `Safety::Safe` (every host hardcoded; config picks closed enums only).

| Fetcher | Upstream | Setup | Coverage |
|---|---|---|---|
| `deal_free_games` | `feed.eikowagenknecht.com` (LootScraper) | zero-config | Epic / Steam / Amazon Prime Gaming / GOG / Humble / itch.io / Apple App Store / Google Play giveaways. `platform` filter; `kind = "loot"` for Twitch-drops / in-game-items (Amazon & Steam only). |
| `deal_steam_daily` | `store.steampowered.com/feeds/daily_deals.xml` (official) | zero-config | Steam Daily / Weekend / Midweek Madness / Weeklong / Special Promotion deals. Discount % parsed from `"Daily Deal - <Title>, X% Off"` titles. |
| `deal_games` | `cheapshark.com/api/1.0/deals` | zero-config | Cross-store top deals sorted by savings. `min_discount` floor, `limit`, `stores` (CheapShark IDs: 1=Steam, 7=GOG, 25=Epic, 11=Humble, 15=Fanatical, …). |

The third-party LootScraper instance is the one non-vendor host, but it has shipped continuously since 2019 (≈2M monthly RSS hits) and absorbs the per-platform scraping complexity (Epic GraphQL, Amazon Luna OAuth, Steam giveaway events) that would otherwise sprawl into eight separate fetchers.

Also bumps the `image` crate features to include `webp` + `gif` so Amazon Prime Gaming cover art (served as WebP from `m.media-amazon.com`) decodes in `list_cards` instead of falling through to empty cells. Same gap would have hit any fetcher returning a WebP / GIF response — this unblocks them all.

## Shape contract (shared across the three)

| Shape | Behaviour |
|---|---|
| `linked_text_block` (default) | Clickable `[Store] Title  $price (X% off from $orig)` rows |
| `text_block` | Same rows, non-linked |
| `markdown_text_block` | `- [<row>](<url>)` bullet list |
| `text` | Single headline — picks the largest discount in the set |
| `entries` | `title → "$price (X% off)"`, `Status` colored by discount tier |
| `bars` | Sorted desc by discount percent |
| `image_linked_list` | Cards with thumbnail + `Store · $price · N% off` subtitle |
| `badge` | `100% → "free this week"` / `≥50% → "N% off"` Ok / `<50% → "N% off"` Warn / empty → `"no deals"` |
| `timeline` | Publish-date sorted, detail carries store + price + discount |

Status color mapping is direction-neutral: `discount_pct ≥ 50%` → `Status::Ok`, otherwise `Status::Warn`. No long-vs-short sentiment encoding.

## Rejected shapes

`Ratio` / `NumberSeries` / `PointSeries` / `Image` / `Calendar` / `Heatmap` — no natural fit. `sample_body()` returns `None` for each so the catalog doesn't suggest broken pairings.

## Compatible renderers

All three fetchers expose the same shape table, so:

- `linked_text_block` → [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/)
- `text_block` → [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) (plus every `animated_*` wrapper)
- `markdown_text_block` → [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/)
- `text` → [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/) / [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/) / `animated_typewriter` / `animated_figlet_morph`
- `entries` → [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/)
- `bars` → [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar/) / [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie/) / [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking/)
- `image_linked_list` → [`list_cards`](https://splashboard.unhappychoice.com/reference/renderers/list/list_cards/)
- `badge` → [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/)
- `timeline` → [`list_timeline`](https://splashboard.unhappychoice.com/reference/renderers/list/list_timeline/)

Plus the post-process animation wrappers (`animated_postfx` / `animated_boot` / `animated_scanlines` / `animated_splitflap` / `animated_wave`) on every shape.

## Test plan

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` ✅ (2333 passed / 0 failed / 17 ignored — 49 new tests added under `fetcher::deal::*`)
- `cargo run --bin splashboard -- catalog fetcher deal_free_games | deal_steam_daily | deal_games` — verified registration, option schemas, compatible renderers
- Smoke-tested with a project-local `.splashboard/dashboard.toml` covering every shape against live upstreams. WebP cover images from Amazon Prime Gaming now render correctly in `list_cards` (this was the trigger for the `image` crate feature bump).

## Catalog (post-merge)

- #68 Gaming — tick `epic_free_games` (shipped as `deal_free_games` covering 8 platforms via LootScraper rather than Epic-only).
- #68 Shopping/deals — tick `game_deals` (shipped as `deal_games`).
- #68 Gaming — add a "shipped" note for `deal_steam_daily` (new, not in roadmap).
- The planned `sale_events` (calendar of upcoming Prime Day / Steam Summer Sale / etc.) stays open — no free public feed publishes vendor-specific sale dates; deferred until a reliable upstream exists.
- The planned `steam_wishlist_sales` (personal Steam wishlist deals) stays open — scoped out of this batch as personal-account data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Three new deal aggregation sources integrated: free games and loot offers tracker across multiple storefronts, Steam daily/weekend/midweek deals feed, and CheapShark cross-store game deals with customizable discount thresholds and store filtering
* Expanded image format support to include WebP and GIF alongside existing PNG and JPEG

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/240)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->