### PR TITLE
feat(fetcher): add *_trending batch — reddit / wikipedia / crypto / huggingface

### DIFF
--- a/src/fetcher/crypto_trending.rs
+++ b/src/fetcher/crypto_trending.rs
@@ -1,0 +1,717 @@
+//! `crypto_trending` — top 15 trending coins on CoinGecko, by user search activity.
+//!
+//! Safety::Safe: both the API host (`api.coingecko.com`) and the coin-page host
+//! (`www.coingecko.com`) are hardcoded; the response carries thumbnail URLs on
+//! `assets.coingecko.com`, which `thumbnails::download_to_cache` accepts as-is once
+//! sniffed for image magic bytes. No API key required.
+//!
+//! Distinct from the shipped `crypto_watchlist` (a user-curated price snapshot for chosen
+//! coins): trending is the inverse — CoinGecko picks the list based on what people are
+//! searching, the user supplies only `count` and an optional quote currency.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, Payload, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::github::common::{cache_key, parse_options, payload};
+use super::thumbnails;
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+const API_URL: &str = "https://api.coingecko.com/api/v3/search/trending";
+const COIN_PAGE_BASE: &str = "https://www.coingecko.com/en/coins";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_BYTES: usize = 5 * 1024 * 1024;
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+/// CoinGecko `/search/trending` returns at most 15 coins; clamping at the source.
+const MAX_COUNT: u32 = 15;
+const DEFAULT_VS_CURRENCY: &str = "usd";
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=15)",
+        required: false,
+        default: Some("10"),
+        description: "Number of trending coins to display.",
+    },
+    OptionSchema {
+        name: "vs_currency",
+        type_hint: "string (lowercase 2-5 letter code)",
+        required: false,
+        default: Some("\"usd\""),
+        description: "Quote currency for the 24h-change column (e.g. `usd`, `jpy`, `eur`, `btc`). Letters only; matches `crypto_watchlist`.",
+    },
+];
+
+pub struct CryptoTrendingFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub count: Option<u32>,
+    #[serde(default)]
+    pub vs_currency: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for CryptoTrendingFetcher {
+    fn name(&self) -> &str {
+        "crypto_trending"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Top trending coins on CoinGecko (ranked by user search activity over the last 24h). No API key required. Companion to the shipped `crypto_watchlist` — same source, but CoinGecko picks the list instead of the user."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_trending_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let vs_currency = resolve_vs_currency(opts.vs_currency.as_deref())?;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let coins = fetch_trending(&vs_currency, count).await?;
+        let body = render_for_shape(&coins, shape).await;
+        Ok(payload(body))
+    }
+}
+
+fn resolve_vs_currency(raw: Option<&str>) -> Result<String, FetchError> {
+    let value = raw
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_lowercase)
+        .unwrap_or_else(|| DEFAULT_VS_CURRENCY.to_string());
+    let valid_len = (2..=5).contains(&value.len());
+    if !valid_len || !value.chars().all(|c| c.is_ascii_lowercase()) {
+        return Err(FetchError::Failed(format!(
+            "crypto_trending: invalid vs_currency `{value}` (lowercase 2-5 letter code)"
+        )));
+    }
+    Ok(value)
+}
+
+/// Trending coin as the renderer wants it. `position` is the 0-indexed slot in CoinGecko's
+/// response (= trending rank). `price_change_24h` is the 24h % move in the requested quote
+/// currency, falling through `None` when CoinGecko hasn't populated that currency yet for a
+/// freshly-trending obscure coin.
+#[derive(Debug, Clone)]
+struct Coin {
+    name: String,
+    symbol: String,
+    slug: String,
+    market_cap_rank: Option<i32>,
+    price_change_24h: Option<f64>,
+    thumb_url: Option<String>,
+    position: usize,
+}
+
+impl Coin {
+    fn url(&self) -> String {
+        format!("{COIN_PAGE_BASE}/{}", self.slug)
+    }
+
+    fn display_label(&self) -> String {
+        format!("{}  {}", self.symbol, self.name)
+    }
+
+    /// Single-line score used by Text / LinkedTextBlock / TextBlock / Entries rows: `+5.2%`,
+    /// `-2.1%`, or `· trending` when the 24h change isn't available for this quote currency.
+    fn score_line(&self) -> String {
+        match self.price_change_24h {
+            Some(pct) => format!("{pct:+.1}% 24h"),
+            None => "· trending".into(),
+        }
+    }
+}
+
+async fn fetch_trending(vs_currency: &str, limit: usize) -> Result<Vec<Coin>, FetchError> {
+    let response = fetch_response().await?;
+    Ok(response
+        .coins
+        .into_iter()
+        .enumerate()
+        .take(limit)
+        .map(|(i, entry)| coin_from(i, entry.item, vs_currency))
+        .collect())
+}
+
+async fn fetch_response() -> Result<TrendingResponse, FetchError> {
+    let res = http()
+        .get(API_URL)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("crypto_trending request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("crypto_trending {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("crypto_trending read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "crypto_trending response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("crypto_trending json parse: {e}")))
+}
+
+fn coin_from(position: usize, item: ApiItem, vs_currency: &str) -> Coin {
+    let price_change_24h = item
+        .data
+        .as_ref()
+        .and_then(|d| d.price_change_percentage_24h.as_ref())
+        .and_then(|map| map.get(vs_currency).copied());
+    Coin {
+        name: item.name,
+        symbol: item.symbol.to_uppercase(),
+        slug: item.slug,
+        market_cap_rank: item.market_cap_rank,
+        price_change_24h,
+        thumb_url: item.thumb.filter(|u| !u.is_empty()),
+        position,
+    }
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+async fn render_for_shape(coins: &[Coin], shape: Shape) -> Body {
+    if matches!(shape, Shape::ImageLinkedList) {
+        let paths = resolve_thumbnails(coins).await;
+        return image_linked_body(coins, &paths);
+    }
+    render_sync(coins, shape)
+}
+
+async fn resolve_thumbnails(coins: &[Coin]) -> Vec<Option<PathBuf>> {
+    let urls: Vec<Option<String>> = coins.iter().map(|c| c.thumb_url.clone()).collect();
+    thumbnails::download_many(&urls).await
+}
+
+fn render_sync(coins: &[Coin], shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: headline(coins),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: coins.iter().map(row_line).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: markdown_body(coins),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: coins.iter().map(entry_row).collect(),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: coins.iter().map(rank_bar).collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: coins
+                .iter()
+                .map(|c| LinkedLine {
+                    text: row_line(c),
+                    url: Some(c.url()),
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn image_linked_body(coins: &[Coin], paths: &[Option<PathBuf>]) -> Body {
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: coins
+            .iter()
+            .enumerate()
+            .map(|(i, c)| ImageLinkedItem {
+                title: c.display_label(),
+                url: Some(c.url()),
+                thumbnail_path: paths
+                    .get(i)
+                    .and_then(|p| p.as_ref())
+                    .map(|p| p.to_string_lossy().into_owned()),
+                subtitle: Some(subtitle_line(c)),
+            })
+            .collect(),
+    })
+}
+
+fn headline(coins: &[Coin]) -> String {
+    coins
+        .first()
+        .map(|c| format!("#1 {}  {}", c.display_label(), c.score_line()))
+        .unwrap_or_else(|| "(no trending coins)".into())
+}
+
+fn row_line(coin: &Coin) -> String {
+    format!(
+        "#{} {}  {}",
+        coin.position + 1,
+        coin.display_label(),
+        coin.score_line()
+    )
+}
+
+fn subtitle_line(coin: &Coin) -> String {
+    let mut s = format!("#{} trending · {}", coin.position + 1, coin.score_line());
+    if let Some(rank) = coin.market_cap_rank {
+        s.push_str(&format!("  · mcap #{rank}"));
+    }
+    s
+}
+
+fn markdown_body(coins: &[Coin]) -> String {
+    coins
+        .iter()
+        .map(|c| {
+            format!(
+                "- **#{} {}** — {}  ([page]({}))",
+                c.position + 1,
+                c.display_label(),
+                c.score_line(),
+                c.url()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn entry_row(coin: &Coin) -> Entry {
+    Entry {
+        key: format!("#{} {}", coin.position + 1, coin.display_label()),
+        value: Some(coin.score_line()),
+        status: None,
+    }
+}
+
+/// Trending rank as `(count - position)` so the top coin gets the tallest bar. Coingecko's
+/// own `score` field is just `0..N` ordering and decays to zero for the lower half — using
+/// `count - position` keeps the chart legible regardless of slot width.
+fn rank_bar(coin: &Coin) -> Bar {
+    Bar {
+        label: coin.display_label(),
+        value: (MAX_COUNT as usize - coin.position).max(1) as u64,
+    }
+}
+
+fn sample_trending_body(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => crate::samples::linked_text_block(&[
+            (
+                "#1 BTC  Bitcoin  +5.2% 24h",
+                Some("https://www.coingecko.com/en/coins/bitcoin"),
+            ),
+            (
+                "#2 ETH  Ethereum  +3.1% 24h",
+                Some("https://www.coingecko.com/en/coins/ethereum"),
+            ),
+        ]),
+        Shape::ImageLinkedList => crate::samples::image_linked_list(&[
+            (
+                "BTC  Bitcoin",
+                Some("https://www.coingecko.com/en/coins/bitcoin"),
+                None,
+                Some("#1 trending · +5.2% 24h  · mcap #1"),
+            ),
+            (
+                "ETH  Ethereum",
+                Some("https://www.coingecko.com/en/coins/ethereum"),
+                None,
+                Some("#2 trending · +3.1% 24h  · mcap #2"),
+            ),
+        ]),
+        Shape::TextBlock => crate::samples::text_block(&[
+            "#1 BTC  Bitcoin  +5.2% 24h",
+            "#2 ETH  Ethereum  +3.1% 24h",
+        ]),
+        Shape::Text => crate::samples::text("#1 BTC  Bitcoin  +5.2% 24h"),
+        Shape::MarkdownTextBlock => crate::samples::markdown(
+            "- **#1 BTC  Bitcoin** — +5.2% 24h  ([page](https://www.coingecko.com/en/coins/bitcoin))\n- **#2 ETH  Ethereum** — +3.1% 24h  ([page](https://www.coingecko.com/en/coins/ethereum))",
+        ),
+        Shape::Entries => crate::samples::entries(&[
+            ("#1 BTC  Bitcoin", "+5.2% 24h"),
+            ("#2 ETH  Ethereum", "+3.1% 24h"),
+        ]),
+        Shape::Bars => crate::samples::bars(&[("BTC  Bitcoin", 15), ("ETH  Ethereum", 14)]),
+        _ => return None,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct TrendingResponse {
+    coins: Vec<TrendingEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrendingEntry {
+    item: ApiItem,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiItem {
+    name: String,
+    symbol: String,
+    slug: String,
+    #[serde(default)]
+    market_cap_rank: Option<i32>,
+    #[serde(default)]
+    thumb: Option<String>,
+    #[serde(default)]
+    data: Option<ApiData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiData {
+    #[serde(default)]
+    price_change_percentage_24h: Option<std::collections::HashMap<String, f64>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration as StdDuration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "crypto-trending".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn coin(name: &str, symbol: &str, slug: &str, position: usize, change: Option<f64>) -> Coin {
+        Coin {
+            name: name.into(),
+            symbol: symbol.into(),
+            slug: slug.into(),
+            market_cap_rank: Some(position as i32 + 1),
+            price_change_24h: change,
+            thumb_url: Some(format!("https://example.com/{slug}.png")),
+            position,
+        }
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.count.is_none());
+        assert!(opts.vs_currency.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_count_and_currency() {
+        let raw: toml::Value = toml::from_str("count = 5\nvs_currency = \"jpy\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.count, Some(5));
+        assert_eq!(opts.vs_currency.as_deref(), Some("jpy"));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn resolve_vs_currency_falls_back_to_default() {
+        assert_eq!(resolve_vs_currency(None).unwrap(), "usd");
+        assert_eq!(resolve_vs_currency(Some("")).unwrap(), "usd");
+    }
+
+    #[test]
+    fn resolve_vs_currency_lowercases_and_rejects_invalid() {
+        assert_eq!(resolve_vs_currency(Some("JPY")).unwrap(), "jpy");
+        assert!(resolve_vs_currency(Some("us")).is_ok());
+        assert!(resolve_vs_currency(Some("a")).is_err());
+        assert!(resolve_vs_currency(Some("toolong")).is_err());
+        assert!(resolve_vs_currency(Some("us1")).is_err());
+    }
+
+    #[test]
+    fn coin_url_uses_slug_off_coingecko_page_base() {
+        let c = coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2));
+        assert_eq!(c.url(), "https://www.coingecko.com/en/coins/bitcoin");
+    }
+
+    #[test]
+    fn coin_score_line_renders_signed_percent_or_trending_fallback() {
+        assert_eq!(coin("a", "A", "a", 0, Some(5.2)).score_line(), "+5.2% 24h");
+        assert_eq!(coin("a", "A", "a", 0, Some(-2.7)).score_line(), "-2.7% 24h");
+        assert_eq!(coin("a", "A", "a", 0, None).score_line(), "· trending");
+    }
+
+    #[test]
+    fn coin_from_extracts_vs_currency_change_and_uppercases_symbol() {
+        let mut prices = std::collections::HashMap::new();
+        prices.insert("usd".to_string(), 5.2);
+        let item = ApiItem {
+            name: "Bitcoin".into(),
+            symbol: "btc".into(),
+            slug: "bitcoin".into(),
+            market_cap_rank: Some(1),
+            thumb: Some("https://assets.coingecko.com/coins/images/1/thumb.png".into()),
+            data: Some(ApiData {
+                price_change_percentage_24h: Some(prices),
+            }),
+        };
+        let c = coin_from(0, item, "usd");
+        assert_eq!(c.symbol, "BTC");
+        assert_eq!(c.price_change_24h, Some(5.2));
+        assert_eq!(c.position, 0);
+        assert_eq!(c.market_cap_rank, Some(1));
+        assert!(c.thumb_url.is_some());
+    }
+
+    #[test]
+    fn coin_from_drops_empty_thumb_url() {
+        let item = ApiItem {
+            name: "x".into(),
+            symbol: "x".into(),
+            slug: "x".into(),
+            market_cap_rank: None,
+            thumb: Some(String::new()),
+            data: None,
+        };
+        let c = coin_from(0, item, "usd");
+        assert!(c.thumb_url.is_none());
+        assert!(c.price_change_24h.is_none());
+    }
+
+    #[test]
+    fn coin_from_returns_none_change_when_vs_currency_absent_from_response() {
+        let mut prices = std::collections::HashMap::new();
+        prices.insert("eur".to_string(), 5.2);
+        let item = ApiItem {
+            name: "x".into(),
+            symbol: "x".into(),
+            slug: "x".into(),
+            market_cap_rank: None,
+            thumb: None,
+            data: Some(ApiData {
+                price_change_percentage_24h: Some(prices),
+            }),
+        };
+        let c = coin_from(0, item, "usd");
+        assert!(c.price_change_24h.is_none());
+    }
+
+    #[test]
+    fn render_sync_text_uses_first_coin_with_rank_prefix() {
+        let body = render_sync(
+            &[coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2))],
+            Shape::Text,
+        );
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("#1"));
+        assert!(t.value.contains("BTC"));
+        assert!(t.value.contains("Bitcoin"));
+        assert!(t.value.contains("+5.2%"));
+    }
+
+    #[test]
+    fn render_sync_text_handles_empty_coins() {
+        let body = render_sync(&[], Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "(no trending coins)");
+    }
+
+    #[test]
+    fn render_sync_linked_text_block_carries_coingecko_url() {
+        let body = render_sync(
+            &[coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2))],
+            Shape::LinkedTextBlock,
+        );
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://www.coingecko.com/en/coins/bitcoin")
+        );
+    }
+
+    #[test]
+    fn render_sync_bars_use_decreasing_rank_score() {
+        let coins = vec![
+            coin("a", "A", "a", 0, None),
+            coin("b", "B", "b", 1, None),
+            coin("c", "C", "c", 14, None),
+        ];
+        let body = render_sync(&coins, Shape::Bars);
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].value, 15);
+        assert_eq!(b.bars[1].value, 14);
+        // position 14 (the last slot) should still be > 0
+        assert_eq!(b.bars[2].value, 1);
+    }
+
+    #[test]
+    fn render_sync_markdown_includes_page_link() {
+        let body = render_sync(
+            &[coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2))],
+            Shape::MarkdownTextBlock,
+        );
+        let Body::MarkdownTextBlock(m) = body else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("[page]("));
+        assert!(m.value.contains("bitcoin"));
+    }
+
+    #[test]
+    fn render_sync_entries_use_rank_prefixed_key_and_score_value() {
+        let body = render_sync(
+            &[coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2))],
+            Shape::Entries,
+        );
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "#1 BTC  Bitcoin");
+        assert_eq!(e.items[0].value.as_deref(), Some("+5.2% 24h"));
+    }
+
+    #[test]
+    fn image_linked_body_pins_paths_and_subtitle_with_mcap_rank() {
+        let coins = vec![coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2))];
+        let paths = vec![Some(PathBuf::from("/tmp/btc.png"))];
+        let body = image_linked_body(&coins, &paths);
+        let Body::ImageLinkedList(d) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items[0].title, "BTC  Bitcoin");
+        assert_eq!(d.items[0].thumbnail_path.as_deref(), Some("/tmp/btc.png"));
+        assert!(
+            d.items[0]
+                .subtitle
+                .as_deref()
+                .unwrap()
+                .contains("#1 trending")
+        );
+        assert!(d.items[0].subtitle.as_deref().unwrap().contains("mcap #1"));
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = CryptoTrendingFetcher;
+        assert_eq!(fetcher.name(), "crypto_trending");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(
+            fetcher
+                .option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["count", "vs_currency"]
+        );
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_shape_and_options() {
+        let fetcher = CryptoTrendingFetcher;
+        let linked = fetcher.cache_key(&ctx(None, Some(Shape::LinkedTextBlock)));
+        let bars = fetcher.cache_key(&ctx(None, Some(Shape::Bars)));
+        let jpy = fetcher.cache_key(&ctx(
+            Some("vs_currency = \"jpy\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        assert_ne!(linked, bars);
+        assert_ne!(linked, jpy);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = CryptoTrendingFetcher
+            .fetch(&ctx(Some("bogus = true"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_vs_currency() {
+        let err = CryptoTrendingFetcher
+            .fetch(&ctx(Some("vs_currency = \"u\""), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("invalid vs_currency"));
+    }
+}

--- a/src/fetcher/huggingface_trending.rs
+++ b/src/fetcher/huggingface_trending.rs
@@ -1,0 +1,697 @@
+//! `huggingface_trending` — trending models / datasets / spaces on Hugging Face Hub.
+//!
+//! Safety::Safe: API host (`huggingface.co`) is hardcoded; the user supplies only `kind`
+//! (closed enum) and `count`. Thumbnails are fetched as a best-effort per-author lookup
+//! against the same fixed host; failed lookups silently leave a row's thumbnail empty
+//! rather than poisoning the whole feed.
+//!
+//! HF's `?sort=trendingScore&direction=-1` is the documented "Trending" sort on the public
+//! Hub API (no auth required), so this fetcher mirrors what huggingface.co/{models,datasets,
+//! spaces} shows under the "Trending" tab.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, Payload, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::github::common::{cache_key, parse_options, payload};
+use super::thumbnails;
+use super::{FetchContext, FetchError, Fetcher, Safety};
+
+const API_BASE: &str = "https://huggingface.co/api";
+const SITE_BASE: &str = "https://huggingface.co";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_BYTES: usize = 5 * 1024 * 1024;
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 30;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "kind",
+        type_hint: "\"models\" | \"datasets\" | \"spaces\"",
+        required: false,
+        default: Some("\"models\""),
+        description: "Which Hub catalog to rank.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Number of trending entries to display.",
+    },
+];
+
+pub struct HuggingfaceTrendingFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub kind: Option<Kind>,
+    #[serde(default)]
+    pub count: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    #[default]
+    Models,
+    Datasets,
+    Spaces,
+}
+
+impl Kind {
+    fn path(self) -> &'static str {
+        match self {
+            Self::Models => "models",
+            Self::Datasets => "datasets",
+            Self::Spaces => "spaces",
+        }
+    }
+
+    /// Path used to build a clickable Hub page URL — same as the API path for all three.
+    fn site_path(self) -> &'static str {
+        self.path()
+    }
+}
+
+#[async_trait]
+impl Fetcher for HuggingfaceTrendingFetcher {
+    fn name(&self) -> &str {
+        "huggingface_trending"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Trending models, datasets, or spaces on Hugging Face Hub via the public `?sort=trendingScore` API (no auth required). Companion to the planned `github_trending` / `wikipedia_trending` family — each surface picks its own list, this one is HF's."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60 * 6
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_trending_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let kind = opts.kind.unwrap_or_default();
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let entries = fetch_trending(kind, count).await?;
+        let body = render_for_shape(&entries, kind, shape).await;
+        Ok(payload(body))
+    }
+}
+
+/// Trending Hub entry as the renderer wants it. `position` is the 0-indexed slot in HF's
+/// response (= trending rank); HF's own `trendingScore` is a float we display rather than
+/// re-rank on. `id` is the canonical `author/repo` slug — we split off `author` for the
+/// per-author avatar lookup that powers `ImageLinkedList`.
+#[derive(Debug, Clone)]
+struct Entrt {
+    id: String,
+    likes: u64,
+    downloads: Option<u64>,
+    pipeline_tag: Option<String>,
+    position: usize,
+}
+
+impl Entrt {
+    fn author(&self) -> Option<&str> {
+        self.id.split_once('/').map(|(a, _)| a)
+    }
+
+    fn url(&self, kind: Kind) -> String {
+        match kind {
+            // Models live at the bare `/{id}` slug; datasets / spaces are namespaced.
+            Kind::Models => format!("{SITE_BASE}/{}", self.id),
+            other => format!("{SITE_BASE}/{}/{}", other.site_path(), self.id),
+        }
+    }
+
+    fn score_line(&self) -> String {
+        let likes = format_count(self.likes);
+        match self.downloads {
+            Some(d) if d > 0 => format!("♥ {likes}  ↓ {}", format_count(d)),
+            _ => format!("♥ {likes}"),
+        }
+    }
+}
+
+async fn fetch_trending(kind: Kind, limit: usize) -> Result<Vec<Entrt>, FetchError> {
+    let url = format!(
+        "{API_BASE}/{}?sort=trendingScore&direction=-1&limit={limit}",
+        kind.path()
+    );
+    let raw: Vec<ApiEntry> = get_json(&url).await?;
+    Ok(raw
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| Entrt {
+            id: e.id,
+            likes: e.likes.unwrap_or(0).max(0) as u64,
+            downloads: e.downloads.map(|d| d.max(0) as u64),
+            pipeline_tag: e.pipeline_tag,
+            position: i,
+        })
+        .collect())
+}
+
+async fn get_json<T: serde::de::DeserializeOwned>(url: &str) -> Result<T, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("huggingface request failed: {e}")))?;
+    let status = res.status();
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("huggingface {status}")));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("huggingface read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "huggingface response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("huggingface json parse: {e}")))
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+async fn render_for_shape(entries: &[Entrt], kind: Kind, shape: Shape) -> Body {
+    if matches!(shape, Shape::ImageLinkedList) {
+        let paths = resolve_thumbnails(entries).await;
+        return image_linked_body(entries, kind, &paths);
+    }
+    render_sync(entries, kind, shape)
+}
+
+/// Avatar URLs aren't carried in the trending response, so resolve them per-author via the
+/// `overview` endpoint. Authors repeat across rows (e.g. `meta-llama` ships several trending
+/// models at once) — in-loop dedup so a 20-row feed doesn't fan out 20 lookups when 4
+/// distinct authors are involved.
+async fn resolve_thumbnails(entries: &[Entrt]) -> Vec<Option<PathBuf>> {
+    let mut cache: std::collections::HashMap<String, Option<String>> =
+        std::collections::HashMap::new();
+    let mut urls: Vec<Option<String>> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let avatar = match entry.author() {
+            Some(author) => match cache.get(author) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let resolved = fetch_avatar_url(author).await;
+                    cache.insert(author.to_string(), resolved.clone());
+                    resolved
+                }
+            },
+            None => None,
+        };
+        urls.push(avatar);
+    }
+    thumbnails::download_many(&urls).await
+}
+
+/// HF puts users and organizations in the same namespace but exposes them via separate API
+/// paths. Try the user endpoint first; on any error fall through to the org endpoint. Either
+/// way the failure is silent — a missing avatar shouldn't break the row.
+async fn fetch_avatar_url(author: &str) -> Option<String> {
+    for kind in ["users", "organizations"] {
+        let url = format!("{API_BASE}/{kind}/{author}/overview");
+        if let Ok(profile) = get_json::<HfProfile>(&url).await
+            && let Some(avatar) = profile.avatar_url.filter(|s| !s.is_empty())
+        {
+            return Some(avatar);
+        }
+    }
+    None
+}
+
+fn render_sync(entries: &[Entrt], kind: Kind, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: headline(entries),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: entries.iter().map(row_line).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: markdown_body(entries, kind),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: entries.iter().map(entry_row).collect(),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: entries.iter().map(likes_bar).collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: entries
+                .iter()
+                .map(|e| LinkedLine {
+                    text: row_line(e),
+                    url: Some(e.url(kind)),
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn image_linked_body(entries: &[Entrt], kind: Kind, paths: &[Option<PathBuf>]) -> Body {
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| ImageLinkedItem {
+                title: format!("#{} {}", e.position + 1, e.id),
+                url: Some(e.url(kind)),
+                thumbnail_path: paths
+                    .get(i)
+                    .and_then(|p| p.as_ref())
+                    .map(|p| p.to_string_lossy().into_owned()),
+                subtitle: Some(subtitle_line(e)),
+            })
+            .collect(),
+    })
+}
+
+fn headline(entries: &[Entrt]) -> String {
+    entries
+        .first()
+        .map(|e| format!("#1 {}  {}", e.id, e.score_line()))
+        .unwrap_or_else(|| "(no trending entries)".into())
+}
+
+fn row_line(entry: &Entrt) -> String {
+    format!(
+        "#{} {}  {}",
+        entry.position + 1,
+        entry.id,
+        entry.score_line()
+    )
+}
+
+fn subtitle_line(entry: &Entrt) -> String {
+    let mut s = entry.score_line();
+    if let Some(tag) = &entry.pipeline_tag {
+        s.push_str(&format!("  · {tag}"));
+    }
+    s
+}
+
+fn markdown_body(entries: &[Entrt], kind: Kind) -> String {
+    entries
+        .iter()
+        .map(|e| {
+            format!(
+                "- **#{} {}** — {}  ([page]({}))",
+                e.position + 1,
+                e.id,
+                e.score_line(),
+                e.url(kind),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn entry_row(entry: &Entrt) -> Entry {
+    Entry {
+        key: format!("#{} {}", entry.position + 1, entry.id),
+        value: Some(entry.score_line()),
+        status: None,
+    }
+}
+
+fn likes_bar(entry: &Entrt) -> Bar {
+    Bar {
+        label: entry.id.clone(),
+        value: entry.likes,
+    }
+}
+
+fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn sample_trending_body(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => crate::samples::linked_text_block(&[
+            (
+                "#1 meta-llama/Llama-3.1-8B-Instruct  ♥ 3.2k  ↓ 2.1M",
+                Some("https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct"),
+            ),
+            (
+                "#2 Qwen/Qwen2.5-72B-Instruct  ♥ 1.8k  ↓ 850.0k",
+                Some("https://huggingface.co/Qwen/Qwen2.5-72B-Instruct"),
+            ),
+        ]),
+        Shape::ImageLinkedList => crate::samples::image_linked_list(&[
+            (
+                "#1 meta-llama/Llama-3.1-8B-Instruct",
+                Some("https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct"),
+                None,
+                Some("♥ 3.2k  ↓ 2.1M  · text-generation"),
+            ),
+            (
+                "#2 Qwen/Qwen2.5-72B-Instruct",
+                Some("https://huggingface.co/Qwen/Qwen2.5-72B-Instruct"),
+                None,
+                Some("♥ 1.8k  ↓ 850.0k  · text-generation"),
+            ),
+        ]),
+        Shape::TextBlock => crate::samples::text_block(&[
+            "#1 meta-llama/Llama-3.1-8B-Instruct  ♥ 3.2k  ↓ 2.1M",
+            "#2 Qwen/Qwen2.5-72B-Instruct  ♥ 1.8k  ↓ 850.0k",
+        ]),
+        Shape::Text => crate::samples::text("#1 meta-llama/Llama-3.1-8B-Instruct  ♥ 3.2k  ↓ 2.1M"),
+        Shape::MarkdownTextBlock => crate::samples::markdown(
+            "- **#1 meta-llama/Llama-3.1-8B-Instruct** — ♥ 3.2k  ↓ 2.1M  ([page](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct))\n- **#2 Qwen/Qwen2.5-72B-Instruct** — ♥ 1.8k  ↓ 850.0k  ([page](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct))",
+        ),
+        Shape::Entries => crate::samples::entries(&[
+            ("#1 meta-llama/Llama-3.1-8B-Instruct", "♥ 3.2k  ↓ 2.1M"),
+            ("#2 Qwen/Qwen2.5-72B-Instruct", "♥ 1.8k  ↓ 850.0k"),
+        ]),
+        Shape::Bars => crate::samples::bars(&[
+            ("meta-llama/Llama-3.1-8B-Instruct", 3_200),
+            ("Qwen/Qwen2.5-72B-Instruct", 1_800),
+        ]),
+        _ => return None,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiEntry {
+    id: String,
+    #[serde(default)]
+    likes: Option<i64>,
+    #[serde(default)]
+    downloads: Option<i64>,
+    #[serde(default)]
+    pipeline_tag: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HfProfile {
+    #[serde(rename = "avatarUrl", default)]
+    avatar_url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration as StdDuration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "hf-trending".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn entry(id: &str, position: usize, likes: u64, downloads: Option<u64>) -> Entrt {
+        Entrt {
+            id: id.into(),
+            likes,
+            downloads,
+            pipeline_tag: Some("text-generation".into()),
+            position,
+        }
+    }
+
+    #[test]
+    fn kind_paths_cover_all_variants() {
+        assert_eq!(Kind::Models.path(), "models");
+        assert_eq!(Kind::Datasets.path(), "datasets");
+        assert_eq!(Kind::Spaces.path(), "spaces");
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.kind.is_none());
+        assert!(opts.count.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_full() {
+        let raw: toml::Value = toml::from_str("kind = \"datasets\"\ncount = 5").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.kind, Some(Kind::Datasets));
+        assert_eq!(opts.count, Some(5));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn entry_author_splits_on_first_slash() {
+        let e = entry("meta-llama/Llama-3.1", 0, 0, None);
+        assert_eq!(e.author(), Some("meta-llama"));
+    }
+
+    #[test]
+    fn entry_author_handles_idless_namespace() {
+        let e = entry("no_slash", 0, 0, None);
+        assert_eq!(e.author(), None);
+    }
+
+    #[test]
+    fn entry_url_uses_bare_slug_for_models_and_namespaced_for_others() {
+        let e = entry("author/repo", 0, 0, None);
+        assert_eq!(e.url(Kind::Models), "https://huggingface.co/author/repo");
+        assert_eq!(
+            e.url(Kind::Datasets),
+            "https://huggingface.co/datasets/author/repo"
+        );
+        assert_eq!(
+            e.url(Kind::Spaces),
+            "https://huggingface.co/spaces/author/repo"
+        );
+    }
+
+    #[test]
+    fn entry_score_line_includes_downloads_when_present() {
+        let with = entry("a/b", 0, 3200, Some(2_100_000));
+        assert_eq!(with.score_line(), "♥ 3.2k  ↓ 2.1M");
+        let without = entry("a/b", 0, 100, None);
+        assert_eq!(without.score_line(), "♥ 100");
+        let zero_dl = entry("a/b", 0, 100, Some(0));
+        assert_eq!(zero_dl.score_line(), "♥ 100");
+    }
+
+    #[test]
+    fn format_count_picks_unit_by_magnitude() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(950), "950");
+        assert_eq!(format_count(1_500), "1.5k");
+        assert_eq!(format_count(1_200_000), "1.2M");
+    }
+
+    #[test]
+    fn render_sync_text_uses_first_entry_with_rank_prefix() {
+        let body = render_sync(
+            &[entry("meta-llama/Llama-3.1", 0, 3200, Some(2_100_000))],
+            Kind::Models,
+            Shape::Text,
+        );
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("#1"));
+        assert!(t.value.contains("meta-llama/Llama-3.1"));
+    }
+
+    #[test]
+    fn render_sync_text_handles_empty_entries() {
+        let body = render_sync(&[], Kind::Models, Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "(no trending entries)");
+    }
+
+    #[test]
+    fn render_sync_linked_text_block_uses_kind_aware_url() {
+        let body = render_sync(
+            &[entry("author/repo", 0, 100, None)],
+            Kind::Datasets,
+            Shape::LinkedTextBlock,
+        );
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://huggingface.co/datasets/author/repo")
+        );
+    }
+
+    #[test]
+    fn render_sync_bars_carry_likes_as_value() {
+        let entries = vec![entry("a/b", 0, 3200, None), entry("c/d", 1, 1800, None)];
+        let body = render_sync(&entries, Kind::Models, Shape::Bars);
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].label, "a/b");
+        assert_eq!(b.bars[0].value, 3200);
+        assert_eq!(b.bars[1].value, 1800);
+    }
+
+    #[test]
+    fn render_sync_markdown_includes_page_link() {
+        let body = render_sync(
+            &[entry("author/repo", 0, 100, None)],
+            Kind::Models,
+            Shape::MarkdownTextBlock,
+        );
+        let Body::MarkdownTextBlock(m) = body else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("[page]("));
+        assert!(m.value.contains("author/repo"));
+    }
+
+    #[test]
+    fn render_sync_entries_use_rank_prefixed_key_and_score_value() {
+        let body = render_sync(
+            &[entry("author/repo", 0, 3200, Some(2_100_000))],
+            Kind::Models,
+            Shape::Entries,
+        );
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "#1 author/repo");
+        assert_eq!(e.items[0].value.as_deref(), Some("♥ 3.2k  ↓ 2.1M"));
+    }
+
+    #[test]
+    fn image_linked_body_pins_paths_and_subtitle_with_pipeline_tag() {
+        let entries = vec![entry("author/repo", 0, 100, Some(50))];
+        let paths = vec![Some(PathBuf::from("/tmp/a.png"))];
+        let body = image_linked_body(&entries, Kind::Models, &paths);
+        let Body::ImageLinkedList(d) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items[0].title, "#1 author/repo");
+        assert_eq!(d.items[0].thumbnail_path.as_deref(), Some("/tmp/a.png"));
+        let subtitle = d.items[0].subtitle.as_deref().unwrap();
+        assert!(subtitle.contains("text-generation"));
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = HuggingfaceTrendingFetcher;
+        assert_eq!(fetcher.name(), "huggingface_trending");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(
+            fetcher
+                .option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["kind", "count"]
+        );
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_shape_and_options() {
+        let fetcher = HuggingfaceTrendingFetcher;
+        let linked = fetcher.cache_key(&ctx(None, Some(Shape::LinkedTextBlock)));
+        let bars = fetcher.cache_key(&ctx(None, Some(Shape::Bars)));
+        let datasets = fetcher.cache_key(&ctx(
+            Some("kind = \"datasets\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        assert_ne!(linked, bars);
+        assert_ne!(linked, datasets);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = HuggingfaceTrendingFetcher
+            .fetch(&ctx(Some("bogus = true"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -16,6 +16,7 @@ pub mod basic;
 pub mod calendar;
 pub mod clock;
 pub mod code;
+pub mod crypto_trending;
 pub mod crypto_watchlist;
 pub mod deal;
 pub mod deariary;
@@ -23,6 +24,7 @@ pub mod feed;
 pub mod git;
 pub mod github;
 pub mod hackernews;
+pub mod huggingface_trending;
 pub mod linear;
 pub mod lobsters;
 pub mod nasa_apod;
@@ -333,11 +335,13 @@ impl Registry {
         r.register(Arc::new(read_store::ReadStoreFetcher));
         r.register(Arc::new(rss::RssFetcher));
         r.register(Arc::new(crypto_watchlist::CryptoWatchlistFetcher));
+        r.register(Arc::new(crypto_trending::CryptoTrendingFetcher));
         r.register(Arc::new(stock_watchlist::StockWatchlistFetcher));
         r.register(Arc::new(random_cat::RandomCatFetcher));
         r.register(Arc::new(random_dog::RandomDogFetcher));
         r.register(Arc::new(nasa_apod::NasaApodFetcher));
         r.register(Arc::new(youtube::YoutubeChannelFetcher));
+        r.register(Arc::new(huggingface_trending::HuggingfaceTrendingFetcher));
         for f in calendar::fetchers() {
             r.register(f);
         }

--- a/src/fetcher/reddit/common.rs
+++ b/src/fetcher/reddit/common.rs
@@ -257,11 +257,11 @@ pub(super) fn sample_post_body(shape: Shape) -> Option<Body> {
     })
 }
 
-fn post_title(post: &Post) -> String {
+pub(super) fn post_title(post: &Post) -> String {
     post.title.as_deref().unwrap_or("(no title)").to_string()
 }
 
-fn post_meta(post: &Post) -> String {
+pub(super) fn post_meta(post: &Post) -> String {
     let subreddit = post
         .subreddit
         .as_deref()

--- a/src/fetcher/reddit/mod.rs
+++ b/src/fetcher/reddit/mod.rs
@@ -5,6 +5,7 @@
 mod client;
 mod common;
 mod subreddit_posts;
+mod trending;
 mod user_comments;
 mod user_posts;
 
@@ -17,5 +18,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(subreddit_posts::RedditSubredditPostsFetcher),
         Arc::new(user_posts::RedditUserPostsFetcher),
         Arc::new(user_comments::RedditUserCommentsFetcher),
+        Arc::new(trending::RedditTrendingFetcher),
     ]
 }

--- a/src/fetcher/reddit/trending.rs
+++ b/src/fetcher/reddit/trending.rs
@@ -1,0 +1,368 @@
+//! `reddit_trending` — site-wide trending via Reddit's `/r/popular.json` listing.
+//!
+//! Distinct from `reddit_subreddit_posts` (a single subreddit) and the `reddit_user_*` family
+//! (one user's submissions / comments): this surfaces what Reddit's algorithm picks as hot
+//! across *all* subreddits right now. Anonymous read on the fixed `www.reddit.com` host →
+//! Safety::Safe.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{parse_options, payload};
+use crate::fetcher::thumbnails;
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Bar, BarsData, Body, MarkdownTextBlockData, Payload, TextData};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::fetch_listing;
+use super::common::{
+    Post, cache_key_for, network_unavailable_body, normalized_count, post_meta, post_title,
+    render_posts, render_posts_image_linked,
+};
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "count",
+    type_hint: "integer (1..=30)",
+    required: false,
+    default: Some("10"),
+    description: "Number of trending posts to display.",
+}];
+
+pub struct RedditTrendingFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for RedditTrendingFetcher {
+    fn name(&self) -> &str {
+        "reddit_trending"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Trending posts across all subreddits via Reddit's public `/r/popular.json` listing — what Reddit picks as hot site-wide right now. Distinct from `reddit_subreddit_posts` (a specific sub) and `reddit_user_posts` (one account's submissions)."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 30
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key_for(self.name(), ctx)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_trending_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let count = normalized_count(opts.count);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        match fetch_listing::<Post>(&listing_path(count)).await {
+            Ok(posts) => Ok(payload(render_for_shape(&posts, shape).await)),
+            Err(err) => Ok(payload(network_unavailable_body(shape, &format!("{err}")))),
+        }
+    }
+}
+
+fn listing_path(count: usize) -> String {
+    format!("/r/popular.json?limit={count}&raw_json=1")
+}
+
+/// `ImageLinkedList` is the one shape that needs an async detour to resolve each post's
+/// thumbnail URL into a local cache path; every other shape is rendered synchronously.
+async fn render_for_shape(posts: &[Post], shape: Shape) -> Body {
+    if matches!(shape, Shape::ImageLinkedList) {
+        let urls: Vec<Option<String>> = posts
+            .iter()
+            .map(|p| p.thumbnail_url().map(str::to_string))
+            .collect();
+        let paths = thumbnails::download_many(&urls).await;
+        return render_posts_image_linked(posts, &paths);
+    }
+    render_trending_sync(posts, shape)
+}
+
+fn render_trending_sync(posts: &[Post], shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: trending_headline(posts),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: markdown_lines(posts),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: posts.iter().map(score_bar).collect(),
+        }),
+        _ => render_posts(posts, shape),
+    }
+}
+
+fn trending_headline(posts: &[Post]) -> String {
+    posts
+        .first()
+        .map(|p| format!("{}  {}", post_meta(p), post_title(p)))
+        .unwrap_or_else(|| "(no trending posts)".into())
+}
+
+fn markdown_lines(posts: &[Post]) -> String {
+    posts
+        .iter()
+        .map(|p| format!("- **{}** — {}", post_title(p), post_meta(p)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Reddit scores can be negative; clamp to 0 because `Bar.value` is `u64`. Downvoted
+/// front-page posts are vanishingly rare, but the trait contract has to hold.
+fn score_bar(post: &Post) -> Bar {
+    Bar {
+        label: post_title(post),
+        value: post.score.unwrap_or(0).max(0) as u64,
+    }
+}
+
+fn sample_trending_body(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "r/news · 25420↑ 1820c  Major breaking story headline",
+                Some("https://www.reddit.com/r/news/comments/abc/"),
+            ),
+            (
+                "r/AskReddit · 18230↑ 4210c  What's your biggest red flag?",
+                Some("https://www.reddit.com/r/AskReddit/comments/def/"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "Major breaking story headline",
+                Some("https://www.reddit.com/r/news/comments/abc/"),
+                None,
+                Some("r/news · 25420↑ 1820c"),
+            ),
+            (
+                "What's your biggest red flag?",
+                Some("https://www.reddit.com/r/AskReddit/comments/def/"),
+                None,
+                Some("r/AskReddit · 18230↑ 4210c"),
+            ),
+        ]),
+        Shape::TextBlock => samples::text_block(&[
+            "r/news · 25420↑ 1820c  Major breaking story headline",
+            "r/AskReddit · 18230↑ 4210c  What's your biggest red flag?",
+        ]),
+        Shape::Text => samples::text("r/news · 25420↑ 1820c  Major breaking story headline"),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- **Major breaking story headline** — r/news · 25420↑ 1820c\n- **What's your biggest red flag?** — r/AskReddit · 18230↑ 4210c",
+        ),
+        Shape::Entries => samples::entries(&[
+            ("Major breaking story headline", "r/news · 25420↑ 1820c"),
+            (
+                "What's your biggest red flag?",
+                "r/AskReddit · 18230↑ 4210c",
+            ),
+        ]),
+        Shape::Bars => samples::bars(&[
+            ("Major breaking story headline", 25420),
+            ("What's your biggest red flag?", 18230),
+        ]),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(shape: Option<Shape>, options: Option<toml::Value>) -> FetchContext {
+        FetchContext {
+            widget_id: "reddit-trending".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options,
+            ..Default::default()
+        }
+    }
+
+    fn post(title: &str, score: i64, sub: &str) -> Post {
+        Post {
+            title: Some(title.into()),
+            score: Some(score),
+            num_comments: Some(0),
+            subreddit: Some(sub.into()),
+            permalink: None,
+            url: Some(format!("https://example.com/{}", title.replace(' ', "_"))),
+            thumbnail: None,
+        }
+    }
+
+    #[test]
+    fn listing_path_targets_r_popular_with_limit() {
+        assert_eq!(listing_path(15), "/r/popular.json?limit=15&raw_json=1");
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.count.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_count() {
+        let raw: toml::Value = toml::from_str("count = 7").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.count, Some(7));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = RedditTrendingFetcher;
+        assert_eq!(fetcher.name(), "reddit_trending");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(
+            fetcher
+                .option_schemas()
+                .iter()
+                .map(|schema| schema.name)
+                .collect::<Vec<_>>(),
+            vec!["count"]
+        );
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "expected sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn render_trending_sync_text_uses_first_post() {
+        let posts = vec![post("first", 100, "rust"), post("second", 50, "go")];
+        let body = render_trending_sync(&posts, Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("first"));
+        assert!(t.value.contains("r/rust"));
+    }
+
+    #[test]
+    fn render_trending_sync_text_handles_empty() {
+        let body = render_trending_sync(&[], Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "(no trending posts)");
+    }
+
+    #[test]
+    fn render_trending_sync_markdown_lists_bullets() {
+        let posts = vec![post("first", 100, "rust"), post("second", 50, "go")];
+        let body = render_trending_sync(&posts, Shape::MarkdownTextBlock);
+        let Body::MarkdownTextBlock(m) = body else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("- **first**"));
+        assert!(m.value.contains("- **second**"));
+        assert!(m.value.contains("r/rust"));
+    }
+
+    #[test]
+    fn render_trending_sync_bars_ranks_by_score_and_clamps_negative() {
+        let posts = vec![post("popular", 9000, "rust"), post("downvoted", -3, "rust")];
+        let body = render_trending_sync(&posts, Shape::Bars);
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].label, "popular");
+        assert_eq!(b.bars[0].value, 9000);
+        assert_eq!(b.bars[1].value, 0);
+    }
+
+    #[test]
+    fn render_trending_sync_delegates_unknown_shapes_to_render_posts() {
+        let posts = vec![post("first", 1, "rust")];
+        let body = render_trending_sync(&posts, Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert!(b.items[0].text.contains("first"));
+    }
+
+    #[test]
+    fn cache_key_changes_with_shape_and_count() {
+        let fetcher = RedditTrendingFetcher;
+        let linked = fetcher.cache_key(&ctx(Some(Shape::LinkedTextBlock), None));
+        let bars = fetcher.cache_key(&ctx(Some(Shape::Bars), None));
+        let custom = fetcher.cache_key(&ctx(
+            Some(Shape::LinkedTextBlock),
+            Some(toml::from_str("count = 30").unwrap()),
+        ));
+        assert_ne!(linked, bars);
+        assert_ne!(linked, custom);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = RedditTrendingFetcher
+            .fetch(&ctx(
+                Some(Shape::TextBlock),
+                Some(toml::from_str("bogus = true").unwrap()),
+            ))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+
+    #[tokio::test]
+    async fn render_for_shape_image_linked_returns_empty_list_for_no_posts() {
+        let body = render_for_shape(&[], Shape::ImageLinkedList).await;
+        match body {
+            Body::ImageLinkedList(data) => assert!(data.items.is_empty()),
+            other => panic!("expected ImageLinkedList, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn render_for_shape_non_image_dispatches_to_sync_renderer() {
+        let body = render_for_shape(&[], Shape::Bars).await;
+        match body {
+            Body::Bars(data) => assert!(data.bars.is_empty()),
+            other => panic!("expected Bars, got {other:?}"),
+        }
+    }
+}

--- a/src/fetcher/wikipedia/mod.rs
+++ b/src/fetcher/wikipedia/mod.rs
@@ -11,6 +11,7 @@ pub mod client;
 pub mod featured;
 pub mod on_this_day;
 pub mod random;
+pub mod trending;
 
 use std::sync::Arc;
 
@@ -21,5 +22,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(on_this_day::WikipediaOnThisDayFetcher),
         Arc::new(featured::WikipediaFeaturedFetcher),
         Arc::new(random::WikipediaRandomFetcher),
+        Arc::new(trending::WikipediaTrendingFetcher),
     ]
 }

--- a/src/fetcher/wikipedia/trending.rs
+++ b/src/fetcher/wikipedia/trending.rs
@@ -1,0 +1,669 @@
+//! `wikipedia_trending` — most-viewed Wikipedia articles for the previous UTC day via the
+//! Wikimedia Pageviews API.
+//!
+//! Safety::Safe: requests target two fixed hosts — `wikimedia.org` for the pageviews list and
+//! `<lang>.wikipedia.org` for per-article summary lookups when the `ImageLinkedList` shape
+//! needs thumbnails. The user-supplied `lang` only swaps the language subdomain; it can't
+//! redirect traffic off the wiki ecosystem.
+//!
+//! The pageviews response is filtered to drop `Main_Page`, search pages, and meta-namespace
+//! entries (`Wikipedia:`, `Portal:`, `File:`, `Category:`, …) so the trending list shows real
+//! articles a reader would actually click. `date` defaults to "yesterday in UTC" because the
+//! API serves complete days only and today's snapshot is not yet finalised.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use chrono::{Datelike, Duration, Utc};
+use serde::Deserialize;
+use url::Url;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::thumbnails;
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    Bar, BarsData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, Payload, TextBlockData, TextData,
+};
+use crate::render::Shape;
+use crate::samples;
+
+use super::client::{DEFAULT_LANG, PageSummary, get, rest_api_base};
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 20;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "lang",
+        type_hint: "string (Wikipedia language code)",
+        required: false,
+        default: Some("\"en\""),
+        description: "Wikipedia language edition.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("10"),
+        description: "Number of trending articles to display.",
+    },
+    OptionSchema {
+        name: "access",
+        type_hint: "\"all-access\" | \"desktop\" | \"mobile-web\" | \"mobile-app\"",
+        required: false,
+        default: Some("\"all-access\""),
+        description: "Which pageview channel to rank by.",
+    },
+];
+
+pub struct WikipediaTrendingFetcher;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    lang: Option<String>,
+    #[serde(default)]
+    count: Option<u32>,
+    #[serde(default)]
+    access: Option<Access>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum Access {
+    /// Default; named `All` instead of `AllAccess` to satisfy clippy's
+    /// `enum_variant_names` lint. Serde rename keeps the user-facing TOML value
+    /// `"all-access"` matching the Wikimedia API path segment.
+    #[default]
+    #[serde(rename = "all-access")]
+    All,
+    Desktop,
+    MobileWeb,
+    MobileApp,
+}
+
+impl Access {
+    fn as_path(self) -> &'static str {
+        match self {
+            Self::All => "all-access",
+            Self::Desktop => "desktop",
+            Self::MobileWeb => "mobile-web",
+            Self::MobileApp => "mobile-app",
+        }
+    }
+}
+
+#[async_trait]
+impl Fetcher for WikipediaTrendingFetcher {
+    fn name(&self) -> &str {
+        "wikipedia_trending"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Most-viewed Wikipedia articles for the previous UTC day via the public Wikimedia pageviews API. Filters out `Main_Page`, search, and meta-namespace pages so the list is real articles. Companion to the shipped `wikipedia_featured` (today's curated pick) and `wikipedia_random`."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60 * 6
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_trending_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let lang = opts.lang.as_deref().unwrap_or(DEFAULT_LANG);
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let access = opts.access.unwrap_or_default();
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+
+        let articles = fetch_trending_articles(lang, access, count).await?;
+        let body = render_for_shape(&articles, shape, lang).await;
+        Ok(payload(body))
+    }
+}
+
+/// Trending article as the renderer wants it — title display form, source page URL, view
+/// count. Thumbnail URL is resolved later (only when the shape needs it) via a per-article
+/// `/page/summary` call.
+#[derive(Debug, Clone)]
+struct Article {
+    title_display: String,
+    title_raw: String,
+    url: String,
+    views: u64,
+}
+
+async fn fetch_trending_articles(
+    lang: &str,
+    access: Access,
+    limit: usize,
+) -> Result<Vec<Article>, FetchError> {
+    let (year, month, day) = previous_utc_day();
+    let url = format!(
+        "https://wikimedia.org/api/rest_v1/metrics/pageviews/top/{lang}.wikipedia/{}/{year}/{month:02}/{day:02}",
+        access.as_path(),
+    );
+    let response: TopResponse = get(&url).await?;
+    Ok(response
+        .items
+        .into_iter()
+        .flat_map(|item| item.articles)
+        .filter(is_real_article)
+        .take(limit)
+        .map(|raw| article_from_raw(lang, raw))
+        .collect())
+}
+
+fn previous_utc_day() -> (i32, u32, u32) {
+    let yesterday = Utc::now() - Duration::days(1);
+    (yesterday.year(), yesterday.month(), yesterday.day())
+}
+
+fn is_real_article(raw: &TopArticle) -> bool {
+    let title = raw.article.as_str();
+    if title == "Main_Page" || title == "-" {
+        return false;
+    }
+    !title.starts_with("Special:")
+        && !title.starts_with("Wikipedia:")
+        && !title.starts_with("Portal:")
+        && !title.starts_with("File:")
+        && !title.starts_with("Category:")
+        && !title.starts_with("Help:")
+        && !title.starts_with("Template:")
+        && !title.starts_with("Talk:")
+}
+
+fn article_from_raw(lang: &str, raw: TopArticle) -> Article {
+    let title_display = raw.article.replace('_', " ");
+    let url = build_article_url(lang, &raw.article);
+    Article {
+        title_display,
+        title_raw: raw.article,
+        url,
+        views: raw.views,
+    }
+}
+
+/// Build a `https://{lang}.wikipedia.org/wiki/{title}` URL. Goes through `url::Url` so reserved
+/// path characters (`#`, `?`, …) and non-ASCII bytes are percent-encoded correctly; underscores
+/// (Wikipedia's canonical title separator) pass through unchanged.
+fn build_article_url(lang: &str, title_raw: &str) -> String {
+    let mut url = Url::parse(&format!("https://{lang}.wikipedia.org/wiki/"))
+        .expect("wiki article base parses");
+    url.path_segments_mut()
+        .expect("wikipedia URL is path-segments-capable")
+        .pop_if_empty()
+        .push(title_raw);
+    url.into()
+}
+
+async fn render_for_shape(articles: &[Article], shape: Shape, lang: &str) -> Body {
+    if matches!(shape, Shape::ImageLinkedList) {
+        let paths = resolve_thumbnails(articles, lang).await;
+        return image_linked_body(articles, &paths);
+    }
+    render_sync(articles, shape)
+}
+
+async fn resolve_thumbnails(articles: &[Article], lang: &str) -> Vec<Option<PathBuf>> {
+    let urls = collect_thumbnail_urls(articles, lang).await;
+    thumbnails::download_many(&urls).await
+}
+
+async fn collect_thumbnail_urls(articles: &[Article], lang: &str) -> Vec<Option<String>> {
+    let base = rest_api_base(lang);
+    let mut out = Vec::with_capacity(articles.len());
+    for article in articles {
+        out.push(fetch_thumbnail_url(&base, &article.title_raw).await);
+    }
+    out
+}
+
+async fn fetch_thumbnail_url(rest_base: &str, title_raw: &str) -> Option<String> {
+    let url = build_summary_url(rest_base, title_raw);
+    let summary: PageSummary = get(&url).await.ok()?;
+    summary.thumbnail_url().map(str::to_string)
+}
+
+fn build_summary_url(rest_base: &str, title_raw: &str) -> String {
+    let mut url =
+        Url::parse(&format!("{rest_base}/page/summary/")).expect("wiki summary base parses");
+    url.path_segments_mut()
+        .expect("wikipedia URL is path-segments-capable")
+        .pop_if_empty()
+        .push(title_raw);
+    url.into()
+}
+
+fn render_sync(articles: &[Article], shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: headline(articles),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: articles.iter().map(article_line).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: markdown_body(articles),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: articles
+                .iter()
+                .map(|a| Entry {
+                    key: a.title_display.clone(),
+                    value: Some(format_views(a.views)),
+                    status: None,
+                })
+                .collect(),
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: articles
+                .iter()
+                .map(|a| Bar {
+                    label: a.title_display.clone(),
+                    value: a.views,
+                })
+                .collect(),
+        }),
+        _ => Body::LinkedTextBlock(LinkedTextBlockData {
+            items: articles
+                .iter()
+                .map(|a| LinkedLine {
+                    text: format!("{}  {}", format_views(a.views), a.title_display),
+                    url: Some(a.url.clone()),
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn image_linked_body(articles: &[Article], paths: &[Option<PathBuf>]) -> Body {
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: articles
+            .iter()
+            .enumerate()
+            .map(|(i, a)| ImageLinkedItem {
+                title: a.title_display.clone(),
+                url: Some(a.url.clone()),
+                thumbnail_path: paths
+                    .get(i)
+                    .and_then(|p| p.as_ref())
+                    .map(|p| p.to_string_lossy().into_owned()),
+                subtitle: Some(format_views(a.views)),
+            })
+            .collect(),
+    })
+}
+
+fn headline(articles: &[Article]) -> String {
+    articles
+        .first()
+        .map(|a| format!("{}  {}", format_views(a.views), a.title_display))
+        .unwrap_or_else(|| "(no trending articles)".into())
+}
+
+fn article_line(article: &Article) -> String {
+    format!("{}  {}", format_views(article.views), article.title_display)
+}
+
+fn markdown_body(articles: &[Article]) -> String {
+    articles
+        .iter()
+        .map(|a| format!("- **{}** — {}", a.title_display, format_views(a.views)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_views(views: u64) -> String {
+    if views >= 1_000_000 {
+        format!("{:.1}M views", views as f64 / 1_000_000.0)
+    } else if views >= 1_000 {
+        format!("{:.1}k views", views as f64 / 1_000.0)
+    } else {
+        format!("{views} views")
+    }
+}
+
+fn sample_trending_body(shape: Shape) -> Option<Body> {
+    Some(match shape {
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "412.0k views  Quokka",
+                Some("https://en.wikipedia.org/wiki/Quokka"),
+            ),
+            (
+                "287.0k views  Apollo 11",
+                Some("https://en.wikipedia.org/wiki/Apollo_11"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "Quokka",
+                Some("https://en.wikipedia.org/wiki/Quokka"),
+                None,
+                Some("412.0k views"),
+            ),
+            (
+                "Apollo 11",
+                Some("https://en.wikipedia.org/wiki/Apollo_11"),
+                None,
+                Some("287.0k views"),
+            ),
+        ]),
+        Shape::TextBlock => {
+            samples::text_block(&["412.0k views  Quokka", "287.0k views  Apollo 11"])
+        }
+        Shape::Text => samples::text("412.0k views  Quokka"),
+        Shape::MarkdownTextBlock => {
+            samples::markdown("- **Quokka** — 412.0k views\n- **Apollo 11** — 287.0k views")
+        }
+        Shape::Entries => {
+            samples::entries(&[("Quokka", "412.0k views"), ("Apollo 11", "287.0k views")])
+        }
+        Shape::Bars => samples::bars(&[("Quokka", 412_000), ("Apollo 11", 287_000)]),
+        _ => return None,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct TopResponse {
+    items: Vec<TopItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TopItem {
+    articles: Vec<TopArticle>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TopArticle {
+    article: String,
+    views: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration as StdDuration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "wiki-trending".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn article(title: &str, views: u64) -> Article {
+        Article {
+            title_display: title.replace('_', " "),
+            title_raw: title.into(),
+            url: format!("https://en.wikipedia.org/wiki/{title}"),
+            views,
+        }
+    }
+
+    #[test]
+    fn access_as_path_covers_all_variants() {
+        assert_eq!(Access::All.as_path(), "all-access");
+        assert_eq!(Access::Desktop.as_path(), "desktop");
+        assert_eq!(Access::MobileWeb.as_path(), "mobile-web");
+        assert_eq!(Access::MobileApp.as_path(), "mobile-app");
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.lang.is_none());
+        assert!(opts.count.is_none());
+        assert!(opts.access.is_none());
+    }
+
+    #[test]
+    fn options_deserialize_full() {
+        let raw: toml::Value =
+            toml::from_str("lang = \"ja\"\ncount = 5\naccess = \"mobile-web\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.lang.as_deref(), Some("ja"));
+        assert_eq!(opts.count, Some(5));
+        assert!(matches!(opts.access, Some(Access::MobileWeb)));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn is_real_article_filters_meta_and_placeholders() {
+        let cases = [
+            ("Main_Page", false),
+            ("-", false),
+            ("Special:Search", false),
+            ("Wikipedia:About", false),
+            ("Portal:Current_events", false),
+            ("File:Logo.svg", false),
+            ("Category:Cats", false),
+            ("Help:Contents", false),
+            ("Template:Stub", false),
+            ("Talk:Quokka", false),
+            ("Quokka", true),
+            ("Apollo_11", true),
+            ("List_of_films", true),
+        ];
+        for (title, expected) in cases {
+            let raw = TopArticle {
+                article: title.into(),
+                views: 1,
+            };
+            assert_eq!(is_real_article(&raw), expected, "title: {title}");
+        }
+    }
+
+    #[test]
+    fn article_from_raw_swaps_underscores_and_percent_encodes_url() {
+        let a = article_from_raw(
+            "en",
+            TopArticle {
+                article: "Apollo_11".into(),
+                views: 100,
+            },
+        );
+        assert_eq!(a.title_display, "Apollo 11");
+        assert_eq!(a.url, "https://en.wikipedia.org/wiki/Apollo_11");
+    }
+
+    #[test]
+    fn article_from_raw_percent_encodes_unsafe_chars() {
+        let a = article_from_raw(
+            "en",
+            TopArticle {
+                article: "Hello#world".into(),
+                views: 1,
+            },
+        );
+        assert!(a.url.ends_with("/wiki/Hello%23world"), "url: {}", a.url);
+    }
+
+    #[test]
+    fn format_views_picks_unit_by_magnitude() {
+        assert_eq!(format_views(412), "412 views");
+        assert_eq!(format_views(1_500), "1.5k views");
+        assert_eq!(format_views(412_000), "412.0k views");
+        assert_eq!(format_views(2_500_000), "2.5M views");
+    }
+
+    #[test]
+    fn render_sync_text_uses_first_article() {
+        let body = render_sync(&[article("Quokka", 412_000)], Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("Quokka"));
+        assert!(t.value.contains("412.0k"));
+    }
+
+    #[test]
+    fn render_sync_text_handles_empty_articles() {
+        let body = render_sync(&[], Shape::Text);
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "(no trending articles)");
+    }
+
+    #[test]
+    fn render_sync_bars_carry_view_count_as_value() {
+        let body = render_sync(
+            &[article("Quokka", 412_000), article("Apollo_11", 287_000)],
+            Shape::Bars,
+        );
+        let Body::Bars(b) = body else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].label, "Quokka");
+        assert_eq!(b.bars[0].value, 412_000);
+        assert_eq!(b.bars[1].label, "Apollo 11");
+        assert_eq!(b.bars[1].value, 287_000);
+    }
+
+    #[test]
+    fn render_sync_entries_pair_title_with_view_count() {
+        let body = render_sync(&[article("Quokka", 412_000)], Shape::Entries);
+        let Body::Entries(e) = body else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "Quokka");
+        assert_eq!(e.items[0].value.as_deref(), Some("412.0k views"));
+    }
+
+    #[test]
+    fn render_sync_markdown_emits_bullet_per_article() {
+        let body = render_sync(
+            &[article("Quokka", 412_000), article("Apollo_11", 287_000)],
+            Shape::MarkdownTextBlock,
+        );
+        let Body::MarkdownTextBlock(m) = body else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("- **Quokka**"));
+        assert!(m.value.contains("- **Apollo 11**"));
+    }
+
+    #[test]
+    fn render_sync_default_to_linked_text_block() {
+        let body = render_sync(&[article("Quokka", 412_000)], Shape::LinkedTextBlock);
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items[0].text, "412.0k views  Quokka");
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://en.wikipedia.org/wiki/Quokka")
+        );
+    }
+
+    #[test]
+    fn image_linked_body_pins_paths_and_subtitle() {
+        let articles = vec![article("Quokka", 412_000), article("Apollo_11", 287_000)];
+        let paths = vec![Some(PathBuf::from("/tmp/q.jpg")), None];
+        let body = image_linked_body(&articles, &paths);
+        let Body::ImageLinkedList(data) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(data.items.len(), 2);
+        assert_eq!(data.items[0].title, "Quokka");
+        assert_eq!(data.items[0].thumbnail_path.as_deref(), Some("/tmp/q.jpg"));
+        assert_eq!(data.items[0].subtitle.as_deref(), Some("412.0k views"));
+        assert_eq!(data.items[1].thumbnail_path, None);
+    }
+
+    #[test]
+    fn previous_utc_day_returns_a_valid_date() {
+        let (year, month, day) = previous_utc_day();
+        assert!((1..=12).contains(&month));
+        assert!((1..=31).contains(&day));
+        assert!(year >= 2024);
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = WikipediaTrendingFetcher;
+        assert_eq!(fetcher.name(), "wikipedia_trending");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(
+            fetcher
+                .option_schemas()
+                .iter()
+                .map(|s| s.name)
+                .collect::<Vec<_>>(),
+            vec!["lang", "count", "access"]
+        );
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}",
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_shape_and_options() {
+        let fetcher = WikipediaTrendingFetcher;
+        let linked = fetcher.cache_key(&ctx(Some("lang = \"en\""), Some(Shape::LinkedTextBlock)));
+        let bars = fetcher.cache_key(&ctx(Some("lang = \"en\""), Some(Shape::Bars)));
+        let custom_lang =
+            fetcher.cache_key(&ctx(Some("lang = \"ja\""), Some(Shape::LinkedTextBlock)));
+        assert_ne!(linked, bars);
+        assert_ne!(linked, custom_lang);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = WikipediaTrendingFetcher
+            .fetch(&ctx(Some("bogus = true"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `*_trending` batch — four sibling fetchers covering the "what's hot right now" axis across distinct public APIs.

| fetcher | source | family | catalog sub-issue |
|---|---|---|---|
| `reddit_trending` | `/r/popular.json` site-wide listing | `reddit_*` | [#67](https://github.com/unhappychoice/splashboard/issues/67) |
| `wikipedia_trending` | Wikimedia pageview top API (previous UTC day) | `wikipedia_*` | [#67](https://github.com/unhappychoice/splashboard/issues/67) |
| `crypto_trending` | CoinGecko `/search/trending` | `crypto_*` | [#68](https://github.com/unhappychoice/splashboard/issues/68) |
| `huggingface_trending` | HF Hub `/api/{models\|datasets\|spaces}?sort=trendingScore` | `huggingface_*` (new) | [#64](https://github.com/unhappychoice/splashboard/issues/64) |

All four are `Safety::Safe` (each host hardcoded; user input is closed enums or numeric counts), all cached, all share the same 7-shape contract:

| Shape | Notes |
|---|---|
| `linked_text_block` (default) | clickable rows via OSC 8 |
| `image_linked_list` | thumbnails — direct from response (crypto), per-row REST summary (wikipedia), per-row reddit thumbnail (reddit), per-author user/org overview (huggingface) |
| `text_block` / `text` / `markdown_text_block` | line variants |
| `entries` | label → score key-value rows |
| `bars` | rank-encoded for the chart family |

Rejected shapes (`Ratio` / `NumberSeries` / `PointSeries` / `Image` / `Calendar` / `Heatmap` / `Badge` / `Timeline`) carry no natural representation for a "snapshot list of items ranked by popularity" — see the spec discussion on the trending batch.

## Design notes

- **Reuse**: `reddit_trending` plugs into the existing `reddit/client.rs` + `Post` DTO + thumbnail pipeline. `common.rs` exposes `post_title` / `post_meta` to the new module so the renderer can build Text / Markdown / Bars without duplicating the formatting helpers.
- **Wikipedia date handling**: defaults to yesterday-in-UTC because the pageviews API serves complete days only and today's snapshot isn't finalised. Filters `Main_Page`, search, and meta namespaces (`Special:` / `Wikipedia:` / `Portal:` / `File:` / `Category:` / `Help:` / `Template:` / `Talk:`) so the list reads as real articles a reader would click.
- **CoinGecko trending bars**: the API's own `score` field decays to zero for the lower half, which makes `chart_bar` collapse. `rank_bar` uses `(MAX_COUNT - position).max(1)` instead so the chart stays informative across the full top-15.
- **HF avatar resolution**: not exposed in the trending response. Falls back to `/api/users/{author}` then `/api/organizations/{author}` (HF puts both in the same namespace but separate API paths). In-loop dedup keeps a 20-row feed at ≤ N distinct lookups when one org ships multiple trending models in the same window.

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 2,609 tests pass (73 new across the four fetchers)
- User smoke-tested via a temporary `.splashboard/dashboard.toml` exercising each fetcher in two shapes (`list_links` + `list_cards` / `chart_bar`): list rendering, OSC 8 links, thumbnails, and number formatting all looked correct.

## Reference pages

After this lands and the docs site rebuilds, the new fetchers will appear at:

- https://splashboard.unhappychoice.com/reference/fetchers/reddit/reddit_trending/
- https://splashboard.unhappychoice.com/reference/fetchers/wikipedia/wikipedia_trending/
- https://splashboard.unhappychoice.com/reference/fetchers/crypto/crypto_trending/
- https://splashboard.unhappychoice.com/reference/fetchers/huggingface/huggingface_trending/

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trending cryptocurrency data source with currency selection
  * Added trending Hugging Face models, datasets, and spaces
  * Added Reddit popular posts trending feed
  * Added Wikipedia trending articles with language and access-type options
  * Multiple display formats supported across all trending sources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->