### PR TITLE
feat(fetcher): add gitlab_* forge family + extend github_* shape coverage

### DIFF
--- a/src/fetcher/forge_items.rs
+++ b/src/fetcher/forge_items.rs
@@ -1,0 +1,455 @@
+//! Shared row model + multi-shape renderer for forge fetchers (`github_*`, `gitlab_*`).
+//!
+//! Both forges return per-PR/MR/issue rows with the same essential fields: a slug label
+//! (`owner/repo#42` or `group/proj!42`), a title, a canonical URL, an author avatar URL, an
+//! `updated_at` timestamp, and an activity counter (comments / notes / upvotes). Each family
+//! parses its own JSON DTO into [`ForgeRow`] and hands the slice to [`render_forge_rows`],
+//! which materialises any of the 8 list-shaped variants:
+//!
+//! `Text` / `TextBlock` / `MarkdownTextBlock` / `LinkedTextBlock` / `ImageLinkedList` /
+//! `Entries` / `Bars` / `Timeline`
+//!
+//! Plus [`render_count_badge`] for the count-pill summary (`"5 open"` Warn / `"0 open ✓"` Ok).
+//!
+//! Sharing the row → body translation keeps `github_*` and `gitlab_*` from drifting on row
+//! formatting, label conventions, or shape coverage as new shapes get added.
+
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData,
+    LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, Status, TextBlockData, TextData,
+    TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+
+/// One forge-side issue / PR / MR. The fetcher fills these from its own DTO; the renderer
+/// only sees this shape, so adding a new shape variant means one switch arm here instead of
+/// touching every fetcher file.
+#[derive(Debug, Clone, Default)]
+pub struct ForgeRow {
+    /// Compact identifier, e.g. `"owner/repo#42"` (GitHub) or `"group/proj!42"` (GitLab MR).
+    /// Forge-family helpers compose this so the label conventions stay in one place per family.
+    pub label: String,
+    pub title: String,
+    /// Canonical web URL. `None` collapses the OSC 8 wrap on `LinkedTextBlock` /
+    /// `ImageLinkedList`, leaving the row as plain text.
+    pub url: Option<String>,
+    /// Author avatar source URL. Only consumed by `ImageLinkedList` rendering, and only after
+    /// the fetcher resolves it to a local cache path via [`super::thumbnails::download_many`].
+    pub avatar_url: Option<String>,
+    /// Resolved local thumbnail path. Pre-fill only for the `ImageLinkedList` shape — other
+    /// shapes don't use it, so leaving it `None` saves a thumbnail-download roundtrip.
+    pub avatar_path: Option<String>,
+    /// Unix seconds UTC. Used by `Timeline`; rendered as relative `"3h ago"` at draw time.
+    pub updated_at_unix: i64,
+    /// Activity weight (comments / notes / upvotes). `Bars` uses this so the bar height
+    /// surfaces "where the discussion is" rather than re-encoding row order.
+    pub activity_count: u64,
+}
+
+/// Render rows into the requested shape. Falls back to `TextBlock` for shape variants the
+/// rows can't meaningfully express (catches accidental misroutes; the runtime guards against
+/// it upstream too).
+pub fn render_forge_rows(rows: &[ForgeRow], shape: Shape) -> Body {
+    match shape {
+        Shape::Text => render_text(rows),
+        Shape::TextBlock => render_text_block(rows),
+        Shape::MarkdownTextBlock => render_markdown(rows),
+        Shape::LinkedTextBlock => render_linked(rows),
+        Shape::ImageLinkedList => render_image_linked(rows),
+        Shape::Entries => render_entries(rows),
+        Shape::Bars => render_bars(rows),
+        Shape::Timeline => render_timeline(rows),
+        _ => render_text_block(rows),
+    }
+}
+
+/// Render a count-pill badge: warm tone when there's open work, calm tone when the queue is
+/// empty. Pass the singular and plural noun separately so verb-shaped labels ("to review",
+/// "to merge") don't get the generic `+s` and end up reading as "2 to reviews".
+pub fn render_count_badge(count: u64, singular: &str, plural: &str) -> Body {
+    let (status, suffix) = if count == 0 {
+        (Status::Ok, " ✓")
+    } else {
+        (Status::Warn, "")
+    };
+    let noun = if count == 1 { singular } else { plural };
+    Body::Badge(BadgeData {
+        status,
+        label: format!("{count} {noun}{suffix}"),
+    })
+}
+
+fn render_text(rows: &[ForgeRow]) -> Body {
+    let value = rows
+        .first()
+        .map(|r| format!("{} {}", r.label, r.title))
+        .unwrap_or_default();
+    Body::Text(TextData { value })
+}
+
+fn render_text_block(rows: &[ForgeRow]) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: rows
+            .iter()
+            .map(|r| format!("{} {}", r.label, r.title))
+            .collect(),
+    })
+}
+
+fn render_markdown(rows: &[ForgeRow]) -> Body {
+    let value = rows
+        .iter()
+        .map(|r| match &r.url {
+            Some(url) => format!("- **{}** [{}]({})", r.label, r.title, url),
+            None => format!("- **{}** {}", r.label, r.title),
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+fn render_linked(rows: &[ForgeRow]) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: rows
+            .iter()
+            .map(|r| LinkedLine {
+                text: format!("{} {}", r.label, r.title),
+                url: r.url.clone(),
+            })
+            .collect(),
+    })
+}
+
+fn render_image_linked(rows: &[ForgeRow]) -> Body {
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: rows
+            .iter()
+            .map(|r| ImageLinkedItem {
+                title: format!("{} {}", r.label, r.title),
+                url: r.url.clone(),
+                thumbnail_path: r.avatar_path.clone(),
+                subtitle: None,
+            })
+            .collect(),
+    })
+}
+
+fn render_entries(rows: &[ForgeRow]) -> Body {
+    Body::Entries(EntriesData {
+        items: rows
+            .iter()
+            .map(|r| Entry {
+                key: r.label.clone(),
+                value: Some(r.title.clone()),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+fn render_bars(rows: &[ForgeRow]) -> Body {
+    Body::Bars(BarsData {
+        bars: rows
+            .iter()
+            .map(|r| Bar {
+                label: r.label.clone(),
+                value: r.activity_count,
+            })
+            .collect(),
+    })
+}
+
+fn render_timeline(rows: &[ForgeRow]) -> Body {
+    Body::Timeline(TimelineData {
+        events: rows
+            .iter()
+            .map(|r| TimelineEvent {
+                timestamp: r.updated_at_unix,
+                title: r.label.clone(),
+                detail: Some(r.title.clone()),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+/// Catalog of shapes the multi-shape list fetchers (`*_my_prs`, `*_review_requests`,
+/// `*_repo_prs/mrs`, `*_repo_issues`) expose. Default is `LinkedTextBlock`. Centralised here so
+/// both forge families share a single table — adding `MarkdownTextBlock` here surfaces it
+/// across both at once.
+pub const LIST_SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::ImageLinkedList,
+    Shape::Entries,
+    Shape::Text,
+    Shape::Bars,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+/// Async dispatcher for list-shaped forge fetchers. Branches on `shape`:
+///
+/// - `Badge` → count-pill summary using the caller's singular / plural noun;
+/// - `ImageLinkedList` → resolves each row's `avatar_url` through the shared thumbnails cache
+///   so the renderer reads from local files;
+/// - anything else → straight through [`render_forge_rows`].
+///
+/// One helper for both github and gitlab so the shape coverage stays uniform.
+pub async fn dispatch_rows_async(
+    mut rows: Vec<ForgeRow>,
+    shape: Shape,
+    badge_singular: &str,
+    badge_plural: &str,
+) -> Body {
+    if shape == Shape::Badge {
+        return render_count_badge(rows.len() as u64, badge_singular, badge_plural);
+    }
+    if shape == Shape::ImageLinkedList {
+        let urls: Vec<Option<String>> = rows.iter().map(|r| r.avatar_url.clone()).collect();
+        let paths = crate::fetcher::thumbnails::download_many(&urls).await;
+        rows.iter_mut().zip(paths).for_each(|(row, path)| {
+            row.avatar_path = path.map(|p| p.to_string_lossy().into_owned());
+        });
+    }
+    render_forge_rows(&rows, shape)
+}
+
+/// Sync sibling of [`dispatch_rows_async`] used by `sample_body`. Skips thumbnail resolution
+/// (samples don't carry real `avatar_url` values) and returns `None` for shapes outside
+/// [`LIST_SHAPES`] so docs generation never accidentally promotes an unsupported variant.
+pub fn dispatch_sample(
+    rows: &[ForgeRow],
+    shape: Shape,
+    badge_singular: &str,
+    badge_plural: &str,
+) -> Option<Body> {
+    if shape == Shape::Badge {
+        return Some(render_count_badge(
+            rows.len() as u64,
+            badge_singular,
+            badge_plural,
+        ));
+    }
+    if !LIST_SHAPES.contains(&shape) {
+        return None;
+    }
+    Some(render_forge_rows(rows, shape))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows() -> Vec<ForgeRow> {
+        vec![
+            ForgeRow {
+                label: "splashboard#54".into(),
+                title: "feat(docs): widget catalogue".into(),
+                url: Some("https://github.com/u/splashboard/pull/54".into()),
+                avatar_url: Some("https://avatars.example/u54.png".into()),
+                avatar_path: Some("/tmp/u54.png".into()),
+                updated_at_unix: 1_774_000_000,
+                activity_count: 7,
+            },
+            ForgeRow {
+                label: "splashboard#51".into(),
+                title: "feat(fetcher): split clock options".into(),
+                url: None,
+                avatar_url: None,
+                avatar_path: None,
+                updated_at_unix: 1_773_800_000,
+                activity_count: 2,
+            },
+        ]
+    }
+
+    #[test]
+    fn text_picks_the_first_row_headline() {
+        let Body::Text(t) = render_forge_rows(&rows(), Shape::Text) else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("splashboard#54"));
+    }
+
+    #[test]
+    fn text_block_emits_one_line_per_row() {
+        let Body::TextBlock(b) = render_forge_rows(&rows(), Shape::TextBlock) else {
+            panic!("expected text block");
+        };
+        assert_eq!(b.lines.len(), 2);
+        assert!(b.lines[1].contains("split clock options"));
+    }
+
+    #[test]
+    fn markdown_links_only_when_url_is_present() {
+        let Body::MarkdownTextBlock(b) = render_forge_rows(&rows(), Shape::MarkdownTextBlock)
+        else {
+            panic!("expected markdown");
+        };
+        assert!(
+            b.value
+                .contains("[feat(docs): widget catalogue](https://github.com")
+        );
+        // Row without url still renders, just without the link syntax.
+        assert!(b.value.contains("- **splashboard#51** feat(fetcher)"));
+    }
+
+    #[test]
+    fn linked_carries_optional_url_through() {
+        let Body::LinkedTextBlock(b) = render_forge_rows(&rows(), Shape::LinkedTextBlock) else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(b.items.len(), 2);
+        assert!(b.items[0].url.is_some());
+        assert!(b.items[1].url.is_none());
+    }
+
+    #[test]
+    fn image_linked_passes_thumbnail_paths_through() {
+        let Body::ImageLinkedList(b) = render_forge_rows(&rows(), Shape::ImageLinkedList) else {
+            panic!("expected image linked list");
+        };
+        assert_eq!(b.items[0].thumbnail_path.as_deref(), Some("/tmp/u54.png"));
+        assert!(b.items[1].thumbnail_path.is_none());
+    }
+
+    #[test]
+    fn entries_maps_label_to_title() {
+        let Body::Entries(b) = render_forge_rows(&rows(), Shape::Entries) else {
+            panic!("expected entries");
+        };
+        assert_eq!(b.items[0].key, "splashboard#54");
+        assert_eq!(
+            b.items[1].value.as_deref(),
+            Some("feat(fetcher): split clock options")
+        );
+    }
+
+    #[test]
+    fn bars_carries_activity_count_as_value() {
+        let Body::Bars(b) = render_forge_rows(&rows(), Shape::Bars) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].value, 7);
+        assert_eq!(b.bars[1].value, 2);
+    }
+
+    #[test]
+    fn timeline_uses_updated_at_unix() {
+        let Body::Timeline(t) = render_forge_rows(&rows(), Shape::Timeline) else {
+            panic!("expected timeline");
+        };
+        assert_eq!(t.events[0].timestamp, 1_774_000_000);
+        assert_eq!(
+            t.events[0].detail.as_deref(),
+            Some("feat(docs): widget catalogue")
+        );
+    }
+
+    #[test]
+    fn unsupported_shape_falls_back_to_text_block() {
+        // Ratio / NumberSeries / Image / etc. shouldn't be routed here — the runtime guards
+        // upstream — but if one slips through the fallback should still be intelligible.
+        let Body::TextBlock(_) = render_forge_rows(&rows(), Shape::Ratio) else {
+            panic!("expected fallback to text block");
+        };
+    }
+
+    #[test]
+    fn count_badge_flips_status_at_zero() {
+        let Body::Badge(b) = render_count_badge(0, "open MR", "open MRs") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "0 open MRs ✓");
+
+        let Body::Badge(b) = render_count_badge(1, "open MR", "open MRs") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert_eq!(b.label, "1 open MR");
+
+        let Body::Badge(b) = render_count_badge(5, "open MR", "open MRs") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "5 open MRs");
+    }
+
+    #[test]
+    fn count_badge_keeps_verb_form_intact_across_counts() {
+        // Verb-shaped labels like "to review" want the same form for 1 and N — no bare 's'
+        // suffix dropped onto the verb.
+        let Body::Badge(b) = render_count_badge(1, "to review", "to review") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "1 to review");
+        let Body::Badge(b) = render_count_badge(3, "to review", "to review") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "3 to review");
+    }
+
+    #[test]
+    fn list_shapes_covers_the_eight_documented_variants() {
+        assert_eq!(LIST_SHAPES.len(), 9);
+        assert_eq!(LIST_SHAPES[0], Shape::LinkedTextBlock);
+        assert!(LIST_SHAPES.contains(&Shape::ImageLinkedList));
+        assert!(LIST_SHAPES.contains(&Shape::Badge));
+    }
+
+    #[tokio::test]
+    async fn dispatch_rows_async_handles_badge_and_passes_through_others() {
+        // Badge short-circuits the row pipeline, so the noun pair is honoured.
+        let Body::Badge(b) = dispatch_rows_async(rows(), Shape::Badge, "open PR", "open PRs").await
+        else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "2 open PRs");
+
+        // Non-Badge / non-ImageLinkedList shapes pass straight through to the row renderer.
+        let Body::TextBlock(t) =
+            dispatch_rows_async(rows(), Shape::TextBlock, "open PR", "open PRs").await
+        else {
+            panic!("expected text block");
+        };
+        assert_eq!(t.lines.len(), 2);
+    }
+
+    #[test]
+    fn dispatch_sample_returns_none_for_unsupported_shapes() {
+        let rows = rows();
+        assert!(dispatch_sample(&rows, Shape::Ratio, "open PR", "open PRs").is_none());
+
+        let Some(Body::Badge(b)) = dispatch_sample(&rows, Shape::Badge, "open PR", "open PRs")
+        else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "2 open PRs");
+
+        let Some(Body::Entries(e)) = dispatch_sample(&rows, Shape::Entries, "open PR", "open PRs")
+        else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 2);
+    }
+
+    #[test]
+    fn empty_rows_collapse_to_empty_bodies() {
+        let Body::Text(t) = render_forge_rows(&[], Shape::Text) else {
+            panic!("expected text");
+        };
+        assert!(t.value.is_empty());
+
+        let Body::TextBlock(b) = render_forge_rows(&[], Shape::TextBlock) else {
+            panic!("expected text block");
+        };
+        assert!(b.lines.is_empty());
+
+        let Body::LinkedTextBlock(b) = render_forge_rows(&[], Shape::LinkedTextBlock) else {
+            panic!("expected linked text block");
+        };
+        assert!(b.items.is_empty());
+    }
+}

--- a/src/fetcher/forge_items.rs
+++ b/src/fetcher/forge_items.rs
@@ -99,13 +99,38 @@ fn render_text_block(rows: &[ForgeRow]) -> Body {
 fn render_markdown(rows: &[ForgeRow]) -> Body {
     let value = rows
         .iter()
-        .map(|r| match &r.url {
-            Some(url) => format!("- **{}** [{}]({})", r.label, r.title, url),
-            None => format!("- **{}** {}", r.label, r.title),
+        .map(|r| {
+            let label = escape_markdown_inline(&r.label);
+            let title = escape_markdown_inline(&r.title);
+            match &r.url {
+                Some(url) => format!("- **{label}** [{title}]({})", escape_markdown_url(url)),
+                None => format!("- **{label}** {title}"),
+            }
         })
         .collect::<Vec<_>>()
         .join("\n");
     Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+/// Escape the small set of Markdown inline metacharacters likely to appear in forge titles
+/// and labels: `\`, `` ` ``, `*`, `_`, `[`, `]`. `<` and `&` are not handled because
+/// `text_markdown` consumes the value as Markdown source and CommonMark treats them as
+/// literal text unless followed by a valid HTML tag — which forge titles never are.
+fn escape_markdown_inline(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('`', "\\`")
+        .replace('*', "\\*")
+        .replace('_', "\\_")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+}
+
+/// URL-side escape limited to the two characters that can break a Markdown link target:
+/// closing paren ends the `(...)`, backslash is the escape glyph itself. Everything else is
+/// already URL-encoded by the forge.
+fn escape_markdown_url(url: &str) -> String {
+    url.replace('\\', "%5C").replace(')', "%29")
 }
 
 fn render_linked(rows: &[ForgeRow]) -> Body {
@@ -294,6 +319,50 @@ mod tests {
         );
         // Row without url still renders, just without the link syntax.
         assert!(b.value.contains("- **splashboard#51** feat(fetcher)"));
+    }
+
+    #[test]
+    fn markdown_escapes_inline_metacharacters_in_label_and_title() {
+        // A title like `fix ](oops)` used to escape the link target prematurely; `*_wip_*`
+        // used to render as bold-italic text instead of literal underscores and asterisks.
+        // Both are user-supplied (forge issue / PR titles) and must round-trip as text, not
+        // markup.
+        let rows = vec![ForgeRow {
+            label: "splashboard#99".into(),
+            title: "fix ](oops) and *_wip_*".into(),
+            url: Some("https://example.com/path?x=1)y".into()),
+            avatar_url: None,
+            avatar_path: None,
+            updated_at_unix: 1_700_000_000,
+            activity_count: 0,
+        }];
+        let Body::MarkdownTextBlock(b) = render_forge_rows(&rows, Shape::MarkdownTextBlock) else {
+            panic!("expected markdown");
+        };
+        // `]` is escaped so it can't close the surrounding markdown link prematurely;
+        // `*` / `_` are escaped so the title stays literal rather than rendering bold /
+        // italic. Parens are intentionally not escaped because they only carry markup
+        // significance inside the link target itself, not in the visible link text.
+        assert!(
+            b.value.contains("fix \\](oops) and \\*\\_wip\\_\\*"),
+            "title not escaped: {}",
+            b.value
+        );
+        // URL keeps its closing paren escaped so it can't truncate the markdown link target.
+        assert!(
+            b.value.contains("1%29y"),
+            "url paren not escaped: {}",
+            b.value
+        );
+    }
+
+    #[test]
+    fn escape_markdown_inline_handles_each_documented_glyph() {
+        assert_eq!(
+            escape_markdown_inline("a\\b`c*d_e[f]g"),
+            "a\\\\b\\`c\\*d\\_e\\[f\\]g"
+        );
+        assert_eq!(escape_markdown_inline("plain text"), "plain text");
     }
 
     #[test]

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -95,16 +95,30 @@ impl Fetcher for GithubActionStatus {
             path.push_str(&format!("&branch={branch}"));
         }
         let res: RunsResponse = rest_get(&path).await?;
+        let shape = ctx.shape.unwrap_or(Shape::Badge);
         let Some(run) = res.workflow_runs.into_iter().next() else {
-            return Ok(payload(Body::Badge(BadgeData {
-                status: Status::Warn,
-                label: "no runs".into(),
-            })));
+            return Ok(payload(no_runs_body(shape)));
         };
-        Ok(payload(render_body(
-            &run,
-            ctx.shape.unwrap_or(Shape::Badge),
-        )))
+        Ok(payload(render_body(&run, shape)))
+    }
+}
+
+fn no_runs_body(shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: "no runs".into(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("status", Some(Status::Warn), "no runs"),
+                entry("branch", None, "?"),
+                entry("conclusion", None, "?"),
+            ],
+        }),
+        _ => Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: "no runs".into(),
+        }),
     }
 }
 
@@ -333,6 +347,25 @@ mod tests {
         };
         assert_eq!(badge.status, Status::Warn);
         assert_eq!(badge.label, "main · cancelled");
+    }
+
+    #[test]
+    fn no_runs_body_respects_each_advertised_shape() {
+        // Empty workflow_runs used to always degrade to Badge regardless of `ctx.shape`,
+        // breaking shape consistency once Entries was advertised in #243.
+        let Body::Badge(b) = no_runs_body(Shape::Badge) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "no runs");
+        let Body::Text(t) = no_runs_body(Shape::Text) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "no runs");
+        let Body::Entries(e) = no_runs_body(Shape::Entries) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].value.as_deref(), Some("no runs"));
+        assert_eq!(e.items[0].status, Some(Status::Warn));
     }
 
     #[test]

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{BadgeData, Body, Payload, Status, TextData};
+use crate::payload::{BadgeData, Body, EntriesData, Entry, Payload, Status, TextData};
 use crate::render::Shape;
 use crate::samples;
 
@@ -13,7 +13,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Badge, Shape::Text];
+const SHAPES: &[Shape] = &[Shape::Badge, Shape::Text, Shape::Entries];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
     OptionSchema {
@@ -74,6 +74,13 @@ impl Fetcher for GithubActionStatus {
         Some(match shape {
             Shape::Badge => samples::badge(Status::Ok, "ci passing"),
             Shape::Text => samples::text("main · passing"),
+            Shape::Entries => Body::Entries(EntriesData {
+                items: vec![
+                    entry("status", Some(Status::Ok), "passing"),
+                    entry("branch", None, "main"),
+                    entry("conclusion", None, "success"),
+                ],
+            }),
             _ => return None,
         })
     }
@@ -119,20 +126,30 @@ struct WorkflowRun {
 
 fn render_body(run: &WorkflowRun, shape: Shape) -> Body {
     let (status, label_word) = classify(run);
+    let branch = run.head_branch.as_deref().unwrap_or("?");
     match shape {
         Shape::Text => Body::Text(TextData {
-            value: format!(
-                "{} · {label_word}",
-                run.head_branch.as_deref().unwrap_or("?")
-            ),
+            value: format!("{branch} · {label_word}"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("status", Some(status), label_word),
+                entry("branch", None, branch),
+                entry("conclusion", None, run.conclusion.as_deref().unwrap_or("?")),
+            ],
         }),
         _ => Body::Badge(BadgeData {
             status,
-            label: format!(
-                "{} · {label_word}",
-                run.head_branch.as_deref().unwrap_or("?")
-            ),
+            label: format!("{branch} · {label_word}"),
         }),
+    }
+}
+
+fn entry(key: &str, status: Option<Status>, value: &str) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.into()),
+        status,
     }
 }
 
@@ -242,7 +259,13 @@ mod tests {
             panic!("expected text sample");
         };
         assert_eq!(text.value, "main · passing");
-        assert!(fetcher.sample_body(Shape::Entries).is_none());
+
+        let Some(Body::Entries(e)) = fetcher.sample_body(Shape::Entries) else {
+            panic!("expected entries sample");
+        };
+        let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(keys, vec!["status", "branch", "conclusion"]);
+        assert!(fetcher.sample_body(Shape::Timeline).is_none());
     }
 
     #[test]

--- a/src/fetcher/github/assigned_issues.rs
+++ b/src/fetcher/github/assigned_issues.rs
@@ -4,22 +4,16 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
-use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload};
-use super::items::{SearchResult, render_items};
+use super::items::{SearchResult, sample_rows, to_forge_rows};
 
-const SHAPES: &[Shape] = &[
-    Shape::LinkedTextBlock,
-    Shape::TextBlock,
-    Shape::Entries,
-    Shape::Timeline,
-];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -54,7 +48,7 @@ impl Fetcher for GithubAssignedIssues {
         60 * 10
     }
     fn shapes(&self) -> &[Shape] {
-        SHAPES
+        LIST_SHAPES
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -63,35 +57,23 @@ impl Fetcher for GithubAssignedIssues {
         cache_key(self.name(), ctx, "")
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
-        Some(match shape {
-            Shape::LinkedTextBlock => samples::linked_text_block(&[
-                (
-                    "unhappychoice/splashboard#41 meta: widget catalog & roadmap",
-                    Some("https://github.com/unhappychoice/splashboard/issues/41"),
-                ),
-                (
-                    "unhappychoice/splashboard#17 theme system",
-                    Some("https://github.com/unhappychoice/splashboard/issues/17"),
-                ),
-            ]),
-            Shape::TextBlock => samples::text_block(&[
-                "unhappychoice/splashboard#41 meta: widget catalog & roadmap",
-                "unhappychoice/splashboard#17 theme system",
-            ]),
-            Shape::Entries => samples::entries(&[
-                ("splashboard #41", "meta: widget catalog"),
-                ("splashboard #17", "theme system"),
-            ]),
-            Shape::Timeline => samples::timeline(&[
-                (
-                    1_774_000_000,
-                    "splashboard#41",
-                    Some("meta: widget catalog"),
-                ),
-                (1_773_500_000, "splashboard#17", Some("theme system")),
-            ]),
-            _ => return None,
-        })
+        let rows = sample_rows(&[
+            (
+                "unhappychoice/splashboard#41",
+                "meta: widget catalog & roadmap",
+                Some("https://github.com/unhappychoice/splashboard/issues/41"),
+                3,
+                1_774_000_000,
+            ),
+            (
+                "unhappychoice/splashboard#17",
+                "theme system",
+                Some("https://github.com/unhappychoice/splashboard/issues/17"),
+                1,
+                1_773_500_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open issue", "open issues")
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
@@ -100,11 +82,10 @@ impl Fetcher for GithubAssignedIssues {
             "/search/issues?q=is%3Aissue+is%3Aopen+assignee%3A%40me&per_page={limit}&sort=updated"
         );
         let res: SearchResult = rest_get(&path).await?;
-        Ok(payload(render_items(
-            &res.items,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-            true,
-        )))
+        let rows = to_forge_rows(&res.items, true);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open issue", "open issues").await;
+        Ok(payload(body))
     }
 }
 
@@ -201,11 +182,18 @@ mod tests {
                 .description()
                 .contains("assigned to the authenticated user")
         );
-        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
         assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
         assert_eq!(fetcher.option_schemas().len(), 1);
         assert_eq!(fetcher.option_schemas()[0].name, "limit");
         assert_eq!(fetcher.option_schemas()[0].default, Some("10"));
+
+        for shape in LIST_SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
 
         let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
         else {
@@ -220,23 +208,10 @@ mod tests {
             Some("https://github.com/unhappychoice/splashboard/issues/17")
         );
 
-        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
-            panic!("expected text block sample");
-        };
-        assert_eq!(text.lines[1], "unhappychoice/splashboard#17 theme system");
-
         let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
             panic!("expected entries sample");
         };
-        assert_eq!(entries.items[0].key, "splashboard #41");
-        assert_eq!(entries.items[1].value.as_deref(), Some("theme system"));
-
-        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
-            panic!("expected timeline sample");
-        };
-        assert_eq!(timeline.events[0].title, "splashboard#41");
-        assert_eq!(timeline.events[1].detail.as_deref(), Some("theme system"));
-        assert!(fetcher.sample_body(Shape::Text).is_none());
+        assert_eq!(entries.items[0].key, "unhappychoice/splashboard#41");
     }
 
     #[test]

--- a/src/fetcher/github/items.rs
+++ b/src/fetcher/github/items.rs
@@ -54,10 +54,21 @@ pub fn repo_from_url(url: &str) -> Option<RepoSlug> {
     RepoSlug::parse(rest)
 }
 
-/// Renders issue / PR items via the shared forge-row pipeline. When `include_repo` is true,
-/// each label is prefixed with `owner/name#42` — used by user-scope fetchers whose results span
-/// many repos. Per-repo fetchers pass `false` so the row stays at `#42`.
+/// Sync-only path for fetchers whose `shapes()` set doesn't include `Badge` /
+/// `ImageLinkedList` (currently `good_first_issues`). Both of those variants need
+/// preprocessing that this signature can't reach: `Badge` needs the row count + a noun pair
+/// for `forge_items::render_count_badge`, and `ImageLinkedList` needs avatar URLs resolved
+/// through `thumbnails::download_many` before render. Fetchers that accept those shapes go
+/// through `forge_items::dispatch_rows_async` instead.
+///
+/// When `include_repo` is true, each label is prefixed with `owner/name#42` (used by
+/// user-scope fetchers whose results span many repos). Per-repo fetchers pass `false` so the
+/// row stays at `#42`.
 pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Body {
+    debug_assert!(
+        !matches!(shape, Shape::Badge | Shape::ImageLinkedList),
+        "render_items is sync-only; route {shape:?} through forge_items::dispatch_rows_async"
+    );
     let rows = to_forge_rows(items, include_repo);
     forge_items::render_forge_rows(&rows, shape)
 }
@@ -294,18 +305,21 @@ mod tests {
     }
 
     #[test]
-    fn render_image_linked_carries_empty_thumbnail_until_resolved() {
-        // The fetcher is responsible for resolving `avatar_url` -> `avatar_path` via the
-        // shared thumbnails downloader before reaching the renderer. Calling `render_items`
-        // directly leaves the column blank — verifies the unresolved path still produces a
-        // structurally valid body rather than crashing.
-        let Body::ImageLinkedList(data) =
-            render_items(&[issue_item()], Shape::ImageLinkedList, true)
-        else {
-            panic!("expected image linked list");
-        };
-        assert_eq!(data.items.len(), 1);
-        assert!(data.items[0].thumbnail_path.is_none());
+    #[should_panic(expected = "render_items is sync-only")]
+    fn render_items_rejects_image_linked_list_in_debug() {
+        // `ImageLinkedList` needs avatar resolution through the async thumbnails downloader,
+        // so the sync helper refuses it rather than silently emitting a row with a blank
+        // thumbnail column. Fetchers accepting that shape route through
+        // `forge_items::dispatch_rows_async` instead.
+        let _ = render_items(&[issue_item()], Shape::ImageLinkedList, true);
+    }
+
+    #[test]
+    #[should_panic(expected = "render_items is sync-only")]
+    fn render_items_rejects_badge_in_debug() {
+        // Same reasoning for `Badge`: it needs the row count + a noun pair, neither of which
+        // are reachable through this signature.
+        let _ = render_items(&[issue_item()], Shape::Badge, false);
     }
 
     #[test]

--- a/src/fetcher/github/items.rs
+++ b/src/fetcher/github/items.rs
@@ -1,18 +1,20 @@
 //! Shared response types for the issue / PR family. The REST search endpoints and the
 //! per-repo PR/issue endpoints return almost the same item shape; they share this struct so
 //! each fetcher can focus on its own URL composition and rendering.
+//!
+//! Rendering goes through [`crate::fetcher::forge_items::render_forge_rows`] so the github and
+//! gitlab families produce structurally identical output for every shape — adding a new shape
+//! variant lights up on both families simultaneously.
 
 use serde::Deserialize;
 
-use crate::payload::{
-    Body, EntriesData, Entry, LinkedLine, LinkedTextBlockData, TextBlockData, TimelineData,
-    TimelineEvent,
-};
+use crate::fetcher::forge_items::{self, ForgeRow};
+use crate::payload::Body;
 use crate::render::Shape;
 
 use super::common::{RepoSlug, parse_timestamp};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct IssueItem {
     pub title: String,
     pub number: u64,
@@ -25,6 +27,18 @@ pub struct IssueItem {
     pub html_url: String,
     #[serde(default)]
     pub state: String,
+    /// Comments count, fed into the `Bars` shape as a per-row activity weight.
+    #[serde(default)]
+    pub comments: u64,
+    /// Author block — only `avatar_url` is used today (for the `ImageLinkedList` shape).
+    #[serde(default)]
+    pub user: Option<GithubUserRef>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct GithubUserRef {
+    #[serde(default)]
+    pub avatar_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -40,78 +54,60 @@ pub fn repo_from_url(url: &str) -> Option<RepoSlug> {
     RepoSlug::parse(rest)
 }
 
-/// Renders issue / PR items to one of `TextBlock` / `LinkedTextBlock` / `Entries` / `Timeline`.
-/// When `include_repo` is true, each line/event is prefixed with `owner/name` — used by
-/// user-scope fetchers that return items across many repos. Per-repo fetchers pass `false` so
-/// the repo name isn't repeated on every row.
+/// Renders issue / PR items via the shared forge-row pipeline. When `include_repo` is true,
+/// each label is prefixed with `owner/name#42` — used by user-scope fetchers whose results span
+/// many repos. Per-repo fetchers pass `false` so the row stays at `#42`.
 pub fn render_items(items: &[IssueItem], shape: Shape, include_repo: bool) -> Body {
-    match shape {
-        Shape::Entries => Body::Entries(EntriesData {
-            items: items
-                .iter()
-                .map(|i| Entry {
-                    key: entries_key(i, include_repo),
-                    value: Some(i.title.clone()),
-                    status: None,
-                })
-                .collect(),
-        }),
-        Shape::LinkedTextBlock => Body::LinkedTextBlock(LinkedTextBlockData {
-            items: items
-                .iter()
-                .map(|i| LinkedLine {
-                    text: format!("{} {}", short_label(i, include_repo), i.title),
-                    url: link_for(i),
-                })
-                .collect(),
-        }),
-        Shape::Timeline => Body::Timeline(TimelineData {
-            events: items
-                .iter()
-                .map(|i| TimelineEvent {
-                    timestamp: parse_timestamp(&i.updated_at),
-                    title: short_label(i, include_repo),
-                    detail: Some(i.title.clone()),
-                    status: None,
-                })
-                .collect(),
-        }),
-        _ => Body::TextBlock(TextBlockData {
-            lines: items
-                .iter()
-                .map(|i| format!("{} {}", short_label(i, include_repo), i.title))
-                .collect(),
-        }),
-    }
+    let rows = to_forge_rows(items, include_repo);
+    forge_items::render_forge_rows(&rows, shape)
 }
 
-fn link_for(i: &IssueItem) -> Option<String> {
-    if i.html_url.is_empty() {
-        None
-    } else {
-        Some(i.html_url.clone())
-    }
+/// Lower-level converter so fetchers can pre-process rows (e.g. resolving thumbnails for
+/// `ImageLinkedList`) before handing them to the shared renderer.
+pub fn to_forge_rows(items: &[IssueItem], include_repo: bool) -> Vec<ForgeRow> {
+    items
+        .iter()
+        .map(|i| to_forge_row(i, include_repo))
+        .collect()
 }
 
-fn short_label(i: &IssueItem, include_repo: bool) -> String {
-    if include_repo {
+/// Build a tiny [`ForgeRow`] set with stable values for `sample_body`. Mirrors the gitlab
+/// helper so both families share the same row-formatting conventions in docs.
+pub fn sample_rows(rows: &[(&str, &str, Option<&str>, u64, i64)]) -> Vec<ForgeRow> {
+    rows.iter()
+        .map(|(label, title, url, activity, ts)| ForgeRow {
+            label: (*label).into(),
+            title: (*title).into(),
+            url: url.map(String::from),
+            avatar_url: None,
+            avatar_path: None,
+            updated_at_unix: *ts,
+            activity_count: *activity,
+        })
+        .collect()
+}
+
+fn to_forge_row(i: &IssueItem, include_repo: bool) -> ForgeRow {
+    let label = if include_repo {
         let repo = repo_from_url(&i.repository_url)
             .map(|s| s.as_path())
             .unwrap_or_else(|| "?".into());
         format!("{repo}#{}", i.number)
     } else {
         format!("#{}", i.number)
-    }
-}
-
-fn entries_key(i: &IssueItem, include_repo: bool) -> String {
-    if include_repo {
-        let name = repo_from_url(&i.repository_url)
-            .map(|s| s.name)
-            .unwrap_or_else(|| "?".into());
-        format!("{name} #{}", i.number)
-    } else {
-        format!("#{}", i.number)
+    };
+    ForgeRow {
+        label,
+        title: i.title.clone(),
+        url: if i.html_url.is_empty() {
+            None
+        } else {
+            Some(i.html_url.clone())
+        },
+        avatar_url: i.user.as_ref().and_then(|u| u.avatar_url.clone()),
+        avatar_path: None,
+        updated_at_unix: parse_timestamp(&i.updated_at),
+        activity_count: i.comments,
     }
 }
 
@@ -128,6 +124,10 @@ mod tests {
             updated_at: "2026-04-22T10:15:30Z".into(),
             html_url: "https://github.com/unhappychoice/splashboard/issues/42".into(),
             state: "open".into(),
+            comments: 3,
+            user: Some(GithubUserRef {
+                avatar_url: Some("https://avatars.example/u.png".into()),
+            }),
         }
     }
 
@@ -153,10 +153,47 @@ mod tests {
     }
 
     #[test]
+    fn to_forge_row_carries_comments_and_avatar_through() {
+        let row = to_forge_row(&issue_item(), true);
+        assert_eq!(row.label, "unhappychoice/splashboard#42");
+        assert_eq!(row.activity_count, 3);
+        assert_eq!(
+            row.avatar_url.as_deref(),
+            Some("https://avatars.example/u.png")
+        );
+        assert!(row.avatar_path.is_none());
+    }
+
+    #[test]
+    fn to_forge_row_without_repo_uses_number_only_label() {
+        let row = to_forge_row(&issue_item(), false);
+        assert_eq!(row.label, "#42");
+    }
+
+    #[test]
+    fn to_forge_row_falls_back_to_question_mark_for_bad_repo_url() {
+        let mut item = issue_item();
+        item.repository_url = "https://api.github.com/not-a-repo".into();
+        let row = to_forge_row(&item, true);
+        assert_eq!(row.label, "?#42");
+    }
+
+    #[test]
+    fn to_forge_row_empty_html_url_collapses_to_none() {
+        let mut item = issue_item();
+        item.html_url.clear();
+        let row = to_forge_row(&item, false);
+        assert!(row.url.is_none());
+    }
+
+    #[test]
     fn render_entries_include_repo_name_and_title() {
         let value = body_json(render_items(&[issue_item()], Shape::Entries, true));
         assert_eq!(value["shape"], "entries");
-        assert_eq!(value["data"]["items"][0]["key"], "splashboard #42");
+        assert_eq!(
+            value["data"]["items"][0]["key"],
+            "unhappychoice/splashboard#42"
+        );
         assert_eq!(
             value["data"]["items"][0]["value"],
             "Fix cached splash mismatch"
@@ -235,12 +272,54 @@ mod tests {
         item.repository_url = "https://api.github.com/not-a-repo".into();
         let value = body_json(render_items(&[item], Shape::Entries, true));
         assert_eq!(value["shape"], "entries");
-        assert_eq!(value["data"]["items"][0]["key"], "? #42");
+        assert_eq!(value["data"]["items"][0]["key"], "?#42");
+    }
+
+    #[test]
+    fn render_bars_uses_comments_count_as_value() {
+        let Body::Bars(data) = render_items(&[issue_item()], Shape::Bars, false) else {
+            panic!("expected bars");
+        };
+        assert_eq!(data.bars[0].value, 3);
+    }
+
+    #[test]
+    fn render_markdown_links_when_url_present() {
+        let Body::MarkdownTextBlock(data) =
+            render_items(&[issue_item()], Shape::MarkdownTextBlock, true)
+        else {
+            panic!("expected markdown");
+        };
+        assert!(data.value.contains("[Fix cached splash mismatch]"));
+    }
+
+    #[test]
+    fn render_image_linked_carries_empty_thumbnail_until_resolved() {
+        // The fetcher is responsible for resolving `avatar_url` -> `avatar_path` via the
+        // shared thumbnails downloader before reaching the renderer. Calling `render_items`
+        // directly leaves the column blank — verifies the unresolved path still produces a
+        // structurally valid body rather than crashing.
+        let Body::ImageLinkedList(data) =
+            render_items(&[issue_item()], Shape::ImageLinkedList, true)
+        else {
+            panic!("expected image linked list");
+        };
+        assert_eq!(data.items.len(), 1);
+        assert!(data.items[0].thumbnail_path.is_none());
     }
 
     #[test]
     fn search_result_defaults_missing_items_to_empty() {
         let result: SearchResult = serde_json::from_str("{}").unwrap();
         assert!(result.items.is_empty());
+    }
+
+    #[test]
+    fn issue_item_tolerates_partial_payloads_for_new_fields() {
+        // Older fixtures and tests construct IssueItem without `comments` / `user`. Both
+        // default cleanly so we don't break callers that pre-date the shape expansion.
+        let item: IssueItem = serde_json::from_str(r#"{"title":"x","number":1}"#).unwrap();
+        assert_eq!(item.comments, 0);
+        assert!(item.user.is_none());
     }
 }

--- a/src/fetcher/github/my_prs.rs
+++ b/src/fetcher/github/my_prs.rs
@@ -5,22 +5,16 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
-use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload};
-use super::items::{SearchResult, render_items};
+use super::items::{SearchResult, sample_rows, to_forge_rows};
 
-const SHAPES: &[Shape] = &[
-    Shape::LinkedTextBlock,
-    Shape::TextBlock,
-    Shape::Entries,
-    Shape::Timeline,
-];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -55,7 +49,7 @@ impl Fetcher for GithubMyPrs {
         60 * 5
     }
     fn shapes(&self) -> &[Shape] {
-        SHAPES
+        LIST_SHAPES
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -64,39 +58,23 @@ impl Fetcher for GithubMyPrs {
         cache_key(self.name(), ctx, "")
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
-        Some(match shape {
-            Shape::LinkedTextBlock => samples::linked_text_block(&[
-                (
-                    "unhappychoice/splashboard#54 feat(docs): generate widget catalogue",
-                    Some("https://github.com/unhappychoice/splashboard/pull/54"),
-                ),
-                (
-                    "unhappychoice/splashboard#51 feat(fetcher): split clock options",
-                    Some("https://github.com/unhappychoice/splashboard/pull/51"),
-                ),
-            ]),
-            Shape::TextBlock => samples::text_block(&[
-                "unhappychoice/splashboard#54 feat(docs): generate widget catalogue",
-                "unhappychoice/splashboard#51 feat(fetcher): split clock options",
-            ]),
-            Shape::Entries => samples::entries(&[
-                ("splashboard #54", "feat(docs): widget catalogue"),
-                ("splashboard #51", "feat(fetcher): split clock options"),
-            ]),
-            Shape::Timeline => samples::timeline(&[
-                (
-                    1_774_000_000,
-                    "splashboard#54",
-                    Some("feat(docs): widget catalogue"),
-                ),
-                (
-                    1_773_800_000,
-                    "splashboard#51",
-                    Some("feat(fetcher): split clock options"),
-                ),
-            ]),
-            _ => return None,
-        })
+        let rows = sample_rows(&[
+            (
+                "unhappychoice/splashboard#54",
+                "feat(docs): generate widget catalogue",
+                Some("https://github.com/unhappychoice/splashboard/pull/54"),
+                7,
+                1_774_000_000,
+            ),
+            (
+                "unhappychoice/splashboard#51",
+                "feat(fetcher): split clock options",
+                Some("https://github.com/unhappychoice/splashboard/pull/51"),
+                2,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open PR", "open PRs")
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
@@ -105,11 +83,10 @@ impl Fetcher for GithubMyPrs {
             "/search/issues?q=is%3Apr+is%3Aopen+author%3A%40me&per_page={limit}&sort=updated"
         );
         let res: SearchResult = rest_get(&path).await?;
-        Ok(payload(render_items(
-            &res.items,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-            true,
-        )))
+        let rows = to_forge_rows(&res.items, true);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open PR", "open PRs").await;
+        Ok(payload(body))
     }
 }
 
@@ -203,11 +180,21 @@ mod tests {
         assert_eq!(fetcher.name(), "github_my_prs");
         assert_eq!(fetcher.safety(), Safety::Safe);
         assert!(fetcher.description().contains("authenticated user"));
-        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
         assert_eq!(fetcher.option_schemas().len(), 1);
         assert_eq!(fetcher.option_schemas()[0].name, "limit");
         assert_eq!(fetcher.option_schemas()[0].default, Some("10"));
         assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+
+        // Every shape in LIST_SHAPES gets a sample so the docs / catalog generators don't
+        // have to special-case the user-scope fetchers.
+        for shape in LIST_SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
 
         let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
         else {
@@ -222,32 +209,15 @@ mod tests {
             Some("https://github.com/unhappychoice/splashboard/pull/51")
         );
 
-        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
-            panic!("expected text block sample");
-        };
-        assert_eq!(
-            text.lines[1],
-            "unhappychoice/splashboard#51 feat(fetcher): split clock options"
-        );
-
         let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
             panic!("expected entries sample");
         };
-        assert_eq!(entries.items[0].key, "splashboard #54");
-        assert_eq!(
-            entries.items[1].value.as_deref(),
-            Some("feat(fetcher): split clock options")
-        );
+        assert_eq!(entries.items[0].key, "unhappychoice/splashboard#54");
 
         let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
             panic!("expected timeline sample");
         };
-        assert_eq!(timeline.events[0].title, "splashboard#54");
-        assert_eq!(
-            timeline.events[1].detail.as_deref(),
-            Some("feat(fetcher): split clock options")
-        );
-        assert!(fetcher.sample_body(Shape::Text).is_none());
+        assert_eq!(timeline.events[0].title, "unhappychoice/splashboard#54");
     }
 
     #[test]

--- a/src/fetcher/github/repo_issues.rs
+++ b/src/fetcher/github/repo_issues.rs
@@ -4,22 +4,16 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
-use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
-use super::items::{IssueItem, render_items};
+use super::items::{IssueItem, sample_rows, to_forge_rows};
 
-const SHAPES: &[Shape] = &[
-    Shape::LinkedTextBlock,
-    Shape::TextBlock,
-    Shape::Entries,
-    Shape::Timeline,
-];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -65,7 +59,7 @@ impl Fetcher for GithubRepoIssues {
         60 * 10
     }
     fn shapes(&self) -> &[Shape] {
-        SHAPES
+        LIST_SHAPES
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -75,29 +69,23 @@ impl Fetcher for GithubRepoIssues {
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
-        Some(match shape {
-            Shape::LinkedTextBlock => samples::linked_text_block(&[
-                (
-                    "#41 meta: widget catalog & roadmap",
-                    Some("https://github.com/unhappychoice/splashboard/issues/41"),
-                ),
-                (
-                    "#17 theme system",
-                    Some("https://github.com/unhappychoice/splashboard/issues/17"),
-                ),
-            ]),
-            Shape::TextBlock => {
-                samples::text_block(&["#41 meta: widget catalog & roadmap", "#17 theme system"])
-            }
-            Shape::Entries => {
-                samples::entries(&[("#41", "meta: widget catalog"), ("#17", "theme system")])
-            }
-            Shape::Timeline => samples::timeline(&[
-                (1_774_000_000, "#41", Some("meta: widget catalog")),
-                (1_773_500_000, "#17", Some("theme system")),
-            ]),
-            _ => return None,
-        })
+        let rows = sample_rows(&[
+            (
+                "#41",
+                "meta: widget catalog & roadmap",
+                Some("https://github.com/unhappychoice/splashboard/issues/41"),
+                3,
+                1_774_000_000,
+            ),
+            (
+                "#17",
+                "theme system",
+                Some("https://github.com/unhappychoice/splashboard/issues/17"),
+                1,
+                1_773_500_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open issue", "open issues")
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
@@ -118,11 +106,10 @@ impl Fetcher for GithubRepoIssues {
             .take(limit as usize)
             .map(|i| i.inner)
             .collect();
-        Ok(payload(render_items(
-            &issues,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-            false,
-        )))
+        let rows = to_forge_rows(&issues, false);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open issue", "open issues").await;
+        Ok(payload(body))
     }
 }
 
@@ -236,10 +223,17 @@ mod tests {
         assert_eq!(fetcher.name(), "github_repo_issues");
         assert_eq!(fetcher.safety(), Safety::Safe);
         assert!(fetcher.description().contains("pull requests filtered out"));
-        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
         assert_eq!(fetcher.option_schemas().len(), 2);
         assert_eq!(fetcher.option_schemas()[0].name, "repo");
         assert_eq!(fetcher.option_schemas()[1].name, "limit");
+
+        for shape in LIST_SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
 
         let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
         else {
@@ -251,23 +245,10 @@ mod tests {
             Some("https://github.com/unhappychoice/splashboard/issues/17")
         );
 
-        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
-            panic!("expected text block sample");
-        };
-        assert_eq!(text.lines[1], "#17 theme system");
-
         let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
             panic!("expected entries sample");
         };
         assert_eq!(entries.items[0].key, "#41");
-        assert_eq!(entries.items[1].value.as_deref(), Some("theme system"));
-
-        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
-            panic!("expected timeline sample");
-        };
-        assert_eq!(timeline.events[0].title, "#41");
-        assert_eq!(timeline.events[1].detail.as_deref(), Some("theme system"));
-        assert!(fetcher.sample_body(Shape::Text).is_none());
     }
 
     #[test]
@@ -295,8 +276,8 @@ mod tests {
             .filter(|item| item.pull_request.is_none())
             .map(|item| item.inner)
             .collect();
-
-        let Body::TextBlock(text) = render_items(&issues, Shape::TextBlock, false) else {
+        let rows = to_forge_rows(&issues, false);
+        let Body::TextBlock(text) = forge_items::render_forge_rows(&rows, Shape::TextBlock) else {
             panic!("expected text block");
         };
         assert_eq!(text.lines, vec!["#41 Keep real issues"]);

--- a/src/fetcher/github/repo_prs.rs
+++ b/src/fetcher/github/repo_prs.rs
@@ -4,22 +4,16 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
-use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
-use super::items::{IssueItem, render_items};
+use super::items::{IssueItem, sample_rows, to_forge_rows};
 
-const SHAPES: &[Shape] = &[
-    Shape::LinkedTextBlock,
-    Shape::TextBlock,
-    Shape::Entries,
-    Shape::Timeline,
-];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -65,7 +59,7 @@ impl Fetcher for GithubRepoPrs {
         60 * 10
     }
     fn shapes(&self) -> &[Shape] {
-        SHAPES
+        LIST_SHAPES
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -75,35 +69,23 @@ impl Fetcher for GithubRepoPrs {
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
-        Some(match shape {
-            Shape::LinkedTextBlock => samples::linked_text_block(&[
-                (
-                    "#54 feat(docs): generate widget catalogue",
-                    Some("https://github.com/unhappychoice/splashboard/pull/54"),
-                ),
-                (
-                    "#51 feat(fetcher): split clock options",
-                    Some("https://github.com/unhappychoice/splashboard/pull/51"),
-                ),
-            ]),
-            Shape::TextBlock => samples::text_block(&[
-                "#54 feat(docs): generate widget catalogue",
-                "#51 feat(fetcher): split clock options",
-            ]),
-            Shape::Entries => samples::entries(&[
-                ("#54", "feat(docs): widget catalogue"),
-                ("#51", "feat(fetcher): split clock options"),
-            ]),
-            Shape::Timeline => samples::timeline(&[
-                (1_774_000_000, "#54", Some("feat(docs): widget catalogue")),
-                (
-                    1_773_800_000,
-                    "#51",
-                    Some("feat(fetcher): split clock options"),
-                ),
-            ]),
-            _ => return None,
-        })
+        let rows = sample_rows(&[
+            (
+                "#54",
+                "feat(docs): generate widget catalogue",
+                Some("https://github.com/unhappychoice/splashboard/pull/54"),
+                7,
+                1_774_000_000,
+            ),
+            (
+                "#51",
+                "feat(fetcher): split clock options",
+                Some("https://github.com/unhappychoice/splashboard/pull/51"),
+                2,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open PR", "open PRs")
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
@@ -114,11 +96,10 @@ impl Fetcher for GithubRepoPrs {
             slug.owner, slug.name
         );
         let items: Vec<IssueItem> = rest_get(&path).await?;
-        Ok(payload(render_items(
-            &items,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-            false,
-        )))
+        let rows = to_forge_rows(&items, false);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open PR", "open PRs").await;
+        Ok(payload(body))
     }
 }
 
@@ -224,10 +205,17 @@ mod tests {
         assert_eq!(fetcher.name(), "github_repo_prs");
         assert_eq!(fetcher.safety(), Safety::Safe);
         assert!(fetcher.description().contains("target repo"));
-        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
         assert_eq!(fetcher.option_schemas().len(), 2);
         assert_eq!(fetcher.option_schemas()[0].name, "repo");
         assert_eq!(fetcher.option_schemas()[1].name, "limit");
+
+        for shape in LIST_SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
 
         let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
         else {
@@ -242,29 +230,10 @@ mod tests {
             Some("https://github.com/unhappychoice/splashboard/pull/51")
         );
 
-        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
-            panic!("expected text block sample");
-        };
-        assert_eq!(text.lines[1], "#51 feat(fetcher): split clock options");
-
         let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
             panic!("expected entries sample");
         };
         assert_eq!(entries.items[0].key, "#54");
-        assert_eq!(
-            entries.items[1].value.as_deref(),
-            Some("feat(fetcher): split clock options")
-        );
-
-        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
-            panic!("expected timeline sample");
-        };
-        assert_eq!(timeline.events[0].title, "#54");
-        assert_eq!(
-            timeline.events[1].detail.as_deref(),
-            Some("feat(fetcher): split clock options")
-        );
-        assert!(fetcher.sample_body(Shape::Text).is_none());
     }
 
     #[test]

--- a/src/fetcher/github/repo_stars.rs
+++ b/src/fetcher/github/repo_stars.rs
@@ -5,15 +5,24 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::options::OptionSchema;
-use crate::payload::{Body, EntriesData, Entry, Payload, TextData};
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status,
+    TextBlockData, TextData,
+};
 use crate::render::Shape;
-use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{RepoSlug, cache_key, parse_options, payload, resolve_repo};
 
-const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries];
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Badge,
+];
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
     name: "repo",
@@ -57,36 +66,83 @@ impl Fetcher for GithubRepoStars {
         cache_key(self.name(), ctx, &extra)
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
-        Some(match shape {
-            Shape::Text => samples::text("★ 142"),
-            Shape::Entries => samples::entries(&[
-                ("stars", "142"),
-                ("forks", "9"),
-                ("watchers", "12"),
-                ("open_issues", "7"),
-            ]),
-            _ => return None,
-        })
+        if !SHAPES.contains(&shape) {
+            return None;
+        }
+        let info = RepoInfo {
+            stargazers_count: 142,
+            forks_count: 9,
+            subscribers_count: 12,
+            open_issues_count: 7,
+        };
+        Some(render_body(&info, shape))
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
         let slug = resolve_repo(opts.repo.as_deref())?;
         let path = format!("/repos/{}/{}", slug.owner, slug.name);
         let repo: RepoInfo = rest_get(&path).await?;
-        let body = match ctx.shape.unwrap_or(Shape::Text) {
-            Shape::Entries => Body::Entries(EntriesData {
-                items: vec![
-                    entry("stars", &repo.stargazers_count.to_string()),
-                    entry("forks", &repo.forks_count.to_string()),
-                    entry("watchers", &repo.subscribers_count.to_string()),
-                    entry("open_issues", &repo.open_issues_count.to_string()),
-                ],
-            }),
-            _ => Body::Text(TextData {
-                value: format!("★ {}", repo.stargazers_count),
-            }),
-        };
-        Ok(payload(body))
+        Ok(payload(render_body(
+            &repo,
+            ctx.shape.unwrap_or(Shape::Text),
+        )))
+    }
+}
+
+fn render_body(info: &RepoInfo, shape: Shape) -> Body {
+    match shape {
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: vec![
+                format!("★ {}", info.stargazers_count),
+                format!("🍴 {}", info.forks_count),
+                format!("👁 {}", info.subscribers_count),
+                format!("🔓 {}", info.open_issues_count),
+            ],
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: format!(
+                "- **★ stars** {}\n- **🍴 forks** {}\n- **👁 watchers** {}\n- **🔓 open issues** {}",
+                info.stargazers_count,
+                info.forks_count,
+                info.subscribers_count,
+                info.open_issues_count
+            ),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("stars", &info.stargazers_count.to_string()),
+                entry("forks", &info.forks_count.to_string()),
+                entry("watchers", &info.subscribers_count.to_string()),
+                entry("open_issues", &info.open_issues_count.to_string()),
+            ],
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "stars".into(),
+                    value: info.stargazers_count,
+                },
+                Bar {
+                    label: "forks".into(),
+                    value: info.forks_count,
+                },
+                Bar {
+                    label: "watchers".into(),
+                    value: info.subscribers_count,
+                },
+                Bar {
+                    label: "open_issues".into(),
+                    value: info.open_issues_count,
+                },
+            ],
+        }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: Status::Ok,
+            label: format!("★ {}", info.stargazers_count),
+        }),
+        _ => Body::Text(TextData {
+            value: format!("★ {}", info.stargazers_count),
+        }),
     }
 }
 
@@ -187,7 +243,17 @@ mod tests {
         assert_eq!(fetcher.name(), "github_repo_stars");
         assert_eq!(fetcher.safety(), Safety::Safe);
         assert!(fetcher.description().contains("watchers"));
-        assert_eq!(fetcher.shapes(), &[Shape::Text, Shape::Entries]);
+        assert_eq!(
+            fetcher.shapes(),
+            &[
+                Shape::Text,
+                Shape::TextBlock,
+                Shape::MarkdownTextBlock,
+                Shape::Entries,
+                Shape::Bars,
+                Shape::Badge,
+            ]
+        );
         assert_eq!(fetcher.default_shape(), Shape::Text);
         assert_eq!(fetcher.option_schemas().len(), 1);
         assert_eq!(fetcher.option_schemas()[0].name, "repo");
@@ -211,6 +277,28 @@ mod tests {
         assert_eq!(entries.items.len(), 4);
         assert_eq!(entries.items[0].key, "stars");
         assert_eq!(entries.items[3].key, "open_issues");
+
+        let Some(Body::TextBlock(t)) = fetcher.sample_body(Shape::TextBlock) else {
+            panic!("expected text block sample");
+        };
+        assert_eq!(t.lines[0], "★ 142");
+
+        let Some(Body::MarkdownTextBlock(m)) = fetcher.sample_body(Shape::MarkdownTextBlock) else {
+            panic!("expected markdown sample");
+        };
+        assert!(m.value.contains("- **★ stars** 142"));
+
+        let Some(Body::Bars(b)) = fetcher.sample_body(Shape::Bars) else {
+            panic!("expected bars sample");
+        };
+        assert_eq!(b.bars[0].value, 142);
+
+        let Some(Body::Badge(bd)) = fetcher.sample_body(Shape::Badge) else {
+            panic!("expected badge sample");
+        };
+        assert_eq!(bd.status, crate::payload::Status::Ok);
+        assert_eq!(bd.label, "★ 142");
+
         assert!(fetcher.sample_body(Shape::Timeline).is_none());
     }
 

--- a/src/fetcher/github/review_requests.rs
+++ b/src/fetcher/github/review_requests.rs
@@ -4,22 +4,16 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
 use crate::options::OptionSchema;
 use crate::payload::{Body, Payload};
 use crate::render::Shape;
-use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::client::rest_get;
 use super::common::{cache_key, parse_options, payload};
-use super::items::{SearchResult, render_items};
+use super::items::{SearchResult, sample_rows, to_forge_rows};
 
-const SHAPES: &[Shape] = &[
-    Shape::LinkedTextBlock,
-    Shape::TextBlock,
-    Shape::Entries,
-    Shape::Timeline,
-];
 const DEFAULT_LIMIT: u32 = 10;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
@@ -54,7 +48,7 @@ impl Fetcher for GithubReviewRequests {
         60 * 5
     }
     fn shapes(&self) -> &[Shape] {
-        SHAPES
+        LIST_SHAPES
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -63,39 +57,23 @@ impl Fetcher for GithubReviewRequests {
         cache_key(self.name(), ctx, "")
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
-        Some(match shape {
-            Shape::LinkedTextBlock => samples::linked_text_block(&[
-                (
-                    "ratatui/ratatui#1234 feat: add pie chart",
-                    Some("https://github.com/ratatui/ratatui/pull/1234"),
-                ),
-                (
-                    "tokio-rs/tokio#5678 fix: race in spawn",
-                    Some("https://github.com/tokio-rs/tokio/pull/5678"),
-                ),
-            ]),
-            Shape::TextBlock => samples::text_block(&[
-                "ratatui/ratatui#1234 feat: add pie chart",
-                "tokio-rs/tokio#5678 fix: race in spawn",
-            ]),
-            Shape::Entries => samples::entries(&[
-                ("ratatui #1234", "feat: add pie chart"),
-                ("tokio #5678", "fix: race in spawn"),
-            ]),
-            Shape::Timeline => samples::timeline(&[
-                (
-                    1_774_000_000,
-                    "ratatui/ratatui#1234",
-                    Some("feat: add pie chart"),
-                ),
-                (
-                    1_773_800_000,
-                    "tokio-rs/tokio#5678",
-                    Some("fix: race in spawn"),
-                ),
-            ]),
-            _ => return None,
-        })
+        let rows = sample_rows(&[
+            (
+                "ratatui/ratatui#1234",
+                "feat: add pie chart",
+                Some("https://github.com/ratatui/ratatui/pull/1234"),
+                5,
+                1_774_000_000,
+            ),
+            (
+                "tokio-rs/tokio#5678",
+                "fix: race in spawn",
+                Some("https://github.com/tokio-rs/tokio/pull/5678"),
+                2,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "to review", "to review")
     }
     async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
         let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
@@ -104,11 +82,10 @@ impl Fetcher for GithubReviewRequests {
             "/search/issues?q=is%3Apr+is%3Aopen+review-requested%3A%40me&per_page={limit}&sort=updated"
         );
         let res: SearchResult = rest_get(&path).await?;
-        Ok(payload(render_items(
-            &res.items,
-            ctx.shape.unwrap_or(Shape::LinkedTextBlock),
-            true,
-        )))
+        let rows = to_forge_rows(&res.items, true);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "to review", "to review").await;
+        Ok(payload(body))
     }
 }
 
@@ -201,11 +178,18 @@ mod tests {
         assert_eq!(fetcher.name(), "github_review_requests");
         assert_eq!(fetcher.safety(), Safety::Safe);
         assert!(fetcher.description().contains("requested reviewer"));
-        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
         assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
         assert_eq!(fetcher.option_schemas().len(), 1);
         assert_eq!(fetcher.option_schemas()[0].name, "limit");
         assert_eq!(fetcher.option_schemas()[0].default, Some("10"));
+
+        for shape in LIST_SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
 
         let Some(Body::LinkedTextBlock(linked)) = fetcher.sample_body(Shape::LinkedTextBlock)
         else {
@@ -220,29 +204,10 @@ mod tests {
             Some("https://github.com/tokio-rs/tokio/pull/5678")
         );
 
-        let Some(Body::TextBlock(text)) = fetcher.sample_body(Shape::TextBlock) else {
-            panic!("expected text block sample");
-        };
-        assert_eq!(text.lines[1], "tokio-rs/tokio#5678 fix: race in spawn");
-
         let Some(Body::Entries(entries)) = fetcher.sample_body(Shape::Entries) else {
             panic!("expected entries sample");
         };
-        assert_eq!(entries.items[0].key, "ratatui #1234");
-        assert_eq!(
-            entries.items[1].value.as_deref(),
-            Some("fix: race in spawn")
-        );
-
-        let Some(Body::Timeline(timeline)) = fetcher.sample_body(Shape::Timeline) else {
-            panic!("expected timeline sample");
-        };
-        assert_eq!(timeline.events[0].title, "ratatui/ratatui#1234");
-        assert_eq!(
-            timeline.events[1].detail.as_deref(),
-            Some("fix: race in spawn")
-        );
-        assert!(fetcher.sample_body(Shape::Text).is_none());
+        assert_eq!(entries.items[0].key, "ratatui/ratatui#1234");
     }
 
     #[test]

--- a/src/fetcher/gitlab/client.rs
+++ b/src/fetcher/gitlab/client.rs
@@ -1,0 +1,347 @@
+//! Shared HTTP client + auth for the `gitlab_*` family. GitLab uses `PRIVATE-TOKEN` (Personal
+//! Access Token) rather than bearer auth as its canonical PAT header; we honour that so users
+//! can paste a token from the GitLab UI directly into `secrets.toml`.
+//!
+//! Every request flows through [`rest_get`], which composes `https://{host}/api/v4{path}` —
+//! `host` is the caller-supplied (and pre-validated) GitLab instance, defaulting to
+//! `gitlab.com`. The fetcher resolves and validates the host before reaching this module, so we
+//! treat it as already-safe here.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+use crate::fetcher::FetchError;
+
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_HOST: &str = "gitlab.com";
+
+static AUTHENTICATED_USERNAME_CACHE: OnceLock<Mutex<Option<(String, String)>>> = OnceLock::new();
+
+pub fn default_host() -> &'static str {
+    DEFAULT_HOST
+}
+
+pub fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub fn resolve_token() -> Result<String, FetchError> {
+    std::env::var("GITLAB_TOKEN").map_err(|_| FetchError::Failed("GITLAB_TOKEN not set".into()))
+}
+
+/// Username of the token-authenticated user. Resolved lazily via `/api/v4/user` and memoised
+/// per-host so the `gitlab_review_requests` widget doesn't pay a roundtrip on every refresh.
+/// Keyed on `host` because two configs pointing at different GitLab instances must not bleed
+/// usernames into each other.
+pub async fn resolve_authenticated_username(host: &str) -> Result<String, FetchError> {
+    let slot = AUTHENTICATED_USERNAME_CACHE.get_or_init(|| Mutex::new(None));
+    if let Some(cached) = slot
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .filter(|(h, _)| h == host)
+    {
+        return Ok(cached.1);
+    }
+    #[derive(Deserialize)]
+    struct Me {
+        username: String,
+    }
+    let me: Me = rest_get(host, "/user").await?;
+    if let Ok(mut g) = slot.lock() {
+        *g = Some((host.into(), me.username.clone()));
+    }
+    Ok(me.username)
+}
+
+#[cfg(test)]
+pub(crate) fn clear_authenticated_username_cache() {
+    if let Ok(mut g) = AUTHENTICATED_USERNAME_CACHE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    {
+        *g = None;
+    }
+}
+
+/// REST GET → deserialize JSON. `path` is the part after `/api/v4` (e.g. `"/user"`,
+/// `"/projects/group%2Fproj"`). Non-2xx responses surface the GitLab `message` field when
+/// present so the error placeholder and the log line are both actionable.
+pub async fn rest_get<T: DeserializeOwned>(host: &str, path: &str) -> Result<T, FetchError> {
+    let token = resolve_token()?;
+    let url = format!("https://{host}/api/v4{path}");
+    let res = http()
+        .get(&url)
+        .header("PRIVATE-TOKEN", &token)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("gitlab request failed: {e}")))?;
+    parse_json(res).await
+}
+
+async fn parse_json<T: DeserializeOwned>(res: reqwest::Response) -> Result<T, FetchError> {
+    let status = res.status();
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("gitlab response body: {e}")))?;
+    if !status.is_success() {
+        return Err(FetchError::Failed(error_message(status, &bytes)));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("gitlab json parse: {e}")))
+}
+
+fn error_message(status: StatusCode, body: &[u8]) -> String {
+    #[derive(Deserialize)]
+    struct ApiError {
+        message: Option<serde_json::Value>,
+        error: Option<String>,
+    }
+    let reported = serde_json::from_slice::<ApiError>(body).ok().and_then(|e| {
+        e.message
+            .as_ref()
+            .map(|m| match m {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            })
+            .or(e.error)
+    });
+    match reported {
+        Some(m) => format!("gitlab {status}: {m}"),
+        None => format!("gitlab {status}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct TestPayload {
+        username: String,
+    }
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        restore: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let lock = crate::paths::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let restore = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let prev = std::env::var(k).ok();
+                    match v {
+                        Some(value) => unsafe { std::env::set_var(k, value) },
+                        None => unsafe { std::env::remove_var(k) },
+                    }
+                    (*k, prev)
+                })
+                .collect();
+            Self {
+                _lock: lock,
+                restore,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.restore {
+                match v {
+                    Some(value) => unsafe { std::env::set_var(k, value) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn default_host_is_gitlab_dot_com() {
+        assert_eq!(default_host(), "gitlab.com");
+    }
+
+    #[test]
+    fn resolve_token_reads_gitlab_token() {
+        let _g = EnvGuard::set(&[("GITLAB_TOKEN", Some("glpat-xxx"))]);
+        assert_eq!(resolve_token().unwrap(), "glpat-xxx");
+    }
+
+    #[test]
+    fn resolve_token_fails_when_unset() {
+        let _g = EnvGuard::set(&[("GITLAB_TOKEN", None)]);
+        let err = resolve_token().unwrap_err();
+        assert!(matches!(err, FetchError::Failed(m) if m == "GITLAB_TOKEN not set"));
+    }
+
+    #[test]
+    fn http_reuses_the_same_client() {
+        assert!(std::ptr::eq(http(), http()));
+    }
+
+    #[test]
+    fn resolve_authenticated_username_returns_cached_value() {
+        let _g = EnvGuard::set(&[("GITLAB_TOKEN", None)]);
+        clear_authenticated_username_cache();
+        *AUTHENTICATED_USERNAME_CACHE
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .unwrap() = Some(("gitlab.com".into(), "root".into()));
+
+        let user = run_async(resolve_authenticated_username("gitlab.com")).unwrap();
+        assert_eq!(user, "root");
+        clear_authenticated_username_cache();
+    }
+
+    #[test]
+    fn resolve_authenticated_username_busts_cache_per_host() {
+        // A cache hit must match the requested host; otherwise switching configs between two
+        // GitLab instances would bleed identities. Requesting a different host than the cached
+        // one falls through to `rest_get`, which (without a token) returns the auth error.
+        let _g = EnvGuard::set(&[("GITLAB_TOKEN", None)]);
+        clear_authenticated_username_cache();
+        *AUTHENTICATED_USERNAME_CACHE
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .unwrap() = Some(("gitlab.com".into(), "root".into()));
+
+        let err = run_async(resolve_authenticated_username("gitlab.example.org")).unwrap_err();
+        assert!(matches!(err, FetchError::Failed(m) if m == "GITLAB_TOKEN not set"));
+        clear_authenticated_username_cache();
+    }
+
+    #[test]
+    fn rest_get_send_error_surfaces_request_failed() {
+        // `\n` in a PRIVATE-TOKEN header forces reqwest to fail at builder time, so the send-
+        // error arm is reachable without hitting the live API.
+        let _g = EnvGuard::set(&[("GITLAB_TOKEN", Some("tok\nbreak"))]);
+        let err = run_async(rest_get::<TestPayload>("gitlab.com", "/user")).unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.starts_with("gitlab request failed:")
+        ));
+    }
+
+    #[test]
+    fn parse_json_deserializes_success_bodies() {
+        let payload = parse_test_payload("200 OK", r#"{"username":"alice"}"#).unwrap();
+        assert_eq!(payload.username, "alice");
+    }
+
+    #[test]
+    fn parse_json_surfaces_string_message_field() {
+        let err =
+            parse_test_payload("404 Not Found", r#"{"message":"404 Not Found"}"#).unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m == "gitlab 404 Not Found: 404 Not Found"
+        ));
+    }
+
+    #[test]
+    fn parse_json_handles_structured_message_objects() {
+        // GitLab sometimes returns `{"message": {"error": "...", "details": [...]}}` rather
+        // than a flat string; the error wrapper should stringify gracefully instead of dropping
+        // it.
+        let err = parse_test_payload(
+            "400 Bad Request",
+            r#"{"message":{"error":"invalid","scope":["user"]}}"#,
+        )
+        .unwrap_err();
+        let FetchError::Failed(m) = err else {
+            panic!("expected Failed");
+        };
+        assert!(m.starts_with("gitlab 400 Bad Request:"));
+    }
+
+    #[test]
+    fn parse_json_falls_back_to_error_field() {
+        let err =
+            parse_test_payload("401 Unauthorized", r#"{"error":"invalid_token"}"#).unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m == "gitlab 401 Unauthorized: invalid_token"
+        ));
+    }
+
+    #[test]
+    fn parse_json_falls_back_to_status_without_a_message() {
+        let err = parse_test_payload("500 Internal Server Error", "{}").unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m == "gitlab 500 Internal Server Error"
+        ));
+    }
+
+    #[test]
+    fn parse_json_surfaces_json_parse_errors() {
+        let err = parse_test_payload("200 OK", "not-json").unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("gitlab json parse")
+        ));
+    }
+
+    fn parse_test_payload(status: &str, body: &str) -> Result<TestPayload, FetchError> {
+        let (url, server) = serve_once(status, body);
+        let response = run_async(async {
+            let response = http().get(&url).send().await.unwrap();
+            parse_json::<TestPayload>(response).await
+        });
+        server.join().unwrap();
+        response
+    }
+
+    fn serve_once(status: &str, body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+}

--- a/src/fetcher/gitlab/common.rs
+++ b/src/fetcher/gitlab/common.rs
@@ -1,0 +1,328 @@
+//! Cross-cutting helpers for the `gitlab_*` fetchers: option parsing, project resolution, host
+//! validation, cache-key construction, slug extraction from git remotes.
+//!
+//! Mirrors `github/common.rs` in shape; the differences are GitLab-specific:
+//!
+//! - [`ProjectPath`] accepts multi-segment paths (`group/subgroup/project`) because GitLab
+//!   nests groups arbitrarily, whereas GitHub's owner/name pair is always two segments.
+//! - Project lookups go to `/api/v4/projects/{path}` with the slashes URL-encoded as `%2F`.
+//! - [`validate_host`] is the trust-boundary check: the `host` option ultimately decides where
+//!   the auth token leaves to, so the parser rejects schemes / slashes / paths / dotless
+//!   trailers before the value ever reaches [`super::client::rest_get`].
+
+use chrono::DateTime;
+use sha2::{Digest, Sha256};
+
+use crate::fetcher::{FetchContext, FetchError};
+use crate::payload::{Body, Payload};
+
+pub fn payload(body: Body) -> Payload {
+    Payload {
+        icon: None,
+        status: None,
+        format: None,
+        body,
+    }
+}
+
+pub fn parse_options<T: serde::de::DeserializeOwned + Default>(
+    raw: Option<&toml::Value>,
+) -> Result<T, String> {
+    match raw {
+        None => Ok(T::default()),
+        Some(value) => value
+            .clone()
+            .try_into::<T>()
+            .map_err(|e| format!("invalid options: {e}")),
+    }
+}
+
+/// Unix timestamp from an RFC3339 string. GitLab sends UTC strings like
+/// `"2026-04-22T10:15:30.123Z"`; chrono parses the fractional seconds gracefully.
+pub fn parse_timestamp(raw: &str) -> i64 {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0)
+}
+
+/// Cache key that mixes fetcher name + shape + format + auxiliary fields (host, project path,
+/// reviewer scope). Stable for identical invocations so the daemon reuses the on-disk file.
+pub fn cache_key(name: &str, ctx: &FetchContext, extra: &str) -> String {
+    let shape = ctx.shape.map(|s| s.as_str()).unwrap_or("default");
+    let raw = format!(
+        "{}|{}|{}|{}",
+        name,
+        shape,
+        ctx.format.as_deref().unwrap_or(""),
+        extra
+    );
+    let digest = Sha256::digest(raw.as_bytes());
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{name}-{hex}")
+}
+
+/// Validate `host` as a bare hostname. Trust-boundary: `host` is the only piece of config that
+/// changes where the auth token leaves to, so we reject anything outside `[a-z0-9.-]` plus the
+/// usual hostname structural rules (no leading / trailing dot or dash, no empty labels, no
+/// schemes, no slashes).
+pub fn validate_host(host: &str) -> Result<&str, String> {
+    let too_short_or_long = host.is_empty() || host.len() > 253;
+    let bad_chars = host
+        .chars()
+        .any(|c| !(c.is_ascii_alphanumeric() || c == '.' || c == '-'));
+    let bad_anchor = host.starts_with('.')
+        || host.ends_with('.')
+        || host.starts_with('-')
+        || host.ends_with('-');
+    let empty_label = host.contains("..");
+    if too_short_or_long || bad_chars || bad_anchor || empty_label {
+        return Err(format!("invalid gitlab host: {host:?}"));
+    }
+    Ok(host)
+}
+
+/// GitLab project identifier. Can carry an arbitrary number of path segments because GitLab
+/// nests groups (`my-group/sub-group/my-project`). Each segment is non-empty and
+/// path-safe — slashes get percent-encoded for the API at lookup time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectPath(String);
+
+impl ProjectPath {
+    pub fn parse(raw: &str) -> Option<Self> {
+        let trimmed = raw.trim().trim_matches('/');
+        // GitLab projects always live under at least one group / namespace, so a bare
+        // single-segment string ("group") never resolves to a real project. Reject it here
+        // so the trailing-slash form ("group/") and a typo'd group name both fail fast
+        // instead of generating a 404 path at the API.
+        let segments: Vec<&str> = trimmed.split('/').collect();
+        let valid = !trimmed.is_empty()
+            && segments.len() >= 2
+            && segments.iter().all(|seg| {
+                !seg.is_empty()
+                    && seg
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+            });
+        valid.then(|| Self(trimmed.into()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// URL-encoded form used as the `{id}` placeholder in `/api/v4/projects/{id}/...`.
+    pub fn encoded(&self) -> String {
+        self.0.replace('/', "%2F")
+    }
+
+    /// Last segment — used by `repo_stars` headlines etc. where the full path would be too long.
+    pub fn name(&self) -> &str {
+        self.0.rsplit('/').next().unwrap_or(self.as_str())
+    }
+}
+
+/// Resolve the project for a repo-scope fetcher: explicit `options.project` wins, otherwise the
+/// git remote of the cwd is parsed. Only matches the configured `host` so a cwd whose remote
+/// lives on a different GitLab instance doesn't get silently mistargeted.
+pub fn resolve_project(explicit: Option<&str>, host: &str) -> Result<ProjectPath, FetchError> {
+    if let Some(raw) = explicit {
+        return ProjectPath::parse(raw)
+            .ok_or_else(|| FetchError::Failed(format!("invalid project option: {raw:?}")));
+    }
+    match remote_project_from_cwd(host) {
+        Some(path) => Ok(path),
+        None => Err(FetchError::Failed(
+            "no project: set `project = \"group/name\"` or run inside a git repo with a gitlab \
+             remote matching `host`"
+                .into(),
+        )),
+    }
+}
+
+fn remote_project_from_cwd(host: &str) -> Option<ProjectPath> {
+    let cwd = std::env::current_dir().ok()?;
+    let repo = gix::discover(&cwd).ok()?;
+    let names: Vec<_> = repo.remote_names().into_iter().collect();
+    let preferred = names
+        .iter()
+        .find(|n| n.as_ref() == "origin")
+        .or_else(|| names.first())?;
+    let remote = repo.find_remote(preferred.as_ref()).ok()?;
+    let url = remote.url(gix::remote::Direction::Fetch)?;
+    project_from_url(&url.to_bstring().to_string(), host)
+}
+
+/// Extract a project path from a git remote URL, only if the URL's host matches the configured
+/// GitLab `host`. Supports the four shapes splashboard users commonly write:
+/// - `git@gitlab.com:group/project(.git)?`
+/// - `https://gitlab.com/group/project(.git)?`
+/// - `https://<user>(:<token>)?@gitlab.com/group/project(.git)?`
+/// - `ssh://git@gitlab.com/group/project(.git)?`
+pub fn project_from_url(url: &str, host: &str) -> Option<ProjectPath> {
+    let host_ssh = format!("git@{host}:");
+    let host_https = format!("https://{host}/");
+    let host_ssh_scheme = format!("ssh://git@{host}/");
+    let rest = url
+        .strip_prefix(&host_ssh)
+        .or_else(|| strip_https_userinfo(url, host))
+        .or_else(|| url.strip_prefix(&host_https))
+        .or_else(|| url.strip_prefix(&host_ssh_scheme))?;
+    let rest = rest.strip_suffix(".git").unwrap_or(rest);
+    ProjectPath::parse(rest)
+}
+
+fn strip_https_userinfo<'a>(url: &'a str, host: &str) -> Option<&'a str> {
+    let after_scheme = url.strip_prefix("https://")?;
+    let (userinfo, after_userinfo) = after_scheme.split_once('@')?;
+    if userinfo.contains('/') {
+        return None;
+    }
+    let host_slash = format!("{host}/");
+    after_userinfo.strip_prefix(&host_slash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_host_accepts_canonical_gitlab_dot_com() {
+        assert_eq!(validate_host("gitlab.com").unwrap(), "gitlab.com");
+    }
+
+    #[test]
+    fn validate_host_accepts_self_hosted_subdomain() {
+        assert_eq!(
+            validate_host("git.example-corp.io").unwrap(),
+            "git.example-corp.io"
+        );
+    }
+
+    #[test]
+    fn validate_host_rejects_schemes_and_paths() {
+        assert!(validate_host("https://gitlab.com").is_err());
+        assert!(validate_host("gitlab.com/api").is_err());
+        assert!(validate_host("gitlab.com:8080").is_err());
+    }
+
+    #[test]
+    fn validate_host_rejects_structural_garbage() {
+        assert!(validate_host("").is_err());
+        assert!(validate_host(".gitlab.com").is_err());
+        assert!(validate_host("gitlab.com.").is_err());
+        assert!(validate_host("-gitlab.com").is_err());
+        assert!(validate_host("gitlab..com").is_err());
+        assert!(validate_host("gitlab com").is_err());
+    }
+
+    #[test]
+    fn project_path_parses_two_and_three_segments() {
+        let two = ProjectPath::parse("group/proj").unwrap();
+        assert_eq!(two.as_str(), "group/proj");
+        assert_eq!(two.encoded(), "group%2Fproj");
+        assert_eq!(two.name(), "proj");
+
+        let three = ProjectPath::parse("group/sub/proj").unwrap();
+        assert_eq!(three.encoded(), "group%2Fsub%2Fproj");
+        assert_eq!(three.name(), "proj");
+    }
+
+    #[test]
+    fn project_path_trims_leading_and_trailing_slashes() {
+        let p = ProjectPath::parse("/group/proj/").unwrap();
+        assert_eq!(p.as_str(), "group/proj");
+    }
+
+    #[test]
+    fn project_path_rejects_invalid_segments() {
+        assert!(ProjectPath::parse("").is_none());
+        assert!(ProjectPath::parse("/").is_none());
+        assert!(ProjectPath::parse("group/").is_none());
+        assert!(ProjectPath::parse("group//proj").is_none());
+        assert!(ProjectPath::parse("group/proj?weird").is_none());
+        assert!(ProjectPath::parse("group/proj space").is_none());
+    }
+
+    #[test]
+    fn project_from_url_matches_each_documented_shape() {
+        let host = "gitlab.com";
+        for url in [
+            "git@gitlab.com:unhappychoice/splashboard.git",
+            "https://gitlab.com/unhappychoice/splashboard",
+            "https://gitlab.com/unhappychoice/splashboard.git",
+            "https://fdncred@gitlab.com/unhappychoice/splashboard.git",
+            "https://user:tok@gitlab.com/unhappychoice/splashboard",
+            "ssh://git@gitlab.com/unhappychoice/splashboard.git",
+        ] {
+            let p = project_from_url(url, host).unwrap_or_else(|| panic!("could not parse {url}"));
+            assert_eq!(p.as_str(), "unhappychoice/splashboard", "url={url}");
+        }
+    }
+
+    #[test]
+    fn project_from_url_carries_subgroups_through() {
+        let p = project_from_url("git@gitlab.com:my-group/sub/proj.git", "gitlab.com").unwrap();
+        assert_eq!(p.as_str(), "my-group/sub/proj");
+    }
+
+    #[test]
+    fn project_from_url_rejects_non_matching_hosts() {
+        // The host gate is what keeps a `gitlab_*` fetcher from picking up a GitHub remote on
+        // a polyrepo machine; the `slug` parser already passes structurally, the host check is
+        // the only safeguard.
+        assert!(
+            project_from_url("git@github.com:unhappychoice/splashboard.git", "gitlab.com")
+                .is_none()
+        );
+        assert!(project_from_url("https://gitlab.example.org/u/proj.git", "gitlab.com").is_none());
+    }
+
+    #[test]
+    fn parse_timestamp_reads_rfc3339_with_fractions() {
+        assert_eq!(parse_timestamp("2026-04-22T10:15:30Z"), 1_776_852_930);
+        assert_eq!(parse_timestamp("2026-04-22T10:15:30.123Z"), 1_776_852_930);
+    }
+
+    #[test]
+    fn parse_timestamp_falls_back_to_zero_on_garbage() {
+        assert_eq!(parse_timestamp("not-a-date"), 0);
+    }
+
+    #[test]
+    fn cache_key_changes_with_extra_and_shape() {
+        let ctx = FetchContext {
+            shape: Some(crate::render::Shape::Entries),
+            ..Default::default()
+        };
+        let a = cache_key("gitlab_repo_mrs", &ctx, "gitlab.com|group/proj");
+        let b = cache_key("gitlab_repo_mrs", &ctx, "gitlab.com|group/proj2");
+        assert_ne!(a, b);
+        assert!(a.starts_with("gitlab_repo_mrs-"));
+    }
+
+    #[test]
+    fn parse_options_returns_default_when_no_table_is_present() {
+        #[derive(Debug, Default, PartialEq, serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Opts {
+            #[serde(default)]
+            host: Option<String>,
+        }
+        let opts: Opts = parse_options(None).unwrap();
+        assert_eq!(opts, Opts::default());
+    }
+
+    #[test]
+    fn parse_options_surfaces_serde_failures() {
+        #[derive(Debug, Default, serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Opts {
+            #[serde(default)]
+            #[allow(dead_code)]
+            host: Option<String>,
+        }
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        let err = parse_options::<Opts>(Some(&raw)).unwrap_err();
+        assert!(err.contains("invalid options"));
+    }
+}

--- a/src/fetcher/gitlab/items.rs
+++ b/src/fetcher/gitlab/items.rs
@@ -1,0 +1,173 @@
+//! GitLab MR / issue DTOs and adapters into [`forge_items::ForgeRow`]. Two row variants
+//! (`include_repo = true` for cross-project user-scope feeds, `false` for repo-scope feeds)
+//! drive whether `references.full` or `references.short` is used as the label — same toggle
+//! convention as the `github_*` family.
+
+use serde::Deserialize;
+
+use crate::fetcher::forge_items::ForgeRow;
+use crate::fetcher::gitlab::common::parse_timestamp;
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct GitlabIssueLike {
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub web_url: String,
+    #[serde(default)]
+    pub updated_at: String,
+    #[serde(default)]
+    pub user_notes_count: u64,
+    #[serde(default)]
+    pub references: GitlabReferences,
+    #[serde(default)]
+    pub author: Option<GitlabAuthor>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct GitlabReferences {
+    #[serde(default)]
+    pub short: String,
+    #[serde(default)]
+    pub full: String,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct GitlabAuthor {
+    #[serde(default)]
+    pub avatar_url: Option<String>,
+}
+
+/// Convert a GitLab MR / issue payload into a renderer-ready row. The `references` block on the
+/// API response already carries the pre-formatted `group/proj!42` (MR) and `group/proj#75`
+/// (issue) labels, so we don't have to re-stitch project + iid ourselves.
+pub fn to_forge_row(item: &GitlabIssueLike, include_repo: bool) -> ForgeRow {
+    let label = if include_repo {
+        item.references.full.clone()
+    } else {
+        item.references.short.clone()
+    };
+    ForgeRow {
+        label: if label.is_empty() { "?".into() } else { label },
+        title: item.title.clone(),
+        url: if item.web_url.is_empty() {
+            None
+        } else {
+            Some(item.web_url.clone())
+        },
+        avatar_url: item.author.as_ref().and_then(|a| a.avatar_url.clone()),
+        avatar_path: None,
+        updated_at_unix: parse_timestamp(&item.updated_at),
+        activity_count: item.user_notes_count,
+    }
+}
+
+pub fn to_forge_rows(items: &[GitlabIssueLike], include_repo: bool) -> Vec<ForgeRow> {
+    items
+        .iter()
+        .map(|i| to_forge_row(i, include_repo))
+        .collect()
+}
+
+/// Build a tiny [`ForgeRow`] set with stable values for `sample_body`. Sharing the helper keeps
+/// every list-shape fetcher (`gitlab_my_mrs`, `gitlab_repo_issues`, …) printing the same
+/// row-formatting conventions in the docs.
+pub fn sample_rows(rows: &[(&str, &str, Option<&str>, u64, i64)]) -> Vec<ForgeRow> {
+    rows.iter()
+        .map(|(label, title, url, activity, ts)| ForgeRow {
+            label: (*label).into(),
+            title: (*title).into(),
+            url: url.map(String::from),
+            avatar_url: None,
+            avatar_path: None,
+            updated_at_unix: *ts,
+            activity_count: *activity,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item() -> GitlabIssueLike {
+        GitlabIssueLike {
+            title: "feat(gitlab): forge family".into(),
+            web_url: "https://gitlab.com/g/p/-/merge_requests/42".into(),
+            updated_at: "2026-04-22T10:15:30Z".into(),
+            user_notes_count: 4,
+            references: GitlabReferences {
+                short: "!42".into(),
+                full: "g/p!42".into(),
+            },
+            author: Some(GitlabAuthor {
+                avatar_url: Some("https://avatars.example/u.png".into()),
+            }),
+        }
+    }
+
+    #[test]
+    fn include_repo_picks_full_reference() {
+        let row = to_forge_row(&item(), true);
+        assert_eq!(row.label, "g/p!42");
+        assert_eq!(row.title, "feat(gitlab): forge family");
+        assert_eq!(
+            row.url.as_deref(),
+            Some("https://gitlab.com/g/p/-/merge_requests/42")
+        );
+        assert_eq!(
+            row.avatar_url.as_deref(),
+            Some("https://avatars.example/u.png")
+        );
+        assert_eq!(row.updated_at_unix, 1_776_852_930);
+        assert_eq!(row.activity_count, 4);
+    }
+
+    #[test]
+    fn exclude_repo_uses_short_reference() {
+        let row = to_forge_row(&item(), false);
+        assert_eq!(row.label, "!42");
+    }
+
+    #[test]
+    fn missing_references_fall_back_to_question_mark() {
+        let mut item = item();
+        item.references.full.clear();
+        item.references.short.clear();
+        let row = to_forge_row(&item, true);
+        assert_eq!(row.label, "?");
+    }
+
+    #[test]
+    fn missing_url_collapses_to_none() {
+        let mut item = item();
+        item.web_url.clear();
+        let row = to_forge_row(&item, true);
+        assert!(row.url.is_none());
+    }
+
+    #[test]
+    fn missing_author_avatar_stays_none() {
+        let mut item = item();
+        item.author = None;
+        let row = to_forge_row(&item, true);
+        assert!(row.avatar_url.is_none());
+    }
+
+    #[test]
+    fn to_forge_rows_maps_each_item() {
+        let rows = to_forge_rows(&[item(), item()], false);
+        assert_eq!(rows.len(), 2);
+        rows.iter().for_each(|r| assert_eq!(r.label, "!42"));
+    }
+
+    #[test]
+    fn deserialize_tolerates_partial_payloads() {
+        let raw = r#"{"title":"x","references":{"short":"!1","full":"g/p!1"}}"#;
+        let item: GitlabIssueLike = serde_json::from_str(raw).unwrap();
+        assert_eq!(item.title, "x");
+        assert!(item.web_url.is_empty());
+        assert_eq!(item.user_notes_count, 0);
+        assert!(item.author.is_none());
+    }
+}

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -12,9 +12,10 @@ use std::sync::Arc;
 pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod items;
+mod my_mrs;
 
 use super::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![]
+    vec![Arc::new(my_mrs::GitlabMyMrs)]
 }

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -1,0 +1,20 @@
+//! GitLab fetchers. All classify as `Safety::Safe`: the API host is config-fixed at trust time
+//! via the `host` option (default `gitlab.com`, validated against a hostname-only allowlist),
+//! and the auth token (`GITLAB_TOKEN`) only ever leaves to that pinned host. Mirrors the
+//! `github_*` family contract; differences from GitHub are documented in
+//! [`client`] and [`common`].
+//!
+//! Auth: `GITLAB_TOKEN` env var (Personal Access Token with `read_api` scope is enough for the
+//! shipped fetchers). Missing auth surfaces as a placeholder payload, not a panic.
+
+use std::sync::Arc;
+
+pub(crate) mod client;
+pub(crate) mod common;
+pub(crate) mod items;
+
+use super::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![]
+}

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod items;
 mod my_mrs;
+mod repo_mrs;
 mod review_requests;
 
 use super::Fetcher;
@@ -21,5 +22,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![
         Arc::new(my_mrs::GitlabMyMrs),
         Arc::new(review_requests::GitlabReviewRequests),
+        Arc::new(repo_mrs::GitlabRepoMrs),
     ]
 }

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -13,9 +13,13 @@ pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod items;
 mod my_mrs;
+mod review_requests;
 
 use super::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(my_mrs::GitlabMyMrs)]
+    vec![
+        Arc::new(my_mrs::GitlabMyMrs),
+        Arc::new(review_requests::GitlabReviewRequests),
+    ]
 }

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod items;
 mod my_mrs;
+mod pipeline_status;
 mod repo_issues;
 mod repo_mrs;
 mod repo_stars;
@@ -27,5 +28,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(repo_mrs::GitlabRepoMrs),
         Arc::new(repo_issues::GitlabRepoIssues),
         Arc::new(repo_stars::GitlabRepoStars),
+        Arc::new(pipeline_status::GitlabPipelineStatus),
     ]
 }

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod items;
 mod my_mrs;
 mod repo_issues;
 mod repo_mrs;
+mod repo_stars;
 mod review_requests;
 
 use super::Fetcher;
@@ -25,5 +26,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(review_requests::GitlabReviewRequests),
         Arc::new(repo_mrs::GitlabRepoMrs),
         Arc::new(repo_issues::GitlabRepoIssues),
+        Arc::new(repo_stars::GitlabRepoStars),
     ]
 }

--- a/src/fetcher/gitlab/mod.rs
+++ b/src/fetcher/gitlab/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod items;
 mod my_mrs;
+mod repo_issues;
 mod repo_mrs;
 mod review_requests;
 
@@ -23,5 +24,6 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(my_mrs::GitlabMyMrs),
         Arc::new(review_requests::GitlabReviewRequests),
         Arc::new(repo_mrs::GitlabRepoMrs),
+        Arc::new(repo_issues::GitlabRepoIssues),
     ]
 }

--- a/src/fetcher/gitlab/my_mrs.rs
+++ b/src/fetcher/gitlab/my_mrs.rs
@@ -1,0 +1,222 @@
+//! `gitlab_my_mrs` — open merge requests authored by the authenticated GitLab user across
+//! every project. Uses `/api/v4/merge_requests?scope=created_by_me&state=opened`.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{default_host, rest_get};
+use super::common::{cache_key, parse_options, payload, validate_host};
+use super::items::{GitlabIssueLike, sample_rows, to_forge_rows};
+
+const DEFAULT_LIMIT: u32 = 10;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "host",
+        type_hint: "hostname",
+        required: false,
+        default: Some("gitlab.com"),
+        description: "GitLab instance host. Use this for self-hosted GitLab.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of MRs to show.",
+    },
+];
+
+pub struct GitlabMyMrs;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for GitlabMyMrs {
+    fn name(&self) -> &str {
+        "gitlab_my_mrs"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Open merge requests authored by the authenticated GitLab user across every project. Use `gitlab_repo_mrs` instead to list MRs against one specific project regardless of who opened them."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 5
+    }
+    fn shapes(&self) -> &[Shape] {
+        LIST_SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let host = host_for_key(ctx);
+        cache_key(self.name(), ctx, &host)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        let rows = sample_rows(&[
+            (
+                "g/splashboard!54",
+                "feat(docs): generate widget catalogue",
+                Some("https://gitlab.com/g/splashboard/-/merge_requests/54"),
+                7,
+                1_774_000_000,
+            ),
+            (
+                "g/splashboard!51",
+                "feat(fetcher): split clock options",
+                Some("https://gitlab.com/g/splashboard/-/merge_requests/51"),
+                2,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open MR", "open MRs")
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let host = resolve_host(opts.host.as_deref())?;
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
+        let path = format!(
+            "/merge_requests?scope=created_by_me&state=opened&per_page={limit}&order_by=updated_at"
+        );
+        let items: Vec<GitlabIssueLike> = rest_get(&host, &path).await?;
+        let rows = to_forge_rows(&items, true);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open MR", "open MRs").await;
+        Ok(payload(body))
+    }
+}
+
+pub(super) fn resolve_host(explicit: Option<&str>) -> Result<String, FetchError> {
+    let host = explicit.unwrap_or(default_host());
+    validate_host(host)
+        .map(String::from)
+        .map_err(FetchError::Failed)
+}
+
+fn host_for_key(ctx: &FetchContext) -> String {
+    ctx.options
+        .as_ref()
+        .and_then(|v| v.get("host"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(default_host())
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::payload::{BadgeData, Status};
+
+    #[test]
+    fn options_deserialize_both_fields() {
+        let raw: toml::Value = toml::from_str("host = \"git.example.org\"\nlimit = 5").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.host.as_deref(), Some("git.example.org"));
+        assert_eq!(opts.limit, Some(5));
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("limit = 5\nbogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn shapes_table_matches_shared_list() {
+        let fetcher = GitlabMyMrs;
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(fetcher.safety(), Safety::Safe);
+    }
+
+    #[test]
+    fn sample_body_covers_every_list_shape_plus_badge() {
+        let fetcher = GitlabMyMrs;
+        for shape in LIST_SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        // Shapes outside the catalogued list (e.g. Ratio) return None instead of an empty body
+        // so docs generation never accidentally promotes them.
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn sample_badge_starts_calm_when_count_is_low_but_warm_when_open() {
+        let fetcher = GitlabMyMrs;
+        let Some(Body::Badge(BadgeData { status, label })) = fetcher.sample_body(Shape::Badge)
+        else {
+            panic!("expected badge");
+        };
+        assert_eq!(status, Status::Warn);
+        assert_eq!(label, "2 open MRs");
+    }
+
+    #[test]
+    fn host_for_key_falls_back_to_default() {
+        assert_eq!(host_for_key(&FetchContext::default()), "gitlab.com");
+    }
+
+    #[test]
+    fn host_for_key_reads_explicit_host_option() {
+        let ctx = FetchContext {
+            options: Some(toml::from_str("host = \"git.example.org\"").unwrap()),
+            ..Default::default()
+        };
+        assert_eq!(host_for_key(&ctx), "git.example.org");
+    }
+
+    #[test]
+    fn cache_key_changes_with_host_option() {
+        let fetcher = GitlabMyMrs;
+        let a = fetcher.cache_key(&FetchContext::default());
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.example.org\"").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(a, b);
+        assert!(a.starts_with("gitlab_my_mrs-"));
+    }
+
+    #[test]
+    fn resolve_host_validates_input() {
+        assert_eq!(resolve_host(None).unwrap(), "gitlab.com");
+        assert!(resolve_host(Some("https://gitlab.com")).is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_host_before_network_request() {
+        let err = GitlabMyMrs
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("host = \"https://gitlab.com\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid gitlab host")
+        ));
+    }
+}

--- a/src/fetcher/gitlab/pipeline_status.rs
+++ b/src/fetcher/gitlab/pipeline_status.rs
@@ -4,6 +4,7 @@
 
 use async_trait::async_trait;
 use serde::Deserialize;
+use url::form_urlencoded::byte_serialize;
 
 use crate::options::OptionSchema;
 use crate::payload::{BadgeData, Body, EntriesData, Entry, Payload, Status, TextData};
@@ -101,7 +102,12 @@ impl Fetcher for GitlabPipelineStatus {
         let project = resolve_project(opts.project.as_deref(), &host)?;
         let mut path = format!("/projects/{}/pipelines?per_page=1", project.encoded());
         if let Some(branch) = opts.branch.as_deref() {
-            path.push_str(&format!("&ref={branch}"));
+            // Branch names can carry `&`, `=`, `#`, `+`, `?`, and slashes (release/v2,
+            // feature/foo&bar). Naive interpolation rewrote the URL semantics and silently
+            // returned the wrong pipeline; percent-encode so the value stays a single
+            // `ref=<branch>` pair.
+            let encoded: String = byte_serialize(branch.as_bytes()).collect();
+            path.push_str(&format!("&ref={encoded}"));
         }
         let pipelines: Vec<Pipeline> = rest_get(&host, &path).await?;
         let shape = ctx.shape.unwrap_or(Shape::Badge);
@@ -330,6 +336,23 @@ mod tests {
         assert_eq!(format_duration(Some(192)), "3m 12s");
         assert_eq!(format_duration(Some(60)), "1m 00s");
         assert_eq!(format_duration(None), "?");
+    }
+
+    #[test]
+    fn byte_serialize_handles_reserved_branch_characters() {
+        // Pin the encoding so a future url-crate version that loosens this set fails the
+        // test rather than silently shipping a request that the GitLab API misroutes.
+        let cases = [
+            ("main", "main"),
+            ("release/v2", "release%2Fv2"),
+            ("feature/foo&bar", "feature%2Ffoo%26bar"),
+            ("name=weird", "name%3Dweird"),
+            ("with spaces", "with+spaces"),
+        ];
+        for (raw, expected) in cases {
+            let actual: String = byte_serialize(raw.as_bytes()).collect();
+            assert_eq!(actual, expected, "raw={raw}");
+        }
     }
 
     #[test]

--- a/src/fetcher/gitlab/pipeline_status.rs
+++ b/src/fetcher/gitlab/pipeline_status.rs
@@ -1,0 +1,326 @@
+//! `gitlab_pipeline_status` — current pipeline state for a GitLab project as a single badge,
+//! optional text line, or `Entries` rollup (status / branch / sha / duration). Uses
+//! `/api/v4/projects/{id}/pipelines?per_page=1[&ref=<branch>]`.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{BadgeData, Body, EntriesData, Entry, Payload, Status, TextData};
+use crate::render::Shape;
+use crate::samples;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{default_host, rest_get};
+use super::common::{ProjectPath, cache_key, parse_options, payload, resolve_project};
+use super::my_mrs::resolve_host;
+
+const SHAPES: &[Shape] = &[Shape::Badge, Shape::Text, Shape::Entries];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "host",
+        type_hint: "hostname",
+        required: false,
+        default: Some("gitlab.com"),
+        description: "GitLab instance host. Use this for self-hosted GitLab.",
+    },
+    OptionSchema {
+        name: "project",
+        type_hint: "\"group/name\" or \"group/sub/name\"",
+        required: false,
+        default: Some("git remote of cwd"),
+        description: "Project to query. Falls back to the current directory's GitLab remote.",
+    },
+    OptionSchema {
+        name: "branch",
+        type_hint: "string",
+        required: false,
+        default: None,
+        description: "Branch (ref) to filter the latest pipeline by. Omit for the most recent pipeline on any branch.",
+    },
+];
+
+pub struct GitlabPipelineStatus;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for GitlabPipelineStatus {
+    fn name(&self) -> &str {
+        "gitlab_pipeline_status"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Latest CI pipeline run for a GitLab project as a pass/fail badge, short text line, or status rollup."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 5
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Badge
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx, &cache_extra(ctx))
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Badge => samples::badge(Status::Ok, "main · passing"),
+            Shape::Text => samples::text("main · passing"),
+            Shape::Entries => Body::Entries(EntriesData {
+                items: vec![
+                    entry("status", Some(Status::Ok), "passing"),
+                    entry("branch", None, "main"),
+                    entry("sha", None, "abc123de"),
+                    entry("duration", None, "3m 12s"),
+                ],
+            }),
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let host = resolve_host(opts.host.as_deref())?;
+        let project = resolve_project(opts.project.as_deref(), &host)?;
+        let mut path = format!("/projects/{}/pipelines?per_page=1", project.encoded());
+        if let Some(branch) = opts.branch.as_deref() {
+            path.push_str(&format!("&ref={branch}"));
+        }
+        let pipelines: Vec<Pipeline> = rest_get(&host, &path).await?;
+        let shape = ctx.shape.unwrap_or(Shape::Badge);
+        let Some(latest) = pipelines.into_iter().next() else {
+            return Ok(payload(Body::Badge(BadgeData {
+                status: Status::Warn,
+                label: "no runs".into(),
+            })));
+        };
+        Ok(payload(render_body(&latest, shape)))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Pipeline {
+    #[serde(default)]
+    status: String,
+    #[serde(default, rename = "ref")]
+    branch: Option<String>,
+    #[serde(default)]
+    sha: Option<String>,
+    #[serde(default)]
+    duration: Option<u64>,
+}
+
+fn render_body(p: &Pipeline, shape: Shape) -> Body {
+    let (status, label_word) = classify(&p.status);
+    let branch = p.branch.as_deref().unwrap_or("?");
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: format!("{branch} · {label_word}"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("status", Some(status), label_word),
+                entry("branch", None, branch),
+                entry("sha", None, &short_sha(p.sha.as_deref())),
+                entry("duration", None, &format_duration(p.duration)),
+            ],
+        }),
+        _ => Body::Badge(BadgeData {
+            status,
+            label: format!("{branch} · {label_word}"),
+        }),
+    }
+}
+
+fn classify(raw: &str) -> (Status, &'static str) {
+    match raw {
+        "success" => (Status::Ok, "passing"),
+        "failed" => (Status::Error, "failing"),
+        "canceled" => (Status::Warn, "cancelled"),
+        "skipped" => (Status::Warn, "skipped"),
+        "manual" => (Status::Warn, "manual"),
+        "running" | "pending" | "created" | "waiting_for_resource" | "preparing" => {
+            (Status::Warn, "running")
+        }
+        _ => (Status::Warn, "unknown"),
+    }
+}
+
+fn entry(key: &str, status: Option<Status>, value: &str) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.into()),
+        status,
+    }
+}
+
+fn short_sha(sha: Option<&str>) -> String {
+    sha.unwrap_or("?").chars().take(8).collect::<String>()
+}
+
+fn format_duration(seconds: Option<u64>) -> String {
+    let Some(s) = seconds else {
+        return "?".into();
+    };
+    let m = s / 60;
+    let r = s % 60;
+    if m == 0 {
+        format!("{r}s")
+    } else {
+        format!("{m}m {r:02}s")
+    }
+}
+
+fn cache_extra(ctx: &FetchContext) -> String {
+    let host = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("host"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(default_host())
+        .to_string();
+    let project = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("project"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .or_else(|| {
+            resolve_project(None, &host)
+                .ok()
+                .map(|p: ProjectPath| p.as_str().to_string())
+        })
+        .unwrap_or_default();
+    let branch = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("branch"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    format!("{host}|{project}|{branch}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pipeline(status: &str) -> Pipeline {
+        Pipeline {
+            status: status.into(),
+            branch: Some("main".into()),
+            sha: Some("abc123def456".into()),
+            duration: Some(192),
+        }
+    }
+
+    #[test]
+    fn options_deserialize_all_fields() {
+        let opts: Options =
+            toml::from_str("host = \"git.example.org\"\nproject = \"g/p\"\nbranch = \"main\"")
+                .unwrap();
+        assert_eq!(opts.host.as_deref(), Some("git.example.org"));
+        assert_eq!(opts.project.as_deref(), Some("g/p"));
+        assert_eq!(opts.branch.as_deref(), Some("main"));
+        assert!(toml::from_str::<Options>("bogus = 1").is_err());
+    }
+
+    #[test]
+    fn shapes_table_lists_the_three_supported_variants() {
+        let fetcher = GitlabPipelineStatus;
+        assert_eq!(
+            fetcher.shapes(),
+            &[Shape::Badge, Shape::Text, Shape::Entries]
+        );
+        assert_eq!(fetcher.default_shape(), Shape::Badge);
+    }
+
+    #[test]
+    fn classify_maps_each_documented_state() {
+        for (raw, expected) in [
+            ("success", Status::Ok),
+            ("failed", Status::Error),
+            ("canceled", Status::Warn),
+            ("skipped", Status::Warn),
+            ("manual", Status::Warn),
+            ("running", Status::Warn),
+            ("pending", Status::Warn),
+            ("created", Status::Warn),
+            ("waiting_for_resource", Status::Warn),
+            ("preparing", Status::Warn),
+            ("totally_unknown", Status::Warn),
+        ] {
+            assert_eq!(classify(raw).0, expected, "raw={raw}");
+        }
+    }
+
+    #[test]
+    fn render_badge_uses_branch_and_label_word() {
+        let Body::Badge(b) = render_body(&pipeline("success"), Shape::Badge) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "main · passing");
+    }
+
+    #[test]
+    fn render_text_falls_back_to_question_mark_for_missing_branch() {
+        let mut p = pipeline("success");
+        p.branch = None;
+        let Body::Text(t) = render_body(&p, Shape::Text) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "? · passing");
+    }
+
+    #[test]
+    fn render_entries_carries_status_branch_sha_duration() {
+        let Body::Entries(e) = render_body(&pipeline("failed"), Shape::Entries) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "status");
+        assert_eq!(e.items[0].status, Some(Status::Error));
+        assert_eq!(e.items[0].value.as_deref(), Some("failing"));
+        assert_eq!(e.items[2].value.as_deref(), Some("abc123de"));
+        assert_eq!(e.items[3].value.as_deref(), Some("3m 12s"));
+    }
+
+    #[test]
+    fn short_sha_truncates_long_hexes_and_falls_back() {
+        assert_eq!(short_sha(Some("abcdef1234567890")), "abcdef12");
+        assert_eq!(short_sha(None), "?");
+    }
+
+    #[test]
+    fn format_duration_renders_seconds_only_or_minutes_seconds() {
+        assert_eq!(format_duration(Some(45)), "45s");
+        assert_eq!(format_duration(Some(192)), "3m 12s");
+        assert_eq!(format_duration(Some(60)), "1m 00s");
+        assert_eq!(format_duration(None), "?");
+    }
+
+    #[test]
+    fn sample_entries_carries_the_four_rollup_rows() {
+        let Some(Body::Entries(e)) = GitlabPipelineStatus.sample_body(Shape::Entries) else {
+            panic!("expected entries");
+        };
+        let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(keys, vec!["status", "branch", "sha", "duration"]);
+    }
+}

--- a/src/fetcher/gitlab/pipeline_status.rs
+++ b/src/fetcher/gitlab/pipeline_status.rs
@@ -106,12 +106,29 @@ impl Fetcher for GitlabPipelineStatus {
         let pipelines: Vec<Pipeline> = rest_get(&host, &path).await?;
         let shape = ctx.shape.unwrap_or(Shape::Badge);
         let Some(latest) = pipelines.into_iter().next() else {
-            return Ok(payload(Body::Badge(BadgeData {
-                status: Status::Warn,
-                label: "no runs".into(),
-            })));
+            return Ok(payload(no_runs_body(shape)));
         };
         Ok(payload(render_body(&latest, shape)))
+    }
+}
+
+fn no_runs_body(shape: Shape) -> Body {
+    match shape {
+        Shape::Text => Body::Text(TextData {
+            value: "no runs".into(),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("status", Some(Status::Warn), "no runs"),
+                entry("branch", None, "?"),
+                entry("sha", None, "?"),
+                entry("duration", None, "?"),
+            ],
+        }),
+        _ => Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: "no runs".into(),
+        }),
     }
 }
 
@@ -313,6 +330,26 @@ mod tests {
         assert_eq!(format_duration(Some(192)), "3m 12s");
         assert_eq!(format_duration(Some(60)), "1m 00s");
         assert_eq!(format_duration(None), "?");
+    }
+
+    #[test]
+    fn no_runs_body_respects_each_advertised_shape() {
+        // Empty pipeline list used to always degrade to Badge regardless of `ctx.shape`,
+        // breaking shape consistency for Text / Entries consumers.
+        let Body::Badge(b) = no_runs_body(Shape::Badge) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "no runs");
+        let Body::Text(t) = no_runs_body(Shape::Text) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "no runs");
+        let Body::Entries(e) = no_runs_body(Shape::Entries) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 4);
+        assert_eq!(e.items[0].value.as_deref(), Some("no runs"));
+        assert_eq!(e.items[0].status, Some(Status::Warn));
     }
 
     #[test]

--- a/src/fetcher/gitlab/repo_issues.rs
+++ b/src/fetcher/gitlab/repo_issues.rs
@@ -1,0 +1,167 @@
+//! `gitlab_repo_issues` — open issues against one specific GitLab project.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{default_host, rest_get};
+use super::common::{ProjectPath, cache_key, parse_options, payload, resolve_project};
+use super::items::{GitlabIssueLike, sample_rows, to_forge_rows};
+use super::my_mrs::resolve_host;
+
+const DEFAULT_LIMIT: u32 = 10;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "host",
+        type_hint: "hostname",
+        required: false,
+        default: Some("gitlab.com"),
+        description: "GitLab instance host. Use this for self-hosted GitLab.",
+    },
+    OptionSchema {
+        name: "project",
+        type_hint: "\"group/name\" or \"group/sub/name\"",
+        required: false,
+        default: Some("git remote of cwd"),
+        description: "Project to query. Falls back to the current directory's GitLab remote.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of issues to show.",
+    },
+];
+
+pub struct GitlabRepoIssues;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for GitlabRepoIssues {
+    fn name(&self) -> &str {
+        "gitlab_repo_issues"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Open issues against one specific GitLab project. Mirrors `github_repo_issues` for GitLab."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 10
+    }
+    fn shapes(&self) -> &[Shape] {
+        LIST_SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx, &cache_extra(ctx))
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        let rows = sample_rows(&[
+            (
+                "#75",
+                "Heatmap renderer eats narrow columns",
+                Some("https://gitlab.com/g/splashboard/-/issues/75"),
+                3,
+                1_774_000_000,
+            ),
+            (
+                "#71",
+                "gitlab_pipeline_status: respect branch option",
+                Some("https://gitlab.com/g/splashboard/-/issues/71"),
+                1,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open issue", "open issues")
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let host = resolve_host(opts.host.as_deref())?;
+        let project = resolve_project(opts.project.as_deref(), &host)?;
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
+        let path = format!(
+            "/projects/{}/issues?state=opened&per_page={limit}&order_by=updated_at",
+            project.encoded()
+        );
+        let items: Vec<GitlabIssueLike> = rest_get(&host, &path).await?;
+        let rows = to_forge_rows(&items, false);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open issue", "open issues").await;
+        Ok(payload(body))
+    }
+}
+
+fn cache_extra(ctx: &FetchContext) -> String {
+    let host = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("host"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(default_host())
+        .to_string();
+    let project = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("project"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .or_else(|| {
+            resolve_project(None, &host)
+                .ok()
+                .map(|p: ProjectPath| p.as_str().to_string())
+        })
+        .unwrap_or_default();
+    format!("{host}|{project}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_deserialize_and_reject_unknown_keys() {
+        let opts: Options =
+            toml::from_str("host = \"git.example.org\"\nproject = \"g/p\"\nlimit = 3").unwrap();
+        assert_eq!(opts.host.as_deref(), Some("git.example.org"));
+        assert_eq!(opts.project.as_deref(), Some("g/p"));
+        assert_eq!(opts.limit, Some(3));
+        assert!(toml::from_str::<Options>("bogus = 1").is_err());
+    }
+
+    #[test]
+    fn shapes_table_matches_shared_list() {
+        let fetcher = GitlabRepoIssues;
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+    }
+
+    #[test]
+    fn sample_body_covers_every_list_shape() {
+        let fetcher = GitlabRepoIssues;
+        for shape in LIST_SHAPES {
+            assert!(fetcher.sample_body(*shape).is_some(), "missing {shape:?}");
+        }
+    }
+}

--- a/src/fetcher/gitlab/repo_mrs.rs
+++ b/src/fetcher/gitlab/repo_mrs.rs
@@ -1,0 +1,201 @@
+//! `gitlab_repo_mrs` — open merge requests against one specific GitLab project. Falls back to
+//! the git remote of the cwd when `project` is unset.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{default_host, rest_get};
+use super::common::{ProjectPath, cache_key, parse_options, payload, resolve_project};
+use super::items::{GitlabIssueLike, sample_rows, to_forge_rows};
+use super::my_mrs::resolve_host;
+
+const DEFAULT_LIMIT: u32 = 10;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "host",
+        type_hint: "hostname",
+        required: false,
+        default: Some("gitlab.com"),
+        description: "GitLab instance host. Use this for self-hosted GitLab.",
+    },
+    OptionSchema {
+        name: "project",
+        type_hint: "\"group/name\" or \"group/sub/name\"",
+        required: false,
+        default: Some("git remote of cwd"),
+        description: "Project to query. Falls back to the current directory's GitLab remote.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of MRs to show.",
+    },
+];
+
+pub struct GitlabRepoMrs;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for GitlabRepoMrs {
+    fn name(&self) -> &str {
+        "gitlab_repo_mrs"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Open merge requests against one specific GitLab project. Use `gitlab_my_mrs` instead for MRs you authored across every project."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 10
+    }
+    fn shapes(&self) -> &[Shape] {
+        LIST_SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx, &cache_extra(ctx))
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        let rows = sample_rows(&[
+            (
+                "!54",
+                "feat(docs): generate widget catalogue",
+                Some("https://gitlab.com/g/splashboard/-/merge_requests/54"),
+                7,
+                1_774_000_000,
+            ),
+            (
+                "!51",
+                "feat(fetcher): split clock options",
+                Some("https://gitlab.com/g/splashboard/-/merge_requests/51"),
+                2,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "open MR", "open MRs")
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let host = resolve_host(opts.host.as_deref())?;
+        let project = resolve_project(opts.project.as_deref(), &host)?;
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
+        let path = format!(
+            "/projects/{}/merge_requests?state=opened&per_page={limit}&order_by=updated_at",
+            project.encoded()
+        );
+        let items: Vec<GitlabIssueLike> = rest_get(&host, &path).await?;
+        let rows = to_forge_rows(&items, false);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "open MR", "open MRs").await;
+        Ok(payload(body))
+    }
+}
+
+fn cache_extra(ctx: &FetchContext) -> String {
+    let host = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("host"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(default_host())
+        .to_string();
+    let project = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("project"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .or_else(|| {
+            resolve_project(None, &host)
+                .ok()
+                .map(|p: ProjectPath| p.as_str().to_string())
+        })
+        .unwrap_or_default();
+    format!("{host}|{project}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn options_deserialize_and_reject_unknown_keys() {
+        let opts: Options =
+            toml::from_str("host = \"git.example.org\"\nproject = \"g/p\"\nlimit = 3").unwrap();
+        assert_eq!(opts.host.as_deref(), Some("git.example.org"));
+        assert_eq!(opts.project.as_deref(), Some("g/p"));
+        assert_eq!(opts.limit, Some(3));
+        assert!(toml::from_str::<Options>("bogus = 1").is_err());
+    }
+
+    #[test]
+    fn shapes_table_matches_shared_list() {
+        let fetcher = GitlabRepoMrs;
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+    }
+
+    #[test]
+    fn sample_body_covers_every_list_shape() {
+        let fetcher = GitlabRepoMrs;
+        for shape in LIST_SHAPES {
+            assert!(fetcher.sample_body(*shape).is_some(), "missing {shape:?}");
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn cache_key_changes_with_project_option() {
+        let fetcher = GitlabRepoMrs;
+        let a = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/c\"").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_project_before_network_request() {
+        let err = GitlabRepoMrs
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("project = \"not a path\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid project option")
+        ));
+    }
+}

--- a/src/fetcher/gitlab/repo_stars.rs
+++ b/src/fetcher/gitlab/repo_stars.rs
@@ -1,0 +1,282 @@
+//! `gitlab_repo_stars` — stargazer count + forks / open-issues rollup for one GitLab project.
+//! GitLab has no separate "watchers" concept, so the `watchers` row that ships with
+//! `github_repo_stars` is omitted here.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status,
+    TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{default_host, rest_get};
+use super::common::{ProjectPath, cache_key, parse_options, payload, resolve_project};
+use super::my_mrs::resolve_host;
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "host",
+        type_hint: "hostname",
+        required: false,
+        default: Some("gitlab.com"),
+        description: "GitLab instance host. Use this for self-hosted GitLab.",
+    },
+    OptionSchema {
+        name: "project",
+        type_hint: "\"group/name\" or \"group/sub/name\"",
+        required: false,
+        default: Some("git remote of cwd"),
+        description: "Project to query. Falls back to the current directory's GitLab remote.",
+    },
+];
+
+pub struct GitlabRepoStars;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for GitlabRepoStars {
+    fn name(&self) -> &str {
+        "gitlab_repo_stars"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Social counters for a GitLab project: stargazers, forks, and open-issue count. GitLab has no separate watchers count, so that row is omitted relative to the GitHub sibling."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx, &cache_extra(ctx))
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        if !SHAPES.contains(&shape) {
+            return None;
+        }
+        let info = ProjectInfo {
+            star_count: 142,
+            forks_count: 9,
+            open_issues_count: 7,
+        };
+        Some(render_body(&info, shape))
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let host = resolve_host(opts.host.as_deref())?;
+        let project = resolve_project(opts.project.as_deref(), &host)?;
+        let path = format!("/projects/{}", project.encoded());
+        let info: ProjectInfo = rest_get(&host, &path).await?;
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+        Ok(payload(render_body(&info, shape)))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectInfo {
+    #[serde(default)]
+    star_count: u64,
+    #[serde(default)]
+    forks_count: u64,
+    #[serde(default)]
+    open_issues_count: u64,
+}
+
+fn render_body(info: &ProjectInfo, shape: Shape) -> Body {
+    match shape {
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: vec![
+                format!("★ {}", info.star_count),
+                format!("🍴 {}", info.forks_count),
+                format!("🔓 {}", info.open_issues_count),
+            ],
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: format!(
+                "- **★ stars** {}\n- **🍴 forks** {}\n- **🔓 open issues** {}",
+                info.star_count, info.forks_count, info.open_issues_count
+            ),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vec![
+                entry("stars", info.star_count),
+                entry("forks", info.forks_count),
+                entry("open_issues", info.open_issues_count),
+            ],
+        }),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "stars".into(),
+                    value: info.star_count,
+                },
+                Bar {
+                    label: "forks".into(),
+                    value: info.forks_count,
+                },
+                Bar {
+                    label: "open_issues".into(),
+                    value: info.open_issues_count,
+                },
+            ],
+        }),
+        Shape::Badge => Body::Badge(BadgeData {
+            status: Status::Ok,
+            label: format!("★ {}", info.star_count),
+        }),
+        _ => Body::Text(TextData {
+            value: format!("★ {}", info.star_count),
+        }),
+    }
+}
+
+fn entry(key: &str, value: u64) -> Entry {
+    Entry {
+        key: key.into(),
+        value: Some(value.to_string()),
+        status: None,
+    }
+}
+
+fn cache_extra(ctx: &FetchContext) -> String {
+    let host = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("host"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(default_host())
+        .to_string();
+    let project = ctx
+        .options
+        .as_ref()
+        .and_then(|v| v.get("project"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .or_else(|| {
+            resolve_project(None, &host)
+                .ok()
+                .map(|p: ProjectPath| p.as_str().to_string())
+        })
+        .unwrap_or_default();
+    format!("{host}|{project}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_deserialize_both_fields() {
+        let opts: Options =
+            toml::from_str("host = \"git.example.org\"\nproject = \"g/p\"").unwrap();
+        assert_eq!(opts.host.as_deref(), Some("git.example.org"));
+        assert_eq!(opts.project.as_deref(), Some("g/p"));
+        assert!(toml::from_str::<Options>("bogus = 1").is_err());
+    }
+
+    #[test]
+    fn shapes_table_lists_the_six_supported_variants() {
+        let fetcher = GitlabRepoStars;
+        assert_eq!(
+            fetcher.shapes(),
+            &[
+                Shape::Text,
+                Shape::TextBlock,
+                Shape::MarkdownTextBlock,
+                Shape::Entries,
+                Shape::Bars,
+                Shape::Badge,
+            ]
+        );
+        assert_eq!(fetcher.default_shape(), Shape::Text);
+    }
+
+    #[test]
+    fn sample_text_carries_the_star_count_headline() {
+        let Some(Body::Text(t)) = GitlabRepoStars.sample_body(Shape::Text) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "★ 142");
+    }
+
+    #[test]
+    fn sample_entries_drops_the_watchers_row() {
+        let Some(Body::Entries(e)) = GitlabRepoStars.sample_body(Shape::Entries) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 3);
+        let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(keys, vec!["stars", "forks", "open_issues"]);
+        assert!(!keys.contains(&"watchers"));
+    }
+
+    #[test]
+    fn sample_bars_value_matches_counts() {
+        let Some(Body::Bars(b)) = GitlabRepoStars.sample_body(Shape::Bars) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].value, 142);
+        assert_eq!(b.bars[1].value, 9);
+        assert_eq!(b.bars[2].value, 7);
+    }
+
+    #[test]
+    fn sample_badge_is_calm_ok_status_for_pure_info() {
+        let Some(Body::Badge(b)) = GitlabRepoStars.sample_body(Shape::Badge) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "★ 142");
+    }
+
+    #[test]
+    fn sample_markdown_uses_bullet_list_with_bold_labels() {
+        let Some(Body::MarkdownTextBlock(m)) =
+            GitlabRepoStars.sample_body(Shape::MarkdownTextBlock)
+        else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("- **★ stars** 142"));
+        assert!(m.value.contains("- **🍴 forks** 9"));
+    }
+
+    #[test]
+    fn render_body_falls_back_to_text_for_unknown_shapes() {
+        let info = ProjectInfo {
+            star_count: 5,
+            forks_count: 0,
+            open_issues_count: 0,
+        };
+        let Body::Text(t) = render_body(&info, Shape::Ratio) else {
+            panic!("expected text fallback");
+        };
+        assert_eq!(t.value, "★ 5");
+    }
+}

--- a/src/fetcher/gitlab/review_requests.rs
+++ b/src/fetcher/gitlab/review_requests.rs
@@ -1,0 +1,166 @@
+//! `gitlab_review_requests` — open MRs where the authenticated GitLab user is a reviewer.
+//! Resolves `@me` to a username via `/api/v4/user` (cached per host) and then queries
+//! `/api/v4/merge_requests?reviewer_username=<me>&state=opened`.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::forge_items::{self, LIST_SHAPES};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::client::{resolve_authenticated_username, rest_get};
+use super::common::{cache_key, parse_options, payload};
+use super::items::{GitlabIssueLike, sample_rows, to_forge_rows};
+use super::my_mrs::resolve_host;
+
+const DEFAULT_LIMIT: u32 = 10;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "host",
+        type_hint: "hostname",
+        required: false,
+        default: Some("gitlab.com"),
+        description: "GitLab instance host. Use this for self-hosted GitLab.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=30)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of MRs to show.",
+    },
+];
+
+pub struct GitlabReviewRequests;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for GitlabReviewRequests {
+    fn name(&self) -> &str {
+        "gitlab_review_requests"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Open merge requests where the authenticated GitLab user is a reviewer. Mirror of `github_review_requests` for GitLab."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 5
+    }
+    fn shapes(&self) -> &[Shape] {
+        LIST_SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx, &host_for_key(ctx))
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        let rows = sample_rows(&[
+            (
+                "g/splashboard!54",
+                "feat(docs): generate widget catalogue",
+                Some("https://gitlab.com/g/splashboard/-/merge_requests/54"),
+                7,
+                1_774_000_000,
+            ),
+            (
+                "other/proj!12",
+                "fix(auth): rotate session token",
+                Some("https://gitlab.com/other/proj/-/merge_requests/12"),
+                1,
+                1_773_800_000,
+            ),
+        ]);
+        forge_items::dispatch_sample(&rows, shape, "to review", "to review")
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let host = resolve_host(opts.host.as_deref())?;
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, 30);
+        let username = resolve_authenticated_username(&host).await?;
+        let path = format!(
+            "/merge_requests?reviewer_username={username}&state=opened&per_page={limit}&order_by=updated_at"
+        );
+        let items: Vec<GitlabIssueLike> = rest_get(&host, &path).await?;
+        let rows = to_forge_rows(&items, true);
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+        let body = forge_items::dispatch_rows_async(rows, shape, "to review", "to review").await;
+        Ok(payload(body))
+    }
+}
+
+fn host_for_key(ctx: &FetchContext) -> String {
+    ctx.options
+        .as_ref()
+        .and_then(|v| v.get("host"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(super::client::default_host())
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{BadgeData, Status};
+
+    #[test]
+    fn options_deserialize_and_reject_unknown_keys() {
+        let opts: Options = toml::from_str("host = \"git.example.org\"\nlimit = 3").unwrap();
+        assert_eq!(opts.host.as_deref(), Some("git.example.org"));
+        assert_eq!(opts.limit, Some(3));
+        assert!(toml::from_str::<Options>("bogus = 1").is_err());
+    }
+
+    #[test]
+    fn shapes_table_matches_shared_list() {
+        let fetcher = GitlabReviewRequests;
+        assert_eq!(fetcher.shapes(), LIST_SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        assert_eq!(fetcher.safety(), Safety::Safe);
+    }
+
+    #[test]
+    fn sample_badge_uses_to_review_noun_without_pluralising() {
+        let Some(Body::Badge(BadgeData { status, label })) =
+            GitlabReviewRequests.sample_body(Shape::Badge)
+        else {
+            panic!("expected badge");
+        };
+        assert_eq!(status, Status::Warn);
+        assert_eq!(label, "2 to review");
+    }
+
+    #[test]
+    fn sample_body_covers_every_list_shape() {
+        let fetcher = GitlabReviewRequests;
+        for shape in LIST_SHAPES {
+            assert!(fetcher.sample_body(*shape).is_some(), "missing {shape:?}");
+        }
+    }
+
+    #[test]
+    fn cache_key_changes_with_host() {
+        let fetcher = GitlabReviewRequests;
+        let a = fetcher.cache_key(&FetchContext::default());
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.example.org\"").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(a, b);
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -24,6 +24,7 @@ pub mod feed;
 pub mod forge_items;
 pub mod git;
 pub mod github;
+pub mod gitlab;
 pub mod hackernews;
 pub mod huggingface_trending;
 pub mod linear;
@@ -397,6 +398,9 @@ impl Registry {
             r.register(f);
         }
         for f in github::fetchers() {
+            r.register(f);
+        }
+        for f in gitlab::fetchers() {
             r.register(f);
         }
         for f in code::fetchers() {

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -21,6 +21,7 @@ pub mod crypto_watchlist;
 pub mod deal;
 pub mod deariary;
 pub mod feed;
+pub mod forge_items;
 pub mod git;
 pub mod github;
 pub mod hackernews;


### PR DESCRIPTION
## Summary

Adds the `gitlab_*` forge family so the per-dir killer feature works on
GitLab repos the same way it does on GitHub, and brings the existing
`github_*` family up to the current shape-coverage convention (8 list
shapes + count badge for list fetchers).

### New fetchers (`Safety::Safe`)

| name | shapes | mirror of |
|---|---|---|
| `gitlab_my_mrs` | 9 | `github_my_prs` |
| `gitlab_review_requests` | 9 | `github_review_requests` |
| `gitlab_repo_mrs` | 9 | `github_repo_prs` |
| `gitlab_repo_issues` | 9 | `github_repo_issues` |
| `gitlab_repo_stars` | 6 | `github_repo_stars` (no `watchers` row, GitLab has no equivalent) |
| `gitlab_pipeline_status` | 3 | `github_action_status` |

Self-hosted GitLab via `host` option; default `gitlab.com`. Host is
validated (hostname-only allowlist) before any auth header leaves the
process, matching the `project_trust_model` rule.

Auth: `GITLAB_TOKEN` env var. PAT needs `read_api` scope for user-scope
queries (`gitlab_my_mrs`, `gitlab_review_requests`); public project
queries (`gitlab_repo_*`, `gitlab_pipeline_status`) are scope-tolerant.

`ProjectPath` accepts arbitrarily nested groups (`group/sub/proj`) and
requires at least two segments so a typo like `group/` fails fast
instead of generating a 404 at the API.

### Shared row model

`src/fetcher/forge_items.rs` carries the `ForgeRow` row struct and the
nine-shape dispatcher used by both forge families. Adding a new shape
variant or label convention now lights up on github and gitlab
simultaneously.

### Extended `github_*` shape coverage

| fetcher | before | after |
|---|---|---|
| `github_my_prs`, `github_review_requests`, `github_assigned_issues`, `github_repo_prs`, `github_repo_issues` | 4 (LinkedTextBlock / TextBlock / Entries / Timeline) | 9 (+ Text / MarkdownTextBlock / ImageLinkedList / Bars / Badge) |
| `github_repo_stars` | 2 (Text / Entries) | 6 (+ TextBlock / MarkdownTextBlock / Bars / Badge) |
| `github_action_status` | 2 (Badge / Text) | 3 (+ Entries) |

Note: the `Entries` key convention for list fetchers changes from `"splashboard #54"` to `"unhappychoice/splashboard#54"` to keep the row label consistent across every shape. Repo-scope fetchers (`github_repo_prs/issues`) already used `#54` and stay unchanged.

## Test plan

- `cargo test --lib`: 2707 pass / 0 fail / 17 ignored
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Manual smoke test on gitlab.com against the `gitlab-org/gitlab`
  project: `gitlab_repo_mrs` (Timeline), `gitlab_repo_issues` (Bars),
  `gitlab_repo_stars` (Entries / Bars / Badge),
  `gitlab_pipeline_status` (Badge / Entries) all render the expected
  shapes. User-scope `gitlab_my_mrs` / `gitlab_review_requests` confirmed
  to surface `403 insufficient_granular_scope` for a PAT without
  `read_api`, demonstrating the placeholder path.
- GitHub extensions verified against `unhappychoice/splashboard`:
  Bars / Badge / ImageLinkedList / MarkdownTextBlock all paint.

## Catalog ticks

Ticks the six checkboxes under `gitlab_*` in #63 once this lands. Also
contributes the broader shape coverage hinted at in #41's "shapes are
the only coupling" rule by making the two forge families produce
structurally identical output for every shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitLab support with new fetchers for merge requests, issues, stars, and pipeline status.
  * Expanded output shapes for GitHub fetchers, enabling additional formatting options (Entries, Bars, Timeline).
  * Added activity indicators (comment/interaction counts) to GitHub issue and pull request listings.

* **Refactor**
  * Consolidated rendering pipeline for list-based outputs across GitHub and GitLab fetchers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->