### PR TITLE
feat(shell): add Nushell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ echo 'eval "$(splashboard init zsh)"'                              >> ~/.zshrc
 echo 'eval "$(splashboard init bash)"'                             >> ~/.bashrc
 echo 'splashboard init fish | source'                              >> ~/.config/fish/config.fish
 echo 'Invoke-Expression (& splashboard init powershell | Out-String)' >> $PROFILE
+splashboard init nushell | save --append ~/.config/nushell/config.nu
 ```
 
 ## Docs

--- a/docs-site/src/content/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/guides/getting-started.md
@@ -130,6 +130,7 @@ echo 'eval "$(splashboard init zsh)"'                              >> ~/.zshrc
 echo 'eval "$(splashboard init bash)"'                             >> ~/.bashrc
 echo 'splashboard init fish | source'                              >> ~/.config/fish/config.fish
 echo 'Invoke-Expression (& splashboard init powershell | Out-String)' >> $PROFILE
+splashboard init nushell | save --append ~/.config/nushell/config.nu
 ```
 
 ## The first splash

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -171,7 +171,7 @@ fn resolve_shell(override_shell: Option<Shell>) -> io::Result<Shell> {
     }
     Err(io::Error::new(
         io::ErrorKind::InvalidInput,
-        "could not detect your shell — pass --shell <bash|zsh|fish|powershell>",
+        "could not detect your shell — pass --shell <bash|zsh|fish|powershell|nushell>",
     ))
 }
 

--- a/src/install/rc.rs
+++ b/src/install/rc.rs
@@ -154,10 +154,14 @@ fn find_block(contents: &str) -> Option<(usize, usize)> {
 }
 
 fn format_block(shell: Shell) -> String {
+    // `trim_end_matches('\n')` keeps spacing consistent for shells whose source_line is
+    // a single inline command (no trailing newline) and the Nushell case where it's the
+    // full snippet from `include_str!` (always terminated with `\n`) — without trimming
+    // the latter would leave a blank line before the close marker.
     format!(
         "{open}\n# Added by `splashboard install`. Safe to remove.\n{line}\n{close}\n",
         open = MARKER_OPEN,
-        line = shell::source_line(shell),
+        line = shell::source_line(shell).trim_end_matches('\n'),
         close = MARKER_CLOSE,
     )
 }
@@ -264,6 +268,9 @@ trailing\n"
         assert!(contents.contains("env_change.PWD"));
         assert!(contents.contains("^splashboard"));
         assert_eq!(contents.matches(MARKER_OPEN).count(), 1);
+        // No blank line between the last snippet line and the close marker — the snippet
+        // is sourced from a file that always ends in `\n`, so format_block must trim it.
+        assert!(contents.contains(&format!("^splashboard\n{MARKER_CLOSE}")));
 
         let up_to_date = wire_shell_rc(Shell::Nushell, Some(rc.clone())).unwrap();
         assert_eq!(up_to_date.action, RcAction::UpToDate);

--- a/src/install/rc.rs
+++ b/src/install/rc.rs
@@ -248,6 +248,27 @@ trailing\n"
         assert!(rc.exists());
     }
 
+    /// Nushell can't use the eval-on-startup indirection the POSIX shells use, so the
+    /// marker block embeds the full snippet inline. Re-running install must still
+    /// replace the block in place rather than appending a second copy.
+    #[test]
+    fn wire_shell_rc_embeds_nushell_snippet_inline_and_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let rc = dir.path().join("config.nu");
+        std::fs::write(&rc, "# user config\n").unwrap();
+
+        let appended = wire_shell_rc(Shell::Nushell, Some(rc.clone())).unwrap();
+        assert_eq!(appended.action, RcAction::Appended);
+        let contents = std::fs::read_to_string(&rc).unwrap();
+        assert!(contents.starts_with("# user config\n"));
+        assert!(contents.contains("env_change.PWD"));
+        assert!(contents.contains("^splashboard"));
+        assert_eq!(contents.matches(MARKER_OPEN).count(), 1);
+
+        let up_to_date = wire_shell_rc(Shell::Nushell, Some(rc.clone())).unwrap();
+        assert_eq!(up_to_date.action, RcAction::UpToDate);
+    }
+
     #[test]
     fn wire_shell_rc_appends_replaces_and_skips_when_current() {
         let dir = tempdir().unwrap();

--- a/src/install/rc.rs
+++ b/src/install/rc.rs
@@ -154,14 +154,15 @@ fn find_block(contents: &str) -> Option<(usize, usize)> {
 }
 
 fn format_block(shell: Shell) -> String {
-    // `trim_end_matches('\n')` keeps spacing consistent for shells whose source_line is
-    // a single inline command (no trailing newline) and the Nushell case where it's the
-    // full snippet from `include_str!` (always terminated with `\n`) — without trimming
-    // the latter would leave a blank line before the close marker.
+    // Trim both `\n` and `\r` so the spacing stays consistent for shells whose source_line
+    // is a single inline command (no trailing newline) and the Nushell case where it's the
+    // full snippet from `include_str!` (always terminated with `\n`, plus a `\r` on Windows
+    // CI where git autocrlf converts the snippet file). Without this the close marker ends
+    // up on its own line below a blank one.
     format!(
         "{open}\n# Added by `splashboard install`. Safe to remove.\n{line}\n{close}\n",
         open = MARKER_OPEN,
-        line = shell::source_line(shell).trim_end_matches('\n'),
+        line = shell::source_line(shell).trim_end_matches(['\n', '\r']),
         close = MARKER_CLOSE,
     )
 }
@@ -268,9 +269,16 @@ trailing\n"
         assert!(contents.contains("env_change.PWD"));
         assert!(contents.contains("^splashboard"));
         assert_eq!(contents.matches(MARKER_OPEN).count(), 1);
-        // No blank line between the last snippet line and the close marker — the snippet
-        // is sourced from a file that always ends in `\n`, so format_block must trim it.
-        assert!(contents.contains(&format!("^splashboard\n{MARKER_CLOSE}")));
+        // No blank line between the last snippet line and the close marker. Uses
+        // `str::lines()` so the assertion works regardless of `\n` vs `\r\n` (Windows CI
+        // under git autocrlf converts the snippet file).
+        let lines: Vec<&str> = contents.lines().collect();
+        let close_idx = lines.iter().position(|l| l == &MARKER_CLOSE).unwrap();
+        assert_eq!(
+            lines[close_idx - 1],
+            "^splashboard",
+            "expected `^splashboard` immediately before close marker, lines: {lines:?}"
+        );
 
         let up_to_date = wire_shell_rc(Shell::Nushell, Some(rc.clone())).unwrap();
         assert_eq!(up_to_date.action, RcAction::UpToDate);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -193,6 +193,15 @@ mod tests {
     }
 
     #[test]
+    fn nushell_snippet_appends_pwd_env_change_hook() {
+        let s = init_snippet(Shell::Nushell);
+        assert!(s.contains("$env.config.hooks.env_change.PWD"));
+        // First-prompt firing (`$before == null`) must be skipped so we don't double-splash
+        // alongside the explicit startup `^splashboard` call below it.
+        assert!(s.contains("$before != null"));
+    }
+
+    #[test]
     fn all_snippets_guard_interactivity() {
         assert!(init_snippet(Shell::Bash).contains("$-"));
         assert!(init_snippet(Shell::Zsh).contains("interactive"));
@@ -201,7 +210,13 @@ mod tests {
 
     #[test]
     fn cd_hooks_call_on_cd_flag_not_bare_splash() {
-        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish, Shell::Powershell] {
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::Powershell,
+            Shell::Nushell,
+        ] {
             let s = init_snippet(shell);
             assert!(
                 s.contains("splashboard --on-cd"),
@@ -224,6 +239,14 @@ mod tests {
         assert_eq!(
             detect_shell(env_with(&[("SHELL", "/opt/homebrew/bin/fish")])),
             Some(Shell::Fish)
+        );
+        assert_eq!(
+            detect_shell(env_with(&[("SHELL", "/usr/local/bin/nu")])),
+            Some(Shell::Nushell)
+        );
+        assert_eq!(
+            detect_shell(env_with(&[("SHELL", "/opt/homebrew/bin/nushell")])),
+            Some(Shell::Nushell)
         );
     }
 
@@ -268,6 +291,8 @@ mod tests {
         assert!(rc.ends_with(".bashrc"));
         let rc = default_rc_path(Shell::Fish).unwrap();
         assert!(rc.ends_with("config.fish"));
+        let rc = default_rc_path(Shell::Nushell).unwrap();
+        assert!(rc.ends_with("config.nu"));
     }
 
     #[test]
@@ -276,6 +301,7 @@ mod tests {
         assert_eq!(Shell::Zsh.as_str(), "zsh");
         assert_eq!(Shell::Fish.as_str(), "fish");
         assert_eq!(Shell::Powershell.as_str(), "powershell");
+        assert_eq!(Shell::Nushell.as_str(), "nushell");
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -302,9 +328,26 @@ mod tests {
 
     #[test]
     fn source_line_covers_all_shells() {
-        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish, Shell::Powershell] {
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::Powershell,
+            Shell::Nushell,
+        ] {
             let line = source_line(shell);
             assert!(line.contains("splashboard"), "{:?}", shell);
         }
+    }
+
+    /// Nushell can't use the same eval-on-startup indirection, so `source_line` returns
+    /// the full snippet. The rc wiring layer then embeds it between the marker comments
+    /// directly; re-running `splashboard install` replaces the block in place.
+    #[test]
+    fn nushell_source_line_embeds_full_snippet() {
+        let line = source_line(Shell::Nushell);
+        assert_eq!(line, init_snippet(Shell::Nushell));
+        assert!(line.contains("env_change.PWD"));
+        assert!(line.contains("^splashboard"));
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -6,6 +6,7 @@ const BASH: &str = include_str!("shells/bash.sh");
 const ZSH: &str = include_str!("shells/zsh.sh");
 const FISH: &str = include_str!("shells/fish.fish");
 const POWERSHELL: &str = include_str!("shells/powershell.ps1");
+const NUSHELL: &str = include_str!("shells/nushell.nu");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum Shell {
@@ -13,6 +14,8 @@ pub enum Shell {
     Zsh,
     Fish,
     Powershell,
+    #[value(alias = "nu")]
+    Nushell,
 }
 
 impl Shell {
@@ -22,6 +25,7 @@ impl Shell {
             Shell::Zsh => "zsh",
             Shell::Fish => "fish",
             Shell::Powershell => "powershell",
+            Shell::Nushell => "nushell",
         }
     }
 }
@@ -32,6 +36,7 @@ pub fn init_snippet(shell: Shell) -> &'static str {
         Shell::Zsh => ZSH,
         Shell::Fish => FISH,
         Shell::Powershell => POWERSHELL,
+        Shell::Nushell => NUSHELL,
     }
 }
 
@@ -67,6 +72,7 @@ fn classify_shell_path(path: &str) -> Option<Shell> {
         "zsh" => Some(Shell::Zsh),
         "fish" => Some(Shell::Fish),
         "pwsh" | "powershell" => Some(Shell::Powershell),
+        "nu" | "nushell" => Some(Shell::Nushell),
         _ => None,
     }
 }
@@ -87,17 +93,27 @@ pub fn default_rc_path(shell: Shell) -> Option<PathBuf> {
             .join("Documents")
             .join("PowerShell")
             .join("Microsoft.PowerShell_profile.ps1"),
+        // Nushell's config can live elsewhere (`~/Library/Application Support/nushell/`
+        // on macOS, `%APPDATA%\nushell\` on Windows), but `~/.config/nushell/config.nu`
+        // is the documented default on Linux and works on macOS too. Users on other
+        // layouts pass `--rc-path` to `splashboard install`.
+        Shell::Nushell => home.join(".config").join("nushell").join("config.nu"),
     })
 }
 
 /// Source line appended inside the marker block; delegates to `splashboard init <shell>`
-/// so any snippet update lands automatically on next shell start.
+/// so any snippet update lands automatically on next shell start. Nushell is the odd
+/// one out: its `source` command requires a parse-time constant path, so we can't use
+/// the same eval-on-startup indirection. Instead `source_line` returns the snippet
+/// itself for Nushell, which `format_block` embeds verbatim between markers — re-running
+/// `splashboard install` rewrites the block in place when the snippet changes.
 pub fn source_line(shell: Shell) -> &'static str {
     match shell {
         Shell::Bash => "eval \"$(splashboard init bash)\"",
         Shell::Zsh => "eval \"$(splashboard init zsh)\"",
         Shell::Fish => "splashboard init fish | source",
         Shell::Powershell => "Invoke-Expression (& splashboard init powershell | Out-String)",
+        Shell::Nushell => NUSHELL,
     }
 }
 

--- a/src/shells/nushell.nu
+++ b/src/shells/nushell.nu
@@ -1,0 +1,10 @@
+# splashboard — render on new shell and on directory change
+$env.config = ($env.config? | default {})
+$env.config.hooks = ($env.config.hooks? | default {})
+$env.config.hooks.env_change = ($env.config.hooks.env_change? | default {})
+$env.config.hooks.env_change.PWD = (
+    $env.config.hooks.env_change.PWD?
+    | default []
+    | append {|before, after| if $before != null and $before != $after { ^splashboard --on-cd } }
+)
+^splashboard


### PR DESCRIPTION
Closes #246.

## Summary

Adds Nushell to the list of shells `splashboard install` / `splashboard init` understand, alongside bash, zsh, fish, and powershell.

- New `Shell::Nushell` variant, accepted by `--shell nushell` (also aliased as `nu`).
- New `src/shells/nushell.nu` snippet that:
  - Defensively builds out `$env.config.hooks.env_change.PWD` (handles missing intermediate keys, preserves any prior hooks).
  - Skips the first-prompt firing (`$before == null`) so the hook doesn't double-splash alongside the explicit startup `^splashboard` call.
- `detect_shell` maps `nu` / `nushell` basenames to `Shell::Nushell`.
- `default_rc_path` points at `~/.config/nushell/config.nu` (Linux default, works on macOS; Windows users pass `--rc-path`).
- `source_line` returns the snippet itself for Nushell, not the eval-on-startup one-liner the POSIX shells use, because Nushell's `source` command requires a parse-time constant path. The rc wiring layer embeds the snippet verbatim between the marker comments; re-running `splashboard install` replaces the block in place.
- Install error message + README + getting-started guide updated.

## Test plan

- `cargo test --lib` — green, including new Nushell-specific cases:
  - `nushell_snippet_appends_pwd_env_change_hook`
  - `nushell_source_line_embeds_full_snippet`
  - `wire_shell_rc_embeds_nushell_snippet_inline_and_is_idempotent`
  - existing exhaustive iterations (`cd_hooks_call_on_cd_flag_not_bare_splash`, `source_line_covers_all_shells`, `as_str_returns_cli_names_for_every_shell`, `default_rc_path_for_known_shells_ends_in_expected_file`) now cover Nushell.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

The one pre-existing `xtask` test failure (`snapshots::tests::representative_fetcher_prefers_documented_examples`) reproduces on `main` too, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nushell support: automatic initialization on startup and on-directory-change hooks; CLI now accepts nushell as a shell option.

* **Documentation**
  * Updated README and Getting Started with Nushell-specific installation instructions.

* **Bug Fixes**
  * Normalized startup snippet embedding to avoid duplicate or malformed marker blocks across platforms.

* **Tests**
  * Added idempotency tests to ensure Nushell wiring is applied exactly once.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->