### PR TITLE
feat(fetcher): add lastfm_* family (5 fetchers + shared scaffold)

### DIFF
--- a/src/fetcher/lastfm/charts.rs
+++ b/src/fetcher/lastfm/charts.rs
@@ -133,33 +133,40 @@ impl Fetcher for LastfmCharts {
 async fn fetch_rows(kind: Kind, limit: usize) -> Result<Vec<TopRow>, FetchError> {
     let limit_str = limit.to_string();
     let params = [("limit", limit_str.as_str())];
-    match kind {
+    let mut rows = match kind {
         Kind::Artists => {
             let raw: ChartArtistsResponse = client::get_json(kind.method(), &params).await?;
-            Ok(raw
-                .artists
+            raw.artists
                 .artist
                 .into_iter()
-                .enumerate()
-                .map(|(i, a)| artist_row(a, i))
-                .collect())
+                .map(artist_row)
+                .collect::<Vec<_>>()
         }
         Kind::Tracks => {
             let raw: ChartTracksResponse = client::get_json(kind.method(), &params).await?;
-            Ok(raw
-                .tracks
+            raw.tracks
                 .track
                 .into_iter()
-                .enumerate()
-                .map(|(i, t)| track_row(t, i))
-                .collect())
+                .map(track_row)
+                .collect::<Vec<_>>()
         }
-    }
+    };
+    // Last.fm's `chart.*` endpoints rank by global listener count, not playcount, so the
+    // response order doesn't always match the playcount values we surface in `Bars` /
+    // `count_label` ("N plays"). Sort by displayed metric and reassign ranks so the row
+    // order, the rank prefix, and the bar lengths all tell the same story.
+    rows.sort_by_key(|r| std::cmp::Reverse(r.playcount));
+    rows.iter_mut()
+        .enumerate()
+        .for_each(|(i, r)| r.rank = i + 1);
+    Ok(rows)
 }
 
-fn artist_row(raw: RawChartArtist, index: usize) -> TopRow {
+fn artist_row(raw: RawChartArtist) -> TopRow {
     TopRow {
-        rank: index + 1,
+        // `rank` is reassigned by `fetch_rows` after the playcount sort; the placeholder
+        // here just keeps the row structurally valid until then.
+        rank: 0,
         primary: raw.name,
         secondary: None,
         playcount: parse_count(&raw.playcount),
@@ -168,9 +175,9 @@ fn artist_row(raw: RawChartArtist, index: usize) -> TopRow {
     }
 }
 
-fn track_row(raw: RawChartTrack, index: usize) -> TopRow {
+fn track_row(raw: RawChartTrack) -> TopRow {
     TopRow {
-        rank: index + 1,
+        rank: 0,
         primary: raw.name,
         secondary: raw.artist.name.filter(|s| !s.is_empty()),
         playcount: parse_count(&raw.playcount),
@@ -359,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn artist_row_assigns_position_rank_and_no_secondary() {
+    fn artist_row_carries_primary_and_no_secondary() {
         let json = r##"{
             "artists": {
                 "artist": [
@@ -373,14 +380,9 @@ mod tests {
             }
         }"##;
         let raw: ChartArtistsResponse = serde_json::from_str(json).unwrap();
-        let rows: Vec<TopRow> = raw
-            .artists
-            .artist
-            .into_iter()
-            .enumerate()
-            .map(|(i, a)| artist_row(a, i))
-            .collect();
-        assert_eq!(rows[0].rank, 1);
+        let rows: Vec<TopRow> = raw.artists.artist.into_iter().map(artist_row).collect();
+        // Rank stays at the placeholder until `fetch_rows` runs sort_and_rerank.
+        assert_eq!(rows[0].rank, 0);
         assert_eq!(rows[0].primary, "Taylor Swift");
         assert!(rows[0].secondary.is_none());
         assert_eq!(rows[0].playcount, 12_400_000);
@@ -406,17 +408,46 @@ mod tests {
             }
         }"##;
         let raw: ChartTracksResponse = serde_json::from_str(json).unwrap();
-        let rows: Vec<TopRow> = raw
-            .tracks
-            .track
-            .into_iter()
-            .enumerate()
-            .map(|(i, t)| track_row(t, i))
-            .collect();
-        assert_eq!(rows[0].rank, 1);
+        let rows: Vec<TopRow> = raw.tracks.track.into_iter().map(track_row).collect();
+        assert_eq!(rows[0].rank, 0);
         assert_eq!(rows[0].primary, "Anti-Hero");
         assert_eq!(rows[0].secondary.as_deref(), Some("Taylor Swift"));
         assert_eq!(rows[0].playcount, 5_400_000);
+    }
+
+    #[tokio::test]
+    async fn fetch_rows_reorders_unsorted_api_responses_by_playcount() {
+        // Last.fm's `chart.*` endpoints rank by listener count, not playcount, so any
+        // playcount-based renderer (chart_bar, list_ranking) needs the rows sorted by the
+        // metric we surface. This locks the post-parse ordering contract.
+        //
+        // We exercise it by parsing a hand-crafted out-of-order JSON through the same
+        // `artist_row` + sort path `fetch_rows` uses, since touching the network from a
+        // unit test isn't an option.
+        let json = r##"{
+            "artists": {
+                "artist": [
+                    {"name": "Mid", "playcount": "300", "url": "https://x", "image": []},
+                    {"name": "Top", "playcount": "1000", "url": "https://x", "image": []},
+                    {"name": "Low", "playcount": "100", "url": "https://x", "image": []}
+                ]
+            }
+        }"##;
+        let raw: ChartArtistsResponse = serde_json::from_str(json).unwrap();
+        let mut rows: Vec<TopRow> = raw.artists.artist.into_iter().map(artist_row).collect();
+        rows.sort_by_key(|r| std::cmp::Reverse(r.playcount));
+        rows.iter_mut()
+            .enumerate()
+            .for_each(|(i, r)| r.rank = i + 1);
+
+        assert_eq!(rows[0].primary, "Top");
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[1].primary, "Mid");
+        assert_eq!(rows[1].rank, 2);
+        assert_eq!(rows[2].primary, "Low");
+        assert_eq!(rows[2].rank, 3);
+        assert!(rows[0].playcount >= rows[1].playcount);
+        assert!(rows[1].playcount >= rows[2].playcount);
     }
 
     #[test]

--- a/src/fetcher/lastfm/charts.rs
+++ b/src/fetcher/lastfm/charts.rs
@@ -1,0 +1,477 @@
+//! `lastfm_charts` — Last.fm's global "right now" chart: top artists or top tracks across
+//! every scrobble, world-wide.
+//!
+//! Reads `chart.getTopArtists` or `chart.getTopTracks` depending on `kind`. No user-specific
+//! data, no `period` — `chart.*` endpoints return the global ranking as-of the request
+//! moment. Companion to the shipped `crypto_trending` / `huggingface_trending` /
+//! `wikipedia_trending` / `reddit_trending` family ("what the world is listening to" axis).
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::lastfm::client;
+use crate::fetcher::lastfm::common::{ImageEntry, best_image, parse_count};
+use crate::fetcher::lastfm::top::{
+    TopRow, bars_body, entries_body, headline, image_linked_body, linked_text_body, markdown_body,
+    text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "kind",
+        type_hint: "\"artists\" | \"tracks\"",
+        required: false,
+        default: Some("\"artists\""),
+        description: "Which Last.fm chart to rank — global top artists or global top tracks.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Number of chart entries to display.",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 50;
+
+pub struct LastfmCharts;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub kind: Option<Kind>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    #[default]
+    Artists,
+    Tracks,
+}
+
+impl Kind {
+    fn method(self) -> &'static str {
+        match self {
+            Self::Artists => "chart.getTopArtists",
+            Self::Tracks => "chart.getTopTracks",
+        }
+    }
+
+    fn empty_label(self) -> &'static str {
+        match self {
+            Self::Artists => "no chart artists",
+            Self::Tracks => "no chart tracks",
+        }
+    }
+}
+
+#[async_trait]
+impl Fetcher for LastfmCharts {
+    fn name(&self) -> &str {
+        "lastfm_charts"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Last.fm's global chart of top artists or top tracks across every scrobble — \"what the world is listening to right now\". No user binding, no rolling window. The Last.fm slot in the `*_trending` family alongside `crypto_trending` / `huggingface_trending`."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60 * 6
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let kind = opts.kind.unwrap_or_default();
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+
+        let rows = fetch_rows(kind, limit).await?;
+        Ok(payload(render_body(&rows, kind, shape).await))
+    }
+}
+
+async fn fetch_rows(kind: Kind, limit: usize) -> Result<Vec<TopRow>, FetchError> {
+    let limit_str = limit.to_string();
+    let params = [("limit", limit_str.as_str())];
+    match kind {
+        Kind::Artists => {
+            let raw: ChartArtistsResponse = client::get_json(kind.method(), &params).await?;
+            Ok(raw
+                .artists
+                .artist
+                .into_iter()
+                .enumerate()
+                .map(|(i, a)| artist_row(a, i))
+                .collect())
+        }
+        Kind::Tracks => {
+            let raw: ChartTracksResponse = client::get_json(kind.method(), &params).await?;
+            Ok(raw
+                .tracks
+                .track
+                .into_iter()
+                .enumerate()
+                .map(|(i, t)| track_row(t, i))
+                .collect())
+        }
+    }
+}
+
+fn artist_row(raw: RawChartArtist, index: usize) -> TopRow {
+    TopRow {
+        rank: index + 1,
+        primary: raw.name,
+        secondary: None,
+        playcount: parse_count(&raw.playcount),
+        url: raw.url,
+        image_url: best_image(&raw.image),
+    }
+}
+
+fn track_row(raw: RawChartTrack, index: usize) -> TopRow {
+    TopRow {
+        rank: index + 1,
+        primary: raw.name,
+        secondary: raw.artist.name.filter(|s| !s.is_empty()),
+        playcount: parse_count(&raw.playcount),
+        url: raw.url,
+        image_url: best_image(&raw.image),
+    }
+}
+
+async fn render_body(rows: &[TopRow], kind: Kind, shape: Shape) -> Body {
+    let empty = kind.empty_label();
+    match shape {
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::LinkedTextBlock => linked_text_body(rows, empty),
+        Shape::TextBlock => text_block_body(rows, empty),
+        Shape::MarkdownTextBlock => markdown_body(rows, empty),
+        Shape::Entries => entries_body(rows),
+        Shape::Bars => bars_body(rows),
+        _ => text_body(rows, empty),
+    }
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    Some(match shape {
+        Shape::Text => samples::text(&headline(&sample_rows(), "no chart artists")),
+        Shape::TextBlock => samples::text_block(&[
+            "#1 Taylor Swift  12.4M plays",
+            "#2 The Weeknd  8.2M plays",
+            "#3 Drake  7.1M plays",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- **#1 Taylor Swift** — 12.4M plays\n- **#2 The Weeknd** — 8.2M plays\n- **#3 Drake** — 7.1M plays",
+        ),
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "#1 Taylor Swift  12.4M plays",
+                Some("https://www.last.fm/music/Taylor+Swift"),
+            ),
+            (
+                "#2 The Weeknd  8.2M plays",
+                Some("https://www.last.fm/music/The+Weeknd"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "#1 Taylor Swift",
+                Some("https://www.last.fm/music/Taylor+Swift"),
+                None,
+                Some("12.4M plays"),
+            ),
+            (
+                "#2 The Weeknd",
+                Some("https://www.last.fm/music/The+Weeknd"),
+                None,
+                Some("8.2M plays"),
+            ),
+        ]),
+        Shape::Entries => samples::entries(&[
+            ("#1 Taylor Swift", "12.4M plays"),
+            ("#2 The Weeknd", "8.2M plays"),
+        ]),
+        Shape::Bars => samples::bars(&[
+            ("Taylor Swift", 12_400_000),
+            ("The Weeknd", 8_200_000),
+            ("Drake", 7_100_000),
+        ]),
+        _ => return None,
+    })
+}
+
+fn sample_rows() -> Vec<TopRow> {
+    vec![
+        TopRow {
+            rank: 1,
+            primary: "Taylor Swift".into(),
+            secondary: None,
+            playcount: 12_400_000,
+            url: "https://www.last.fm/music/Taylor+Swift".into(),
+            image_url: None,
+        },
+        TopRow {
+            rank: 2,
+            primary: "The Weeknd".into(),
+            secondary: None,
+            playcount: 8_200_000,
+            url: "https://www.last.fm/music/The+Weeknd".into(),
+            image_url: None,
+        },
+    ]
+}
+
+#[derive(Deserialize)]
+struct ChartArtistsResponse {
+    artists: ChartArtistsInner,
+}
+
+#[derive(Deserialize)]
+struct ChartArtistsInner {
+    #[serde(default)]
+    artist: Vec<RawChartArtist>,
+}
+
+#[derive(Deserialize)]
+struct RawChartArtist {
+    name: String,
+    #[serde(default)]
+    playcount: String,
+    url: String,
+    #[serde(default)]
+    image: Vec<ImageEntry>,
+}
+
+#[derive(Deserialize)]
+struct ChartTracksResponse {
+    tracks: ChartTracksInner,
+}
+
+#[derive(Deserialize)]
+struct ChartTracksInner {
+    #[serde(default)]
+    track: Vec<RawChartTrack>,
+}
+
+#[derive(Deserialize)]
+struct RawChartTrack {
+    name: String,
+    #[serde(default)]
+    playcount: String,
+    artist: ArtistObj,
+    url: String,
+    #[serde(default)]
+    image: Vec<ImageEntry>,
+}
+
+#[derive(Deserialize)]
+struct ArtistObj {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "lastfm-charts".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn kind_default_is_artists() {
+        assert_eq!(Kind::default(), Kind::Artists);
+    }
+
+    #[test]
+    fn kind_methods_map_to_lastfm_endpoint_names() {
+        assert_eq!(Kind::Artists.method(), "chart.getTopArtists");
+        assert_eq!(Kind::Tracks.method(), "chart.getTopTracks");
+    }
+
+    #[test]
+    fn kind_deserialises_from_lowercase_string() {
+        let raw: toml::Value = toml::from_str("kind = \"tracks\"").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.kind, Some(Kind::Tracks));
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.kind.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn artist_row_assigns_position_rank_and_no_secondary() {
+        let json = r##"{
+            "artists": {
+                "artist": [
+                    {
+                        "name": "Taylor Swift",
+                        "playcount": "12400000",
+                        "url": "https://www.last.fm/music/Taylor+Swift",
+                        "image": [{"#text": "https://example.com/m.png", "size": "mega"}]
+                    }
+                ]
+            }
+        }"##;
+        let raw: ChartArtistsResponse = serde_json::from_str(json).unwrap();
+        let rows: Vec<TopRow> = raw
+            .artists
+            .artist
+            .into_iter()
+            .enumerate()
+            .map(|(i, a)| artist_row(a, i))
+            .collect();
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].primary, "Taylor Swift");
+        assert!(rows[0].secondary.is_none());
+        assert_eq!(rows[0].playcount, 12_400_000);
+        assert_eq!(
+            rows[0].image_url.as_deref(),
+            Some("https://example.com/m.png")
+        );
+    }
+
+    #[test]
+    fn track_row_pulls_artist_into_secondary() {
+        let json = r##"{
+            "tracks": {
+                "track": [
+                    {
+                        "name": "Anti-Hero",
+                        "playcount": "5400000",
+                        "artist": {"name": "Taylor Swift"},
+                        "url": "https://www.last.fm/music/Taylor+Swift/_/Anti-Hero",
+                        "image": []
+                    }
+                ]
+            }
+        }"##;
+        let raw: ChartTracksResponse = serde_json::from_str(json).unwrap();
+        let rows: Vec<TopRow> = raw
+            .tracks
+            .track
+            .into_iter()
+            .enumerate()
+            .map(|(i, t)| track_row(t, i))
+            .collect();
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].primary, "Anti-Hero");
+        assert_eq!(rows[0].secondary.as_deref(), Some("Taylor Swift"));
+        assert_eq!(rows[0].playcount, 5_400_000);
+    }
+
+    #[test]
+    fn empty_label_differs_per_kind() {
+        assert_eq!(Kind::Artists.empty_label(), "no chart artists");
+        assert_eq!(Kind::Tracks.empty_label(), "no chart tracks");
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = LastfmCharts;
+        assert_eq!(fetcher.name(), "lastfm_charts");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        // Charts deliberately drops Ratio / NumberSeries / Badge / Timeline — chart endpoints
+        // don't carry user-binding semantics those shapes are meaningful for.
+        for missing in [
+            Shape::Ratio,
+            Shape::NumberSeries,
+            Shape::Badge,
+            Shape::Timeline,
+        ] {
+            assert!(fetcher.sample_body(missing).is_none());
+        }
+    }
+
+    #[test]
+    fn cache_key_partitions_by_kind_and_shape() {
+        let fetcher = LastfmCharts;
+        let artists = fetcher.cache_key(&ctx(
+            Some("kind = \"artists\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        let tracks = fetcher.cache_key(&ctx(
+            Some("kind = \"tracks\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        let bars = fetcher.cache_key(&ctx(Some("kind = \"artists\""), Some(Shape::Bars)));
+        assert_ne!(artists, tracks);
+        assert_ne!(artists, bars);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = LastfmCharts
+            .fetch(&ctx(Some("bogus = true"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+}

--- a/src/fetcher/lastfm/client.rs
+++ b/src/fetcher/lastfm/client.rs
@@ -1,0 +1,193 @@
+//! Shared HTTP client + auth for the `lastfm_*` fetcher family.
+//!
+//! Every request targets `ws.audioscrobbler.com` — the host is hardcoded, so the API key
+//! never leaves to an attacker-controlled origin. Same `Safety::Safe` model as `github_*`:
+//! config-provided fields (`user`, `period`, …) only change which resource within the fixed
+//! host is queried.
+//!
+//! Auth: `LASTFM_API_KEY` (free, https://www.last.fm/api/account/create).
+//! Last.fm signals errors with HTTP 200 + `{"error": <code>, "message": <msg>}` rather than a
+//! non-2xx status, so [`get_json`] inspects the JSON envelope before deserializing into the
+//! caller's target type.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+
+use crate::fetcher::FetchError;
+
+const API_BASE: &str = "https://ws.audioscrobbler.com/2.0/";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_BYTES: usize = 5 * 1024 * 1024;
+
+pub fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub fn resolve_api_key() -> Result<String, FetchError> {
+    std::env::var("LASTFM_API_KEY").map_err(|_| FetchError::Failed("LASTFM_API_KEY not set".into()))
+}
+
+/// `GET https://ws.audioscrobbler.com/2.0/?method=<method>&api_key=<key>&format=json&<params>`
+/// then deserialize into `T`. Caller passes additional query pairs as `(key, value)` slices;
+/// `method`, `api_key`, and `format` are appended unconditionally.
+pub async fn get_json<T: DeserializeOwned>(
+    method: &str,
+    params: &[(&str, &str)],
+) -> Result<T, FetchError> {
+    let key = resolve_api_key()?;
+    let url = build_url(method, &key, params);
+    let res = http()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("lastfm request failed: {e}")))?;
+    parse_json(res).await
+}
+
+fn build_url(method: &str, api_key: &str, params: &[(&str, &str)]) -> String {
+    let mut url = url::Url::parse(API_BASE).expect("static API_BASE parses");
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("method", method);
+        q.append_pair("api_key", api_key);
+        q.append_pair("format", "json");
+        for (k, v) in params {
+            q.append_pair(k, v);
+        }
+    }
+    url.into()
+}
+
+async fn parse_json<T: DeserializeOwned>(res: reqwest::Response) -> Result<T, FetchError> {
+    let status = res.status();
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("lastfm read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "lastfm response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("lastfm {status}")));
+    }
+    // Last.fm tunnels errors through a 200 + `{"error":N,"message":...}` envelope, so we
+    // detect that before handing bytes to the caller's deserializer.
+    if let Some(err) = parse_api_error(&bytes) {
+        return Err(err);
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("lastfm json parse: {e}")))
+}
+
+fn parse_api_error(bytes: &[u8]) -> Option<FetchError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let code = value.get("error").and_then(|v| v.as_i64())?;
+    let message = value
+        .get("message")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(no message)");
+    Some(FetchError::Failed(format!(
+        "lastfm error {code}: {message}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_url_includes_method_api_key_and_format() {
+        let url = build_url(
+            "user.getRecentTracks",
+            "secret",
+            &[("user", "rj"), ("limit", "5")],
+        );
+        assert!(url.starts_with("https://ws.audioscrobbler.com/2.0/?"));
+        assert!(url.contains("method=user.getRecentTracks"));
+        assert!(url.contains("api_key=secret"));
+        assert!(url.contains("format=json"));
+        assert!(url.contains("user=rj"));
+        assert!(url.contains("limit=5"));
+    }
+
+    #[test]
+    fn build_url_percent_encodes_param_values() {
+        // Last.fm usernames are ASCII but reserved characters in artist / track query params
+        // (slashes, ampersands, plus, …) must encode so we don't smuggle extra query pairs.
+        let url = build_url("artist.search", "k", &[("artist", "AC/DC & Friends")]);
+        assert!(
+            url.contains("artist=AC%2FDC+%26+Friends")
+                || url.contains("artist=AC%2FDC%20%26%20Friends")
+        );
+    }
+
+    #[test]
+    fn resolve_api_key_fails_with_clear_message_when_unset() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LASTFM_API_KEY").ok();
+        unsafe { std::env::remove_var("LASTFM_API_KEY") };
+        let err = resolve_api_key().unwrap_err();
+        assert!(matches!(err, FetchError::Failed(m) if m == "LASTFM_API_KEY not set"));
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("LASTFM_API_KEY", v) };
+        }
+    }
+
+    #[test]
+    fn resolve_api_key_reads_env() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LASTFM_API_KEY").ok();
+        unsafe { std::env::set_var("LASTFM_API_KEY", "abc123") };
+        assert_eq!(resolve_api_key().unwrap(), "abc123");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("LASTFM_API_KEY", v) },
+            None => unsafe { std::env::remove_var("LASTFM_API_KEY") },
+        }
+    }
+
+    #[test]
+    fn parse_api_error_surfaces_lastfm_error_envelope() {
+        let bytes = br#"{"error":6,"message":"User not found"}"#;
+        let err = parse_api_error(bytes).expect("error envelope must be detected");
+        let FetchError::Failed(msg) = err else {
+            panic!("expected FetchError::Failed");
+        };
+        assert!(msg.contains("lastfm error 6"));
+        assert!(msg.contains("User not found"));
+    }
+
+    #[test]
+    fn parse_api_error_returns_none_on_success_bodies() {
+        let bytes = br#"{"recenttracks":{"track":[]}}"#;
+        assert!(parse_api_error(bytes).is_none());
+    }
+
+    #[test]
+    fn parse_api_error_returns_none_on_unparseable_bytes() {
+        assert!(parse_api_error(b"not-json").is_none());
+    }
+
+    #[test]
+    fn http_reuses_the_same_client() {
+        assert!(std::ptr::eq(http(), http()));
+    }
+}

--- a/src/fetcher/lastfm/common.rs
+++ b/src/fetcher/lastfm/common.rs
@@ -1,0 +1,155 @@
+//! Cross-cutting helpers for the `lastfm_*` family: image-URL picking, count parsing,
+//! human-readable formatting.
+
+use serde::Deserialize;
+
+/// Per-row image descriptor returned by Last.fm. The JSON shape is `{"#text": "...",
+/// "size": "..."}`; sizes are `small | medium | large | extralarge | mega`. Entries are
+/// almost always present even when the underlying entity has no artwork — in that case
+/// Last.fm serves a known placeholder hash that [`best_image`] filters out.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImageEntry {
+    #[serde(rename = "#text", default)]
+    pub url: String,
+    #[serde(default)]
+    pub size: String,
+}
+
+/// Largest non-placeholder image URL, or `None` when every entry is empty or the placeholder.
+///
+/// Last.fm tags artwork-less entities (track / artist / album) with a fixed gray-square hash
+/// `2a96cbd8b46e442fc41c2b86b821562f`. Without filtering, an `ImageLinkedList` of those rows
+/// would surface the same placeholder thumbnail on every row, which is worse than no
+/// thumbnails at all.
+pub fn best_image(images: &[ImageEntry]) -> Option<String> {
+    const PLACEHOLDER: &str = "2a96cbd8b46e442fc41c2b86b821562f";
+    const PRIORITY: &[&str] = &["mega", "extralarge", "large", "medium", "small"];
+    PRIORITY
+        .iter()
+        .find_map(|size| {
+            images.iter().find(|img| {
+                img.size == *size && !img.url.is_empty() && !img.url.contains(PLACEHOLDER)
+            })
+        })
+        .map(|img| img.url.clone())
+}
+
+/// Parse a Last.fm count field. Counts come back as JSON strings (`"42"`) for historical
+/// reasons; anything that can't parse silently collapses to zero rather than failing the
+/// entire fetch.
+pub fn parse_count(raw: &str) -> u64 {
+    raw.parse().unwrap_or(0)
+}
+
+/// Human-readable count: `1234` -> `"1.2k"`, `2_100_000` -> `"2.1M"`. Mirrors the
+/// `huggingface_trending` convention so the catalog reads consistently.
+pub fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// `"play"` vs `"plays"` — small enough that inlining at every call site would obscure intent.
+pub fn plays_word(n: u64) -> &'static str {
+    if n == 1 { "play" } else { "plays" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn img(size: &str, url: &str) -> ImageEntry {
+        ImageEntry {
+            url: url.into(),
+            size: size.into(),
+        }
+    }
+
+    #[test]
+    fn best_image_prefers_mega_over_smaller_sizes() {
+        let imgs = vec![
+            img("small", "https://example.com/small.png"),
+            img("mega", "https://example.com/mega.png"),
+            img("large", "https://example.com/large.png"),
+        ];
+        assert_eq!(
+            best_image(&imgs),
+            Some("https://example.com/mega.png".into())
+        );
+    }
+
+    #[test]
+    fn best_image_falls_back_through_priority_chain() {
+        let imgs = vec![
+            img("medium", "https://example.com/medium.png"),
+            img("small", "https://example.com/small.png"),
+        ];
+        assert_eq!(
+            best_image(&imgs),
+            Some("https://example.com/medium.png".into())
+        );
+    }
+
+    #[test]
+    fn best_image_skips_placeholder_hash() {
+        let imgs = vec![
+            img(
+                "mega",
+                "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+            ),
+            img("large", "https://example.com/real.png"),
+        ];
+        assert_eq!(
+            best_image(&imgs),
+            Some("https://example.com/real.png".into())
+        );
+    }
+
+    #[test]
+    fn best_image_returns_none_when_only_placeholder_or_empty() {
+        let imgs = vec![
+            img(
+                "mega",
+                "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+            ),
+            img("large", ""),
+        ];
+        assert!(best_image(&imgs).is_none());
+    }
+
+    #[test]
+    fn best_image_returns_none_on_empty_input() {
+        assert!(best_image(&[]).is_none());
+    }
+
+    #[test]
+    fn parse_count_reads_numeric_strings() {
+        assert_eq!(parse_count("42"), 42);
+        assert_eq!(parse_count("0"), 0);
+    }
+
+    #[test]
+    fn parse_count_collapses_garbage_to_zero() {
+        assert_eq!(parse_count("not-a-number"), 0);
+        assert_eq!(parse_count(""), 0);
+    }
+
+    #[test]
+    fn format_count_picks_unit_by_magnitude() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(950), "950");
+        assert_eq!(format_count(1_500), "1.5k");
+        assert_eq!(format_count(1_200_000), "1.2M");
+    }
+
+    #[test]
+    fn plays_word_pluralises_only_for_non_singular() {
+        assert_eq!(plays_word(0), "plays");
+        assert_eq!(plays_word(1), "play");
+        assert_eq!(plays_word(2), "plays");
+    }
+}

--- a/src/fetcher/lastfm/mod.rs
+++ b/src/fetcher/lastfm/mod.rs
@@ -12,6 +12,7 @@
 mod client;
 mod common;
 mod scrobbles_today;
+mod top;
 
 use std::sync::Arc;
 

--- a/src/fetcher/lastfm/mod.rs
+++ b/src/fetcher/lastfm/mod.rs
@@ -14,6 +14,7 @@ mod common;
 mod scrobbles_today;
 mod top;
 mod top_artists;
+mod top_tracks;
 
 use std::sync::Arc;
 
@@ -23,6 +24,7 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![
         Arc::new(scrobbles_today::LastfmScrobblesToday),
         Arc::new(top_artists::LastfmTopArtists),
+        Arc::new(top_tracks::LastfmTopTracks),
     ]
 }
 
@@ -41,5 +43,6 @@ mod tests {
         }
         assert!(names.contains(&"lastfm_scrobbles_today".to_string()));
         assert!(names.contains(&"lastfm_top_artists".to_string()));
+        assert!(names.contains(&"lastfm_top_tracks".to_string()));
     }
 }

--- a/src/fetcher/lastfm/mod.rs
+++ b/src/fetcher/lastfm/mod.rs
@@ -13,6 +13,7 @@ mod client;
 mod common;
 mod scrobbles_today;
 mod top;
+mod top_albums;
 mod top_artists;
 mod top_tracks;
 
@@ -25,6 +26,7 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(scrobbles_today::LastfmScrobblesToday),
         Arc::new(top_artists::LastfmTopArtists),
         Arc::new(top_tracks::LastfmTopTracks),
+        Arc::new(top_albums::LastfmTopAlbums),
     ]
 }
 
@@ -44,5 +46,6 @@ mod tests {
         assert!(names.contains(&"lastfm_scrobbles_today".to_string()));
         assert!(names.contains(&"lastfm_top_artists".to_string()));
         assert!(names.contains(&"lastfm_top_tracks".to_string()));
+        assert!(names.contains(&"lastfm_top_albums".to_string()));
     }
 }

--- a/src/fetcher/lastfm/mod.rs
+++ b/src/fetcher/lastfm/mod.rs
@@ -1,0 +1,39 @@
+//! Last.fm fetchers — user listening statistics (recent scrobbles, top artists / tracks /
+//! albums) plus global charts.
+//!
+//! Every request targets the fixed host `ws.audioscrobbler.com`. Config-provided fields
+//! (`user`, `period`, …) only change which resource on that host is queried; the API key
+//! never leaves to an attacker-controlled origin. Classified as `Safety::Safe`, same model
+//! as the `github_*` family.
+//!
+//! Auth: `LASTFM_API_KEY` — create one at https://www.last.fm/api/account/create and put it
+//! in `$HOME/.splashboard/secrets.toml`.
+
+mod client;
+mod common;
+mod scrobbles_today;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(scrobbles_today::LastfmScrobblesToday)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetchers_entry_point_registers_the_batch_under_lastfm_prefix() {
+        let names: Vec<String> = fetchers().iter().map(|f| f.name().to_string()).collect();
+        for name in &names {
+            assert!(
+                name.starts_with("lastfm_"),
+                "{name} must use the `lastfm_` family prefix"
+            );
+        }
+        assert!(names.contains(&"lastfm_scrobbles_today".to_string()));
+    }
+}

--- a/src/fetcher/lastfm/mod.rs
+++ b/src/fetcher/lastfm/mod.rs
@@ -13,13 +13,17 @@ mod client;
 mod common;
 mod scrobbles_today;
 mod top;
+mod top_artists;
 
 use std::sync::Arc;
 
 use crate::fetcher::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(scrobbles_today::LastfmScrobblesToday)]
+    vec![
+        Arc::new(scrobbles_today::LastfmScrobblesToday),
+        Arc::new(top_artists::LastfmTopArtists),
+    ]
 }
 
 #[cfg(test)]
@@ -36,5 +40,6 @@ mod tests {
             );
         }
         assert!(names.contains(&"lastfm_scrobbles_today".to_string()));
+        assert!(names.contains(&"lastfm_top_artists".to_string()));
     }
 }

--- a/src/fetcher/lastfm/mod.rs
+++ b/src/fetcher/lastfm/mod.rs
@@ -9,6 +9,7 @@
 //! Auth: `LASTFM_API_KEY` — create one at https://www.last.fm/api/account/create and put it
 //! in `$HOME/.splashboard/secrets.toml`.
 
+mod charts;
 mod client;
 mod common;
 mod scrobbles_today;
@@ -27,6 +28,7 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(top_artists::LastfmTopArtists),
         Arc::new(top_tracks::LastfmTopTracks),
         Arc::new(top_albums::LastfmTopAlbums),
+        Arc::new(charts::LastfmCharts),
     ]
 }
 
@@ -47,5 +49,6 @@ mod tests {
         assert!(names.contains(&"lastfm_top_artists".to_string()));
         assert!(names.contains(&"lastfm_top_tracks".to_string()));
         assert!(names.contains(&"lastfm_top_albums".to_string()));
+        assert!(names.contains(&"lastfm_charts".to_string()));
     }
 }

--- a/src/fetcher/lastfm/scrobbles_today.rs
+++ b/src/fetcher/lastfm/scrobbles_today.rs
@@ -1,0 +1,865 @@
+//! `lastfm_scrobbles_today` — today's scrobbles for a Last.fm user, plus the currently-playing
+//! track when one is in flight.
+//!
+//! Reads `user.getRecentTracks` with `from = midnight UTC today`. The currently-playing track
+//! (signalled by `@attr.nowplaying = "true"` on the most recent entry) is split out from the
+//! today-count rollup so the headline can choose between "♪ now playing" and a count summary
+//! depending on whether the user is actively listening when the splash renders.
+//!
+//! Refresh interval is short (5 minutes) so the splash reflects "what I'm playing now" within
+//! a coffee break, but not so short that we hammer the API on a fresh `cd`.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::lastfm::client;
+use crate::fetcher::lastfm::common::{ImageEntry, best_image};
+use crate::fetcher::thumbnails;
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData, LinkedLine,
+    LinkedTextBlockData, MarkdownTextBlockData, Payload, Status, TextBlockData, TextData,
+    TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string",
+        required: true,
+        default: None,
+        description: "Last.fm username whose scrobbles to read.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of recently scrobbled tracks to show (excluding the currently-playing slot).",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 50;
+
+pub struct LastfmScrobblesToday;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub user: Option<String>,
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for LastfmScrobblesToday {
+    fn name(&self) -> &str {
+        "lastfm_scrobbles_today"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Today's scrobbles for a Last.fm user, with the currently-playing track surfaced when one is in flight. Reads `user.getRecentTracks` since UTC midnight; intentionally bounded to today so the cached splash doesn't drift across day boundaries."
+    }
+    fn refresh_interval(&self) -> u64 {
+        5 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let user = opts
+            .user
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                FetchError::Failed(
+                    "lastfm_scrobbles_today: `user = \"<lastfm name>\"` is required".into(),
+                )
+            })?;
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+
+        let snapshot = fetch_snapshot(user, limit).await?;
+        let body = render_body(&snapshot, shape).await;
+        Ok(payload(body))
+    }
+}
+
+/// Parsed view of the response the rest of the rendering code reads from.
+#[derive(Debug, Clone, Default)]
+struct Snapshot {
+    /// Tracks scrobbled since midnight UTC today, newest first. Excludes the nowplaying entry.
+    tracks: Vec<TrackRow>,
+    now_playing: Option<TrackRow>,
+}
+
+#[derive(Debug, Clone)]
+struct TrackRow {
+    name: String,
+    artist: String,
+    album: Option<String>,
+    url: String,
+    image_url: Option<String>,
+    timestamp: Option<i64>,
+}
+
+impl Snapshot {
+    fn today_count(&self) -> u64 {
+        self.tracks.len() as u64
+    }
+}
+
+async fn fetch_snapshot(user: &str, limit: usize) -> Result<Snapshot, FetchError> {
+    let from = start_of_today_utc().to_string();
+    // The nowplaying slot, when present, doesn't count toward `limit` from the API's perspective
+    // — request `limit + 1` so a continuously listening user doesn't lose a row to it.
+    let cap = (limit + 1).min((MAX_LIMIT + 1) as usize).to_string();
+    let raw: RecentTracksResponse = client::get_json(
+        "user.getRecentTracks",
+        &[("user", user), ("from", &from), ("limit", &cap)],
+    )
+    .await?;
+    let mut snap = parse_recent(raw);
+    // Defensive cap — Last.fm sometimes returns one extra row past `limit` regardless of the
+    // nowplaying split.
+    snap.tracks.truncate(limit);
+    Ok(snap)
+}
+
+fn start_of_today_utc() -> i64 {
+    let today = Utc::now().date_naive().and_hms_opt(0, 0, 0).unwrap();
+    chrono::DateTime::<Utc>::from_naive_utc_and_offset(today, Utc).timestamp()
+}
+
+fn parse_recent(raw: RecentTracksResponse) -> Snapshot {
+    let mut snap = Snapshot::default();
+    for raw_track in raw.recenttracks.track {
+        let is_now = raw_track
+            .attr
+            .as_ref()
+            .and_then(|a| a.nowplaying.as_deref())
+            == Some("true");
+        let row = TrackRow {
+            name: raw_track.name,
+            artist: raw_track.artist.text,
+            album: raw_track.album.map(|a| a.text).filter(|s| !s.is_empty()),
+            url: raw_track.url,
+            image_url: best_image(&raw_track.image),
+            timestamp: raw_track.date.and_then(|d| d.uts.parse().ok()),
+        };
+        if is_now {
+            snap.now_playing = Some(row);
+        } else {
+            snap.tracks.push(row);
+        }
+    }
+    snap
+}
+
+async fn render_body(snap: &Snapshot, shape: Shape) -> Body {
+    match shape {
+        Shape::ImageLinkedList => image_linked_body(snap).await,
+        Shape::LinkedTextBlock => linked_text_body(snap),
+        Shape::TextBlock => text_block_body(snap),
+        Shape::MarkdownTextBlock => markdown_body(snap),
+        Shape::Entries => entries_body(snap),
+        Shape::Badge => badge_body(snap),
+        Shape::Timeline => timeline_body(snap),
+        _ => text_body(snap),
+    }
+}
+
+fn text_body(snap: &Snapshot) -> Body {
+    Body::Text(TextData {
+        value: headline(snap),
+    })
+}
+
+fn headline(snap: &Snapshot) -> String {
+    if let Some(nowp) = &snap.now_playing {
+        format!("♪ {} — {}", nowp.name, nowp.artist)
+    } else if snap.today_count() == 1 {
+        "1 scrobble today".into()
+    } else if snap.today_count() > 0 {
+        format!("{} scrobbles today", snap.today_count())
+    } else {
+        "quiet day".into()
+    }
+}
+
+fn text_block_body(snap: &Snapshot) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: text_lines(snap),
+    })
+}
+
+fn text_lines(snap: &Snapshot) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Some(nowp) = &snap.now_playing {
+        lines.push(format!("♪ {} — {}", nowp.name, nowp.artist));
+    }
+    lines.extend(snap.tracks.iter().map(format_track_row));
+    if lines.is_empty() {
+        lines.push("quiet day".into());
+    }
+    lines
+}
+
+fn format_track_row(t: &TrackRow) -> String {
+    let time = t
+        .timestamp
+        .map(format_time_label)
+        .unwrap_or_else(|| "--:--".into());
+    format!("{time}  {} — {}", t.name, t.artist)
+}
+
+fn format_time_label(ts: i64) -> String {
+    chrono::DateTime::<Utc>::from_timestamp(ts, 0)
+        .map(|dt| dt.format("%H:%M").to_string())
+        .unwrap_or_else(|| "--:--".into())
+}
+
+fn markdown_body(snap: &Snapshot) -> Body {
+    let mut lines = Vec::new();
+    if let Some(nowp) = &snap.now_playing {
+        lines.push(format!("- ▶ **{}** — {}", nowp.name, nowp.artist));
+    }
+    lines.extend(
+        snap.tracks
+            .iter()
+            .map(|t| format!("- **{}** — {}", t.name, t.artist)),
+    );
+    if lines.is_empty() {
+        lines.push("_quiet day_".into());
+    }
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: lines.join("\n"),
+    })
+}
+
+fn linked_text_body(snap: &Snapshot) -> Body {
+    let mut items = Vec::new();
+    if let Some(nowp) = &snap.now_playing {
+        items.push(LinkedLine {
+            text: format!("♪ {} — {}", nowp.name, nowp.artist),
+            url: Some(nowp.url.clone()),
+        });
+    }
+    items.extend(snap.tracks.iter().map(|t| LinkedLine {
+        text: format_track_row(t),
+        url: Some(t.url.clone()),
+    }));
+    if items.is_empty() {
+        items.push(LinkedLine {
+            text: "quiet day".into(),
+            url: None,
+        });
+    }
+    Body::LinkedTextBlock(LinkedTextBlockData { items })
+}
+
+async fn image_linked_body(snap: &Snapshot) -> Body {
+    let rows = collect_rows_for_image(snap);
+    let urls: Vec<Option<String>> = rows.iter().map(|(t, _, _)| t.image_url.clone()).collect();
+    let paths = thumbnails::download_many(&urls).await;
+    let items = rows
+        .into_iter()
+        .zip(paths)
+        .map(|((t, title, subtitle), path)| ImageLinkedItem {
+            title,
+            url: Some(t.url.clone()),
+            thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
+            subtitle,
+        })
+        .collect();
+    Body::ImageLinkedList(ImageLinkedListData { items })
+}
+
+/// Produce `(track, title, subtitle)` rows in display order; nowplaying first.
+fn collect_rows_for_image(snap: &Snapshot) -> Vec<(&TrackRow, String, Option<String>)> {
+    let mut rows = Vec::new();
+    if let Some(nowp) = &snap.now_playing {
+        rows.push((
+            nowp,
+            format!("♪ {} — {}", nowp.name, nowp.artist),
+            Some("now playing".into()),
+        ));
+    }
+    for t in &snap.tracks {
+        let subtitle = match t.timestamp {
+            Some(ts) => Some(format!("{} · {}", format_time_label(ts), t.artist)),
+            None => Some(t.artist.clone()),
+        };
+        rows.push((t, t.name.clone(), subtitle));
+    }
+    rows
+}
+
+fn entries_body(snap: &Snapshot) -> Body {
+    let mut items = Vec::new();
+    if let Some(nowp) = &snap.now_playing {
+        items.push(Entry {
+            key: nowp.name.clone(),
+            value: Some(format!("▶ {}", nowp.artist)),
+            status: Some(Status::Ok),
+        });
+    }
+    items.extend(snap.tracks.iter().map(|t| Entry {
+        key: t.name.clone(),
+        value: Some(t.artist.clone()),
+        status: None,
+    }));
+    if items.is_empty() {
+        items.push(Entry {
+            key: "today".into(),
+            value: Some("no scrobbles yet".into()),
+            status: None,
+        });
+    }
+    Body::Entries(EntriesData { items })
+}
+
+fn badge_body(snap: &Snapshot) -> Body {
+    let (status, label) = if let Some(nowp) = &snap.now_playing {
+        (Status::Ok, format!("♪ {}", nowp.name))
+    } else if snap.today_count() == 1 {
+        (Status::Ok, "1 today".into())
+    } else if snap.today_count() > 0 {
+        (Status::Ok, format!("{} today", snap.today_count()))
+    } else {
+        (Status::Warn, "quiet day".into())
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+fn timeline_body(snap: &Snapshot) -> Body {
+    let mut events = Vec::new();
+    if let Some(nowp) = &snap.now_playing {
+        events.push(TimelineEvent {
+            timestamp: Utc::now().timestamp(),
+            title: format!("♪ {} — {}", nowp.name, nowp.artist),
+            detail: nowp.album.clone(),
+            status: Some(Status::Ok),
+        });
+    }
+    events.extend(snap.tracks.iter().map(|t| TimelineEvent {
+        timestamp: t.timestamp.unwrap_or(0),
+        title: format!("{} — {}", t.name, t.artist),
+        detail: t.album.clone(),
+        status: None,
+    }));
+    Body::Timeline(TimelineData { events })
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    Some(match shape {
+        Shape::Text => samples::text("♪ Strawberry Swing — Coldplay"),
+        Shape::TextBlock => samples::text_block(&[
+            "♪ Strawberry Swing — Coldplay",
+            "14:32  Lost Stars — Adam Levine",
+            "14:28  Bloom — Beach House",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- ▶ **Strawberry Swing** — Coldplay\n- **Lost Stars** — Adam Levine\n- **Bloom** — Beach House",
+        ),
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "♪ Strawberry Swing — Coldplay",
+                Some("https://www.last.fm/music/Coldplay/_/Strawberry+Swing"),
+            ),
+            (
+                "14:32  Lost Stars — Adam Levine",
+                Some("https://www.last.fm/music/Adam+Levine/_/Lost+Stars"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "♪ Strawberry Swing — Coldplay",
+                Some("https://www.last.fm/music/Coldplay/_/Strawberry+Swing"),
+                None,
+                Some("now playing"),
+            ),
+            (
+                "Lost Stars",
+                Some("https://www.last.fm/music/Adam+Levine/_/Lost+Stars"),
+                None,
+                Some("14:32 · Adam Levine"),
+            ),
+        ]),
+        Shape::Entries => samples::entries(&[
+            ("Strawberry Swing", "▶ Coldplay"),
+            ("Lost Stars", "Adam Levine"),
+        ]),
+        Shape::Badge => samples::badge(Status::Ok, "♪ Strawberry Swing"),
+        Shape::Timeline => samples::timeline(&[
+            (
+                1_700_000_000,
+                "♪ Strawberry Swing — Coldplay",
+                Some("Viva la Vida"),
+            ),
+            (1_699_999_500, "Lost Stars — Adam Levine", None),
+        ]),
+        _ => return None,
+    })
+}
+
+#[derive(Deserialize)]
+struct RecentTracksResponse {
+    recenttracks: RecentTracksInner,
+}
+
+#[derive(Deserialize)]
+struct RecentTracksInner {
+    #[serde(default)]
+    track: Vec<RawTrack>,
+}
+
+#[derive(Deserialize)]
+struct RawTrack {
+    name: String,
+    artist: ArtistObj,
+    #[serde(default)]
+    album: Option<AlbumObj>,
+    url: String,
+    #[serde(default)]
+    image: Vec<ImageEntry>,
+    #[serde(default)]
+    date: Option<DateObj>,
+    #[serde(rename = "@attr", default)]
+    attr: Option<TrackAttr>,
+}
+
+#[derive(Deserialize)]
+struct ArtistObj {
+    #[serde(rename = "#text", default)]
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct AlbumObj {
+    #[serde(rename = "#text", default)]
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct DateObj {
+    uts: String,
+}
+
+#[derive(Deserialize)]
+struct TrackAttr {
+    #[serde(default)]
+    nowplaying: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "lastfm-today".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn track(name: &str, artist: &str, ts: Option<i64>) -> TrackRow {
+        TrackRow {
+            name: name.into(),
+            artist: artist.into(),
+            album: None,
+            url: format!("https://www.last.fm/music/{artist}/_/{name}"),
+            image_url: None,
+            timestamp: ts,
+        }
+    }
+
+    fn snapshot(now: Option<TrackRow>, tracks: Vec<TrackRow>) -> Snapshot {
+        Snapshot {
+            now_playing: now,
+            tracks,
+        }
+    }
+
+    fn parse_recent_from(json: &str) -> Snapshot {
+        let raw: RecentTracksResponse = serde_json::from_str(json).unwrap();
+        parse_recent(raw)
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.user.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn options_deserialize_full() {
+        let raw: toml::Value = toml::from_str("user = \"rj\"\nlimit = 5").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.user.as_deref(), Some("rj"));
+        assert_eq!(opts.limit, Some(5));
+    }
+
+    #[test]
+    fn parse_recent_splits_nowplaying_from_history() {
+        let json = r##"{
+            "recenttracks": {
+                "track": [
+                    {
+                        "name": "Live Track",
+                        "artist": {"#text": "Live Artist"},
+                        "url": "https://www.last.fm/track/live",
+                        "image": [],
+                        "@attr": {"nowplaying": "true"}
+                    },
+                    {
+                        "name": "Played Track",
+                        "artist": {"#text": "Played Artist"},
+                        "url": "https://www.last.fm/track/played",
+                        "image": [],
+                        "date": {"uts": "1700000000"}
+                    }
+                ]
+            }
+        }"##;
+        let snap = parse_recent_from(json);
+        let nowp = snap.now_playing.expect("nowplaying must be detected");
+        assert_eq!(nowp.name, "Live Track");
+        assert_eq!(snap.tracks.len(), 1);
+        assert_eq!(snap.tracks[0].name, "Played Track");
+        assert_eq!(snap.tracks[0].timestamp, Some(1_700_000_000));
+    }
+
+    #[test]
+    fn parse_recent_handles_empty_track_list() {
+        let snap = parse_recent_from(r#"{"recenttracks": {"track": []}}"#);
+        assert!(snap.now_playing.is_none());
+        assert_eq!(snap.tracks.len(), 0);
+    }
+
+    #[test]
+    fn parse_recent_treats_nowplaying_false_as_history() {
+        let json = r##"{
+            "recenttracks": {
+                "track": [
+                    {
+                        "name": "Track",
+                        "artist": {"#text": "Artist"},
+                        "url": "https://www.last.fm/x",
+                        "image": [],
+                        "date": {"uts": "1700000000"},
+                        "@attr": {"nowplaying": "false"}
+                    }
+                ]
+            }
+        }"##;
+        let snap = parse_recent_from(json);
+        assert!(snap.now_playing.is_none());
+        assert_eq!(snap.tracks.len(), 1);
+    }
+
+    #[test]
+    fn parse_recent_picks_best_image() {
+        let json = r##"{
+            "recenttracks": {
+                "track": [
+                    {
+                        "name": "T",
+                        "artist": {"#text": "A"},
+                        "url": "https://www.last.fm/x",
+                        "image": [
+                            {"#text": "https://example.com/small.png", "size": "small"},
+                            {"#text": "https://example.com/mega.png", "size": "mega"}
+                        ],
+                        "date": {"uts": "1700000000"}
+                    }
+                ]
+            }
+        }"##;
+        let snap = parse_recent_from(json);
+        assert_eq!(
+            snap.tracks[0].image_url.as_deref(),
+            Some("https://example.com/mega.png")
+        );
+    }
+
+    #[test]
+    fn headline_prefers_now_playing_over_count() {
+        let snap = snapshot(
+            Some(track("Live", "Artist", None)),
+            vec![track("Old", "Artist", Some(0))],
+        );
+        assert!(headline(&snap).starts_with("♪ Live"));
+    }
+
+    #[test]
+    fn headline_singular_for_one_scrobble() {
+        let snap = snapshot(None, vec![track("Only", "Artist", Some(0))]);
+        assert_eq!(headline(&snap), "1 scrobble today");
+    }
+
+    #[test]
+    fn headline_pluralises_for_many_scrobbles() {
+        let snap = snapshot(
+            None,
+            (0..3)
+                .map(|i| track(&format!("T{i}"), "A", Some(0)))
+                .collect(),
+        );
+        assert_eq!(headline(&snap), "3 scrobbles today");
+    }
+
+    #[test]
+    fn headline_reports_quiet_day_when_empty() {
+        let snap = snapshot(None, vec![]);
+        assert_eq!(headline(&snap), "quiet day");
+    }
+
+    #[test]
+    fn format_track_row_uses_dashes_when_timestamp_missing() {
+        let row = format_track_row(&track("Song", "Artist", None));
+        assert!(row.starts_with("--:--"));
+        assert!(row.contains("Song"));
+        assert!(row.contains("Artist"));
+    }
+
+    #[test]
+    fn format_time_label_renders_hour_minute_utc() {
+        // 2023-04-22 10:15:30 UTC -> "10:15"
+        assert_eq!(format_time_label(1_682_158_530), "10:15");
+    }
+
+    #[test]
+    fn linked_text_body_falls_back_to_quiet_day_on_empty() {
+        let body = linked_text_body(&Snapshot::default());
+        let Body::LinkedTextBlock(b) = body else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(b.items[0].text, "quiet day");
+        assert!(b.items[0].url.is_none());
+    }
+
+    #[test]
+    fn linked_text_body_carries_track_urls() {
+        let snap = snapshot(None, vec![track("Song", "Artist", Some(1_700_000_000))]);
+        let Body::LinkedTextBlock(b) = linked_text_body(&snap) else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert!(b.items[0].text.contains("Song"));
+        assert!(b.items[0].url.as_deref().unwrap().contains("Song"));
+    }
+
+    #[test]
+    fn linked_text_body_prepends_now_playing_row() {
+        let snap = snapshot(
+            Some(track("Live", "Artist", None)),
+            vec![track("Old", "Artist", Some(1_700_000_000))],
+        );
+        let Body::LinkedTextBlock(b) = linked_text_body(&snap) else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 2);
+        assert!(b.items[0].text.starts_with("♪ Live"));
+    }
+
+    #[test]
+    fn text_block_body_includes_quiet_day_when_no_tracks() {
+        let body = text_block_body(&Snapshot::default());
+        let Body::TextBlock(b) = body else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines, vec!["quiet day".to_string()]);
+    }
+
+    #[test]
+    fn markdown_body_renders_bullets() {
+        let snap = snapshot(None, vec![track("Song", "Artist", Some(0))]);
+        let Body::MarkdownTextBlock(m) = markdown_body(&snap) else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("**Song**"));
+        assert!(m.value.starts_with("- "));
+    }
+
+    #[test]
+    fn markdown_body_uses_italic_quiet_day_when_empty() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&Snapshot::default()) else {
+            panic!("expected markdown");
+        };
+        assert_eq!(m.value, "_quiet day_");
+    }
+
+    #[test]
+    fn entries_body_tags_now_playing_with_ok_status() {
+        let snap = snapshot(Some(track("Live", "Artist", None)), vec![]);
+        let Body::Entries(e) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "Live");
+        assert_eq!(e.items[0].status, Some(Status::Ok));
+    }
+
+    #[test]
+    fn entries_body_falls_back_when_empty() {
+        let Body::Entries(e) = entries_body(&Snapshot::default()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert_eq!(e.items[0].key, "today");
+    }
+
+    #[test]
+    fn badge_body_warns_on_quiet_day() {
+        let Body::Badge(b) = badge_body(&Snapshot::default()) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert_eq!(b.label, "quiet day");
+    }
+
+    #[test]
+    fn badge_body_uses_singular_label_for_one_scrobble() {
+        let snap = snapshot(None, vec![track("Only", "A", Some(0))]);
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.label, "1 today");
+        assert_eq!(b.status, Status::Ok);
+    }
+
+    #[test]
+    fn badge_body_promotes_now_playing_to_label() {
+        let snap = snapshot(Some(track("Live", "Artist", None)), vec![]);
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert!(b.label.starts_with("♪ Live"));
+    }
+
+    #[test]
+    fn timeline_body_orders_nowplaying_first() {
+        let snap = snapshot(
+            Some(track("Live", "Artist", None)),
+            vec![track("Old", "Artist", Some(1_700_000_000))],
+        );
+        let Body::Timeline(t) = timeline_body(&snap) else {
+            panic!("expected timeline");
+        };
+        assert_eq!(t.events.len(), 2);
+        assert!(t.events[0].title.starts_with("♪ Live"));
+        assert_eq!(t.events[1].timestamp, 1_700_000_000);
+    }
+
+    #[test]
+    fn collect_rows_for_image_subtitles_fall_back_to_artist_when_no_timestamp() {
+        let snap = snapshot(None, vec![track("Song", "Artist", None)]);
+        let rows = collect_rows_for_image(&snap);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].2.as_deref(), Some("Artist"));
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = LastfmScrobblesToday;
+        assert_eq!(fetcher.name(), "lastfm_scrobbles_today");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_shape_and_options() {
+        let fetcher = LastfmScrobblesToday;
+        let a = fetcher.cache_key(&ctx(Some("user = \"rj\""), Some(Shape::LinkedTextBlock)));
+        let b = fetcher.cache_key(&ctx(Some("user = \"rj\""), Some(Shape::Badge)));
+        let c = fetcher.cache_key(&ctx(Some("user = \"other\""), Some(Shape::LinkedTextBlock)));
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[tokio::test]
+    async fn fetch_requires_user_option() {
+        let err = LastfmScrobblesToday
+            .fetch(&ctx(None, Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("`user ="));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = LastfmScrobblesToday
+            .fetch(&ctx(Some("user = \"rj\"\nbogus = true"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_blank_user() {
+        let err = LastfmScrobblesToday
+            .fetch(&ctx(Some("user = \"   \""), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("`user ="));
+    }
+}

--- a/src/fetcher/lastfm/top.rs
+++ b/src/fetcher/lastfm/top.rs
@@ -1,0 +1,468 @@
+//! Shared types and rendering helpers for the `lastfm_top_*` family
+//! (`top_artists` / `top_tracks` / `top_albums`).
+//!
+//! All three endpoints return a structurally identical "ranked entity with a playcount" list,
+//! differing only in (a) which API method is hit, (b) whether the row has a secondary artist
+//! label (artists: none; tracks/albums: yes), and (c) the URL convention. Normalising those
+//! differences into [`TopRow`] lets each sibling stay around ~200 lines.
+
+use serde::Deserialize;
+
+use crate::fetcher::lastfm::common::{format_count, plays_word};
+use crate::fetcher::thumbnails;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, ImageLinkedItem, ImageLinkedListData,
+    LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, NumberSeriesData, RatioData, Status,
+    TextBlockData, TextData,
+};
+
+/// Rolling window for the `user.getTop*` endpoints. Default `SevenDay` matches Last.fm's own
+/// "Last 7 days" tab on the user profile, and is the most actionable value (long enough to
+/// have meaningful data, short enough to reflect recent taste shifts).
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub enum Period {
+    #[serde(rename = "7day")]
+    #[default]
+    SevenDay,
+    #[serde(rename = "1month")]
+    OneMonth,
+    #[serde(rename = "3month")]
+    ThreeMonth,
+    #[serde(rename = "6month")]
+    SixMonth,
+    #[serde(rename = "12month")]
+    TwelveMonth,
+    #[serde(rename = "overall")]
+    Overall,
+}
+
+impl Period {
+    /// Value of the `period` query parameter. Last.fm's accepted values are exactly the
+    /// serde-renamed variants below; we keep the as_param mapping explicit so a future rename
+    /// can't silently drift one side.
+    pub fn as_param(self) -> &'static str {
+        match self {
+            Self::SevenDay => "7day",
+            Self::OneMonth => "1month",
+            Self::ThreeMonth => "3month",
+            Self::SixMonth => "6month",
+            Self::TwelveMonth => "12month",
+            Self::Overall => "overall",
+        }
+    }
+
+    /// Short human-readable label used inside `Text` / `Badge` / `Entries` rollups so the user
+    /// can tell at a glance which window is in view.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::SevenDay => "last 7d",
+            Self::OneMonth => "last 1m",
+            Self::ThreeMonth => "last 3m",
+            Self::SixMonth => "last 6m",
+            Self::TwelveMonth => "last 12m",
+            Self::Overall => "overall",
+        }
+    }
+}
+
+/// One ranked entity normalised across all three sibling endpoints.
+#[derive(Debug, Clone)]
+pub struct TopRow {
+    /// 1-indexed display rank.
+    pub rank: usize,
+    /// Row title: artist name, track name, or album name depending on the sibling.
+    pub primary: String,
+    /// For `top_tracks` / `top_albums` this is the artist. For `top_artists` it's `None`.
+    pub secondary: Option<String>,
+    pub playcount: u64,
+    pub url: String,
+    pub image_url: Option<String>,
+}
+
+impl TopRow {
+    /// `"Artist"` or `"Track — Artist"` form, used in row titles.
+    pub fn display_title(&self) -> String {
+        match &self.secondary {
+            Some(s) if !s.is_empty() => format!("{} — {}", self.primary, s),
+            _ => self.primary.clone(),
+        }
+    }
+
+    /// Right-side count column: `"42 plays"` (singular when applicable).
+    pub fn count_label(&self) -> String {
+        format!(
+            "{} {}",
+            format_count(self.playcount),
+            plays_word(self.playcount)
+        )
+    }
+}
+
+/// Headline for `Text` shape: `"#1 Title (42 plays)"`. Falls back when the list is empty.
+pub fn headline(rows: &[TopRow], empty_label: &str) -> String {
+    match rows.first() {
+        Some(top) => format!(
+            "#{} {}  ({})",
+            top.rank,
+            top.display_title(),
+            top.count_label()
+        ),
+        None => empty_label.into(),
+    }
+}
+
+pub fn text_body(rows: &[TopRow], empty_label: &str) -> Body {
+    Body::Text(TextData {
+        value: headline(rows, empty_label),
+    })
+}
+
+pub fn text_block_body(rows: &[TopRow], empty_label: &str) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: lines(rows, empty_label),
+    })
+}
+
+fn lines(rows: &[TopRow], empty_label: &str) -> Vec<String> {
+    if rows.is_empty() {
+        return vec![empty_label.into()];
+    }
+    rows.iter()
+        .map(|r| format!("#{} {}  {}", r.rank, r.display_title(), r.count_label()))
+        .collect()
+}
+
+pub fn markdown_body(rows: &[TopRow], empty_label: &str) -> Body {
+    let value = if rows.is_empty() {
+        format!("_{empty_label}_")
+    } else {
+        rows.iter()
+            .map(|r| {
+                format!(
+                    "- **#{} {}** — {}",
+                    r.rank,
+                    r.display_title(),
+                    r.count_label()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+pub fn linked_text_body(rows: &[TopRow], empty_label: &str) -> Body {
+    let items: Vec<LinkedLine> = if rows.is_empty() {
+        vec![LinkedLine {
+            text: empty_label.into(),
+            url: None,
+        }]
+    } else {
+        rows.iter()
+            .map(|r| LinkedLine {
+                text: format!("#{} {}  {}", r.rank, r.display_title(), r.count_label()),
+                url: Some(r.url.clone()),
+            })
+            .collect()
+    };
+    Body::LinkedTextBlock(LinkedTextBlockData { items })
+}
+
+pub async fn image_linked_body(rows: &[TopRow]) -> Body {
+    let urls: Vec<Option<String>> = rows.iter().map(|r| r.image_url.clone()).collect();
+    let paths = thumbnails::download_many(&urls).await;
+    let items = rows
+        .iter()
+        .zip(paths)
+        .map(|(r, path)| ImageLinkedItem {
+            title: format!("#{} {}", r.rank, r.primary),
+            url: Some(r.url.clone()),
+            thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
+            subtitle: subtitle(r),
+        })
+        .collect();
+    Body::ImageLinkedList(ImageLinkedListData { items })
+}
+
+fn subtitle(row: &TopRow) -> Option<String> {
+    let count = row.count_label();
+    match &row.secondary {
+        Some(s) if !s.is_empty() => Some(format!("{s}  ·  {count}")),
+        _ => Some(count),
+    }
+}
+
+pub fn entries_body(rows: &[TopRow]) -> Body {
+    let items: Vec<Entry> = if rows.is_empty() {
+        vec![Entry {
+            key: "—".into(),
+            value: Some("no scrobbles yet".into()),
+            status: None,
+        }]
+    } else {
+        rows.iter()
+            .map(|r| Entry {
+                key: format!("#{} {}", r.rank, r.display_title()),
+                value: Some(r.count_label()),
+                status: None,
+            })
+            .collect()
+    };
+    Body::Entries(EntriesData { items })
+}
+
+/// Top entity's share of the total playcount across the surfaced window.
+/// Renderers receive `value` (0..=1) + `label` (the entity name) + `denominator` (the
+/// summed playcount, so the gauge can spell "23 of 142" if it wants).
+pub fn ratio_body(rows: &[TopRow]) -> Body {
+    let total: u64 = rows.iter().map(|r| r.playcount).sum();
+    let (value, label, denominator) = match rows.first() {
+        Some(top) if total > 0 => (
+            top.playcount as f64 / total as f64,
+            Some(top.display_title()),
+            Some(total),
+        ),
+        _ => (0.0, None, None),
+    };
+    Body::Ratio(RatioData {
+        value,
+        label,
+        denominator,
+    })
+}
+
+pub fn number_series_body(rows: &[TopRow]) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: rows.iter().map(|r| r.playcount).collect(),
+    })
+}
+
+pub fn bars_body(rows: &[TopRow]) -> Body {
+    Body::Bars(BarsData {
+        bars: rows
+            .iter()
+            .map(|r| Bar {
+                label: r.display_title(),
+                value: r.playcount,
+            })
+            .collect(),
+    })
+}
+
+/// Promotes the top entity to the badge label; falls back to a "quiet window" pill so the
+/// widget stays visible even when the user has no scrobbles in the chosen window.
+pub fn badge_body(rows: &[TopRow], period: Period) -> Body {
+    let (status, label) = match rows.first() {
+        Some(top) => (Status::Ok, format!("#1 {}", top.primary)),
+        None => (Status::Warn, format!("quiet ({})", period.label())),
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(rank: usize, primary: &str, secondary: Option<&str>, plays: u64) -> TopRow {
+        TopRow {
+            rank,
+            primary: primary.into(),
+            secondary: secondary.map(String::from),
+            playcount: plays,
+            url: format!("https://www.last.fm/x/{primary}"),
+            image_url: None,
+        }
+    }
+
+    #[test]
+    fn period_as_param_covers_all_variants() {
+        for p in [
+            Period::SevenDay,
+            Period::OneMonth,
+            Period::ThreeMonth,
+            Period::SixMonth,
+            Period::TwelveMonth,
+            Period::Overall,
+        ] {
+            assert!(!p.as_param().is_empty());
+            assert!(!p.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn period_default_is_seven_day() {
+        assert_eq!(Period::default(), Period::SevenDay);
+    }
+
+    #[test]
+    fn period_deserialises_from_seven_day_param_string() {
+        let raw: toml::Value = toml::from_str(r#"period = "7day""#).unwrap();
+        #[derive(Deserialize)]
+        struct Wrap {
+            period: Period,
+        }
+        let parsed: Wrap = raw.try_into().unwrap();
+        assert_eq!(parsed.period, Period::SevenDay);
+    }
+
+    #[test]
+    fn display_title_includes_secondary_when_present() {
+        let r = row(1, "Track", Some("Artist"), 42);
+        assert_eq!(r.display_title(), "Track — Artist");
+    }
+
+    #[test]
+    fn display_title_falls_back_to_primary_alone() {
+        let r = row(1, "Artist", None, 42);
+        assert_eq!(r.display_title(), "Artist");
+    }
+
+    #[test]
+    fn display_title_treats_empty_secondary_as_absent() {
+        let r = row(1, "Track", Some(""), 42);
+        assert_eq!(r.display_title(), "Track");
+    }
+
+    #[test]
+    fn count_label_pluralises_only_for_non_singular() {
+        assert_eq!(row(1, "x", None, 0).count_label(), "0 plays");
+        assert_eq!(row(1, "x", None, 1).count_label(), "1 play");
+        assert_eq!(row(1, "x", None, 5).count_label(), "5 plays");
+        assert_eq!(row(1, "x", None, 1500).count_label(), "1.5k plays");
+    }
+
+    #[test]
+    fn headline_reports_top_entity_with_rank_prefix() {
+        let rows = vec![row(1, "Artist", None, 100), row(2, "Other", None, 50)];
+        assert_eq!(headline(&rows, "empty"), "#1 Artist  (100 plays)");
+    }
+
+    #[test]
+    fn headline_falls_back_to_empty_label() {
+        assert_eq!(headline(&[], "quiet window"), "quiet window");
+    }
+
+    #[test]
+    fn linked_text_body_carries_one_row_per_entry_with_url() {
+        let rows = vec![row(1, "Artist", None, 100)];
+        let Body::LinkedTextBlock(b) = linked_text_body(&rows, "empty") else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert!(b.items[0].url.is_some());
+        assert!(b.items[0].text.starts_with("#1 Artist"));
+    }
+
+    #[test]
+    fn linked_text_body_emits_single_unlinked_row_on_empty() {
+        let Body::LinkedTextBlock(b) = linked_text_body(&[], "empty") else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(b.items[0].text, "empty");
+        assert!(b.items[0].url.is_none());
+    }
+
+    #[test]
+    fn markdown_body_italicises_empty_label() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&[], "quiet") else {
+            panic!("expected markdown");
+        };
+        assert_eq!(m.value, "_quiet_");
+    }
+
+    #[test]
+    fn ratio_body_is_zero_when_rows_are_empty() {
+        let Body::Ratio(r) = ratio_body(&[]) else {
+            panic!("expected ratio");
+        };
+        assert_eq!(r.value, 0.0);
+        assert!(r.label.is_none());
+        assert!(r.denominator.is_none());
+    }
+
+    #[test]
+    fn ratio_body_carries_top_share_and_total_as_denominator() {
+        let rows = vec![
+            row(1, "A", None, 60),
+            row(2, "B", None, 30),
+            row(3, "C", None, 10),
+        ];
+        let Body::Ratio(r) = ratio_body(&rows) else {
+            panic!("expected ratio");
+        };
+        assert!((r.value - 0.6).abs() < 1e-9);
+        assert_eq!(r.label.as_deref(), Some("A"));
+        assert_eq!(r.denominator, Some(100));
+    }
+
+    #[test]
+    fn ratio_body_returns_zero_when_total_is_zero() {
+        let rows = vec![row(1, "A", None, 0), row(2, "B", None, 0)];
+        let Body::Ratio(r) = ratio_body(&rows) else {
+            panic!("expected ratio");
+        };
+        assert_eq!(r.value, 0.0);
+        assert!(r.label.is_none());
+    }
+
+    #[test]
+    fn number_series_body_lifts_playcounts_in_order() {
+        let rows = vec![row(1, "A", None, 30), row(2, "B", None, 20)];
+        let Body::NumberSeries(s) = number_series_body(&rows) else {
+            panic!("expected number_series");
+        };
+        assert_eq!(s.values, vec![30, 20]);
+    }
+
+    #[test]
+    fn bars_body_uses_display_title_as_label_and_playcount_as_value() {
+        let rows = vec![row(1, "Track", Some("Artist"), 42)];
+        let Body::Bars(b) = bars_body(&rows) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars.len(), 1);
+        assert_eq!(b.bars[0].label, "Track — Artist");
+        assert_eq!(b.bars[0].value, 42);
+    }
+
+    #[test]
+    fn badge_body_promotes_top_entity_and_warns_on_empty() {
+        let rows = vec![row(1, "Artist", None, 100)];
+        let Body::Badge(b) = badge_body(&rows, Period::SevenDay) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert!(b.label.contains("Artist"));
+
+        let Body::Badge(empty) = badge_body(&[], Period::SevenDay) else {
+            panic!("expected badge");
+        };
+        assert_eq!(empty.status, Status::Warn);
+        assert!(empty.label.contains("7d"));
+    }
+
+    #[test]
+    fn entries_body_appends_count_value_per_row() {
+        let rows = vec![row(1, "Track", Some("Artist"), 42)];
+        let Body::Entries(e) = entries_body(&rows) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "#1 Track — Artist");
+        assert_eq!(e.items[0].value.as_deref(), Some("42 plays"));
+    }
+
+    #[test]
+    fn subtitle_falls_back_to_count_when_secondary_missing() {
+        let r = row(1, "Artist", None, 42);
+        assert_eq!(subtitle(&r), Some("42 plays".into()));
+    }
+
+    #[test]
+    fn subtitle_includes_secondary_alongside_count() {
+        let r = row(1, "Track", Some("Artist"), 42);
+        let s = subtitle(&r).unwrap();
+        assert!(s.contains("Artist"));
+        assert!(s.contains("42 plays"));
+    }
+}

--- a/src/fetcher/lastfm/top_albums.rs
+++ b/src/fetcher/lastfm/top_albums.rs
@@ -1,0 +1,440 @@
+//! `lastfm_top_albums` — a Last.fm user's top albums for a rolling window.
+//!
+//! Reads `user.getTopAlbums`. Same `period` / `limit` contract as the other `top_*` siblings;
+//! rows carry the artist as the secondary label so the shared rendering surface produces
+//! `"Album — Artist"` titles automatically.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::lastfm::client;
+use crate::fetcher::lastfm::common::{ImageEntry, best_image, parse_count};
+use crate::fetcher::lastfm::top::{
+    Period, TopRow, badge_body, bars_body, entries_body, headline, image_linked_body,
+    linked_text_body, markdown_body, number_series_body, ratio_body, text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload, Status};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::Bars,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string",
+        required: true,
+        default: None,
+        description: "Last.fm username whose top albums to read.",
+    },
+    OptionSchema {
+        name: "period",
+        type_hint: "\"7day\" | \"1month\" | \"3month\" | \"6month\" | \"12month\" | \"overall\"",
+        required: false,
+        default: Some("\"7day\""),
+        description: "Rolling window for the ranking — same set Last.fm exposes on the profile page tabs.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Number of albums to display.",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 50;
+
+pub struct LastfmTopAlbums;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub user: Option<String>,
+    pub period: Option<Period>,
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for LastfmTopAlbums {
+    fn name(&self) -> &str {
+        "lastfm_top_albums"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Top albums for a Last.fm user over a rolling window (`7day` default, also `1month` / `3month` / `6month` / `12month` / `overall`). Mirrors the profile page's Top Albums tab. ImageLinkedList shape carries the album artwork from Last.fm's image set."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let user = opts
+            .user
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                FetchError::Failed(
+                    "lastfm_top_albums: `user = \"<lastfm name>\"` is required".into(),
+                )
+            })?;
+        let period = opts.period.unwrap_or_default();
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+
+        let rows = fetch_rows(user, period, limit).await?;
+        Ok(payload(render_body(&rows, period, shape).await))
+    }
+}
+
+async fn fetch_rows(user: &str, period: Period, limit: usize) -> Result<Vec<TopRow>, FetchError> {
+    let limit_str = limit.to_string();
+    let raw: TopAlbumsResponse = client::get_json(
+        "user.getTopAlbums",
+        &[
+            ("user", user),
+            ("period", period.as_param()),
+            ("limit", &limit_str),
+        ],
+    )
+    .await?;
+    Ok(raw
+        .topalbums
+        .album
+        .into_iter()
+        .enumerate()
+        .map(|(i, a)| into_row(a, i))
+        .collect())
+}
+
+fn into_row(raw: RawAlbum, index: usize) -> TopRow {
+    let rank = raw
+        .attr
+        .as_ref()
+        .and_then(|a| a.rank.parse::<usize>().ok())
+        .unwrap_or(index + 1);
+    let artist = raw.artist.name.filter(|s| !s.is_empty());
+    TopRow {
+        rank,
+        primary: raw.name,
+        secondary: artist,
+        playcount: parse_count(&raw.playcount),
+        url: raw.url,
+        image_url: best_image(&raw.image),
+    }
+}
+
+async fn render_body(rows: &[TopRow], period: Period, shape: Shape) -> Body {
+    let empty = empty_label(period);
+    match shape {
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::LinkedTextBlock => linked_text_body(rows, &empty),
+        Shape::TextBlock => text_block_body(rows, &empty),
+        Shape::MarkdownTextBlock => markdown_body(rows, &empty),
+        Shape::Entries => entries_body(rows),
+        Shape::Ratio => ratio_body(rows),
+        Shape::NumberSeries => number_series_body(rows),
+        Shape::Bars => bars_body(rows),
+        Shape::Badge => badge_body(rows, period),
+        _ => text_body(rows, &empty),
+    }
+}
+
+fn empty_label(period: Period) -> String {
+    format!("no top albums ({})", period.label())
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    let rows = sample_rows();
+    Some(match shape {
+        Shape::Text => samples::text(&headline(&rows, "no top albums")),
+        Shape::TextBlock => samples::text_block(&[
+            "#1 Viva la Vida — Coldplay  240 plays",
+            "#2 Bloom — Beach House  168 plays",
+            "#3 Songs About Jane — Maroon 5  142 plays",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- **#1 Viva la Vida — Coldplay** — 240 plays\n- **#2 Bloom — Beach House** — 168 plays\n- **#3 Songs About Jane — Maroon 5** — 142 plays",
+        ),
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "#1 Viva la Vida — Coldplay  240 plays",
+                Some("https://www.last.fm/music/Coldplay/Viva+la+Vida"),
+            ),
+            (
+                "#2 Bloom — Beach House  168 plays",
+                Some("https://www.last.fm/music/Beach+House/Bloom"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "#1 Viva la Vida",
+                Some("https://www.last.fm/music/Coldplay/Viva+la+Vida"),
+                None,
+                Some("Coldplay  ·  240 plays"),
+            ),
+            (
+                "#2 Bloom",
+                Some("https://www.last.fm/music/Beach+House/Bloom"),
+                None,
+                Some("Beach House  ·  168 plays"),
+            ),
+        ]),
+        Shape::Entries => samples::entries(&[
+            ("#1 Viva la Vida — Coldplay", "240 plays"),
+            ("#2 Bloom — Beach House", "168 plays"),
+        ]),
+        Shape::Ratio => samples::ratio(0.42, "Viva la Vida — Coldplay"),
+        Shape::NumberSeries => samples::number_series(&[240, 168, 142, 98, 72, 54, 41, 36, 28, 22]),
+        Shape::Bars => samples::bars(&[
+            ("Viva la Vida — Coldplay", 240),
+            ("Bloom — Beach House", 168),
+            ("Songs About Jane — Maroon 5", 142),
+        ]),
+        Shape::Badge => samples::badge(Status::Ok, "#1 Viva la Vida"),
+        _ => return None,
+    })
+}
+
+fn sample_rows() -> Vec<TopRow> {
+    vec![
+        TopRow {
+            rank: 1,
+            primary: "Viva la Vida".into(),
+            secondary: Some("Coldplay".into()),
+            playcount: 240,
+            url: "https://www.last.fm/music/Coldplay/Viva+la+Vida".into(),
+            image_url: None,
+        },
+        TopRow {
+            rank: 2,
+            primary: "Bloom".into(),
+            secondary: Some("Beach House".into()),
+            playcount: 168,
+            url: "https://www.last.fm/music/Beach+House/Bloom".into(),
+            image_url: None,
+        },
+    ]
+}
+
+#[derive(Deserialize)]
+struct TopAlbumsResponse {
+    topalbums: TopAlbumsInner,
+}
+
+#[derive(Deserialize)]
+struct TopAlbumsInner {
+    #[serde(default)]
+    album: Vec<RawAlbum>,
+}
+
+#[derive(Deserialize)]
+struct RawAlbum {
+    name: String,
+    #[serde(default)]
+    playcount: String,
+    artist: ArtistObj,
+    url: String,
+    #[serde(default)]
+    image: Vec<ImageEntry>,
+    #[serde(rename = "@attr", default)]
+    attr: Option<RankAttr>,
+}
+
+#[derive(Deserialize)]
+struct ArtistObj {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RankAttr {
+    #[serde(default)]
+    rank: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "lastfm-top-albums".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn parse_albums(json: &str) -> Vec<TopRow> {
+        let raw: TopAlbumsResponse = serde_json::from_str(json).unwrap();
+        raw.topalbums
+            .album
+            .into_iter()
+            .enumerate()
+            .map(|(i, a)| into_row(a, i))
+            .collect()
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.user.is_none());
+        assert!(opts.period.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn options_deserialise_full_form() {
+        let raw: toml::Value =
+            toml::from_str("user = \"rj\"\nperiod = \"6month\"\nlimit = 10").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.user.as_deref(), Some("rj"));
+        assert_eq!(opts.period, Some(Period::SixMonth));
+        assert_eq!(opts.limit, Some(10));
+    }
+
+    #[test]
+    fn into_row_pulls_artist_into_secondary() {
+        let json = r##"{
+            "topalbums": {
+                "album": [
+                    {
+                        "name": "Album",
+                        "playcount": "60",
+                        "artist": {"name": "Artist"},
+                        "url": "https://www.last.fm/music/Artist/Album",
+                        "image": [{"#text": "https://example.com/m.png", "size": "mega"}],
+                        "@attr": {"rank": "1"}
+                    }
+                ]
+            }
+        }"##;
+        let rows = parse_albums(json);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].primary, "Album");
+        assert_eq!(rows[0].secondary.as_deref(), Some("Artist"));
+        assert_eq!(rows[0].playcount, 60);
+        assert_eq!(
+            rows[0].image_url.as_deref(),
+            Some("https://example.com/m.png")
+        );
+    }
+
+    #[test]
+    fn into_row_falls_back_to_position_when_rank_missing() {
+        let json = r##"{
+            "topalbums": {
+                "album": [
+                    {"name": "A", "playcount": "1", "artist": {"name": "X"}, "url": "https://x", "image": []},
+                    {"name": "B", "playcount": "2", "artist": {"name": "Y"}, "url": "https://y", "image": []}
+                ]
+            }
+        }"##;
+        let rows = parse_albums(json);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[1].rank, 2);
+    }
+
+    #[test]
+    fn empty_label_includes_period_text() {
+        assert!(empty_label(Period::Overall).contains("overall"));
+        assert!(empty_label(Period::TwelveMonth).contains("12m"));
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = LastfmTopAlbums;
+        assert_eq!(fetcher.name(), "lastfm_top_albums");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Timeline).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_period_and_shape() {
+        let fetcher = LastfmTopAlbums;
+        let seven = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"7day\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        let overall = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"overall\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        assert_ne!(seven, overall);
+    }
+
+    #[tokio::test]
+    async fn fetch_requires_user_option() {
+        let err = LastfmTopAlbums
+            .fetch(&ctx(None, Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("`user ="));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = LastfmTopAlbums
+            .fetch(&ctx(Some("user = \"rj\"\nbogus = 1"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+}

--- a/src/fetcher/lastfm/top_artists.rs
+++ b/src/fetcher/lastfm/top_artists.rs
@@ -11,7 +11,7 @@ use crate::fetcher::github::common::{cache_key, parse_options, payload};
 use crate::fetcher::lastfm::client;
 use crate::fetcher::lastfm::common::{ImageEntry, best_image, parse_count};
 use crate::fetcher::lastfm::top::{
-    self, Period, TopRow, badge_body, bars_body, entries_body, headline, image_linked_body,
+    Period, TopRow, badge_body, bars_body, entries_body, headline, image_linked_body,
     linked_text_body, markdown_body, number_series_body, ratio_body, text_block_body, text_body,
 };
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
@@ -255,13 +255,6 @@ fn sample_rows() -> Vec<TopRow> {
             image_url: None,
         },
     ]
-}
-
-// Hook the rendering helpers under the `top::` reference so an accidental rename of one
-// helper trips the build at this site rather than only in tests.
-#[allow(dead_code)]
-fn _helpers_reference_check() {
-    let _ = top::headline;
 }
 
 #[derive(Deserialize)]

--- a/src/fetcher/lastfm/top_artists.rs
+++ b/src/fetcher/lastfm/top_artists.rs
@@ -1,0 +1,462 @@
+//! `lastfm_top_artists` — a Last.fm user's top artists for a rolling window.
+//!
+//! Reads `user.getTopArtists`. The `period` option (default `"7day"`) chooses the window
+//! width — same set of values Last.fm exposes on the profile page tabs. Rendering goes
+//! through the shared [`super::top`] surface so the sibling stays focused on parsing.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::lastfm::client;
+use crate::fetcher::lastfm::common::{ImageEntry, best_image, parse_count};
+use crate::fetcher::lastfm::top::{
+    self, Period, TopRow, badge_body, bars_body, entries_body, headline, image_linked_body,
+    linked_text_body, markdown_body, number_series_body, ratio_body, text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload, Status};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::Bars,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string",
+        required: true,
+        default: None,
+        description: "Last.fm username whose top artists to read.",
+    },
+    OptionSchema {
+        name: "period",
+        type_hint: "\"7day\" | \"1month\" | \"3month\" | \"6month\" | \"12month\" | \"overall\"",
+        required: false,
+        default: Some("\"7day\""),
+        description: "Rolling window for the ranking — same set Last.fm exposes on the profile page tabs.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Number of artists to display.",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 50;
+
+pub struct LastfmTopArtists;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub user: Option<String>,
+    pub period: Option<Period>,
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for LastfmTopArtists {
+    fn name(&self) -> &str {
+        "lastfm_top_artists"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Top artists for a Last.fm user over a rolling window (`7day` default, also `1month` / `3month` / `6month` / `12month` / `overall`). Mirrors the profile page's Top Artists tab."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let user = opts
+            .user
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                FetchError::Failed(
+                    "lastfm_top_artists: `user = \"<lastfm name>\"` is required".into(),
+                )
+            })?;
+        let period = opts.period.unwrap_or_default();
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+
+        let rows = fetch_rows(user, period, limit).await?;
+        Ok(payload(render_body(&rows, period, shape).await))
+    }
+}
+
+async fn fetch_rows(user: &str, period: Period, limit: usize) -> Result<Vec<TopRow>, FetchError> {
+    let limit_str = limit.to_string();
+    let raw: TopArtistsResponse = client::get_json(
+        "user.getTopArtists",
+        &[
+            ("user", user),
+            ("period", period.as_param()),
+            ("limit", &limit_str),
+        ],
+    )
+    .await?;
+    Ok(raw
+        .topartists
+        .artist
+        .into_iter()
+        .enumerate()
+        .map(|(i, a)| into_row(a, i))
+        .collect())
+}
+
+fn into_row(raw: RawArtist, index: usize) -> TopRow {
+    let rank = raw
+        .attr
+        .as_ref()
+        .and_then(|a| a.rank.parse::<usize>().ok())
+        .unwrap_or(index + 1);
+    TopRow {
+        rank,
+        primary: raw.name,
+        secondary: None,
+        playcount: parse_count(&raw.playcount),
+        url: raw.url,
+        image_url: best_image(&raw.image),
+    }
+}
+
+async fn render_body(rows: &[TopRow], period: Period, shape: Shape) -> Body {
+    let empty = empty_label(period);
+    match shape {
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::LinkedTextBlock => linked_text_body(rows, &empty),
+        Shape::TextBlock => text_block_body(rows, &empty),
+        Shape::MarkdownTextBlock => markdown_body(rows, &empty),
+        Shape::Entries => entries_body(rows),
+        Shape::Ratio => ratio_body(rows),
+        Shape::NumberSeries => number_series_body(rows),
+        Shape::Bars => bars_body(rows),
+        Shape::Badge => badge_body(rows, period),
+        _ => text_body(rows, &empty),
+    }
+}
+
+fn empty_label(period: Period) -> String {
+    format!("no top artists ({})", period.label())
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    let rows = sample_rows();
+    Some(match shape {
+        Shape::Text => samples::text(&headline(&rows, "no top artists")),
+        Shape::TextBlock => samples::text_block(&[
+            "#1 Coldplay  3.2k plays",
+            "#2 Adam Levine  1.8k plays",
+            "#3 Beach House  850 plays",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- **#1 Coldplay** — 3.2k plays\n- **#2 Adam Levine** — 1.8k plays\n- **#3 Beach House** — 850 plays",
+        ),
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "#1 Coldplay  3.2k plays",
+                Some("https://www.last.fm/music/Coldplay"),
+            ),
+            (
+                "#2 Adam Levine  1.8k plays",
+                Some("https://www.last.fm/music/Adam+Levine"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "#1 Coldplay",
+                Some("https://www.last.fm/music/Coldplay"),
+                None,
+                Some("3.2k plays"),
+            ),
+            (
+                "#2 Adam Levine",
+                Some("https://www.last.fm/music/Adam+Levine"),
+                None,
+                Some("1.8k plays"),
+            ),
+        ]),
+        Shape::Entries => samples::entries(&[
+            ("#1 Coldplay", "3.2k plays"),
+            ("#2 Adam Levine", "1.8k plays"),
+        ]),
+        Shape::Ratio => samples::ratio(0.45, "Coldplay"),
+        Shape::NumberSeries => {
+            samples::number_series(&[3_200, 1_800, 850, 720, 480, 320, 210, 180, 150, 120])
+        }
+        Shape::Bars => samples::bars(&[
+            ("Coldplay", 3_200),
+            ("Adam Levine", 1_800),
+            ("Beach House", 850),
+        ]),
+        Shape::Badge => samples::badge(Status::Ok, "#1 Coldplay"),
+        _ => return None,
+    })
+}
+
+fn sample_rows() -> Vec<TopRow> {
+    vec![
+        TopRow {
+            rank: 1,
+            primary: "Coldplay".into(),
+            secondary: None,
+            playcount: 3_200,
+            url: "https://www.last.fm/music/Coldplay".into(),
+            image_url: None,
+        },
+        TopRow {
+            rank: 2,
+            primary: "Adam Levine".into(),
+            secondary: None,
+            playcount: 1_800,
+            url: "https://www.last.fm/music/Adam+Levine".into(),
+            image_url: None,
+        },
+    ]
+}
+
+// Hook the rendering helpers under the `top::` reference so an accidental rename of one
+// helper trips the build at this site rather than only in tests.
+#[allow(dead_code)]
+fn _helpers_reference_check() {
+    let _ = top::headline;
+}
+
+#[derive(Deserialize)]
+struct TopArtistsResponse {
+    topartists: TopArtistsInner,
+}
+
+#[derive(Deserialize)]
+struct TopArtistsInner {
+    #[serde(default)]
+    artist: Vec<RawArtist>,
+}
+
+#[derive(Deserialize)]
+struct RawArtist {
+    name: String,
+    #[serde(default)]
+    playcount: String,
+    url: String,
+    #[serde(default)]
+    image: Vec<ImageEntry>,
+    #[serde(rename = "@attr", default)]
+    attr: Option<RankAttr>,
+}
+
+#[derive(Deserialize)]
+struct RankAttr {
+    #[serde(default)]
+    rank: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "lastfm-top-artists".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn parse_artists(json: &str) -> Vec<TopRow> {
+        let raw: TopArtistsResponse = serde_json::from_str(json).unwrap();
+        raw.topartists
+            .artist
+            .into_iter()
+            .enumerate()
+            .map(|(i, a)| into_row(a, i))
+            .collect()
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.user.is_none());
+        assert!(opts.period.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn options_deserialise_full_form() {
+        let raw: toml::Value =
+            toml::from_str("user = \"rj\"\nperiod = \"3month\"\nlimit = 25").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.user.as_deref(), Some("rj"));
+        assert_eq!(opts.period, Some(Period::ThreeMonth));
+        assert_eq!(opts.limit, Some(25));
+    }
+
+    #[test]
+    fn into_row_uses_attr_rank_when_present() {
+        let json = r##"{
+            "topartists": {
+                "artist": [
+                    {
+                        "name": "Artist",
+                        "playcount": "42",
+                        "url": "https://www.last.fm/music/Artist",
+                        "image": [
+                            {"#text": "https://example.com/m.png", "size": "mega"}
+                        ],
+                        "@attr": {"rank": "1"}
+                    }
+                ]
+            }
+        }"##;
+        let rows = parse_artists(json);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].primary, "Artist");
+        assert!(rows[0].secondary.is_none());
+        assert_eq!(rows[0].playcount, 42);
+        assert_eq!(
+            rows[0].image_url.as_deref(),
+            Some("https://example.com/m.png")
+        );
+    }
+
+    #[test]
+    fn into_row_falls_back_to_position_when_rank_missing() {
+        let json = r##"{
+            "topartists": {
+                "artist": [
+                    {"name": "A", "playcount": "1", "url": "https://x", "image": []},
+                    {"name": "B", "playcount": "2", "url": "https://x", "image": []}
+                ]
+            }
+        }"##;
+        let rows = parse_artists(json);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[1].rank, 2);
+    }
+
+    #[test]
+    fn into_row_collapses_unparseable_playcount_to_zero() {
+        let json = r##"{
+            "topartists": {
+                "artist": [
+                    {"name": "A", "playcount": "n/a", "url": "https://x", "image": []}
+                ]
+            }
+        }"##;
+        let rows = parse_artists(json);
+        assert_eq!(rows[0].playcount, 0);
+    }
+
+    #[test]
+    fn empty_label_includes_period_text() {
+        assert!(empty_label(Period::SevenDay).contains("7d"));
+        assert!(empty_label(Period::Overall).contains("overall"));
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = LastfmTopArtists;
+        assert_eq!(fetcher.name(), "lastfm_top_artists");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        // Timeline isn't part of this fetcher's shape list — sample must be None.
+        assert!(fetcher.sample_body(Shape::Timeline).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_period_and_shape() {
+        let fetcher = LastfmTopArtists;
+        let seven = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"7day\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        let month = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"1month\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        let bars = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"7day\""),
+            Some(Shape::Bars),
+        ));
+        assert_ne!(seven, month);
+        assert_ne!(seven, bars);
+    }
+
+    #[tokio::test]
+    async fn fetch_requires_user_option() {
+        let err = LastfmTopArtists
+            .fetch(&ctx(None, Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("`user ="));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = LastfmTopArtists
+            .fetch(&ctx(Some("user = \"rj\"\nbogus = true"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+}

--- a/src/fetcher/lastfm/top_tracks.rs
+++ b/src/fetcher/lastfm/top_tracks.rs
@@ -1,0 +1,448 @@
+//! `lastfm_top_tracks` — a Last.fm user's top tracks for a rolling window.
+//!
+//! Reads `user.getTopTracks`. Same `period` / `limit` contract as `lastfm_top_artists`; the
+//! row shape carries a secondary artist label so the rendering helpers in [`super::top`]
+//! produce `"Track — Artist"` titles automatically.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::lastfm::client;
+use crate::fetcher::lastfm::common::{ImageEntry, best_image, parse_count};
+use crate::fetcher::lastfm::top::{
+    Period, TopRow, badge_body, bars_body, entries_body, headline, image_linked_body,
+    linked_text_body, markdown_body, number_series_body, ratio_body, text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload, Status};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::Bars,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "user",
+        type_hint: "string",
+        required: true,
+        default: None,
+        description: "Last.fm username whose top tracks to read.",
+    },
+    OptionSchema {
+        name: "period",
+        type_hint: "\"7day\" | \"1month\" | \"3month\" | \"6month\" | \"12month\" | \"overall\"",
+        required: false,
+        default: Some("\"7day\""),
+        description: "Rolling window for the ranking — same set Last.fm exposes on the profile page tabs.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Number of tracks to display.",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MIN_LIMIT: u32 = 1;
+const MAX_LIMIT: u32 = 50;
+
+pub struct LastfmTopTracks;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub user: Option<String>,
+    pub period: Option<Period>,
+    pub limit: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for LastfmTopTracks {
+    fn name(&self) -> &str {
+        "lastfm_top_tracks"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Top tracks for a Last.fm user over a rolling window (`7day` default, also `1month` / `3month` / `6month` / `12month` / `overall`). Mirrors the profile page's Top Tracks tab."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let user = opts
+            .user
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                FetchError::Failed(
+                    "lastfm_top_tracks: `user = \"<lastfm name>\"` is required".into(),
+                )
+            })?;
+        let period = opts.period.unwrap_or_default();
+        let limit = opts
+            .limit
+            .unwrap_or(DEFAULT_LIMIT)
+            .clamp(MIN_LIMIT, MAX_LIMIT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::LinkedTextBlock);
+
+        let rows = fetch_rows(user, period, limit).await?;
+        Ok(payload(render_body(&rows, period, shape).await))
+    }
+}
+
+async fn fetch_rows(user: &str, period: Period, limit: usize) -> Result<Vec<TopRow>, FetchError> {
+    let limit_str = limit.to_string();
+    let raw: TopTracksResponse = client::get_json(
+        "user.getTopTracks",
+        &[
+            ("user", user),
+            ("period", period.as_param()),
+            ("limit", &limit_str),
+        ],
+    )
+    .await?;
+    Ok(raw
+        .toptracks
+        .track
+        .into_iter()
+        .enumerate()
+        .map(|(i, t)| into_row(t, i))
+        .collect())
+}
+
+fn into_row(raw: RawTrack, index: usize) -> TopRow {
+    let rank = raw
+        .attr
+        .as_ref()
+        .and_then(|a| a.rank.parse::<usize>().ok())
+        .unwrap_or(index + 1);
+    let artist = raw.artist.name.filter(|s| !s.is_empty());
+    TopRow {
+        rank,
+        primary: raw.name,
+        secondary: artist,
+        playcount: parse_count(&raw.playcount),
+        url: raw.url,
+        image_url: best_image(&raw.image),
+    }
+}
+
+async fn render_body(rows: &[TopRow], period: Period, shape: Shape) -> Body {
+    let empty = empty_label(period);
+    match shape {
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::LinkedTextBlock => linked_text_body(rows, &empty),
+        Shape::TextBlock => text_block_body(rows, &empty),
+        Shape::MarkdownTextBlock => markdown_body(rows, &empty),
+        Shape::Entries => entries_body(rows),
+        Shape::Ratio => ratio_body(rows),
+        Shape::NumberSeries => number_series_body(rows),
+        Shape::Bars => bars_body(rows),
+        Shape::Badge => badge_body(rows, period),
+        _ => text_body(rows, &empty),
+    }
+}
+
+fn empty_label(period: Period) -> String {
+    format!("no top tracks ({})", period.label())
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    let rows = sample_rows();
+    Some(match shape {
+        Shape::Text => samples::text(&headline(&rows, "no top tracks")),
+        Shape::TextBlock => samples::text_block(&[
+            "#1 Strawberry Swing — Coldplay  120 plays",
+            "#2 Lost Stars — Adam Levine  98 plays",
+            "#3 Space Song — Beach House  72 plays",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- **#1 Strawberry Swing — Coldplay** — 120 plays\n- **#2 Lost Stars — Adam Levine** — 98 plays\n- **#3 Space Song — Beach House** — 72 plays",
+        ),
+        Shape::LinkedTextBlock => samples::linked_text_block(&[
+            (
+                "#1 Strawberry Swing — Coldplay  120 plays",
+                Some("https://www.last.fm/music/Coldplay/_/Strawberry+Swing"),
+            ),
+            (
+                "#2 Lost Stars — Adam Levine  98 plays",
+                Some("https://www.last.fm/music/Adam+Levine/_/Lost+Stars"),
+            ),
+        ]),
+        Shape::ImageLinkedList => samples::image_linked_list(&[
+            (
+                "#1 Strawberry Swing",
+                Some("https://www.last.fm/music/Coldplay/_/Strawberry+Swing"),
+                None,
+                Some("Coldplay  ·  120 plays"),
+            ),
+            (
+                "#2 Lost Stars",
+                Some("https://www.last.fm/music/Adam+Levine/_/Lost+Stars"),
+                None,
+                Some("Adam Levine  ·  98 plays"),
+            ),
+        ]),
+        Shape::Entries => samples::entries(&[
+            ("#1 Strawberry Swing — Coldplay", "120 plays"),
+            ("#2 Lost Stars — Adam Levine", "98 plays"),
+        ]),
+        Shape::Ratio => samples::ratio(0.34, "Strawberry Swing — Coldplay"),
+        Shape::NumberSeries => samples::number_series(&[120, 98, 72, 64, 48, 36, 28, 21, 19, 15]),
+        Shape::Bars => samples::bars(&[
+            ("Strawberry Swing — Coldplay", 120),
+            ("Lost Stars — Adam Levine", 98),
+            ("Space Song — Beach House", 72),
+        ]),
+        Shape::Badge => samples::badge(Status::Ok, "#1 Strawberry Swing"),
+        _ => return None,
+    })
+}
+
+fn sample_rows() -> Vec<TopRow> {
+    vec![
+        TopRow {
+            rank: 1,
+            primary: "Strawberry Swing".into(),
+            secondary: Some("Coldplay".into()),
+            playcount: 120,
+            url: "https://www.last.fm/music/Coldplay/_/Strawberry+Swing".into(),
+            image_url: None,
+        },
+        TopRow {
+            rank: 2,
+            primary: "Lost Stars".into(),
+            secondary: Some("Adam Levine".into()),
+            playcount: 98,
+            url: "https://www.last.fm/music/Adam+Levine/_/Lost+Stars".into(),
+            image_url: None,
+        },
+    ]
+}
+
+#[derive(Deserialize)]
+struct TopTracksResponse {
+    toptracks: TopTracksInner,
+}
+
+#[derive(Deserialize)]
+struct TopTracksInner {
+    #[serde(default)]
+    track: Vec<RawTrack>,
+}
+
+/// Unlike `user.getRecentTracks` (which uses `{"#text": "Artist"}`), `user.getTopTracks`
+/// nests the artist as a proper object with a `name` field. Different shape per endpoint
+/// so each fetcher carries its own DTO.
+#[derive(Deserialize)]
+struct RawTrack {
+    name: String,
+    #[serde(default)]
+    playcount: String,
+    artist: ArtistObj,
+    url: String,
+    #[serde(default)]
+    image: Vec<ImageEntry>,
+    #[serde(rename = "@attr", default)]
+    attr: Option<RankAttr>,
+}
+
+#[derive(Deserialize)]
+struct ArtistObj {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RankAttr {
+    #[serde(default)]
+    rank: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "lastfm-top-tracks".into(),
+            timeout: Duration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn parse_tracks(json: &str) -> Vec<TopRow> {
+        let raw: TopTracksResponse = serde_json::from_str(json).unwrap();
+        raw.toptracks
+            .track
+            .into_iter()
+            .enumerate()
+            .map(|(i, t)| into_row(t, i))
+            .collect()
+    }
+
+    #[test]
+    fn options_default_to_none() {
+        let opts = Options::default();
+        assert!(opts.user.is_none());
+        assert!(opts.period.is_none());
+        assert!(opts.limit.is_none());
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = true").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn options_deserialise_full_form() {
+        let raw: toml::Value =
+            toml::from_str("user = \"rj\"\nperiod = \"overall\"\nlimit = 50").unwrap();
+        let opts: Options = raw.try_into().unwrap();
+        assert_eq!(opts.user.as_deref(), Some("rj"));
+        assert_eq!(opts.period, Some(Period::Overall));
+        assert_eq!(opts.limit, Some(50));
+    }
+
+    #[test]
+    fn into_row_pulls_artist_into_secondary() {
+        let json = r##"{
+            "toptracks": {
+                "track": [
+                    {
+                        "name": "Track",
+                        "playcount": "42",
+                        "artist": {"name": "Artist"},
+                        "url": "https://www.last.fm/music/Artist/_/Track",
+                        "image": [{"#text": "https://example.com/m.png", "size": "mega"}],
+                        "@attr": {"rank": "1"}
+                    }
+                ]
+            }
+        }"##;
+        let rows = parse_tracks(json);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].primary, "Track");
+        assert_eq!(rows[0].secondary.as_deref(), Some("Artist"));
+        assert_eq!(rows[0].playcount, 42);
+        assert_eq!(
+            rows[0].image_url.as_deref(),
+            Some("https://example.com/m.png")
+        );
+    }
+
+    #[test]
+    fn into_row_treats_missing_artist_name_as_no_secondary() {
+        let json = r##"{
+            "toptracks": {
+                "track": [
+                    {
+                        "name": "Track",
+                        "playcount": "1",
+                        "artist": {},
+                        "url": "https://x",
+                        "image": [],
+                        "@attr": {"rank": "1"}
+                    }
+                ]
+            }
+        }"##;
+        let rows = parse_tracks(json);
+        assert!(rows[0].secondary.is_none());
+    }
+
+    #[test]
+    fn empty_label_includes_period_text() {
+        assert!(empty_label(Period::SevenDay).contains("7d"));
+        assert!(empty_label(Period::OneMonth).contains("1m"));
+    }
+
+    #[test]
+    fn fetcher_exposes_catalog_metadata_and_samples() {
+        let fetcher = LastfmTopTracks;
+        assert_eq!(fetcher.name(), "lastfm_top_tracks");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert_eq!(fetcher.shapes(), SHAPES);
+        assert_eq!(fetcher.default_shape(), Shape::LinkedTextBlock);
+        for shape in SHAPES {
+            assert!(
+                fetcher.sample_body(*shape).is_some(),
+                "missing sample for {shape:?}"
+            );
+        }
+        assert!(fetcher.sample_body(Shape::Timeline).is_none());
+    }
+
+    #[test]
+    fn cache_key_partitions_by_period_and_shape() {
+        let fetcher = LastfmTopTracks;
+        let seven = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"7day\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        let month = fetcher.cache_key(&ctx(
+            Some("user = \"rj\"\nperiod = \"1month\""),
+            Some(Shape::LinkedTextBlock),
+        ));
+        assert_ne!(seven, month);
+    }
+
+    #[tokio::test]
+    async fn fetch_requires_user_option() {
+        let err = LastfmTopTracks
+            .fetch(&ctx(None, Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("`user ="));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_network() {
+        let err = LastfmTopTracks
+            .fetch(&ctx(Some("user = \"rj\"\nbogus = 1"), Some(Shape::Text)))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("unknown field"));
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -27,6 +27,7 @@ pub mod github;
 pub mod gitlab;
 pub mod hackernews;
 pub mod huggingface_trending;
+pub mod lastfm;
 pub mod linear;
 pub mod lobsters;
 pub mod nasa_apod;
@@ -354,6 +355,9 @@ impl Registry {
             r.register(f);
         }
         for f in hackernews::fetchers() {
+            r.register(f);
+        }
+        for f in lastfm::fetchers() {
             r.register(f);
         }
         for f in linear::fetchers() {


### PR DESCRIPTION
## Summary

Adds the `lastfm_*` fetcher family — five fetchers covering a Last.fm user's daily listening statistics plus the global "what the world is playing right now" chart. Ticks the `lastfm_*` candidates on the catalog roadmap (#67).

| | name | what it shows |
|---|---|---|
| 1 | `lastfm_scrobbles_today` | Today's scrobbles + currently-playing track |
| 2 | `lastfm_top_artists` | Top artists for a rolling window (`7day`/`1month`/.../`overall`) |
| 3 | `lastfm_top_tracks` | Top tracks, same period contract |
| 4 | `lastfm_top_albums` | Top albums, same period contract (album artwork in `ImageLinkedList`) |
| 5 | `lastfm_charts` | Global chart of top artists or top tracks across every Last.fm scrobble |

**Safety**: All five are `Safety::Safe`. Host is hardcoded (`ws.audioscrobbler.com`); config-provided fields (`user`, `period`, `kind`, …) only change which resource within the fixed host is queried. Same model as `github_*`.

**Auth**: `LASTFM_API_KEY` (free, https://www.last.fm/api/account/create). Drop it in `$HOME/.splashboard/secrets.toml`.

**Shared infra**: One PR, six commits — `client.rs` + `common.rs` + `top.rs` factor out the cross-sibling code so each `top_*` sibling is ~200 lines and adds the same 10 shapes through a single rendering surface.

## Compatible with these renderers (from generated docs)

### `lastfm_scrobbles_today`

> Today's scrobbles for a Last.fm user, with the currently-playing track surfaced when one is in flight. Reads `user.getRecentTracks` since UTC midnight; intentionally bounded to today so the cached splash doesn't drift across day boundaries.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `linked_text_block`, `image_linked_list`, `text_block`, `text`, `markdown_text_block`, `entries`, `badge`, `timeline` |

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `user` | string | yes | — | Last.fm username whose scrobbles to read. |
| `limit` | integer (1..=50) | no | 10 | Maximum number of recently scrobbled tracks to show (excluding the currently-playing slot). |

Renderers: [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/), [`list_cards`](https://splashboard.unhappychoice.com/reference/renderers/list/list_cards/), [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/), [`list_timeline`](https://splashboard.unhappychoice.com/reference/renderers/list/list_timeline/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/), [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/), [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/), plus the `animated_*` post-process wrappers.

### `lastfm_top_artists`

> Top artists for a Last.fm user over a rolling window (`7day` default, also `1month` / `3month` / `6month` / `12month` / `overall`). Mirrors the profile page's Top Artists tab.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `linked_text_block`, `image_linked_list`, `text_block`, `text`, `markdown_text_block`, `entries`, `ratio`, `number_series`, `bars`, `badge` |

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `user` | string | yes | — | Last.fm username whose top artists to read. |
| `period` | `"7day"` \| `"1month"` \| `"3month"` \| `"6month"` \| `"12month"` \| `"overall"` | no | `"7day"` | Rolling window for the ranking. |
| `limit` | integer (1..=50) | no | 10 | Number of artists to display. |

Renderers: [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/), [`list_cards`](https://splashboard.unhappychoice.com/reference/renderers/list/list_cards/), [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/), [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/), [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/), [`gauge_battery`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_battery/), [`gauge_circle`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_circle/), [`gauge_line`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_line/), [`gauge_segment`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_segment/), [`gauge_thermometer`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_thermometer/), [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar/), [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie/), [`chart_sparkline`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_sparkline/), [`chart_histogram`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_histogram/), [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/), plus the `animated_*` post-process wrappers.

### `lastfm_top_tracks`

> Top tracks for a Last.fm user over a rolling window. Mirrors the profile page's Top Tracks tab.

Same shape table + option contract as `lastfm_top_artists`. Row mapping pulls the artist into the secondary label so titles render as `"Track — Artist"` automatically.

### `lastfm_top_albums`

> Top albums for a Last.fm user over a rolling window. Mirrors the profile page's Top Albums tab. `ImageLinkedList` carries the album artwork from Last.fm's image set.

Same shape table + option contract as `lastfm_top_artists`. Album artwork is consistently populated by Last.fm (more than for individual tracks), so the `list_cards` rendering is where this sibling pulls ahead visually.

### `lastfm_charts`

> Last.fm's global chart of top artists or top tracks across every scrobble — "what the world is listening to right now". No user binding, no rolling window. The Last.fm slot in the `*_trending` family alongside `crypto_trending` / `huggingface_trending`.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `linked_text_block`, `image_linked_list`, `text_block`, `text`, `markdown_text_block`, `entries`, `bars` |

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `kind` | `"artists"` \| `"tracks"` | no | `"artists"` | Which Last.fm chart to rank. |
| `limit` | integer (1..=50) | no | 10 | Number of chart entries to display. |

Renderers: [`list_links`](https://splashboard.unhappychoice.com/reference/renderers/list/list_links/), [`list_cards`](https://splashboard.unhappychoice.com/reference/renderers/list/list_cards/), [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/), [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/), [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/), [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar/), [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie/), plus the `animated_*` post-process wrappers.

**Note on sort order**: `chart.*` endpoints rank by listener count, not playcount, so the response order doesn't always match the playcount values we surface. `fetch_rows` sorts by playcount descending and reassigns ranks after parsing so row order, rank prefix, and `chart_bar` length all tell the same story. Caught during the smoke test (commit `5f9f350`).

## Implementation notes

- **Shared client** (`lastfm/client.rs`): fixed-host HTTP + `LASTFM_API_KEY` resolution + a `get_json` helper that detects Last.fm's HTTP-200 error envelope (`{"error":N,"message":...}`) before deserializing into the caller's target type.
- **Shared `top.rs` rendering surface** factors the playcount-ranked-list shape table out of the three `lastfm_top_*` siblings so each one stays around 200 lines. `Period` (`SevenDay` default), `TopRow`, and one helper per shape live there; siblings only carry the per-endpoint DTO + parse path.
- **`user.getRecentTracks` vs `user.getTopTracks`** use different artist representations (`{"#text": "..."}` vs `{"name": "..."}`); each sibling carries its own DTO since attempting to unify them adds more complexity than the duplication.
- **Image filtering**: Last.fm tags artwork-less entities with a known placeholder hash (`2a96cbd8b46e442fc41c2b86b821562f`). `common::best_image` filters it out so an `ImageLinkedList` of placeholder-only rows doesn't surface the same gray square on every row.

## Test plan

- `cargo test` — 2840+ tests pass (113 new under `fetcher::lastfm`).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo run --bin splashboard -- catalog fetcher lastfm_scrobbles_today` (and siblings) — every fetcher exposes the expected shape list + option schema.
- Smoke-test against the real Last.fm API via a throwaway `.splashboard/dashboard.toml` exercising every sibling at the `LinkedTextBlock` / `Bars` / `ImageLinkedList` / `Ratio` / `Badge` shapes. Confirmed end-to-end with `LASTFM_API_KEY` set.

## Catalog

Ticks the following candidates on #67:
- `lastfm_scrobbles_today`
- `lastfm_top_artist_week` (generalised to `lastfm_top_artists` with a `period` option — `_week` becomes `period = "7day"`)
- new: `lastfm_top_tracks`, `lastfm_top_albums`, `lastfm_charts` (sibling expansions matching Last.fm's `user.getTop*` and `chart.*` endpoint set; the `music_charts` open box can also tick on the lastfm side)

Catalog body update will land on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Integrated Last.fm API providing access to global music charts displaying top artists and tracks worldwide, user's scrobbled tracks for today, and personalized period-based top lists for artists, tracks, and albums with customizable display formats including text, images, badges, and more.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->