### PR TITLE
feat(fetcher): add steam_* family (player_summary, recently_played, owned_games, charts)

### DIFF
--- a/src/fetcher/basic/bars.rs
+++ b/src/fetcher/basic/bars.rs
@@ -59,10 +59,12 @@ impl RealtimeFetcher for BasicBars {
                     Bar {
                         label: "alice".into(),
                         value: 12,
+                        value_label: None,
                     },
                     Bar {
                         label: "bob".into(),
                         value: 7,
+                        value_label: None,
                     },
                 ],
             })
@@ -80,6 +82,7 @@ impl RealtimeFetcher for BasicBars {
                 .map(|b| Bar {
                     label: b.label,
                     value: b.value,
+                    value_label: None,
                 })
                 .collect(),
         }))

--- a/src/fetcher/code/comments.rs
+++ b/src/fetcher/code/comments.rs
@@ -263,6 +263,7 @@ fn render_body(totals: Totals, shape: Shape, limit: usize, unit: Unit) -> Body {
                 .map(|(name, stat)| Bar {
                     label: name.clone(),
                     value: bar_value(stat, unit),
+                    value_label: None,
                 })
                 .collect(),
         }),

--- a/src/fetcher/code/files.rs
+++ b/src/fetcher/code/files.rs
@@ -170,7 +170,11 @@ fn bars_body(scan: Scan) -> Body {
             .top_level
             .into_iter()
             .take(TOP_LEVEL_LIMIT)
-            .map(|(label, value)| Bar { label, value })
+            .map(|(label, value)| Bar {
+                label,
+                value,
+                value_label: None,
+            })
             .collect(),
     })
 }

--- a/src/fetcher/code/largest_files.rs
+++ b/src/fetcher/code/largest_files.rs
@@ -290,6 +290,7 @@ fn bars_body(scan: Scan, limit: usize) -> Body {
             .map(|(path, n)| Bar {
                 label: path,
                 value: n,
+                value_label: None,
             })
             .collect(),
     })
@@ -516,14 +517,17 @@ mod tests {
                     Bar {
                         label: "src/render/mod.rs".into(),
                         value: 1234,
+                        value_label: None
                     },
                     Bar {
                         label: "src/fetcher/git/mod.rs".into(),
                         value: 812,
+                        value_label: None
                     },
                     Bar {
                         label: "src/payload.rs".into(),
                         value: 640,
+                        value_label: None
                     },
                 ],
             })

--- a/src/fetcher/code/loc.rs
+++ b/src/fetcher/code/loc.rs
@@ -268,6 +268,7 @@ fn render_body(totals: Totals, shape: Shape, limit: usize, unit: Unit) -> Body {
                 .map(|(lang, n)| Bar {
                     label: lang,
                     value: n,
+                    value_label: None,
                 })
                 .collect(),
         }),

--- a/src/fetcher/code/todos.rs
+++ b/src/fetcher/code/todos.rs
@@ -318,7 +318,11 @@ fn render_body(scan: ScanResult, shape: Shape, limit: usize) -> Body {
                 .file_counts
                 .into_iter()
                 .take(limit)
-                .map(|(p, c)| Bar { label: p, value: c })
+                .map(|(p, c)| Bar {
+                    label: p,
+                    value: c,
+                    value_label: None,
+                })
                 .collect(),
         }),
         _ => text_summary(scan.total, scan.files_with_hits),
@@ -715,10 +719,12 @@ mod tests {
                     Bar {
                         label: "b.rs".into(),
                         value: 2,
+                        value_label: None
                     },
                     Bar {
                         label: "a.rs".into(),
                         value: 1,
+                        value_label: None
                     },
                 ]
             ),

--- a/src/fetcher/crypto_trending.rs
+++ b/src/fetcher/crypto_trending.rs
@@ -351,6 +351,7 @@ fn rank_bar(coin: &Coin) -> Bar {
     Bar {
         label: coin.display_label(),
         value: (MAX_COUNT as usize - coin.position).max(1) as u64,
+        value_label: None,
     }
 }
 

--- a/src/fetcher/crypto_watchlist.rs
+++ b/src/fetcher/crypto_watchlist.rs
@@ -419,6 +419,7 @@ fn bars_body(snapshot: &Snapshot) -> Body {
             .map(|c| Bar {
                 label: format!("{} {}", c.arrow(), c.symbol),
                 value: (c.change_24h.abs() * PCT_TO_BP).round() as u64,
+                value_label: None,
             })
             .collect(),
     })

--- a/src/fetcher/deal/common.rs
+++ b/src/fetcher/deal/common.rs
@@ -143,6 +143,7 @@ pub(super) fn bars_body(rows: &[DealRow]) -> Body {
             .map(|r| Bar {
                 label: truncate(&r.title, LABEL_MAX_CHARS),
                 value: r.discount_pct.unwrap_or(0) as u64,
+                value_label: None,
             })
             .collect(),
     })

--- a/src/fetcher/forge_items.rs
+++ b/src/fetcher/forge_items.rs
@@ -179,6 +179,7 @@ fn render_bars(rows: &[ForgeRow]) -> Body {
             .map(|r| Bar {
                 label: r.label.clone(),
                 value: r.activity_count,
+                value_label: None,
             })
             .collect(),
     })

--- a/src/fetcher/git/age.rs
+++ b/src/fetcher/git/age.rs
@@ -341,14 +341,17 @@ fn bars_body(age: &Age) -> Body {
             Bar {
                 label: "years".into(),
                 value: age.years as u64,
+                value_label: None,
             },
             Bar {
                 label: "months".into(),
                 value: age.months as u64,
+                value_label: None,
             },
             Bar {
                 label: "days".into(),
                 value: age.days as u64,
+                value_label: None,
             },
         ],
     })

--- a/src/fetcher/git/churn.rs
+++ b/src/fetcher/git/churn.rs
@@ -190,6 +190,7 @@ fn render_body(ranked: Vec<(String, u64)>, shape: Shape) -> Body {
                 .map(|(path, count)| Bar {
                     label: path,
                     value: count,
+                    value_label: None,
                 })
                 .collect(),
         }),

--- a/src/fetcher/git/contributors.rs
+++ b/src/fetcher/git/contributors.rs
@@ -171,6 +171,7 @@ fn render_body(ranked: Vec<(String, u64)>, shape: Shape) -> Body {
                 .map(|(name, count)| Bar {
                     label: name,
                     value: count,
+                    value_label: None,
                 })
                 .collect(),
         }),
@@ -281,10 +282,12 @@ mod tests {
                     Bar {
                         label: "alice".into(),
                         value: 3,
+                        value_label: None
                     },
                     Bar {
                         label: "bob".into(),
                         value: 1,
+                        value_label: None
                     },
                 ],
             })

--- a/src/fetcher/github/action_history.rs
+++ b/src/fetcher/github/action_history.rs
@@ -132,10 +132,12 @@ impl Fetcher for GithubActionHistory {
                     Bar {
                         label: "passed".into(),
                         value: 25,
+                        value_label: None,
                     },
                     Bar {
                         label: "failed".into(),
                         value: 5,
+                        value_label: None,
                     },
                 ],
             }),
@@ -221,10 +223,12 @@ fn render_body(runs: &[WorkflowRun], shape: Shape) -> Body {
                     Bar {
                         label: "passed".into(),
                         value: passed,
+                        value_label: None,
                     },
                     Bar {
                         label: "failed".into(),
                         value: failed,
+                        value_label: None,
                     },
                 ],
             })

--- a/src/fetcher/github/contributors_monthly.rs
+++ b/src/fetcher/github/contributors_monthly.rs
@@ -251,6 +251,7 @@ fn render_body(rows: &[(String, u64)], shape: Shape) -> Body {
                 .map(|(n, c)| Bar {
                     label: n.clone(),
                     value: *c,
+                    value_label: None,
                 })
                 .collect(),
         }),

--- a/src/fetcher/github/languages.rs
+++ b/src/fetcher/github/languages.rs
@@ -130,7 +130,11 @@ fn build_body(raw: BTreeMap<String, u64>, shape: Shape, limit: usize) -> Body {
         _ => Body::Bars(BarsData {
             bars: sorted
                 .into_iter()
-                .map(|(label, value)| Bar { label, value })
+                .map(|(label, value)| Bar {
+                    label,
+                    value,
+                    value_label: None,
+                })
                 .collect(),
         }),
     }

--- a/src/fetcher/github/repo_stars.rs
+++ b/src/fetcher/github/repo_stars.rs
@@ -121,18 +121,22 @@ fn render_body(info: &RepoInfo, shape: Shape) -> Body {
                 Bar {
                     label: "stars".into(),
                     value: info.stargazers_count,
+                    value_label: None,
                 },
                 Bar {
                     label: "forks".into(),
                     value: info.forks_count,
+                    value_label: None,
                 },
                 Bar {
                     label: "watchers".into(),
                     value: info.subscribers_count,
+                    value_label: None,
                 },
                 Bar {
                     label: "open_issues".into(),
                     value: info.open_issues_count,
+                    value_label: None,
                 },
             ],
         }),

--- a/src/fetcher/gitlab/repo_stars.rs
+++ b/src/fetcher/gitlab/repo_stars.rs
@@ -136,14 +136,17 @@ fn render_body(info: &ProjectInfo, shape: Shape) -> Body {
                 Bar {
                     label: "stars".into(),
                     value: info.star_count,
+                    value_label: None,
                 },
                 Bar {
                     label: "forks".into(),
                     value: info.forks_count,
+                    value_label: None,
                 },
                 Bar {
                     label: "open_issues".into(),
                     value: info.open_issues_count,
+                    value_label: None,
                 },
             ],
         }),

--- a/src/fetcher/huggingface_trending.rs
+++ b/src/fetcher/huggingface_trending.rs
@@ -382,6 +382,7 @@ fn likes_bar(entry: &Entrt) -> Bar {
     Bar {
         label: entry.id.clone(),
         value: entry.likes,
+        value_label: None,
     }
 }
 

--- a/src/fetcher/lastfm/top.rs
+++ b/src/fetcher/lastfm/top.rs
@@ -244,6 +244,9 @@ pub fn bars_body(rows: &[TopRow]) -> Body {
             .map(|r| Bar {
                 label: r.display_title(),
                 value: r.playcount,
+                // Carry the row's pluralised play-count ("1.5k plays") so the value column
+                // reads with units in `list_ranking` instead of the bare `u64`.
+                value_label: Some(r.count_label()),
             })
             .collect(),
     })

--- a/src/fetcher/linear/cycle.rs
+++ b/src/fetcher/linear/cycle.rs
@@ -521,7 +521,11 @@ fn state_breakdown(view: &CycleView) -> Vec<Bar> {
     }
     let mut bars: Vec<Bar> = counts
         .into_iter()
-        .map(|(label, value)| Bar { label, value })
+        .map(|(label, value)| Bar {
+            label,
+            value,
+            value_label: None,
+        })
         .collect();
     bars.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.label.cmp(&b.label)));
     bars

--- a/src/fetcher/linear/issues.rs
+++ b/src/fetcher/linear/issues.rs
@@ -603,7 +603,11 @@ fn tally(views: &[IssueView], extract: &dyn Fn(&IssueView) -> String) -> Vec<Bar
     }
     let mut bars: Vec<Bar> = counts
         .into_iter()
-        .map(|(label, value)| Bar { label, value })
+        .map(|(label, value)| Bar {
+            label,
+            value,
+            value_label: None,
+        })
         .collect();
     bars.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.label.cmp(&b.label)));
     bars

--- a/src/fetcher/linear/notifications.rs
+++ b/src/fetcher/linear/notifications.rs
@@ -591,7 +591,11 @@ fn tally_by_type(views: &[NotifView]) -> Vec<Bar> {
     }
     let mut bars: Vec<Bar> = counts
         .into_iter()
-        .map(|(label, value)| Bar { label, value })
+        .map(|(label, value)| Bar {
+            label,
+            value,
+            value_label: None,
+        })
         .collect();
     bars.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.label.cmp(&b.label)));
     bars

--- a/src/fetcher/lobsters/top.rs
+++ b/src/fetcher/lobsters/top.rs
@@ -159,14 +159,17 @@ impl Fetcher for LobstersTopFetcher {
                     Bar {
                         label: "Show: terminal dashboard …".into(),
                         value: 75,
+                        value_label: None,
                     },
                     Bar {
                         label: "Fake Notepad++ for Mac".into(),
                         value: 41,
+                        value_label: None,
                     },
                     Bar {
                         label: "This Wasm interpreter fits …".into(),
                         value: 29,
+                        value_label: None,
                     },
                 ],
             }),
@@ -292,6 +295,7 @@ fn render_body(items: &[Item], shape: Shape) -> Body {
                 .map(|it| Bar {
                     label: title_or_placeholder(it),
                     value: it.score.unwrap_or(0).max(0) as u64,
+                    value_label: None,
                 })
                 .collect(),
         }),
@@ -554,6 +558,7 @@ mod tests {
                 bars: vec![Bar {
                     label: "flagged".into(),
                     value: 0,
+                    value_label: None
                 }],
             })
         );

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -41,6 +41,7 @@ pub mod read_store;
 pub mod reddit;
 pub mod rss;
 pub mod static_text;
+pub mod steam;
 pub mod stock_watchlist;
 pub mod system;
 pub mod thumbnails;
@@ -373,6 +374,9 @@ impl Registry {
             r.register(f);
         }
         for f in reddit::fetchers() {
+            r.register(f);
+        }
+        for f in steam::fetchers() {
             r.register(f);
         }
         for f in weather::fetchers() {

--- a/src/fetcher/net/interfaces.rs
+++ b/src/fetcher/net/interfaces.rs
@@ -75,6 +75,7 @@ fn body_for_shape(ifaces: &[NetIface], shape: Shape) -> Option<Body> {
                 .map(|i| Bar {
                     label: i.name.clone(),
                     value: i.rx_bytes.saturating_add(i.tx_bytes),
+                    value_label: None,
                 })
                 .collect(),
         }),

--- a/src/fetcher/net/speedtest.rs
+++ b/src/fetcher/net/speedtest.rs
@@ -232,10 +232,12 @@ fn body_for_shape(s: &Speedtest, shape: Shape) -> Option<Body> {
                 Bar {
                     label: "↓ download".into(),
                     value: s.download_mbps.round() as u64,
+                    value_label: None,
                 },
                 Bar {
                     label: "↑ upload".into(),
                     value: s.upload_mbps.round() as u64,
+                    value_label: None,
                 },
             ],
         }),

--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -506,6 +506,7 @@ value = "main""#,
                     bars: vec![Bar {
                         label: "todo".into(),
                         value: 3,
+                        value_label: None,
                     }],
                 }),
             ),

--- a/src/fetcher/reddit/trending.rs
+++ b/src/fetcher/reddit/trending.rs
@@ -140,6 +140,7 @@ fn score_bar(post: &Post) -> Bar {
     Bar {
         label: post_title(post),
         value: post.score.unwrap_or(0).max(0) as u64,
+        value_label: None,
     }
 }
 

--- a/src/fetcher/steam/charts.rs
+++ b/src/fetcher/steam/charts.rs
@@ -1,0 +1,299 @@
+//! `steam_charts` — global top-played games on Steam right now (concurrent-player count).
+//!
+//! Reads the public `ISteamChartsService/GetMostPlayedGames/v1` endpoint (no auth required).
+//! That endpoint returns appid + concurrent count but no name, so the fetcher fans out parallel
+//! `store.steampowered.com/api/appdetails?filters=basic` calls to resolve names; failures fall
+//! through to a `app/<appid>` placeholder so a single 404 doesn't sink the chart.
+//!
+//! The Steam slot in the `*_trending` family alongside `crypto_trending` /
+//! `huggingface_trending` / `lastfm_charts` — "what the world is playing right now".
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::steam::client;
+use crate::fetcher::steam::common::format_count;
+use crate::fetcher::steam::games::{
+    GameRow, badge_body, bars_body, entries_body, image_body, image_linked_body, linked_text_body,
+    markdown_body, number_series_body, text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Bars,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::Text,
+    Shape::NumberSeries,
+    Shape::Image,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "count",
+    type_hint: "integer (1..=30)",
+    required: false,
+    default: Some("10"),
+    description: "Number of chart entries to display.",
+}];
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 30;
+const APPDETAIL_CONCURRENCY: usize = 4;
+const EMPTY_LABEL: &str = "chart unavailable";
+
+pub struct SteamCharts;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for SteamCharts {
+    fn name(&self) -> &str {
+        "steam_charts"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Global most-played games on Steam right now, ranked by concurrent in-game count. Reads the public `ISteamChartsService/GetMostPlayedGames` endpoint (no auth) and resolves game names via parallel `appdetails` calls — the Steam slot in the `*_trending` family."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60 * 6
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::Bars);
+
+        let ranks = fetch_ranks(count).await?;
+        let names = resolve_names(&ranks).await;
+        let rows = rows_from_ranks(&ranks, &names);
+        Ok(payload(render_body(&rows, shape).await))
+    }
+}
+
+async fn fetch_ranks(count: usize) -> Result<Vec<RawRank>, FetchError> {
+    let raw: ChartsResponse =
+        client::get_json_public("ISteamChartsService/GetMostPlayedGames/v1/", &[]).await?;
+    let mut ranks = raw.response.ranks.unwrap_or_default();
+    ranks.truncate(count);
+    Ok(ranks)
+}
+
+async fn resolve_names(ranks: &[RawRank]) -> HashMap<u32, String> {
+    let sem = appdetail_semaphore();
+    let mut set: JoinSet<(u32, Option<String>)> = JoinSet::new();
+    for r in ranks {
+        let appid = r.appid;
+        let sem = sem.clone();
+        set.spawn(async move {
+            let _permit = sem.acquire_owned().await.ok();
+            (appid, fetch_app_name(appid).await)
+        });
+    }
+    let mut out = HashMap::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok((appid, Some(name))) = res {
+            out.insert(appid, name);
+        }
+    }
+    out
+}
+
+fn appdetail_semaphore() -> std::sync::Arc<Semaphore> {
+    static SEM: OnceLock<std::sync::Arc<Semaphore>> = OnceLock::new();
+    SEM.get_or_init(|| std::sync::Arc::new(Semaphore::new(APPDETAIL_CONCURRENCY)))
+        .clone()
+}
+
+async fn fetch_app_name(appid: u32) -> Option<String> {
+    let appid_str = appid.to_string();
+    let raw: AppDetailsResponse = client::get_store_json(
+        "api/appdetails",
+        &[
+            ("appids", &appid_str),
+            ("filters", "basic"),
+            ("cc", "us"),
+            ("l", "english"),
+        ],
+    )
+    .await
+    .ok()?;
+    raw.0
+        .get(&appid_str)
+        .and_then(|entry| entry.data.as_ref())
+        .map(|data| data.name.clone())
+        .filter(|n| !n.is_empty())
+}
+
+fn rows_from_ranks(ranks: &[RawRank], names: &HashMap<u32, String>) -> Vec<GameRow> {
+    ranks
+        .iter()
+        .map(|r| GameRow {
+            rank: r.rank as usize,
+            appid: r.appid,
+            name: names
+                .get(&r.appid)
+                .cloned()
+                .unwrap_or_else(|| format!("app/{}", r.appid)),
+            value: r.peak_in_game,
+            value_label: peak_label(r.peak_in_game),
+        })
+        .collect()
+}
+
+/// `1.2M peak` — the chart endpoint reports 24-hour peak concurrent count rather than the
+/// live "right now" number (Valve doesn't expose the latter on this rollup), so the unit
+/// reads "peak" rather than "players" to stay honest about what's shown.
+fn peak_label(n: u64) -> String {
+    format!("{} peak", format_count(n))
+}
+
+async fn render_body(rows: &[GameRow], shape: Shape) -> Body {
+    match shape {
+        Shape::Bars => bars_body(rows),
+        Shape::Entries => entries_body(rows, EMPTY_LABEL),
+        Shape::TextBlock => text_block_body(rows, EMPTY_LABEL),
+        Shape::MarkdownTextBlock => markdown_body(rows, EMPTY_LABEL),
+        Shape::LinkedTextBlock => linked_text_body(rows, EMPTY_LABEL),
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::NumberSeries => number_series_body(rows),
+        Shape::Image => image_body(rows).await,
+        Shape::Badge => badge_body(rows, "today", "chart unavailable"),
+        _ => text_body(rows, EMPTY_LABEL),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChartsResponse {
+    response: ChartsBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ChartsBody {
+    #[serde(default)]
+    ranks: Option<Vec<RawRank>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRank {
+    rank: u32,
+    appid: u32,
+    /// 24-hour peak concurrent players. `ISteamChartsService/GetMostPlayedGames/v1` omits the
+    /// instantaneous "right now" count; this `peak_in_game` rollup is what the endpoint exposes
+    /// and what SteamDB / steamcharts.com surface as their headline metric.
+    #[serde(default)]
+    peak_in_game: u64,
+}
+
+/// Steam returns `appdetails` as a top-level map keyed by appid string. Each value carries a
+/// `success` flag plus an optional `data` block; failed lookups omit `data` entirely.
+#[derive(Debug, Deserialize)]
+struct AppDetailsResponse(HashMap<String, AppDetailsEntry>);
+
+#[derive(Debug, Deserialize)]
+struct AppDetailsEntry {
+    #[serde(default)]
+    data: Option<AppDetailsData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppDetailsData {
+    #[serde(default)]
+    name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetcher_metadata_is_in_steam_family_and_safe_for_public_endpoint() {
+        let f = SteamCharts;
+        assert_eq!(f.name(), "steam_charts");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert!(f.refresh_interval() > 0);
+    }
+
+    #[test]
+    fn rows_from_ranks_fills_names_when_present_and_falls_back_otherwise() {
+        let ranks = vec![
+            RawRank {
+                rank: 1,
+                appid: 730,
+                peak_in_game: 1_500_000,
+            },
+            RawRank {
+                rank: 2,
+                appid: 999_999,
+                peak_in_game: 50_000,
+            },
+        ];
+        let mut names = HashMap::new();
+        names.insert(730_u32, "Counter-Strike 2".into());
+
+        let rows = rows_from_ranks(&ranks, &names);
+        assert_eq!(rows[0].name, "Counter-Strike 2");
+        assert_eq!(rows[1].name, "app/999999");
+        assert_eq!(rows[0].value, 1_500_000);
+        assert_eq!(rows[0].value_label, "1.5M peak");
+    }
+
+    #[test]
+    fn peak_label_drops_player_unit_and_keeps_magnitude() {
+        assert_eq!(peak_label(0), "0 peak");
+        assert_eq!(peak_label(750), "750 peak");
+        assert_eq!(peak_label(1_500_000), "1.5M peak");
+    }
+
+    #[test]
+    fn options_clamp_count_to_supported_range() {
+        let opts = Options { count: Some(99) };
+        let clamped = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT);
+        assert_eq!(clamped, MAX_COUNT);
+    }
+
+    #[test]
+    fn options_struct_rejects_unknown_keys() {
+        let raw = toml::Value::try_from(serde_json::json!({"unknown": 1})).unwrap();
+        let err = parse_options::<Options>(Some(&raw)).unwrap_err();
+        assert!(err.contains("invalid options"));
+    }
+}

--- a/src/fetcher/steam/client.rs
+++ b/src/fetcher/steam/client.rs
@@ -1,0 +1,221 @@
+//! Shared HTTP client + auth for the `steam_*` fetcher family.
+//!
+//! Targets `api.steampowered.com` (Web API) and `store.steampowered.com` (store appdetails
+//! used by `steam_charts` to resolve appid → game name). Both hosts are hardcoded — config
+//! can only change *which resource* on those hosts is queried, never the host itself, so the
+//! family stays `Safety::Safe`.
+//!
+//! Auth: `STEAM_API_KEY` (free, https://steamcommunity.com/dev/apikey). The chart endpoint
+//! [`get_json_public`] is open and skips the key entirely.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+
+use crate::fetcher::FetchError;
+
+const API_BASE: &str = "https://api.steampowered.com";
+const STORE_BASE: &str = "https://store.steampowered.com";
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_BYTES: usize = 5 * 1024 * 1024;
+
+pub fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+pub fn resolve_api_key() -> Result<String, FetchError> {
+    std::env::var("STEAM_API_KEY").map_err(|_| FetchError::Failed("STEAM_API_KEY not set".into()))
+}
+
+/// Resolve a Steam ID from explicit option or `STEAM_ID` env. Mirrors steamfetch's resolution
+/// order so the same env works across both tools. Returns a trimmed non-empty `String`.
+pub fn resolve_steam_id(explicit: Option<&str>) -> Result<String, FetchError> {
+    let from_option = explicit.map(str::trim).filter(|s| !s.is_empty());
+    if let Some(id) = from_option {
+        return Ok(id.to_string());
+    }
+    std::env::var("STEAM_ID")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            FetchError::Failed(
+                "steam_id missing: set `steam_id = \"<id64>\"` or export STEAM_ID".into(),
+            )
+        })
+}
+
+/// Authenticated `GET https://api.steampowered.com/<path>?key=<key>&<params>`.
+pub async fn get_json<T: DeserializeOwned>(
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<T, FetchError> {
+    let key = resolve_api_key()?;
+    let mut url = url::Url::parse(&format!("{API_BASE}/{path}"))
+        .map_err(|e| FetchError::Failed(format!("steam invalid path {path:?}: {e}")))?;
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("key", &key);
+        for (k, v) in params {
+            q.append_pair(k, v);
+        }
+    }
+    request_json(url.as_str()).await
+}
+
+/// Unauthenticated `GET https://api.steampowered.com/<path>?<params>`. Used by `steam_charts`
+/// (`ISteamChartsService/GetMostPlayedGames`), which is public and rejects requests that carry
+/// a stray `key=` parameter on some shards.
+pub async fn get_json_public<T: DeserializeOwned>(
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<T, FetchError> {
+    let mut url = url::Url::parse(&format!("{API_BASE}/{path}"))
+        .map_err(|e| FetchError::Failed(format!("steam invalid path {path:?}: {e}")))?;
+    {
+        let mut q = url.query_pairs_mut();
+        for (k, v) in params {
+            q.append_pair(k, v);
+        }
+    }
+    request_json(url.as_str()).await
+}
+
+/// `GET https://store.steampowered.com/<path>?<params>`. Used to resolve appid → game name +
+/// header image for the chart fetcher.
+pub async fn get_store_json<T: DeserializeOwned>(
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<T, FetchError> {
+    let mut url = url::Url::parse(&format!("{STORE_BASE}/{path}"))
+        .map_err(|e| FetchError::Failed(format!("steam store invalid path {path:?}: {e}")))?;
+    {
+        let mut q = url.query_pairs_mut();
+        for (k, v) in params {
+            q.append_pair(k, v);
+        }
+    }
+    request_json(url.as_str()).await
+}
+
+async fn request_json<T: DeserializeOwned>(url: &str) -> Result<T, FetchError> {
+    let res = http()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("steam request failed: {e}")))?;
+    parse_json(res).await
+}
+
+async fn parse_json<T: DeserializeOwned>(res: reqwest::Response) -> Result<T, FetchError> {
+    let status = res.status();
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("steam read body: {e}")))?;
+    if bytes.len() > MAX_BYTES {
+        return Err(FetchError::Failed(format!(
+            "steam response too large ({} bytes, cap {MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!("steam {status}")));
+    }
+    serde_json::from_slice(&bytes).map_err(|e| FetchError::Failed(format!("steam json parse: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_api_key_fails_with_clear_message_when_unset() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("STEAM_API_KEY").ok();
+        unsafe { std::env::remove_var("STEAM_API_KEY") };
+        let err = resolve_api_key().unwrap_err();
+        assert!(matches!(err, FetchError::Failed(m) if m == "STEAM_API_KEY not set"));
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("STEAM_API_KEY", v) };
+        }
+    }
+
+    #[test]
+    fn resolve_api_key_reads_env() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("STEAM_API_KEY").ok();
+        unsafe { std::env::set_var("STEAM_API_KEY", "abc123") };
+        assert_eq!(resolve_api_key().unwrap(), "abc123");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("STEAM_API_KEY", v) },
+            None => unsafe { std::env::remove_var("STEAM_API_KEY") },
+        }
+    }
+
+    #[test]
+    fn resolve_steam_id_prefers_explicit_option_over_env() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("STEAM_ID").ok();
+        unsafe { std::env::set_var("STEAM_ID", "env-id") };
+        assert_eq!(resolve_steam_id(Some("option-id")).unwrap(), "option-id");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("STEAM_ID", v) },
+            None => unsafe { std::env::remove_var("STEAM_ID") },
+        }
+    }
+
+    #[test]
+    fn resolve_steam_id_falls_back_to_env_when_option_missing_or_blank() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("STEAM_ID").ok();
+        unsafe { std::env::set_var("STEAM_ID", "env-id") };
+        assert_eq!(resolve_steam_id(None).unwrap(), "env-id");
+        assert_eq!(resolve_steam_id(Some("   ")).unwrap(), "env-id");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("STEAM_ID", v) },
+            None => unsafe { std::env::remove_var("STEAM_ID") },
+        }
+    }
+
+    #[test]
+    fn resolve_steam_id_errors_when_neither_set() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("STEAM_ID").ok();
+        unsafe { std::env::remove_var("STEAM_ID") };
+        let err = resolve_steam_id(None).unwrap_err();
+        let FetchError::Failed(msg) = err else {
+            panic!("expected FetchError::Failed");
+        };
+        assert!(msg.contains("steam_id"));
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("STEAM_ID", v) };
+        }
+    }
+
+    #[test]
+    fn http_reuses_the_same_client() {
+        assert!(std::ptr::eq(http(), http()));
+    }
+}

--- a/src/fetcher/steam/common.rs
+++ b/src/fetcher/steam/common.rs
@@ -1,0 +1,83 @@
+//! Cross-cutting helpers for the `steam_*` family: appid-derived URLs, playtime formatting,
+//! count units.
+
+/// Steam store landing page for an app: `https://store.steampowered.com/app/<appid>/`.
+pub fn store_url(appid: u32) -> String {
+    format!("https://store.steampowered.com/app/{appid}/")
+}
+
+/// CDN header image for an app — the wide "capsule" graphic Valve serves on every store page.
+/// Path is stable for every released app; missing images 404 silently, which the thumbnail
+/// fetcher already handles.
+pub fn header_image_url(appid: u32) -> String {
+    format!("https://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg")
+}
+
+/// `4830` minutes -> `"80h"`. `45` minutes -> `"45m"`. Anything ≥ 1 hour rounds down to whole
+/// hours so the row stays narrow; the catalog's recently-played / owned-games widgets read as
+/// "hours played", not "minutes played".
+pub fn format_minutes(minutes: u32) -> String {
+    if minutes >= 60 {
+        format!("{}h", minutes / 60)
+    } else {
+        format!("{minutes}m")
+    }
+}
+
+/// Human-readable concurrent-player count: `1234` -> `"1.2k"`, `2_100_000` -> `"2.1M"`.
+/// Mirrors `lastfm::common::format_count` so the catalog reads consistently across families.
+pub fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// `"player"` vs `"players"` — kept inline-able but spelled out so call sites read naturally.
+pub fn players_word(n: u64) -> &'static str {
+    if n == 1 { "player" } else { "players" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_url_includes_appid_path_segment() {
+        assert_eq!(store_url(730), "https://store.steampowered.com/app/730/");
+    }
+
+    #[test]
+    fn header_image_url_targets_steam_cdn_with_appid() {
+        let url = header_image_url(730);
+        assert!(url.starts_with("https://cdn.akamai.steamstatic.com/"));
+        assert!(url.contains("/730/header.jpg"));
+    }
+
+    #[test]
+    fn format_minutes_collapses_minutes_into_hours_above_threshold() {
+        assert_eq!(format_minutes(0), "0m");
+        assert_eq!(format_minutes(59), "59m");
+        assert_eq!(format_minutes(60), "1h");
+        assert_eq!(format_minutes(90), "1h");
+        assert_eq!(format_minutes(4830), "80h");
+    }
+
+    #[test]
+    fn format_count_picks_unit_by_magnitude() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(950), "950");
+        assert_eq!(format_count(1_500), "1.5k");
+        assert_eq!(format_count(1_200_000), "1.2M");
+    }
+
+    #[test]
+    fn players_word_pluralises_only_for_non_singular() {
+        assert_eq!(players_word(0), "players");
+        assert_eq!(players_word(1), "player");
+        assert_eq!(players_word(2), "players");
+    }
+}

--- a/src/fetcher/steam/games.rs
+++ b/src/fetcher/steam/games.rs
@@ -1,0 +1,356 @@
+//! Shared shape body builders for the `steam_recently_played` / `steam_owned_games` /
+//! `steam_charts` siblings.
+//!
+//! All three surface a ranked list of games where each row carries an appid, a display name,
+//! a numeric value (minutes played / concurrent players), and a store URL derived from the
+//! appid. Normalising into [`GameRow`] lets every sibling stay around the catalog's
+//! ~100-lines-per-fetcher guideline.
+
+use crate::fetcher::steam::common::{format_count, header_image_url, players_word, store_url};
+use crate::fetcher::thumbnails;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, ImageData, ImageLinkedItem,
+    ImageLinkedListData, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, NumberSeriesData,
+    RatioData, Status, TextBlockData, TextData,
+};
+
+/// Normalised view of one game in a ranked list. `value` carries minutes for playtime-flavoured
+/// fetchers (recently-played, owned-games) and concurrent-player count for the chart fetcher.
+/// `value_label` lets each fetcher format the right side of the row appropriately ("80h",
+/// "1.2k players") without leaking format strings into the helpers.
+#[derive(Debug, Clone)]
+pub struct GameRow {
+    pub rank: usize,
+    pub appid: u32,
+    pub name: String,
+    pub value: u64,
+    pub value_label: String,
+}
+
+impl GameRow {
+    pub fn store_url(&self) -> String {
+        store_url(self.appid)
+    }
+
+    pub fn header_image(&self) -> String {
+        header_image_url(self.appid)
+    }
+}
+
+pub fn headline(rows: &[GameRow], empty_label: &str) -> String {
+    match rows.first() {
+        Some(top) => format!("#{} {}  ({})", top.rank, top.name, top.value_label),
+        None => empty_label.into(),
+    }
+}
+
+pub fn text_body(rows: &[GameRow], empty_label: &str) -> Body {
+    Body::Text(TextData {
+        value: headline(rows, empty_label),
+    })
+}
+
+pub fn text_block_body(rows: &[GameRow], empty_label: &str) -> Body {
+    Body::TextBlock(TextBlockData {
+        lines: lines(rows, empty_label),
+    })
+}
+
+fn lines(rows: &[GameRow], empty_label: &str) -> Vec<String> {
+    if rows.is_empty() {
+        return vec![empty_label.into()];
+    }
+    rows.iter()
+        .map(|r| format!("#{} {}  {}", r.rank, r.name, r.value_label))
+        .collect()
+}
+
+pub fn markdown_body(rows: &[GameRow], empty_label: &str) -> Body {
+    let value = if rows.is_empty() {
+        format!("_{empty_label}_")
+    } else {
+        rows.iter()
+            .map(|r| format!("- **#{} {}** — {}", r.rank, r.name, r.value_label))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+pub fn linked_text_body(rows: &[GameRow], empty_label: &str) -> Body {
+    let items: Vec<LinkedLine> = if rows.is_empty() {
+        vec![LinkedLine {
+            text: empty_label.into(),
+            url: None,
+        }]
+    } else {
+        rows.iter()
+            .map(|r| LinkedLine {
+                text: format!("#{} {}  {}", r.rank, r.name, r.value_label),
+                url: Some(r.store_url()),
+            })
+            .collect()
+    };
+    Body::LinkedTextBlock(LinkedTextBlockData { items })
+}
+
+pub async fn image_linked_body(rows: &[GameRow]) -> Body {
+    let urls: Vec<Option<String>> = rows.iter().map(|r| Some(r.header_image())).collect();
+    let paths = thumbnails::download_many(&urls).await;
+    let items = rows
+        .iter()
+        .zip(paths)
+        .map(|(r, path)| ImageLinkedItem {
+            title: format!("#{} {}", r.rank, r.name),
+            url: Some(r.store_url()),
+            thumbnail_path: path.map(|p| p.to_string_lossy().into_owned()),
+            subtitle: Some(r.value_label.clone()),
+        })
+        .collect();
+    Body::ImageLinkedList(ImageLinkedListData { items })
+}
+
+pub fn entries_body(rows: &[GameRow], empty_label: &str) -> Body {
+    let items: Vec<Entry> = if rows.is_empty() {
+        vec![Entry {
+            key: "—".into(),
+            value: Some(empty_label.into()),
+            status: None,
+        }]
+    } else {
+        rows.iter()
+            .map(|r| Entry {
+                key: format!("#{} {}", r.rank, r.name),
+                value: Some(r.value_label.clone()),
+                status: None,
+            })
+            .collect()
+    };
+    Body::Entries(EntriesData { items })
+}
+
+/// Top game's share of the total value across the surfaced window. `denominator` carries the
+/// summed value so a gauge can spell "80h of 142h" if it wants.
+pub fn ratio_body(rows: &[GameRow]) -> Body {
+    let total: u64 = rows.iter().map(|r| r.value).sum();
+    let (value, label, denominator) = match rows.first() {
+        Some(top) if total > 0 => (
+            top.value as f64 / total as f64,
+            Some(top.name.clone()),
+            Some(total),
+        ),
+        _ => (0.0, None, None),
+    };
+    Body::Ratio(RatioData {
+        value,
+        label,
+        denominator,
+    })
+}
+
+pub fn number_series_body(rows: &[GameRow]) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: rows.iter().map(|r| r.value).collect(),
+    })
+}
+
+pub fn bars_body(rows: &[GameRow]) -> Body {
+    Body::Bars(BarsData {
+        bars: rows
+            .iter()
+            .map(|r| Bar {
+                label: r.name.clone(),
+                value: r.value,
+                // Carry the fetcher's formatted unit so `list_ranking` shows `"80h"` or
+                // `"2024-07-03"` in the value column instead of the raw `u64`.
+                value_label: Some(r.value_label.clone()),
+            })
+            .collect(),
+    })
+}
+
+/// Top game's header image as a standalone Image body — the value-add is the cover art, not
+/// a list. Falls back to an empty path when the list is empty so the empty-state placeholder
+/// kicks in at `render_payload`.
+pub async fn image_body(rows: &[GameRow]) -> Body {
+    let path = match rows.first() {
+        Some(top) => thumbnails::download_to_cache(&top.header_image())
+            .await
+            .ok()
+            .flatten()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        None => String::new(),
+    };
+    Body::Image(ImageData { path })
+}
+
+/// Promotes the top game to the badge label; falls back to a quiet-window pill so the widget
+/// stays visible when the user has no recent playtime / the chart is empty. `unit_label`
+/// distinguishes "Xh this week" (playtime fetchers) from "1.2k players" (chart fetcher) — the
+/// caller picks the unit the top row's value is denominated in.
+pub fn badge_body(rows: &[GameRow], unit_label: &str, empty_label: &str) -> Body {
+    let (status, label) = match rows.first() {
+        Some(top) => (Status::Ok, format!("#1 {} · {}", top.name, top.value_label)),
+        None => (Status::Warn, format!("{empty_label} ({unit_label})")),
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+/// `"42 players"` (singular when applicable) — exposed so the chart fetcher can build a
+/// `value_label` without re-deriving the pluralisation rule.
+pub fn players_label(n: u64) -> String {
+    format!("{} {}", format_count(n), players_word(n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(rank: usize, appid: u32, name: &str, value: u64, label: &str) -> GameRow {
+        GameRow {
+            rank,
+            appid,
+            name: name.into(),
+            value,
+            value_label: label.into(),
+        }
+    }
+
+    #[test]
+    fn store_url_and_header_image_are_appid_derived() {
+        let r = row(1, 730, "CS2", 0, "");
+        assert!(r.store_url().contains("/app/730/"));
+        assert!(r.header_image().contains("/730/header.jpg"));
+    }
+
+    #[test]
+    fn headline_reports_top_row_with_rank_prefix() {
+        let rows = vec![
+            row(1, 730, "CS2", 60, "60h"),
+            row(2, 570, "Dota 2", 30, "30h"),
+        ];
+        assert_eq!(headline(&rows, "empty"), "#1 CS2  (60h)");
+    }
+
+    #[test]
+    fn headline_falls_back_to_empty_label() {
+        assert_eq!(headline(&[], "quiet"), "quiet");
+    }
+
+    #[test]
+    fn linked_text_body_carries_store_url_per_row() {
+        let rows = vec![row(1, 730, "CS2", 60, "60h")];
+        let Body::LinkedTextBlock(b) = linked_text_body(&rows, "empty") else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert!(b.items[0].url.as_deref().unwrap().contains("/app/730/"));
+        assert!(b.items[0].text.contains("CS2"));
+    }
+
+    #[test]
+    fn linked_text_body_emits_unlinked_empty_row_on_empty_input() {
+        let Body::LinkedTextBlock(b) = linked_text_body(&[], "empty") else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert!(b.items[0].url.is_none());
+    }
+
+    #[test]
+    fn ratio_body_is_zero_when_rows_are_empty() {
+        let Body::Ratio(r) = ratio_body(&[]) else {
+            panic!("expected ratio");
+        };
+        assert_eq!(r.value, 0.0);
+        assert!(r.label.is_none());
+        assert!(r.denominator.is_none());
+    }
+
+    #[test]
+    fn ratio_body_carries_top_share_and_total_as_denominator() {
+        let rows = vec![
+            row(1, 1, "A", 60, "60"),
+            row(2, 2, "B", 30, "30"),
+            row(3, 3, "C", 10, "10"),
+        ];
+        let Body::Ratio(r) = ratio_body(&rows) else {
+            panic!("expected ratio");
+        };
+        assert!((r.value - 0.6).abs() < 1e-9);
+        assert_eq!(r.label.as_deref(), Some("A"));
+        assert_eq!(r.denominator, Some(100));
+    }
+
+    #[test]
+    fn ratio_body_returns_zero_when_total_is_zero() {
+        let rows = vec![row(1, 1, "A", 0, "0"), row(2, 2, "B", 0, "0")];
+        let Body::Ratio(r) = ratio_body(&rows) else {
+            panic!("expected ratio");
+        };
+        assert_eq!(r.value, 0.0);
+        assert!(r.label.is_none());
+    }
+
+    #[test]
+    fn number_series_lifts_values_in_order() {
+        let rows = vec![row(1, 1, "A", 30, "30"), row(2, 2, "B", 20, "20")];
+        let Body::NumberSeries(s) = number_series_body(&rows) else {
+            panic!("expected number_series");
+        };
+        assert_eq!(s.values, vec![30, 20]);
+    }
+
+    #[test]
+    fn bars_body_uses_name_as_label_and_value_as_height() {
+        let rows = vec![row(1, 1, "CS2", 60, "60h")];
+        let Body::Bars(b) = bars_body(&rows) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].label, "CS2");
+        assert_eq!(b.bars[0].value, 60);
+    }
+
+    #[test]
+    fn entries_body_uses_value_label_column() {
+        let rows = vec![row(1, 1, "CS2", 60, "60h")];
+        let Body::Entries(e) = entries_body(&rows, "empty") else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "#1 CS2");
+        assert_eq!(e.items[0].value.as_deref(), Some("60h"));
+    }
+
+    #[test]
+    fn badge_body_promotes_top_row_and_warns_on_empty() {
+        let rows = vec![row(1, 1, "CS2", 60, "60h")];
+        let Body::Badge(b) = badge_body(&rows, "this week", "no playtime") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert!(b.label.contains("CS2"));
+        assert!(b.label.contains("60h"));
+
+        let Body::Badge(empty) = badge_body(&[], "this week", "no playtime") else {
+            panic!("expected badge");
+        };
+        assert_eq!(empty.status, Status::Warn);
+        assert!(empty.label.contains("this week"));
+    }
+
+    #[test]
+    fn players_label_pluralises_only_for_non_singular() {
+        assert_eq!(players_label(0), "0 players");
+        assert_eq!(players_label(1), "1 player");
+        assert_eq!(players_label(1500), "1.5k players");
+    }
+
+    #[test]
+    fn markdown_body_italicises_empty_label() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&[], "quiet") else {
+            panic!("expected markdown");
+        };
+        assert_eq!(m.value, "_quiet_");
+    }
+}

--- a/src/fetcher/steam/mod.rs
+++ b/src/fetcher/steam/mod.rs
@@ -1,0 +1,38 @@
+//! Steam fetchers — Steam Web API readouts: player profile, recently-played games, owned
+//! game library, and the global most-played chart.
+//!
+//! Every authenticated request targets the fixed host `api.steampowered.com`. Config-provided
+//! fields (`steam_id`, `count`, …) only change which resource on that host is queried; the API
+//! key never leaves to an attacker-controlled origin. Classified as `Safety::Safe`, same model
+//! as the `github_*` and `lastfm_*` families.
+//!
+//! Auth: `STEAM_API_KEY` — create one at https://steamcommunity.com/dev/apikey and put it in
+//! `$HOME/.splashboard/secrets.toml`.
+
+mod client;
+mod player_summary;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(player_summary::SteamPlayerSummary)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetchers_entry_point_registers_the_batch_under_steam_prefix() {
+        let names: Vec<String> = fetchers().iter().map(|f| f.name().to_string()).collect();
+        for name in &names {
+            assert!(
+                name.starts_with("steam_"),
+                "{name} must use the `steam_` family prefix"
+            );
+        }
+        assert!(names.contains(&"steam_player_summary".to_string()));
+    }
+}

--- a/src/fetcher/steam/mod.rs
+++ b/src/fetcher/steam/mod.rs
@@ -3,12 +3,16 @@
 //!
 //! Every authenticated request targets the fixed host `api.steampowered.com`. Config-provided
 //! fields (`steam_id`, `count`, …) only change which resource on that host is queried; the API
-//! key never leaves to an attacker-controlled origin. Classified as `Safety::Safe`, same model
-//! as the `github_*` and `lastfm_*` families.
+//! key never leaves to an attacker-controlled origin. The `steam_charts` fetcher also calls the
+//! `store.steampowered.com/api/appdetails` store endpoint to resolve appid → game name (the
+//! chart endpoint itself returns appid-only), again with a fixed host. Both are classified as
+//! `Safety::Safe`, same model as the `github_*` and `lastfm_*` families.
 //!
 //! Auth: `STEAM_API_KEY` — create one at https://steamcommunity.com/dev/apikey and put it in
-//! `$HOME/.splashboard/secrets.toml`.
+//! `$HOME/.splashboard/secrets.toml`. `steam_charts` is the only family member that needs no
+//! key (the chart endpoint is public).
 
+mod charts;
 mod client;
 mod common;
 mod games;
@@ -25,6 +29,7 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(player_summary::SteamPlayerSummary),
         Arc::new(recently_played::SteamRecentlyPlayed),
         Arc::new(owned_games::SteamOwnedGames),
+        Arc::new(charts::SteamCharts),
     ]
 }
 
@@ -44,5 +49,6 @@ mod tests {
         assert!(names.contains(&"steam_player_summary".to_string()));
         assert!(names.contains(&"steam_recently_played".to_string()));
         assert!(names.contains(&"steam_owned_games".to_string()));
+        assert!(names.contains(&"steam_charts".to_string()));
     }
 }

--- a/src/fetcher/steam/mod.rs
+++ b/src/fetcher/steam/mod.rs
@@ -10,14 +10,20 @@
 //! `$HOME/.splashboard/secrets.toml`.
 
 mod client;
+mod common;
+mod games;
 mod player_summary;
+mod recently_played;
 
 use std::sync::Arc;
 
 use crate::fetcher::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(player_summary::SteamPlayerSummary)]
+    vec![
+        Arc::new(player_summary::SteamPlayerSummary),
+        Arc::new(recently_played::SteamRecentlyPlayed),
+    ]
 }
 
 #[cfg(test)]
@@ -34,5 +40,6 @@ mod tests {
             );
         }
         assert!(names.contains(&"steam_player_summary".to_string()));
+        assert!(names.contains(&"steam_recently_played".to_string()));
     }
 }

--- a/src/fetcher/steam/mod.rs
+++ b/src/fetcher/steam/mod.rs
@@ -12,6 +12,7 @@
 mod client;
 mod common;
 mod games;
+mod owned_games;
 mod player_summary;
 mod recently_played;
 
@@ -23,6 +24,7 @@ pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![
         Arc::new(player_summary::SteamPlayerSummary),
         Arc::new(recently_played::SteamRecentlyPlayed),
+        Arc::new(owned_games::SteamOwnedGames),
     ]
 }
 
@@ -41,5 +43,6 @@ mod tests {
         }
         assert!(names.contains(&"steam_player_summary".to_string()));
         assert!(names.contains(&"steam_recently_played".to_string()));
+        assert!(names.contains(&"steam_owned_games".to_string()));
     }
 }

--- a/src/fetcher/steam/owned_games.rs
+++ b/src/fetcher/steam/owned_games.rs
@@ -1,0 +1,393 @@
+//! `steam_owned_games` — the configured Steam user's library ranked by total playtime
+//! (default) or most-recently launched (`sort = "recent"`).
+//!
+//! Reads `IPlayerService/GetOwnedGames/v1?include_appinfo=1&include_played_free_games=1`. The
+//! complementary read to `steam_recently_played`: same source family, all-time window.
+
+use async_trait::async_trait;
+use chrono::TimeZone;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::steam::client;
+use crate::fetcher::steam::common::format_minutes;
+use crate::fetcher::steam::games::{
+    GameRow, badge_body, bars_body, entries_body, image_body, image_linked_body, linked_text_body,
+    markdown_body, number_series_body, ratio_body, text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Bars,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::Text,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::Image,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "steam_id",
+        type_hint: "string (Steam64 id)",
+        required: false,
+        default: None,
+        description: "Steam64 id of the user whose library to read. Falls back to the `STEAM_ID` env var when omitted.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum number of games to display.",
+    },
+    OptionSchema {
+        name: "sort",
+        type_hint: "\"playtime\" | \"recent\"",
+        required: false,
+        default: Some("\"playtime\""),
+        description: "Sort order: `playtime` ranks by total minutes; `recent` ranks by last-launched time.",
+    },
+];
+
+const DEFAULT_COUNT: u32 = 10;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 20;
+const EMPTY_LABEL: &str = "no owned games";
+
+pub struct SteamOwnedGames;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub steam_id: Option<String>,
+    pub count: Option<u32>,
+    pub sort: Option<Sort>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Sort {
+    #[default]
+    Playtime,
+    Recent,
+}
+
+#[async_trait]
+impl Fetcher for SteamOwnedGames {
+    fn name(&self) -> &str {
+        "steam_owned_games"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "The configured Steam user's library ranked by total minutes (`sort = \"playtime\"`, default) or by most-recently launched (`sort = \"recent\"`). Complement to `steam_recently_played` over the all-time window."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60 * 6
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let steam_id = client::resolve_steam_id(opts.steam_id.as_deref())?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let sort = opts.sort.unwrap_or_default();
+        let shape = ctx.shape.unwrap_or(Shape::Bars);
+
+        let games = fetch_games(&steam_id).await?;
+        let rows = rows_from_games(&games, sort, count);
+        let body = render_body(&rows, &games, shape, sort).await;
+        Ok(payload(body))
+    }
+}
+
+async fn fetch_games(steam_id: &str) -> Result<Vec<RawGame>, FetchError> {
+    let raw: OwnedGamesResponse = client::get_json(
+        "IPlayerService/GetOwnedGames/v1/",
+        &[
+            ("steamid", steam_id),
+            ("include_appinfo", "1"),
+            ("include_played_free_games", "1"),
+        ],
+    )
+    .await?;
+    Ok(raw.response.games.unwrap_or_default())
+}
+
+fn rows_from_games(games: &[RawGame], sort: Sort, count: usize) -> Vec<GameRow> {
+    let mut sorted: Vec<&RawGame> = games.iter().collect();
+    match sort {
+        Sort::Playtime => sorted.sort_by_key(|g| std::cmp::Reverse(g.playtime_forever)),
+        Sort::Recent => sorted.sort_by_key(|g| std::cmp::Reverse(g.rtime_last_played)),
+    }
+    sorted
+        .into_iter()
+        .take(count)
+        .enumerate()
+        .map(|(i, g)| GameRow {
+            rank: i + 1,
+            appid: g.appid,
+            name: display_name(g),
+            value: g.playtime_forever as u64,
+            // Bars / NumberSeries always carry minutes so the bar heights stay comparable
+            // even when sorted by recency; only the displayed `value_label` switches with the
+            // sort axis so the row "means what its column says".
+            value_label: match sort {
+                Sort::Playtime => format_minutes(g.playtime_forever),
+                Sort::Recent => last_played_label(g.rtime_last_played),
+            },
+        })
+        .collect()
+}
+
+/// Steam's `rtime_last_played` is unix seconds. A value of 0 means "never launched" (Steam
+/// records this for owned-but-never-opened games). Recency reads faster as a relative pill
+/// (`"today"` / `"2d ago"` / `"1w ago"`); falls back to an absolute ISO date past ~30 days so
+/// the label doesn't decay to a giant unit. The 6-hour refresh interval means the relative
+/// label can drift by at most one quantum (e.g. "today" → "1d ago") before the next refresh,
+/// which is acceptable for a glance widget.
+fn last_played_label(ts: u64) -> String {
+    if ts == 0 {
+        return "never".into();
+    }
+    let now = chrono::Utc::now().timestamp();
+    relative_label(now, ts as i64)
+}
+
+fn relative_label(now: i64, ts: i64) -> String {
+    let secs = (now - ts).max(0);
+    const DAY: i64 = 86_400;
+    const WEEK: i64 = 7 * DAY;
+    let days = secs / DAY;
+    match days {
+        0 => "today".into(),
+        1 => "yesterday".into(),
+        2..=6 => format!("{days}d ago"),
+        7..=29 => format!("{}w ago", days / 7),
+        _ => match chrono::Utc.timestamp_opt(ts, 0).single() {
+            Some(dt) => dt.format("%Y-%m-%d").to_string(),
+            None => format!("ts:{ts}"),
+        },
+    }
+}
+
+fn display_name(g: &RawGame) -> String {
+    if g.name.trim().is_empty() {
+        format!("app/{}", g.appid)
+    } else {
+        g.name.clone()
+    }
+}
+
+async fn render_body(rows: &[GameRow], games: &[RawGame], shape: Shape, sort: Sort) -> Body {
+    match shape {
+        Shape::Bars => bars_body(rows),
+        Shape::Entries => entries_body(rows, EMPTY_LABEL),
+        Shape::TextBlock => text_block_body(rows, EMPTY_LABEL),
+        Shape::MarkdownTextBlock => markdown_body(rows, EMPTY_LABEL),
+        Shape::LinkedTextBlock => linked_text_body(rows, EMPTY_LABEL),
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::Ratio => ratio_body(rows),
+        Shape::NumberSeries => number_series_body(rows),
+        Shape::Image => image_body(rows).await,
+        Shape::Badge => badge_body(rows, sort.label(), "library empty"),
+        _ => text_body_with_summary(rows, games),
+    }
+}
+
+impl Sort {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Playtime => "all-time",
+            Self::Recent => "recent",
+        }
+    }
+}
+
+fn text_body_with_summary(rows: &[GameRow], games: &[RawGame]) -> Body {
+    if rows.is_empty() {
+        return text_body(rows, EMPTY_LABEL);
+    }
+    let total: u32 = games.iter().map(|g| g.playtime_forever).sum();
+    Body::Text(crate::payload::TextData {
+        value: format!(
+            "{} across {} owned games",
+            format_minutes(total),
+            games.len()
+        ),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct OwnedGamesResponse {
+    response: OwnedGamesBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct OwnedGamesBody {
+    #[serde(default)]
+    games: Option<Vec<RawGame>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawGame {
+    appid: u32,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    playtime_forever: u32,
+    #[serde(default)]
+    rtime_last_played: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_games() -> Vec<RawGame> {
+        vec![
+            RawGame {
+                appid: 730,
+                name: "Counter-Strike 2".into(),
+                playtime_forever: 4830,
+                rtime_last_played: 1_715_000_000,
+            },
+            RawGame {
+                appid: 570,
+                name: "Dota 2".into(),
+                playtime_forever: 12_000,
+                rtime_last_played: 1_700_000_000,
+            },
+            RawGame {
+                appid: 440,
+                name: "Team Fortress 2".into(),
+                playtime_forever: 0,
+                rtime_last_played: 1_720_000_000,
+            },
+        ]
+    }
+
+    #[test]
+    fn fetcher_metadata_is_in_steam_family() {
+        let f = SteamOwnedGames;
+        assert_eq!(f.name(), "steam_owned_games");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert!(f.refresh_interval() > 0);
+    }
+
+    #[test]
+    fn playtime_sort_ranks_dota_first_and_labels_with_hours() {
+        let rows = rows_from_games(&sample_games(), Sort::Playtime, 10);
+        assert_eq!(rows[0].name, "Dota 2");
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[1].name, "Counter-Strike 2");
+        // 12_000 min / 60 = 200h
+        assert_eq!(rows[0].value_label, "200h");
+    }
+
+    #[test]
+    fn recent_sort_ranks_tf2_first_and_labels_with_relative_pill() {
+        let rows = rows_from_games(&sample_games(), Sort::Recent, 10);
+        assert_eq!(rows[0].name, "Team Fortress 2");
+        assert_eq!(rows[1].name, "Counter-Strike 2");
+        // ts 1_720_000_000 is years in the past from any plausible test runtime → ISO fallback.
+        assert!(
+            rows[0].value_label.starts_with("20"),
+            "expected ISO date fallback for old ts, got {:?}",
+            rows[0].value_label
+        );
+    }
+
+    #[test]
+    fn last_played_label_reports_never_when_timestamp_is_zero() {
+        assert_eq!(last_played_label(0), "never");
+    }
+
+    #[test]
+    fn relative_label_picks_unit_by_age_bucket() {
+        // Anchor a fixed `now` so the table doesn't drift with the real clock.
+        let now = 1_750_000_000_i64;
+        const DAY: i64 = 86_400;
+        assert_eq!(relative_label(now, now), "today");
+        assert_eq!(relative_label(now, now - DAY), "yesterday");
+        assert_eq!(relative_label(now, now - 3 * DAY), "3d ago");
+        assert_eq!(relative_label(now, now - 14 * DAY), "2w ago");
+        // 60 days back falls through to the ISO date fallback.
+        let iso = relative_label(now, now - 60 * DAY);
+        assert!(iso.starts_with("20"), "expected ISO fallback, got {iso:?}");
+        assert_eq!(iso.len(), 10);
+    }
+
+    #[test]
+    fn relative_label_does_not_panic_on_future_timestamps() {
+        // Clock skew between Steam and the host can produce ts > now; clamp to "today".
+        let now = 1_750_000_000_i64;
+        assert_eq!(relative_label(now, now + 3600), "today");
+    }
+
+    #[test]
+    fn count_caps_the_returned_rows() {
+        let rows = rows_from_games(&sample_games(), Sort::Playtime, 1);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn display_name_falls_back_to_app_id_when_name_is_blank() {
+        let g = RawGame {
+            appid: 42,
+            name: "  ".into(),
+            playtime_forever: 0,
+            rtime_last_played: 0,
+        };
+        assert_eq!(display_name(&g), "app/42");
+    }
+
+    #[test]
+    fn text_shape_summarises_total_library_playtime() {
+        let games = sample_games();
+        let rows = rows_from_games(&games, Sort::Playtime, 10);
+        let Body::Text(t) = text_body_with_summary(&rows, &games) else {
+            panic!("expected text body");
+        };
+        // 4830 + 12000 + 0 = 16830 -> 280h
+        assert!(t.value.starts_with("280h"));
+        assert!(t.value.contains("3 owned"));
+    }
+
+    #[test]
+    fn sort_default_is_playtime() {
+        assert_eq!(Sort::default(), Sort::Playtime);
+    }
+
+    #[test]
+    fn options_struct_parses_sort_keyword() {
+        let raw = toml::Value::try_from(serde_json::json!({"sort": "recent"})).unwrap();
+        let opts: Options = parse_options(Some(&raw)).unwrap();
+        assert_eq!(opts.sort, Some(Sort::Recent));
+    }
+}

--- a/src/fetcher/steam/player_summary.rs
+++ b/src/fetcher/steam/player_summary.rs
@@ -1,0 +1,549 @@
+//! `steam_player_summary` — the configured Steam user's profile snapshot: persona name,
+//! Steam level, online status, currently-playing game, and last-logoff timestamp.
+//!
+//! Reads `ISteamUser/GetPlayerSummaries/v2` and `IPlayerService/GetSteamLevel/v1` in parallel.
+//! Same single-read-many-shapes pattern as `lastfm` family's user-scoped fetchers: every shape
+//! reformats the same snapshot.
+
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::steam::client;
+use crate::fetcher::thumbnails;
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, ImageData, ImageLinkedItem, ImageLinkedListData,
+    LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, Payload, Status, TextBlockData,
+    TextData,
+};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::TextBlock,
+    Shape::Text,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::Entries,
+    Shape::Badge,
+    Shape::Image,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "steam_id",
+    type_hint: "string (Steam64 id)",
+    required: false,
+    default: None,
+    description: "Steam64 id of the profile to read. Falls back to the `STEAM_ID` env var when omitted.",
+}];
+
+pub struct SteamPlayerSummary;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub steam_id: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for SteamPlayerSummary {
+    fn name(&self) -> &str {
+        "steam_player_summary"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "The configured Steam user's profile snapshot: persona name, level, online status, currently-playing game, and last-logoff timestamp. Reads `GetPlayerSummaries` and `GetSteamLevel` in parallel."
+    }
+    fn refresh_interval(&self) -> u64 {
+        30 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let steam_id = client::resolve_steam_id(opts.steam_id.as_deref())?;
+        let shape = ctx.shape.unwrap_or(Shape::TextBlock);
+
+        let snapshot = fetch_snapshot(&steam_id).await?;
+        Ok(payload(render_body(&snapshot, shape).await))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Snapshot {
+    steam_id: String,
+    persona: String,
+    profile_url: String,
+    avatar_url: Option<String>,
+    state: PersonaState,
+    current_game: Option<String>,
+    last_logoff: Option<i64>,
+    level: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PersonaState {
+    Offline,
+    Online,
+    Busy,
+    Away,
+    Snooze,
+    LookingToTrade,
+    LookingToPlay,
+    InGame,
+}
+
+impl PersonaState {
+    fn from_code(code: u8, in_game: bool) -> Self {
+        if in_game {
+            return Self::InGame;
+        }
+        match code {
+            1 => Self::Online,
+            2 => Self::Busy,
+            3 => Self::Away,
+            4 => Self::Snooze,
+            5 => Self::LookingToTrade,
+            6 => Self::LookingToPlay,
+            _ => Self::Offline,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Offline => "offline",
+            Self::Online => "online",
+            Self::Busy => "busy",
+            Self::Away => "away",
+            Self::Snooze => "snooze",
+            Self::LookingToTrade => "trading",
+            Self::LookingToPlay => "looking to play",
+            Self::InGame => "in game",
+        }
+    }
+
+    fn badge_status(self) -> Status {
+        match self {
+            Self::Online | Self::InGame | Self::LookingToTrade | Self::LookingToPlay => Status::Ok,
+            Self::Busy | Self::Away | Self::Snooze | Self::Offline => Status::Warn,
+        }
+    }
+
+    /// Per-row `Entries` status pip. Offline returns `None` so a fresh-spawned offline profile
+    /// doesn't decorate the status row with a yellow pip — only "actively in something other
+    /// than online" surfaces a warning.
+    fn entry_status(self) -> Option<Status> {
+        match self {
+            Self::Offline => None,
+            other => Some(other.badge_status()),
+        }
+    }
+}
+
+async fn fetch_snapshot(steam_id: &str) -> Result<Snapshot, FetchError> {
+    let (player_res, level_res) = tokio::join!(fetch_player(steam_id), fetch_level(steam_id));
+    let player = player_res?;
+    let level = level_res.ok().flatten();
+    Ok(Snapshot {
+        steam_id: steam_id.to_string(),
+        persona: player.personaname,
+        profile_url: player.profileurl,
+        avatar_url: Some(player.avatarfull).filter(|s| !s.is_empty()),
+        state: PersonaState::from_code(player.personastate, player.gameid.is_some()),
+        current_game: player
+            .gameextrainfo
+            .filter(|s| !s.is_empty())
+            .or_else(|| player.gameid.map(|id| format!("app/{id}"))),
+        last_logoff: player.lastlogoff,
+        level,
+    })
+}
+
+async fn fetch_player(steam_id: &str) -> Result<RawPlayer, FetchError> {
+    let raw: PlayerSummariesResponse = client::get_json(
+        "ISteamUser/GetPlayerSummaries/v2/",
+        &[("steamids", steam_id)],
+    )
+    .await?;
+    raw.response
+        .players
+        .into_iter()
+        .next()
+        .ok_or_else(|| FetchError::Failed(format!("steam: no player for id {steam_id}")))
+}
+
+async fn fetch_level(steam_id: &str) -> Result<Option<u32>, FetchError> {
+    let raw: SteamLevelResponse =
+        client::get_json("IPlayerService/GetSteamLevel/v1/", &[("steamid", steam_id)]).await?;
+    Ok(raw.response.player_level)
+}
+
+async fn render_body(snap: &Snapshot, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => text_body(snap),
+        Shape::TextBlock => text_block_body(snap),
+        Shape::MarkdownTextBlock => markdown_body(snap),
+        Shape::LinkedTextBlock => linked_text_body(snap),
+        Shape::ImageLinkedList => image_linked_body(snap).await,
+        Shape::Entries => entries_body(snap),
+        Shape::Badge => badge_body(snap),
+        Shape::Image => image_body(snap).await,
+        _ => text_body(snap),
+    }
+}
+
+fn headline(snap: &Snapshot) -> String {
+    let mut parts = vec![snap.persona.clone()];
+    if let Some(lv) = snap.level {
+        parts.push(format!("Lv {lv}"));
+    }
+    if let Some(game) = &snap.current_game {
+        parts.push(format!("in {game}"));
+    } else {
+        parts.push(snap.state.label().into());
+    }
+    parts.join(" · ")
+}
+
+fn text_body(snap: &Snapshot) -> Body {
+    Body::Text(TextData {
+        value: headline(snap),
+    })
+}
+
+fn text_block_body(snap: &Snapshot) -> Body {
+    Body::TextBlock(TextBlockData { lines: lines(snap) })
+}
+
+fn markdown_body(snap: &Snapshot) -> Body {
+    let value = lines(snap)
+        .into_iter()
+        .enumerate()
+        .map(|(i, line)| if i == 0 { format!("**{line}**") } else { line })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Body::MarkdownTextBlock(MarkdownTextBlockData { value })
+}
+
+fn lines(snap: &Snapshot) -> Vec<String> {
+    let mut lines = vec![snap.persona.clone()];
+    if let Some(lv) = snap.level {
+        lines.push(format!("Level {lv}"));
+    }
+    lines.push(format!("Status: {}", snap.state.label()));
+    if let Some(game) = &snap.current_game {
+        lines.push(format!("Playing: {game}"));
+    } else if let Some(ts) = snap.last_logoff {
+        lines.push(format!("Last seen: {}", format_last_logoff(ts)));
+    }
+    lines
+}
+
+fn linked_text_body(snap: &Snapshot) -> Body {
+    Body::LinkedTextBlock(LinkedTextBlockData {
+        items: vec![LinkedLine {
+            text: headline(snap),
+            url: Some(snap.profile_url.clone()),
+        }],
+    })
+}
+
+async fn image_linked_body(snap: &Snapshot) -> Body {
+    let path = match snap.avatar_url.as_deref() {
+        Some(url) => thumbnails::download_to_cache(url)
+            .await
+            .ok()
+            .flatten()
+            .map(|p| p.to_string_lossy().into_owned()),
+        None => None,
+    };
+    Body::ImageLinkedList(ImageLinkedListData {
+        items: vec![ImageLinkedItem {
+            title: snap.persona.clone(),
+            url: Some(snap.profile_url.clone()),
+            thumbnail_path: path,
+            subtitle: Some(subtitle(snap)),
+        }],
+    })
+}
+
+fn subtitle(snap: &Snapshot) -> String {
+    match (&snap.level, &snap.current_game) {
+        (Some(lv), Some(game)) => format!("Lv {lv} · in {game}"),
+        (Some(lv), None) => format!("Lv {lv} · {}", snap.state.label()),
+        (None, Some(game)) => format!("in {game}"),
+        (None, None) => snap.state.label().into(),
+    }
+}
+
+fn entries_body(snap: &Snapshot) -> Body {
+    let mut items = vec![Entry {
+        key: "persona".into(),
+        value: Some(snap.persona.clone()),
+        status: None,
+    }];
+    if let Some(lv) = snap.level {
+        items.push(Entry {
+            key: "level".into(),
+            value: Some(lv.to_string()),
+            status: None,
+        });
+    }
+    items.push(Entry {
+        key: "status".into(),
+        value: Some(snap.state.label().into()),
+        status: snap.state.entry_status(),
+    });
+    if let Some(game) = &snap.current_game {
+        items.push(Entry {
+            key: "playing".into(),
+            value: Some(game.clone()),
+            status: None,
+        });
+    }
+    if let Some(ts) = snap.last_logoff {
+        items.push(Entry {
+            key: "last seen".into(),
+            value: Some(format_last_logoff(ts)),
+            status: None,
+        });
+    }
+    items.push(Entry {
+        key: "steam id".into(),
+        value: Some(snap.steam_id.clone()),
+        status: None,
+    });
+    Body::Entries(EntriesData { items })
+}
+
+fn badge_body(snap: &Snapshot) -> Body {
+    let label = match &snap.current_game {
+        Some(game) => format!("in {game}"),
+        None => snap.state.label().into(),
+    };
+    Body::Badge(BadgeData {
+        status: snap.state.badge_status(),
+        label,
+    })
+}
+
+async fn image_body(snap: &Snapshot) -> Body {
+    let path = match snap.avatar_url.as_deref() {
+        Some(url) => thumbnails::download_to_cache(url)
+            .await
+            .ok()
+            .flatten()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        None => String::new(),
+    };
+    Body::Image(ImageData { path })
+}
+
+fn format_last_logoff(ts: i64) -> String {
+    // The `lastlogoff` field is unix seconds UTC; format it as an ISO date so cached payloads
+    // don't bake in a stale relative-time string. Renderers that want "3h ago" can re-derive
+    // it from a Timeline shape — this fetcher only emits absolute snapshots.
+    match Utc.timestamp_opt(ts, 0).single() {
+        Some(dt) => dt.format("%Y-%m-%d").to_string(),
+        None => format!("ts:{ts}"),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PlayerSummariesResponse {
+    response: PlayerSummariesBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PlayerSummariesBody {
+    #[serde(default)]
+    players: Vec<RawPlayer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPlayer {
+    #[serde(default)]
+    personaname: String,
+    #[serde(default)]
+    profileurl: String,
+    #[serde(default)]
+    avatarfull: String,
+    #[serde(default)]
+    personastate: u8,
+    #[serde(default)]
+    lastlogoff: Option<i64>,
+    #[serde(default)]
+    gameid: Option<String>,
+    #[serde(default)]
+    gameextrainfo: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SteamLevelResponse {
+    response: SteamLevelBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SteamLevelBody {
+    #[serde(default)]
+    player_level: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(state: PersonaState, current_game: Option<&str>) -> Snapshot {
+        Snapshot {
+            steam_id: "76561197960287930".into(),
+            persona: "Robin".into(),
+            profile_url: "https://steamcommunity.com/id/robinwalker/".into(),
+            avatar_url: Some("https://example.com/avatar.jpg".into()),
+            state,
+            current_game: current_game.map(String::from),
+            last_logoff: Some(1_700_000_000),
+            level: Some(25),
+        }
+    }
+
+    #[test]
+    fn fetcher_metadata_is_in_steam_family() {
+        let f = SteamPlayerSummary;
+        assert_eq!(f.name(), "steam_player_summary");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert!(f.shapes().contains(&Shape::Badge));
+    }
+
+    #[test]
+    fn persona_state_promotes_in_game_when_gameid_is_present() {
+        assert_eq!(PersonaState::from_code(1, true), PersonaState::InGame);
+        assert_eq!(PersonaState::from_code(0, true), PersonaState::InGame);
+    }
+
+    #[test]
+    fn persona_state_labels_each_variant() {
+        for s in [
+            PersonaState::Offline,
+            PersonaState::Online,
+            PersonaState::Busy,
+            PersonaState::Away,
+            PersonaState::Snooze,
+            PersonaState::LookingToTrade,
+            PersonaState::LookingToPlay,
+            PersonaState::InGame,
+        ] {
+            assert!(!s.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn persona_state_offline_drops_entry_pip_but_keeps_warn_badge_status() {
+        // Offline is benign in the per-row Entries view (no warning pip) but still degrades
+        // the all-in-one Badge status — "user is not online" is a warning compared to
+        // "actively in game".
+        assert!(PersonaState::Offline.entry_status().is_none());
+        assert_eq!(PersonaState::Offline.badge_status(), Status::Warn);
+        assert_eq!(PersonaState::Online.entry_status(), Some(Status::Ok));
+        assert_eq!(PersonaState::Busy.badge_status(), Status::Warn);
+    }
+
+    #[test]
+    fn headline_includes_level_and_current_game_when_present() {
+        let snap = sample(PersonaState::InGame, Some("Counter-Strike 2"));
+        let h = headline(&snap);
+        assert!(h.contains("Robin"));
+        assert!(h.contains("Lv 25"));
+        assert!(h.contains("in Counter-Strike 2"));
+    }
+
+    #[test]
+    fn headline_falls_back_to_state_label_when_not_in_game() {
+        let snap = sample(PersonaState::Online, None);
+        let h = headline(&snap);
+        assert!(h.contains("Robin"));
+        assert!(h.contains("online"));
+    }
+
+    #[test]
+    fn entries_body_tags_status_row_with_state_status() {
+        let snap = sample(PersonaState::Online, None);
+        let Body::Entries(e) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        let status_row = e.items.iter().find(|i| i.key == "status").unwrap();
+        assert_eq!(status_row.status, Some(Status::Ok));
+        assert!(e.items.iter().any(|i| i.key == "steam id"));
+    }
+
+    #[test]
+    fn linked_text_body_carries_profile_url() {
+        let snap = sample(PersonaState::Online, None);
+        let Body::LinkedTextBlock(b) = linked_text_body(&snap) else {
+            panic!("expected linked_text_block");
+        };
+        assert_eq!(b.items.len(), 1);
+        assert_eq!(
+            b.items[0].url.as_deref(),
+            Some("https://steamcommunity.com/id/robinwalker/")
+        );
+    }
+
+    #[test]
+    fn badge_body_uses_in_game_label_when_playing() {
+        let snap = sample(PersonaState::InGame, Some("Dota 2"));
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert!(b.label.contains("Dota 2"));
+    }
+
+    #[test]
+    fn format_last_logoff_renders_iso_date_for_valid_timestamps() {
+        let s = format_last_logoff(1_700_000_000);
+        // 2023-11-14 UTC
+        assert_eq!(s, "2023-11-14");
+    }
+
+    #[test]
+    fn markdown_body_bolds_only_the_persona_line() {
+        let snap = sample(PersonaState::Online, None);
+        let Body::MarkdownTextBlock(m) = markdown_body(&snap) else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.starts_with("**Robin**"));
+        assert!(m.value.contains("\nLevel 25"));
+    }
+
+    #[test]
+    fn subtitle_combines_level_and_current_game_when_both_present() {
+        let snap = sample(PersonaState::InGame, Some("Dota 2"));
+        assert_eq!(subtitle(&snap), "Lv 25 · in Dota 2");
+    }
+
+    #[test]
+    fn subtitle_falls_back_when_level_or_game_missing() {
+        let mut snap = sample(PersonaState::Online, None);
+        assert_eq!(subtitle(&snap), "Lv 25 · online");
+        snap.level = None;
+        assert_eq!(subtitle(&snap), "online");
+    }
+}

--- a/src/fetcher/steam/recently_played.rs
+++ b/src/fetcher/steam/recently_played.rs
@@ -1,0 +1,284 @@
+//! `steam_recently_played` — games the configured Steam user has played in the last two
+//! weeks, with per-game minutes-this-week from the `playtime_2weeks` field.
+//!
+//! Reads `IPlayerService/GetRecentlyPlayedGames/v1`. Rolls up the `playtime_2weeks` totals
+//! across the response for the headline ("Xh across N games") so the catalog's
+//! `steam_playtime_week` candidate is covered by this fetcher's `Text` shape rather than a
+//! separate read.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::steam::client;
+use crate::fetcher::steam::common::format_minutes;
+use crate::fetcher::steam::games::{
+    GameRow, badge_body, bars_body, entries_body, image_body, image_linked_body, linked_text_body,
+    markdown_body, number_series_body, ratio_body, text_block_body, text_body,
+};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{Body, Payload};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Bars,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::LinkedTextBlock,
+    Shape::ImageLinkedList,
+    Shape::Text,
+    Shape::Ratio,
+    Shape::NumberSeries,
+    Shape::Image,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "steam_id",
+        type_hint: "string (Steam64 id)",
+        required: false,
+        default: None,
+        description: "Steam64 id of the user whose recent playtime to read. Falls back to the `STEAM_ID` env var when omitted.",
+    },
+    OptionSchema {
+        name: "count",
+        type_hint: "integer (1..=20)",
+        required: false,
+        default: Some("5"),
+        description: "Maximum number of recently-played games to display.",
+    },
+];
+
+const DEFAULT_COUNT: u32 = 5;
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 20;
+const EMPTY_LABEL: &str = "no playtime this week";
+
+pub struct SteamRecentlyPlayed;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub steam_id: Option<String>,
+    pub count: Option<u32>,
+}
+
+#[async_trait]
+impl Fetcher for SteamRecentlyPlayed {
+    fn name(&self) -> &str {
+        "steam_recently_played"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Games the configured Steam user has launched in the last two weeks, with per-game minutes from `playtime_2weeks`. The Text shape sums the window for a `steam_playtime_week`-style headline; Bars / Entries break it out per game."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let steam_id = client::resolve_steam_id(opts.steam_id.as_deref())?;
+        let count = opts
+            .count
+            .unwrap_or(DEFAULT_COUNT)
+            .clamp(MIN_COUNT, MAX_COUNT) as usize;
+        let shape = ctx.shape.unwrap_or(Shape::Bars);
+
+        let games = fetch_games(&steam_id, count).await?;
+        let rows = rows_from_games(&games);
+        let body = render_body(&rows, &games, shape).await;
+        Ok(payload(body))
+    }
+}
+
+async fn fetch_games(steam_id: &str, count: usize) -> Result<Vec<RawGame>, FetchError> {
+    let count_str = count.to_string();
+    let raw: RecentlyPlayedResponse = client::get_json(
+        "IPlayerService/GetRecentlyPlayedGames/v1/",
+        &[("steamid", steam_id), ("count", &count_str)],
+    )
+    .await?;
+    Ok(raw.response.games.unwrap_or_default())
+}
+
+fn rows_from_games(games: &[RawGame]) -> Vec<GameRow> {
+    games
+        .iter()
+        .enumerate()
+        .map(|(i, g)| GameRow {
+            rank: i + 1,
+            appid: g.appid,
+            name: display_name(g),
+            value: g.playtime_2weeks as u64,
+            value_label: format_minutes(g.playtime_2weeks),
+        })
+        .collect()
+}
+
+fn display_name(g: &RawGame) -> String {
+    if g.name.trim().is_empty() {
+        format!("app/{}", g.appid)
+    } else {
+        g.name.clone()
+    }
+}
+
+async fn render_body(rows: &[GameRow], games: &[RawGame], shape: Shape) -> Body {
+    match shape {
+        Shape::Bars => bars_body(rows),
+        Shape::Entries => entries_body(rows, EMPTY_LABEL),
+        Shape::TextBlock => text_block_body(rows, EMPTY_LABEL),
+        Shape::MarkdownTextBlock => markdown_body(rows, EMPTY_LABEL),
+        Shape::LinkedTextBlock => linked_text_body(rows, EMPTY_LABEL),
+        Shape::ImageLinkedList => image_linked_body(rows).await,
+        Shape::Ratio => ratio_body(rows),
+        Shape::NumberSeries => number_series_body(rows),
+        Shape::Image => image_body(rows).await,
+        Shape::Badge => badge_body(rows, "this week", "no playtime"),
+        _ => text_body_with_summary(rows, games),
+    }
+}
+
+/// Text shape collapses the row list into a `Xh across N games this week` headline so the
+/// catalog's `steam_playtime_week` slot is covered without a second fetcher.
+fn text_body_with_summary(rows: &[GameRow], games: &[RawGame]) -> Body {
+    if rows.is_empty() {
+        return text_body(rows, EMPTY_LABEL);
+    }
+    let total: u32 = games.iter().map(|g| g.playtime_2weeks).sum();
+    Body::Text(crate::payload::TextData {
+        value: format!(
+            "{} across {} games this week",
+            format_minutes(total),
+            rows.len()
+        ),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct RecentlyPlayedResponse {
+    response: RecentlyPlayedBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RecentlyPlayedBody {
+    #[serde(default)]
+    games: Option<Vec<RawGame>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawGame {
+    appid: u32,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    playtime_2weeks: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_games() -> Vec<RawGame> {
+        vec![
+            RawGame {
+                appid: 730,
+                name: "Counter-Strike 2".into(),
+                playtime_2weeks: 480,
+            },
+            RawGame {
+                appid: 570,
+                name: "Dota 2".into(),
+                playtime_2weeks: 120,
+            },
+        ]
+    }
+
+    #[test]
+    fn fetcher_metadata_is_in_steam_family() {
+        let f = SteamRecentlyPlayed;
+        assert_eq!(f.name(), "steam_recently_played");
+        assert_eq!(f.safety(), Safety::Safe);
+        assert!(f.refresh_interval() > 0);
+        assert!(f.shapes().contains(&Shape::Bars));
+        assert!(f.shapes().contains(&Shape::Text));
+    }
+
+    #[test]
+    fn rows_from_games_assigns_ranks_in_order() {
+        let rows = rows_from_games(&sample_games());
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[1].rank, 2);
+        assert_eq!(rows[0].appid, 730);
+        assert_eq!(rows[0].value_label, "8h");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_app_id_when_name_is_blank() {
+        let g = RawGame {
+            appid: 42,
+            name: "  ".into(),
+            playtime_2weeks: 10,
+        };
+        assert_eq!(display_name(&g), "app/42");
+    }
+
+    #[test]
+    fn text_shape_collapses_into_weekly_summary() {
+        let games = sample_games();
+        let rows = rows_from_games(&games);
+        let Body::Text(t) = text_body_with_summary(&rows, &games) else {
+            panic!("expected text body");
+        };
+        // 480 + 120 = 600 minutes -> "10h"
+        assert!(t.value.starts_with("10h"));
+        assert!(t.value.contains("2 games"));
+    }
+
+    #[test]
+    fn text_shape_falls_back_to_empty_label_when_no_games() {
+        let Body::Text(t) = text_body_with_summary(&[], &[]) else {
+            panic!("expected text body");
+        };
+        assert_eq!(t.value, EMPTY_LABEL);
+    }
+
+    #[test]
+    fn options_struct_rejects_unknown_keys() {
+        let raw = toml::Value::try_from(serde_json::json!({"bogus": 1})).unwrap();
+        let err = parse_options::<Options>(Some(&raw)).unwrap_err();
+        assert!(err.contains("invalid options"));
+    }
+
+    #[test]
+    fn options_struct_parses_steam_id_and_count() {
+        let raw = toml::Value::try_from(serde_json::json!({
+            "steam_id": "76561197960287930",
+            "count": 10
+        }))
+        .unwrap();
+        let opts: Options = parse_options(Some(&raw)).unwrap();
+        assert_eq!(opts.steam_id.as_deref(), Some("76561197960287930"));
+        assert_eq!(opts.count, Some(10));
+    }
+}

--- a/src/fetcher/stock_watchlist.rs
+++ b/src/fetcher/stock_watchlist.rs
@@ -492,6 +492,7 @@ fn bars_body(snapshot: &Snapshot) -> Body {
             .map(|s| Bar {
                 label: format!("{} {}", s.arrow(), s.symbol),
                 value: (s.change_pct.abs() * PCT_TO_BP).round() as u64,
+                value_label: None,
             })
             .collect(),
     })

--- a/src/fetcher/system/mod.rs
+++ b/src/fetcher/system/mod.rs
@@ -409,6 +409,7 @@ fn disk_bars(disks: &Disks) -> Vec<Bar> {
         .map(|d| Bar {
             label: d.mount_point().to_string_lossy().into_owned(),
             value: d.total_space().saturating_sub(d.available_space()),
+            value_label: None,
         })
         .collect()
 }

--- a/src/fetcher/weather/forecast.rs
+++ b/src/fetcher/weather/forecast.rs
@@ -446,6 +446,7 @@ fn bars(forecast: &Forecast) -> Body {
             .map(|d| Bar {
                 label: weekday_short(d.date.weekday()).into(),
                 value: u64::from(d.precip_probability),
+                value_label: None,
             })
             .collect(),
     })

--- a/src/fetcher/weather/now.rs
+++ b/src/fetcher/weather/now.rs
@@ -300,6 +300,7 @@ fn precipitation_bars(hourly: &[HourPoint]) -> Body {
                 // Bars are integer-valued; multiply by 10 to keep one decimal of precision
                 // (i.e. units = "tenths of mm" / "tenths of an inch").
                 value: (h.precipitation.max(0.0) * 10.0).round() as u64,
+                value_label: None,
             })
             .collect(),
     })

--- a/src/fetcher/wikipedia/trending.rs
+++ b/src/fetcher/wikipedia/trending.rs
@@ -295,6 +295,7 @@ fn render_sync(articles: &[Article], shape: Shape) -> Body {
                 .map(|a| Bar {
                     label: a.title_display.clone(),
                     value: a.views,
+                    value_label: None,
                 })
                 .collect(),
         }),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -217,6 +217,13 @@ pub struct BarsData {
 pub struct Bar {
     pub label: String,
     pub value: u64,
+    /// Optional pre-formatted right-column text shown by text-first renderers (`list_ranking`).
+    /// Visual renderers (`chart_bar`, `chart_pie`) ignore this — they only consume `value`. Let
+    /// fetchers carry a unit (`"80h"`, `"1.5M peak"`, `"2024-07-03"`) so the value column reads
+    /// as the fetcher intended rather than a raw `u64`. Omitted = renderers fall back to the
+    /// numeric `value` printed as-is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_label: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -507,10 +514,12 @@ mod tests {
                 Bar {
                     label: "a".into(),
                     value: 3,
+                    value_label: None,
                 },
                 Bar {
                     label: "b".into(),
                     value: 5,
+                    value_label: None,
                 },
             ],
         }));

--- a/src/render/chart_bar.rs
+++ b/src/render/chart_bar.rs
@@ -171,14 +171,17 @@ mod tests {
             Bar {
                 label: "a".into(),
                 value: 3,
+                value_label: None,
             },
             Bar {
                 label: "b".into(),
                 value: 7,
+                value_label: None,
             },
             Bar {
                 label: "c".into(),
                 value: 5,
+                value_label: None,
             },
         ];
         let _ = render_to_buffer(&payload(bars), 30, 10);
@@ -195,18 +198,22 @@ mod tests {
             Bar {
                 label: "a".into(),
                 value: 3,
+                value_label: None,
             },
             Bar {
                 label: "b".into(),
                 value: 9,
+                value_label: None,
             },
             Bar {
                 label: "c".into(),
                 value: 1,
+                value_label: None,
             },
             Bar {
                 label: "d".into(),
                 value: 5,
+                value_label: None,
             },
         ];
         let out = capped_bars(&BarsData { bars }, Some(2));
@@ -221,10 +228,12 @@ mod tests {
             Bar {
                 label: "a".into(),
                 value: 1,
+                value_label: None,
             },
             Bar {
                 label: "b".into(),
                 value: 9,
+                value_label: None,
             },
         ];
         let out = capped_bars(&BarsData { bars }, None);

--- a/src/render/chart_pie.rs
+++ b/src/render/chart_pie.rs
@@ -126,6 +126,7 @@ mod tests {
         Bar {
             label: label.into(),
             value,
+            value_label: None,
         }
     }
 

--- a/src/render/list_ranking.rs
+++ b/src/render/list_ranking.rs
@@ -41,10 +41,10 @@ const OPTION_SCHEMAS: &[OptionSchema] = &[
 const MEDALS: [&str; 3] = ["🥇", "🥈", "🥉"];
 const COLUMN_GAP: &str = "  ";
 
-/// Top-N ranking for the `Bars` shape. Sorts descending, prints `<rank> <label>  <value>` rows
-/// with the rank-prefix and value columns aligned across rows. Sibling to `chart_bar` — same
-/// shape, text-first treatment instead of a glyph chart. Use `style = "medal"` to highlight
-/// the podium with 🥇/🥈/🥉.
+/// Rank-prefixed list view for the `Bars` shape. Preserves the fetcher's bar order — sort is
+/// the fetcher's responsibility, not the renderer's, so that fetchers emitting recency-sorted
+/// (`steam_owned_games sort = "recent"`), alphabetical, or any non-value-desc order display as
+/// intended. Use `style = "medal"` to highlight the top three with 🥇/🥈/🥉.
 pub struct ListRankingRenderer;
 
 impl Renderer for ListRankingRenderer {
@@ -52,7 +52,7 @@ impl Renderer for ListRankingRenderer {
         "list_ranking"
     }
     fn description(&self) -> &'static str {
-        "Top-N table sorted high-to-low: rank prefix (`1.` / `2.` numbers, 🥇/🥈/🥉 medals, or none), label, and right-aligned value column. The text-first sibling of `chart_bar` — pick this when the values matter more than their relative bar lengths."
+        "Rank-prefixed table preserving the fetcher's bar order: rank prefix (`1.` / `2.` numbers, 🥇/🥈/🥉 medals, or none), label, and right-aligned value column. The text-first sibling of `chart_bar` — pick this when the values matter more than their relative bar lengths. Sort is the fetcher's responsibility; `max_items` truncates from the head."
     }
     fn accepts(&self) -> &[Shape] {
         &[Shape::Bars]
@@ -88,7 +88,7 @@ fn render_ranking(
     if area.width == 0 || area.height == 0 {
         return;
     }
-    let rows = sorted_rows(data, opts.max_items);
+    let rows = capped_rows(data, opts.max_items);
     let style = opts.style.as_deref().unwrap_or("number");
     let prefixes: Vec<String> = (0..rows.len()).map(|i| rank_prefix(i, style)).collect();
     let widths = column_widths(&prefixes, &rows);
@@ -111,7 +111,7 @@ fn render_ranking(
     let lines: Vec<Line> = rows
         .iter()
         .zip(prefixes.iter())
-        .map(|((label, value), prefix)| compose_line(prefix, label, *value, effective, theme))
+        .map(|(row, prefix)| compose_line(prefix, &row.label, &row.display, effective, theme))
         .collect();
     frame.render_widget(
         Paragraph::new(lines).style(Style::default().fg(theme.text)),
@@ -119,13 +119,25 @@ fn render_ranking(
     );
 }
 
-fn sorted_rows(data: &BarsData, cap: Option<usize>) -> Vec<(String, u64)> {
-    let mut rows: Vec<(String, u64)> = data
+/// Row view. `display` is what the right column actually prints — `Bar.value_label` when
+/// present, otherwise the numeric value stringified.
+struct Row {
+    label: String,
+    display: String,
+}
+
+/// Build rows in the fetcher's bar order. `max_items` truncates from the head — sort is the
+/// fetcher's job (lastfm's `chart.getTop*` is server-ranked, steam's `_owned_games` sorts by
+/// playtime or recency per its `sort` option, basic_bars carries the user-authored order).
+fn capped_rows(data: &BarsData, cap: Option<usize>) -> Vec<Row> {
+    let mut rows: Vec<Row> = data
         .bars
         .iter()
-        .map(|b| (b.label.clone(), b.value))
+        .map(|b| Row {
+            label: b.label.clone(),
+            display: b.value_label.clone().unwrap_or_else(|| b.value.to_string()),
+        })
         .collect();
-    rows.sort_by_key(|r| std::cmp::Reverse(r.1));
     if let Some(n) = cap {
         rows.truncate(n);
     }
@@ -157,17 +169,17 @@ impl Widths {
     }
 }
 
-fn column_widths(prefixes: &[String], rows: &[(String, u64)]) -> Widths {
+fn column_widths(prefixes: &[String], rows: &[Row]) -> Widths {
     Widths {
         prefix: prefixes.iter().map(|p| display_width(p)).max().unwrap_or(0),
         label: rows
             .iter()
-            .map(|(l, _)| l.chars().count())
+            .map(|r| r.label.chars().count())
             .max()
             .unwrap_or(0),
         value: rows
             .iter()
-            .map(|(_, v)| v.to_string().chars().count())
+            .map(|r| r.display.chars().count())
             .max()
             .unwrap_or(0),
     }
@@ -176,7 +188,7 @@ fn column_widths(prefixes: &[String], rows: &[(String, u64)]) -> Widths {
 fn compose_line<'a>(
     prefix: &str,
     label: &str,
-    value: u64,
+    value: &str,
     widths: Widths,
     theme: &Theme,
 ) -> Line<'a> {
@@ -190,7 +202,7 @@ fn compose_line<'a>(
     }
     spans.push(Span::raw(fit_label(label, widths.label)));
     spans.push(Span::raw(COLUMN_GAP));
-    spans.push(Span::raw(pad_left(&value.to_string(), widths.value)));
+    spans.push(Span::raw(pad_left(value, widths.value)));
     Line::from(spans)
 }
 
@@ -277,6 +289,7 @@ mod tests {
                     .map(|(l, v)| Bar {
                         label: (*l).into(),
                         value: *v,
+                        value_label: None,
                     })
                     .collect(),
             }),
@@ -289,7 +302,10 @@ mod tests {
     }
 
     #[test]
-    fn renders_descending_with_default_numeric_prefix() {
+    fn preserves_fetcher_bar_order_with_numeric_prefix() {
+        // The fetcher owns sort order — renderer just rank-prefixes the bars as they arrive.
+        // A recency-sorted owned_games list, a server-ranked lastfm chart, and a user-authored
+        // basic_bars list all show in their respective intended order.
         let p = payload(&[("alice", 3), ("bob", 7), ("carol", 5)]);
         let spec = RenderSpec::Short("list_ranking".into());
         let buf = render_with(&spec, &p, 30, 3);
@@ -297,32 +313,35 @@ mod tests {
         let row1 = line_text(&buf, 1);
         let row2 = line_text(&buf, 2);
         assert!(
-            row0.contains("1.") && row0.contains("bob"),
+            row0.contains("1.") && row0.contains("alice"),
             "row0: {row0:?}"
         );
         assert!(
-            row1.contains("2.") && row1.contains("carol"),
+            row1.contains("2.") && row1.contains("bob"),
             "row1: {row1:?}"
         );
         assert!(
-            row2.contains("3.") && row2.contains("alice"),
+            row2.contains("3.") && row2.contains("carol"),
             "row2: {row2:?}"
         );
     }
 
     #[test]
-    fn max_items_caps_top_n() {
+    fn max_items_truncates_from_the_head_preserving_order() {
         #[derive(serde::Deserialize)]
         struct W {
             render: RenderSpec,
         }
         let w: W = toml::from_str(r#"render = { type = "list_ranking", max_items = 2 }"#).unwrap();
+        // With auto-sort gone, max_items keeps the first 2 in the fetcher's order — not the
+        // numerically top 2. A fetcher that wants "top N by value" sorts itself.
         let p = payload(&[("a", 1), ("b", 9), ("c", 5), ("d", 7)]);
         let buf = render_with(&w.render, &p, 30, 4);
         let joined: String = (0..4).map(|y| line_text(&buf, y)).collect();
-        assert!(joined.contains("b"), "missing top: {joined:?}");
-        assert!(joined.contains("d"), "missing second: {joined:?}");
+        assert!(joined.contains("a"), "missing first: {joined:?}");
+        assert!(joined.contains("b"), "missing second: {joined:?}");
         assert!(!joined.contains("c"), "third should be capped: {joined:?}");
+        assert!(!joined.contains("d"), "fourth should be capped: {joined:?}");
     }
 
     #[test]
@@ -345,6 +364,61 @@ mod tests {
     }
 
     #[test]
+    fn value_label_overrides_numeric_value_when_present() {
+        // Fetchers pre-format a unit ("80h", "2024-07-03") in `Bar.value_label`. The right
+        // column prints that text instead of stringifying `value`, so a recent-launches widget
+        // shows dates rather than unix timestamps and a steam top-games widget shows hours
+        // rather than raw minutes.
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Bars(BarsData {
+                bars: vec![
+                    Bar {
+                        label: "Game A".into(),
+                        value: 4830,
+                        value_label: Some("80h".into()),
+                    },
+                    Bar {
+                        label: "Game B".into(),
+                        value: 12_000,
+                        value_label: Some("200h".into()),
+                    },
+                ],
+            }),
+        };
+        let spec = RenderSpec::Short("list_ranking".into());
+        let buf = render_with(&spec, &payload, 30, 2);
+        let row0 = line_text(&buf, 0);
+        let row1 = line_text(&buf, 1);
+        assert!(row0.contains("Game A") && row0.contains("80h"), "{row0:?}");
+        assert!(row1.contains("Game B") && row1.contains("200h"), "{row1:?}");
+        assert!(!row0.contains("4830"), "raw value leaked: {row0:?}");
+        assert!(!row1.contains("12000"), "raw value leaked: {row1:?}");
+    }
+
+    #[test]
+    fn missing_value_label_falls_back_to_numeric_value() {
+        let payload = Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::Bars(BarsData {
+                bars: vec![Bar {
+                    label: "alpha".into(),
+                    value: 42,
+                    value_label: None,
+                }],
+            }),
+        };
+        let spec = RenderSpec::Short("list_ranking".into());
+        let buf = render_with(&spec, &payload, 30, 1);
+        let row0 = line_text(&buf, 0);
+        assert!(row0.contains("42"), "{row0:?}");
+    }
+
+    #[test]
     fn style_none_omits_prefix() {
         #[derive(serde::Deserialize)]
         struct W {
@@ -355,7 +429,8 @@ mod tests {
         let buf = render_with(&w.render, &p, 30, 2);
         let r0 = line_text(&buf, 0);
         assert!(!r0.contains("1."), "row0: {r0:?}");
-        assert!(r0.trim_start().starts_with("beta"), "row0: {r0:?}");
+        // First in the fetcher's order (alpha) leads the rendered list now that auto-sort is gone.
+        assert!(r0.trim_start().starts_with("alpha"), "row0: {r0:?}");
     }
 
     #[test]

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -145,6 +145,7 @@ pub fn bars(bs: &[(&str, u64)]) -> Body {
             .map(|(l, v)| Bar {
                 label: (*l).into(),
                 value: *v,
+                value_label: None,
             })
             .collect(),
     })


### PR DESCRIPTION
## Summary

Adds the `steam_*` fetcher family — Steam Web API readouts, mirroring the `lastfm_*` family layout (shared `client.rs` + `common.rs` + `games.rs`, one file per fetcher).

| Fetcher | Source | Auth | Shapes |
| --- | --- | --- | --- |
| `steam_player_summary` | `GetPlayerSummaries` + `GetSteamLevel` | `STEAM_API_KEY` + `steam_id` | 8 |
| `steam_recently_played` | `GetRecentlyPlayedGames` | `STEAM_API_KEY` + `steam_id` | 11 |
| `steam_owned_games` | `GetOwnedGames` | `STEAM_API_KEY` + `steam_id` | 11 |
| `steam_charts` | `GetMostPlayedGames` + store `appdetails` | none (public) | 10 |

All four are `Safety::Safe` — `api.steampowered.com` / `store.steampowered.com` are hardcoded, config only picks which resource is queried. `STEAM_API_KEY` goes in `$HOME/.splashboard/secrets.toml`; `STEAM_ID` resolves from a per-fetcher option or the `STEAM_ID` env var (same precedence as the `steamfetch` CLI).

### Renderer infra change

`Bar` gains an optional `value_label: Option<String>` field. `list_ranking` previously printed `Bar.value` as a raw `u64`, so fetchers could not control the value column's unit. Now:

- text-first renderers (`list_ranking`) print `value_label` when present; visual renderers (`chart_bar` / `chart_pie`) keep ignoring it.
- `list_ranking` preserves the fetcher's bar order instead of re-sorting by value — sort is the fetcher's responsibility, matching the other Bars renderers. `max_items` truncates from the head.
- `lastfm_top_*` / `lastfm_charts` bars now carry their pluralised play-count unit, so `list_ranking` shows `1.5k plays` instead of `1500`.

Notable decisions:

- `steam_recently_played`'s `Text` shape sums `playtime_2weeks` into an "Xh across N games this week" headline, covering the catalog's `steam_playtime_week` candidate without a second read.
- `steam_owned_games sort = "recent"` labels the value column with a relative pill (`today` / `3d ago` / `2w ago`, ISO date past 30 days); the bar value stays in minutes so `chart_bar` heights remain comparable.
- `steam_charts` reports `peak_in_game` (24h peak concurrent) — `GetMostPlayedGames` does not expose the live "right now" count — labelled `... peak` to stay honest. appid → name is an N+1 over the store `appdetails` endpoint, fanned out with a 4-permit semaphore; per-app failures fall back to an `app/<id>` placeholder.

## Test plan

- `cargo test` — 2893 lib + 12 integration tests green (62 new under `fetcher::steam` + `render::list_ranking` value_label / order coverage).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Smoke-tested via a local `.splashboard/dashboard.toml` (`splashboard watch`): all four fetchers across `chart_bar` / `list_ranking` / `grid_table` / `list_cards` / `status_badge` / `text_ascii`, confirmed value columns, ordering, peak labels, and relative dates render correctly.

## Catalog

Ticks `#68` (Life & Ambient — Gaming): `steam_recently_played`, `steam_playtime_week` (absorbed into `steam_recently_played`'s Text shape), `steam_charts`. `steam_player_summary` / `steam_owned_games` are family siblings added alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Steam integration with four new fetchers: top charts, player summary, recently played games, and owned games library.
  * Bar charts now support optional value labels for enhanced display formatting.

* **Improvements**
  * Bar ranking display now preserves data order instead of automatically sorting by value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->