### PR TITLE
test: improve line coverage via incremental test additions

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -570,6 +570,50 @@ mod tests {
     }
 
     #[test]
+    fn warm_from_without_disk_returns_an_empty_cache() {
+        // `watch` calls `warm_from(disk_cache.as_ref(), ...)`, and `Cache::open_default()` can
+        // hand back `None`. The `None` disk arm skips the `extend` entirely — every requested
+        // key simply starts cold and the fetch loop fills it in.
+        let mem = MemCache::warm_from(None, ["present", "absent"]);
+        assert!(<MemCache as CacheBackend>::load(&mem, "present").is_none());
+        assert_eq!(mem.generation(), 0);
+    }
+
+    #[test]
+    fn is_lock_stale_returns_false_when_file_is_missing() {
+        // A vanished lock file (another process already cleared it) must not read as stale —
+        // `metadata` fails and the `Ok(meta) else` arm bails to `false`.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("never-created.lock");
+        assert!(!is_lock_stale(&missing, Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn ensure_parent_is_ok_for_a_path_without_a_parent() {
+        // The filesystem root has no parent component, so `ensure_parent` takes the `None`
+        // arm and short-circuits to `Ok` instead of attempting a `create_dir_all`.
+        assert!(ensure_parent(Path::new("/")).is_ok());
+    }
+
+    #[test]
+    fn io_err_wraps_a_display_value_into_an_other_kind_error() {
+        let err = io_err("disk on fire");
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(err.to_string().contains("disk on fire"));
+    }
+
+    #[test]
+    fn try_acquire_with_returns_none_when_lock_dir_cannot_be_created() {
+        // Nest the lock dir under a regular file: `create_dir_all` fails with a
+        // non-`AlreadyExists` error, exercising the `Err(_) => None` arm of `try_acquire_with`.
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("not-a-dir");
+        std::fs::write(&file, "x").unwrap();
+        let unwritable = file.join("nested");
+        assert!(Lock::try_acquire_with(&unwritable, "k", Duration::from_secs(60)).is_none());
+    }
+
+    #[test]
     fn concurrent_stores_leave_valid_final_file() {
         use std::sync::Arc;
         use std::thread;

--- a/src/fetcher/code/scan.rs
+++ b/src/fetcher/code/scan.rs
@@ -368,6 +368,40 @@ mod tests {
         .unwrap();
     }
 
+    /// Index entries that aren't regular files (symlinks) and paths whose bytes aren't valid
+    /// UTF-8 take the early-`continue` branches in both walkers: the symlink fails
+    /// `is_regular_file` (its index mode is `SYMLINK`, not `FILE`), and a non-UTF-8 path fails
+    /// the `str::from_utf8` decode before any classification or read. The non-UTF-8 half is
+    /// Linux-only — APFS / NTFS reject such filenames at the filesystem layer.
+    #[test]
+    #[cfg(unix)]
+    fn tracked_walkers_skip_symlinks_and_non_utf8_paths() {
+        use std::os::unix::fs::symlink;
+
+        let (_tmp, repo) = make_repo();
+        let dir = repo.workdir().unwrap();
+        write_file(dir, "keep.rs", "fn keep() {}\n");
+        symlink("keep.rs", dir.join("link.rs")).unwrap();
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            let bad = dir.join(std::ffi::OsStr::from_bytes(b"bad\xffname.txt"));
+            std::fs::write(&bad, "bytes\n").unwrap();
+        }
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-q", "-m", "fixture"]);
+
+        // Only `keep.rs` survives: `link.rs` is skipped as a non-regular file and the
+        // non-UTF-8 entry is skipped as an undecodable path — neither is ever visited.
+        let mut path_hits = Vec::new();
+        for_each_tracked_path(&repo, |path| path_hits.push(path.to_string())).unwrap();
+        assert_eq!(path_hits, vec!["keep.rs".to_string()]);
+
+        let mut file_hits = Vec::new();
+        for_each_tracked_file(&repo, |path, _| file_hits.push(path.to_string())).unwrap();
+        assert_eq!(file_hits, vec!["keep.rs".to_string()]);
+    }
+
     #[test]
     fn tokei_stat_walker_reports_classified_files_only() {
         let (_tmp, repo) = make_repo();

--- a/src/fetcher/crypto_trending.rs
+++ b/src/fetcher/crypto_trending.rs
@@ -715,4 +715,56 @@ mod tests {
             .unwrap_err();
         assert!(format!("{err}").contains("invalid vs_currency"));
     }
+
+    #[test]
+    fn render_sync_text_block_lists_rank_prefixed_rows() {
+        let coins = vec![
+            coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2)),
+            coin("Ethereum", "ETH", "ethereum", 1, None),
+        ];
+        let Body::TextBlock(b) = render_sync(&coins, Shape::TextBlock) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 2);
+        assert!(b.lines[0].starts_with("#1 BTC  Bitcoin"));
+        assert!(b.lines[0].contains("+5.2% 24h"));
+        assert!(b.lines[1].starts_with("#2 ETH  Ethereum"));
+        assert!(b.lines[1].contains("· trending"));
+    }
+
+    #[tokio::test]
+    async fn render_for_shape_delegates_non_image_shape_to_render_sync() {
+        let coins = vec![coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2))];
+        let Body::Text(t) = render_for_shape(&coins, Shape::Text).await else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("#1"));
+        assert!(t.value.contains("BTC"));
+    }
+
+    /// `thumb_url = None` keeps `resolve_thumbnails` fully offline — `download_many`
+    /// short-circuits empty URLs to `None` without any network I/O.
+    #[tokio::test]
+    async fn render_for_shape_image_linked_resolves_thumbnails_offline() {
+        let mut btc = coin("Bitcoin", "BTC", "bitcoin", 0, Some(5.2));
+        btc.thumb_url = None;
+        let mut eth = coin("Ethereum", "ETH", "ethereum", 1, None);
+        eth.thumb_url = None;
+        let Body::ImageLinkedList(d) = render_for_shape(&[btc, eth], Shape::ImageLinkedList).await
+        else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items.len(), 2);
+        assert_eq!(d.items[0].title, "BTC  Bitcoin");
+        assert!(d.items[0].thumbnail_path.is_none());
+        assert_eq!(
+            d.items[0].url.as_deref(),
+            Some("https://www.coingecko.com/en/coins/bitcoin")
+        );
+    }
+
+    #[test]
+    fn http_client_is_built_once_and_shared() {
+        assert!(std::ptr::eq(http(), http()));
+    }
 }

--- a/src/fetcher/deal/common.rs
+++ b/src/fetcher/deal/common.rs
@@ -236,6 +236,23 @@ mod tests {
         }
     }
 
+    fn custom_row(
+        sale_price: Option<&str>,
+        original_price: Option<&str>,
+        discount_pct: Option<u32>,
+    ) -> DealRow {
+        DealRow {
+            title: "Game".into(),
+            image_url: None,
+            sale_price: sale_price.map(str::to_string),
+            original_price: original_price.map(str::to_string),
+            discount_pct,
+            store: None,
+            link: "https://example.com/deal".into(),
+            published: None,
+        }
+    }
+
     #[test]
     fn label_omits_missing_fields() {
         let bare = row("Bare", None, None);
@@ -347,5 +364,134 @@ mod tests {
         assert!(body_for_shape(&[], Shape::Heatmap).is_none());
         assert!(body_for_shape(&[], Shape::Calendar).is_none());
         assert!(body_for_shape(&[], Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn label_drops_original_price_when_absent() {
+        let r = custom_row(Some("$4.99"), None, Some(50));
+        assert_eq!(r.label(), "Game  $4.99 (50% off)");
+    }
+
+    #[test]
+    fn label_shows_bare_price_when_no_discount_known() {
+        let r = custom_row(Some("$4.99"), None, None);
+        assert_eq!(r.label(), "Game  $4.99");
+    }
+
+    #[test]
+    fn label_shows_discount_only_when_no_price_known() {
+        let r = custom_row(None, None, Some(30));
+        assert_eq!(r.label(), "Game  30% off");
+    }
+
+    #[test]
+    fn body_for_shape_dispatches_each_supported_variant() {
+        let rows = vec![row("A", Some(60), Some("Steam"))];
+        for (shape, ok) in [
+            (
+                Shape::LinkedTextBlock,
+                matches!(
+                    body_for_shape(&rows, Shape::LinkedTextBlock),
+                    Some(Body::LinkedTextBlock(_))
+                ),
+            ),
+            (
+                Shape::TextBlock,
+                matches!(
+                    body_for_shape(&rows, Shape::TextBlock),
+                    Some(Body::TextBlock(_))
+                ),
+            ),
+            (
+                Shape::MarkdownTextBlock,
+                matches!(
+                    body_for_shape(&rows, Shape::MarkdownTextBlock),
+                    Some(Body::MarkdownTextBlock(_))
+                ),
+            ),
+            (
+                Shape::Text,
+                matches!(body_for_shape(&rows, Shape::Text), Some(Body::Text(_))),
+            ),
+            (
+                Shape::Entries,
+                matches!(
+                    body_for_shape(&rows, Shape::Entries),
+                    Some(Body::Entries(_))
+                ),
+            ),
+            (
+                Shape::Bars,
+                matches!(body_for_shape(&rows, Shape::Bars), Some(Body::Bars(_))),
+            ),
+            (
+                Shape::Badge,
+                matches!(body_for_shape(&rows, Shape::Badge), Some(Body::Badge(_))),
+            ),
+            (
+                Shape::Timeline,
+                matches!(
+                    body_for_shape(&rows, Shape::Timeline),
+                    Some(Body::Timeline(_))
+                ),
+            ),
+        ] {
+            assert!(ok, "body_for_shape mismatch for {shape:?}");
+        }
+    }
+
+    #[test]
+    fn linked_text_block_carries_link_per_row() {
+        let rows = vec![row("A", Some(20), Some("Steam"))];
+        let Body::LinkedTextBlock(data) = linked_text_block_body(&rows) else {
+            panic!("expected linked text block");
+        };
+        assert_eq!(
+            data.items[0].url.as_deref(),
+            Some("https://example.com/deal")
+        );
+        assert!(data.items[0].text.starts_with("[Steam]"));
+    }
+
+    #[test]
+    fn text_block_body_lists_one_line_per_row() {
+        let rows = vec![row("A", Some(20), None), row("B", None, None)];
+        let Body::TextBlock(data) = text_block_body(&rows) else {
+            panic!("expected text block");
+        };
+        assert_eq!(data.lines.len(), 2);
+        assert_eq!(data.lines[1], "B");
+    }
+
+    #[test]
+    fn entries_value_covers_all_price_discount_combinations() {
+        let rows = vec![
+            custom_row(Some("$4.99"), None, Some(50)),
+            custom_row(Some("$4.99"), None, None),
+            custom_row(None, None, Some(50)),
+            custom_row(None, None, None),
+        ];
+        let Body::Entries(data) = entries_body(&rows) else {
+            panic!("expected entries");
+        };
+        assert_eq!(data.items[0].value.as_deref(), Some("$4.99 (50% off)"));
+        assert_eq!(data.items[1].value.as_deref(), Some("$4.99"));
+        assert_eq!(data.items[2].value.as_deref(), Some("50% off"));
+        assert_eq!(data.items[3].value.as_deref(), Some("—"));
+    }
+
+    #[tokio::test]
+    async fn image_linked_body_keeps_rows_without_thumbnails() {
+        let rows = vec![row("A", Some(60), Some("Steam")), row("B", Some(10), None)];
+        let Body::ImageLinkedList(data) = image_linked_body(&rows).await else {
+            panic!("expected image linked list");
+        };
+        assert_eq!(data.items.len(), 2);
+        assert!(data.items[0].thumbnail_path.is_none());
+        assert_eq!(
+            data.items[0].url.as_deref(),
+            Some("https://example.com/deal")
+        );
+        assert!(data.items[0].subtitle.as_ref().unwrap().contains("Steam"));
     }
 }

--- a/src/fetcher/deal/free_games.rs
+++ b/src/fetcher/deal/free_games.rs
@@ -350,9 +350,22 @@ fn sample_body_for(shape: Shape) -> Option<Body> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{TimeZone, Utc};
+    use feed_rs::model::{Link, Text};
 
     fn opts(raw: &str) -> toml::Value {
         toml::from_str(raw).expect("test toml must parse")
+    }
+
+    fn titled_entry(title: &str) -> Entry {
+        Entry {
+            title: Some(Text {
+                content_type: "text/plain".parse().unwrap(),
+                src: None,
+                content: title.into(),
+            }),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -486,5 +499,103 @@ mod tests {
         a.options = Some(opts("platform = \"epic\""));
         b.options = Some(opts("platform = \"steam\""));
         assert_ne!(f.cache_key(&a), f.cache_key(&b));
+    }
+
+    fn fetch_err(toml: &str) -> String {
+        let f = FreeGamesFetcher;
+        let ctx = FetchContext {
+            options: Some(opts(toml)),
+            ..Default::default()
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        match rt.block_on(f.fetch(&ctx)) {
+            Err(FetchError::Failed(msg)) => msg,
+            other => panic!("expected FetchError::Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fetch_rejects_unknown_option_key() {
+        // `deny_unknown_fields` on Options surfaces through `parse_options` before any network.
+        assert!(fetch_err("bogus = 1").to_lowercase().contains("bogus"));
+    }
+
+    #[test]
+    fn fetch_rejects_unknown_platform_before_network() {
+        let msg = fetch_err("platform = \"origin\"");
+        assert!(msg.contains("origin"), "msg: {msg}");
+        assert!(msg.contains("unknown platform"), "msg: {msg}");
+    }
+
+    #[test]
+    fn fetch_rejects_unknown_kind_before_network() {
+        let msg = fetch_err("kind = \"bundle\"");
+        assert!(msg.contains("bundle"), "msg: {msg}");
+        assert!(msg.contains("unknown kind"), "msg: {msg}");
+    }
+
+    #[test]
+    fn fetch_rejects_loot_on_non_loot_platform() {
+        // Epic exposes no loot feed — the incompatibility is caught before constructing a URL.
+        let msg = fetch_err("platform = \"epic\"\nkind = \"loot\"");
+        assert!(msg.contains("loot"), "msg: {msg}");
+        assert!(
+            msg.contains("amazon") && msg.contains("steam"),
+            "msg: {msg}"
+        );
+        assert!(msg.contains("epic"), "msg: {msg}");
+    }
+
+    #[test]
+    fn entry_to_row_splits_store_and_marks_offer_free() {
+        let entry = Entry {
+            title: Some(Text {
+                content_type: "text/plain".parse().unwrap(),
+                src: None,
+                content: "Epic Games (Game) - Subnautica".into(),
+            }),
+            published: Some(Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()),
+            links: vec![Link {
+                href: "https://store.epicgames.com/p/subnautica".into(),
+                rel: None,
+                media_type: None,
+                href_lang: None,
+                title: None,
+                length: None,
+            }],
+            ..Default::default()
+        };
+        let row = entry_to_row(&entry);
+        assert_eq!(row.store.as_deref(), Some("Epic Games"));
+        assert_eq!(row.title, "Subnautica");
+        assert_eq!(row.link, "https://store.epicgames.com/p/subnautica");
+        assert_eq!(row.sale_price.as_deref(), Some("Free"));
+        assert_eq!(row.discount_pct, Some(100));
+        assert_eq!(
+            row.published,
+            Some(Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn entry_to_row_falls_back_for_titleless_linkless_entry() {
+        let row = entry_to_row(&Entry::default());
+        assert_eq!(row.title, "(unnamed offer)");
+        assert_eq!(row.link, "https://example.com/");
+        assert!(row.store.is_none());
+    }
+
+    #[test]
+    fn entry_to_row_uses_updated_timestamp_when_published_absent() {
+        let mut entry = titled_entry("just a title");
+        entry.published = None;
+        entry.updated = Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+        let row = entry_to_row(&entry);
+        assert_eq!(row.published, entry.updated);
+        // Title without the `<Store> (<Kind>) -` prefix keeps the raw text and no store.
+        assert!(row.store.is_none());
+        assert_eq!(row.title, "just a title");
     }
 }

--- a/src/fetcher/deal/free_games.rs
+++ b/src/fetcher/deal/free_games.rs
@@ -598,4 +598,66 @@ mod tests {
         assert!(row.store.is_none());
         assert_eq!(row.title, "just a title");
     }
+
+    const ALL_PLATFORMS: [Platform; 9] = [
+        Platform::All,
+        Platform::Epic,
+        Platform::Steam,
+        Platform::Amazon,
+        Platform::Gog,
+        Platform::Humble,
+        Platform::Itch,
+        Platform::Apple,
+        Platform::Google,
+    ];
+
+    #[test]
+    fn config_value_is_a_distinct_lowercase_token_for_every_platform() {
+        let tokens: Vec<&str> = ALL_PLATFORMS.iter().map(|p| p.config_value()).collect();
+        assert_eq!(
+            tokens,
+            [
+                "all", "epic", "steam", "amazon", "gog", "humble", "itch", "apple", "google"
+            ]
+        );
+    }
+
+    #[test]
+    fn url_slug_blanks_the_aggregate_feed_and_codes_every_storefront() {
+        assert_eq!(Platform::All.url_slug(), "");
+        let coded: Vec<&str> = ALL_PLATFORMS.iter().skip(1).map(|p| p.url_slug()).collect();
+        assert_eq!(
+            coded,
+            [
+                "epic", "steam", "amazon", "gog", "humble", "itch", "apple", "google"
+            ]
+        );
+    }
+
+    #[test]
+    fn feed_url_for_every_non_aggregate_platform_embeds_its_slug() {
+        for platform in ALL_PLATFORMS.iter().skip(1).copied() {
+            let url = platform.feed_url(Kind::Game);
+            assert_eq!(
+                url,
+                format!("{FEED_BASE}/lootscraper_{}_game.xml", platform.url_slug())
+            );
+        }
+    }
+
+    #[test]
+    fn parse_platform_accepts_every_known_storefront() {
+        for platform in ALL_PLATFORMS {
+            let parsed = parse_platform(Some(platform.config_value())).unwrap();
+            assert_eq!(parsed, platform);
+        }
+        // The matcher lowercases first, so a mixed-case storefront still resolves.
+        assert_eq!(parse_platform(Some("GoG")).unwrap(), Platform::Gog);
+    }
+
+    #[test]
+    fn parse_kind_accepts_the_explicit_game_keyword() {
+        assert_eq!(parse_kind(Some("game")).unwrap(), Kind::Game);
+        assert_eq!(parse_kind(Some(" GAME ")).unwrap(), Kind::Game);
+    }
 }

--- a/src/fetcher/deal/games.rs
+++ b/src/fetcher/deal/games.rs
@@ -306,6 +306,11 @@ fn sample_body_for(shape: Shape) -> Option<Body> {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
     use super::*;
 
     #[test]
@@ -432,5 +437,103 @@ mod tests {
         a.options = Some(toml::from_str("min_discount = 50").unwrap());
         b.options = Some(toml::from_str("min_discount = 80").unwrap());
         assert_ne!(f.cache_key(&a), f.cache_key(&b));
+    }
+
+    #[test]
+    fn store_name_maps_every_known_id() {
+        let cases = [
+            ("2", "GamersGate"),
+            ("3", "GreenManGaming"),
+            ("4", "Amazon"),
+            ("5", "GameStop"),
+            ("7", "GOG"),
+            ("8", "Origin"),
+            ("11", "Humble Store"),
+            ("13", "Ubisoft Store"),
+            ("15", "Fanatical"),
+            ("21", "WinGameStore"),
+            ("23", "GameBillet"),
+            ("24", "Voidu"),
+            ("27", "Gamesplanet"),
+            ("29", "2Game"),
+            ("30", "IndieGala"),
+            ("31", "Blizzard Shop"),
+            ("33", "DLGamer"),
+        ];
+        for (id, name) in cases {
+            assert_eq!(store_name(id), name, "store id {id}");
+        }
+    }
+
+    #[test]
+    fn fetch_deals_parses_success_body() {
+        let body = r#"[{"title":"Disco Elysium","dealID":"d1","storeID":"1","salePrice":"9.99","normalPrice":"39.99","savings":"75.0","thumb":"https://example.com/t.jpg"}]"#;
+        let (url, server) = serve_once("200 OK", body);
+        let deals = run_async(fetch_deals(&url)).unwrap();
+        server.join().unwrap();
+        assert_eq!(deals.len(), 1);
+        assert_eq!(deals[0].title, "Disco Elysium");
+        assert_eq!(deals[0].deal_id, "d1");
+        assert_eq!(deals[0].store_id, "1");
+    }
+
+    #[test]
+    fn fetch_deals_surfaces_non_success_status() {
+        let (url, server) = serve_once("503 Service Unavailable", "");
+        let err = run_async(fetch_deals(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("deal_games 503")));
+    }
+
+    #[test]
+    fn fetch_deals_surfaces_json_parse_errors() {
+        let (url, server) = serve_once("200 OK", "not-json");
+        let err = run_async(fetch_deals(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("deal_games json parse")));
+    }
+
+    #[test]
+    fn fetch_deals_surfaces_request_failures() {
+        let err = run_async(fetch_deals("not-a-url")).unwrap_err();
+        assert!(
+            matches!(err, FetchError::Failed(msg) if msg.contains("deal_games request failed"))
+        );
+    }
+
+    #[test]
+    fn fetch_deals_rejects_oversized_body() {
+        let body = format!("[{}", " ".repeat(MAX_BYTES + 1));
+        let (url, server) = serve_once("200 OK", &body);
+        let err = run_async(fetch_deals(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(err, FetchError::Failed(msg) if msg.contains("response too large")));
+    }
+
+    fn serve_once(status: &str, body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
     }
 }

--- a/src/fetcher/deal/steam_daily.rs
+++ b/src/fetcher/deal/steam_daily.rs
@@ -203,6 +203,27 @@ fn sample_body_for(shape: Shape) -> Option<Body> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{TimeZone, Utc};
+    use feed_rs::model::{Link, Text};
+
+    fn text(content: &str) -> Text {
+        Text {
+            content_type: "text/plain".parse().unwrap(),
+            src: None,
+            content: content.into(),
+        }
+    }
+
+    fn link(href: &str) -> Link {
+        Link {
+            href: href.into(),
+            rel: None,
+            media_type: None,
+            href_lang: None,
+            title: None,
+            length: None,
+        }
+    }
 
     #[test]
     fn parse_title_extracts_daily_deal_discount() {
@@ -279,5 +300,69 @@ mod tests {
         }
         assert!(f.sample_body(Shape::ImageLinkedList).is_none());
         assert!(f.sample_body(Shape::Heatmap).is_none());
+    }
+
+    #[test]
+    fn entry_to_row_parses_steam_title_link_and_store() {
+        let entry = Entry {
+            title: Some(text("Daily Deal - Portal 2, 75% Off")),
+            links: vec![link("https://store.steampowered.com/app/620/Portal_2/")],
+            published: Some(Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()),
+            ..Default::default()
+        };
+        let row = entry_to_row(&entry);
+        assert_eq!(row.title, "Portal 2");
+        assert_eq!(row.discount_pct, Some(75));
+        assert_eq!(row.store.as_deref(), Some(STORE));
+        assert_eq!(row.link, "https://store.steampowered.com/app/620/Portal_2/");
+        assert_eq!(row.published, entry.published);
+        assert!(row.image_url.is_none());
+        assert!(row.sale_price.is_none());
+        assert!(row.original_price.is_none());
+    }
+
+    #[test]
+    fn entry_to_row_names_titleless_entries_unnamed_deal() {
+        let row = entry_to_row(&Entry::default());
+        assert_eq!(row.title, "(unnamed deal)");
+        assert!(row.discount_pct.is_none());
+    }
+
+    #[test]
+    fn entry_to_row_falls_back_to_steam_store_url_when_link_missing() {
+        let entry = Entry {
+            title: Some(text("Weekend Deal - Hades, 50% Off")),
+            ..Default::default()
+        };
+        let row = entry_to_row(&entry);
+        assert_eq!(row.link, "https://store.steampowered.com");
+        assert_eq!(row.title, "Hades");
+        assert_eq!(row.discount_pct, Some(50));
+    }
+
+    #[test]
+    fn entry_to_row_uses_updated_timestamp_when_published_absent() {
+        let updated = Utc.with_ymd_and_hms(2026, 5, 1, 9, 0, 0).unwrap();
+        let entry = Entry {
+            title: Some(text("Midweek Madness - Celeste, 60% Off")),
+            updated: Some(updated),
+            ..Default::default()
+        };
+        let row = entry_to_row(&entry);
+        assert_eq!(row.published, Some(updated));
+        assert_eq!(row.title, "Celeste");
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_options() {
+        let f = SteamDailyFetcher;
+        let bare = f.cache_key(&FetchContext::default());
+        assert!(bare.starts_with(NAME), "got: {bare}");
+        let with_opts = f.cache_key(&FetchContext {
+            options: Some(toml::from_str("count = 5").unwrap()),
+            ..Default::default()
+        });
+        assert!(with_opts.starts_with(NAME), "got: {with_opts}");
+        assert_ne!(bare, with_opts);
     }
 }

--- a/src/fetcher/forge_items.rs
+++ b/src/fetcher/forge_items.rs
@@ -505,6 +505,95 @@ mod tests {
         assert_eq!(e.items.len(), 2);
     }
 
+    #[tokio::test]
+    async fn dispatch_rows_async_image_linked_list_resolves_thumbnails_offline() {
+        // ImageLinkedList runs each row's avatar_url through the thumbnail cache. A None
+        // avatar_url and an unsupported-scheme URL both resolve to None without any network,
+        // so the branch is exercised offline and the thumbnail cells stay empty.
+        let rows = vec![
+            ForgeRow {
+                label: "splashboard#1".into(),
+                title: "no avatar".into(),
+                url: Some("https://example.com/1".into()),
+                avatar_url: None,
+                avatar_path: None,
+                updated_at_unix: 0,
+                activity_count: 0,
+            },
+            ForgeRow {
+                label: "splashboard#2".into(),
+                title: "unsupported avatar scheme".into(),
+                url: None,
+                avatar_url: Some("ftp://example.com/avatar.png".into()),
+                avatar_path: None,
+                updated_at_unix: 0,
+                activity_count: 0,
+            },
+        ];
+        let Body::ImageLinkedList(b) =
+            dispatch_rows_async(rows, Shape::ImageLinkedList, "open PR", "open PRs").await
+        else {
+            panic!("expected image linked list");
+        };
+        assert_eq!(b.items.len(), 2);
+        assert!(b.items.iter().all(|i| i.thumbnail_path.is_none()));
+        assert!(b.items[0].title.starts_with("splashboard#1"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn dispatch_rows_async_image_linked_list_fills_avatar_path_from_cache_hit() {
+        use sha2::{Digest, Sha256};
+        // A pre-seeded thumbnail cache lets the ImageLinkedList branch resolve avatar_url to a
+        // local path with no network: download_to_cache short-circuits on the existing file
+        // and dispatch_rows_async copies the resolved path onto the row.
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var("SPLASHBOARD_HOME").ok();
+        unsafe { std::env::set_var("SPLASHBOARD_HOME", tmp.path()) };
+
+        let avatar = "https://avatars.example/seeded.png";
+        let hash: String = Sha256::digest(avatar.as_bytes())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        let dir = tmp.path().join("cache").join("thumbnails");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{hash}.png")), b"seeded-png").unwrap();
+
+        let rows = vec![ForgeRow {
+            label: "splashboard#9".into(),
+            title: "has a cached avatar".into(),
+            url: Some("https://example.com/9".into()),
+            avatar_url: Some(avatar.into()),
+            avatar_path: None,
+            updated_at_unix: 0,
+            activity_count: 0,
+        }];
+        let body = dispatch_rows_async(rows, Shape::ImageLinkedList, "open PR", "open PRs").await;
+
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
+                None => std::env::remove_var("SPLASHBOARD_HOME"),
+            }
+        }
+
+        let Body::ImageLinkedList(b) = body else {
+            panic!("expected image linked list");
+        };
+        let resolved = b.items[0]
+            .thumbnail_path
+            .as_deref()
+            .expect("cache hit should resolve a local thumbnail path");
+        assert!(
+            resolved.ends_with(&format!("{hash}.png")),
+            "resolved path should point at the seeded cache file: {resolved}"
+        );
+    }
+
     #[test]
     fn empty_rows_collapse_to_empty_bodies() {
         let Body::Text(t) = render_forge_rows(&[], Shape::Text) else {

--- a/src/fetcher/forge_items.rs
+++ b/src/fetcher/forge_items.rs
@@ -540,6 +540,29 @@ mod tests {
         assert!(b.items[0].title.starts_with("splashboard#1"));
     }
 
+    /// RAII guard: points `SPLASHBOARD_HOME` at a temp dir and restores it on drop, so a
+    /// panic mid-test can't leak the override into later tests sharing the process env.
+    struct SplashHomeGuard(Option<String>);
+
+    impl SplashHomeGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let previous = std::env::var("SPLASHBOARD_HOME").ok();
+            unsafe { std::env::set_var("SPLASHBOARD_HOME", path) };
+            Self(previous)
+        }
+    }
+
+    impl Drop for SplashHomeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
+                    None => std::env::remove_var("SPLASHBOARD_HOME"),
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn dispatch_rows_async_image_linked_list_fills_avatar_path_from_cache_hit() {
@@ -551,8 +574,7 @@ mod tests {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        let previous = std::env::var("SPLASHBOARD_HOME").ok();
-        unsafe { std::env::set_var("SPLASHBOARD_HOME", tmp.path()) };
+        let _home = SplashHomeGuard::set(tmp.path());
 
         let avatar = "https://avatars.example/seeded.png";
         let hash: String = Sha256::digest(avatar.as_bytes())
@@ -573,13 +595,6 @@ mod tests {
             activity_count: 0,
         }];
         let body = dispatch_rows_async(rows, Shape::ImageLinkedList, "open PR", "open PRs").await;
-
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
-                None => std::env::remove_var("SPLASHBOARD_HOME"),
-            }
-        }
 
         let Body::ImageLinkedList(b) = body else {
             panic!("expected image linked list");

--- a/src/fetcher/git/repo_name.rs
+++ b/src/fetcher/git/repo_name.rs
@@ -213,6 +213,25 @@ mod tests {
         assert_eq!(detected, Some("isolated".into()));
     }
 
+    /// At the filesystem root there is no directory basename and no git repo above it, so both
+    /// arms of `detect_name` come up empty and `fetch` lands on the literal `"project"` fallback.
+    #[cfg(unix)]
+    #[test]
+    fn fetch_falls_back_to_project_when_cwd_has_no_basename() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir("/").unwrap();
+        let payload = run_async(GitRepoName.fetch(&ctx()));
+        std::env::set_current_dir(prev).unwrap();
+
+        let Body::Text(text) = payload.unwrap().body else {
+            panic!("expected text payload");
+        };
+        assert_eq!(text.value, "project");
+    }
+
     #[test]
     fn fetch_returns_repo_name_from_cwd_repo() {
         let _lock = crate::paths::TEST_ENV_LOCK

--- a/src/fetcher/github/action_history.rs
+++ b/src/fetcher/github/action_history.rs
@@ -601,6 +601,11 @@ mod tests {
         // to fall through to `resolve_repo(None)`, which discovers the cwd's git remote. Running
         // under `cargo test` from this workspace means resolution succeeds and the resulting key
         // must therefore differ from the no-context baseline (empty extra string).
+        //
+        // `resolve_repo(None)` reads the process-global cwd, which sibling tests mutate under
+        // `TEST_ENV_LOCK` (e.g. the `code/*` fetchers). Hold the same lock so a concurrent
+        // `set_current_dir` cannot change the discovered remote between calls.
+        let _guard = EnvGuard::set(&[]);
         let fetcher = GithubActionHistory;
         let resolved = fetcher.cache_key(&ctx(
             Some("limit = 5"),
@@ -620,6 +625,7 @@ mod tests {
             Some("compact"),
         ));
         assert_eq!(resolved, again);
+        drop(_guard);
     }
 
     #[test]

--- a/src/fetcher/github/action_status.rs
+++ b/src/fetcher/github/action_status.rs
@@ -369,6 +369,37 @@ mod tests {
     }
 
     #[test]
+    fn render_entries_lists_classified_status_branch_and_conclusion() {
+        assert!(matches!(
+            render_body(&run("completed", Some("failure")), Shape::Entries),
+            Body::Entries(e)
+                if e.items.len() == 3
+                    && e.items[0].key == "status"
+                    && e.items[0].status == Some(Status::Error)
+                    && e.items[0].value.as_deref() == Some("failing")
+                    && e.items[1].key == "branch"
+                    && e.items[1].status.is_none()
+                    && e.items[1].value.as_deref() == Some("main")
+                    && e.items[2].key == "conclusion"
+                    && e.items[2].value.as_deref() == Some("failure"),
+        ));
+    }
+
+    #[test]
+    fn render_entries_conclusion_falls_back_to_question_mark_when_absent() {
+        // A still-running workflow has no `conclusion`; the Entries row must degrade to `?`
+        // rather than carry an empty string.
+        assert!(matches!(
+            render_body(&run("in_progress", None), Shape::Entries),
+            Body::Entries(e)
+                if e.items[0].value.as_deref() == Some("running")
+                    && e.items[0].status == Some(Status::Warn)
+                    && e.items[2].key == "conclusion"
+                    && e.items[2].value.as_deref() == Some("?"),
+        ));
+    }
+
+    #[test]
     fn render_text_falls_back_to_question_mark_for_missing_branch() {
         let body = render_body(
             &run_with_branch("completed", Some("success"), None),

--- a/src/fetcher/gitlab/common.rs
+++ b/src/fetcher/gitlab/common.rs
@@ -335,8 +335,9 @@ mod tests {
     fn resolve_project_falls_back_to_the_cwd_git_remote() {
         // With no explicit `project`, resolution walks the cwd's git remote. The suite runs
         // inside splashboard's own repo, whose `origin` lives on github.com — passing that
-        // host lets the generic prefix parser recover `unhappychoice/splashboard` from the
-        // remote URL, exercising the `Some(path) => Ok(path)` arm.
+        // host lets the generic prefix parser recover the `group/project` path from the
+        // remote URL, exercising the `Some(path) => Ok(path)` arm. Assert the structural
+        // shape rather than a literal slug so forks and mirrors don't fail the test.
         let _lock = crate::paths::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -345,7 +346,12 @@ mod tests {
         let resolved = resolve_project(None, "github.com");
         std::env::set_current_dir(previous).unwrap();
         let path = resolved.expect("cwd repo remote should resolve a project");
-        assert_eq!(path.as_str(), "unhappychoice/splashboard");
+        let segments: Vec<&str> = path.as_str().split('/').collect();
+        assert!(
+            segments.len() >= 2 && segments.iter().all(|s| !s.is_empty()),
+            "expected a `group/project` path, got {:?}",
+            path.as_str()
+        );
     }
 
     #[test]

--- a/src/fetcher/gitlab/common.rs
+++ b/src/fetcher/gitlab/common.rs
@@ -313,6 +313,42 @@ mod tests {
     }
 
     #[test]
+    fn payload_wraps_body_and_leaves_all_metadata_unset() {
+        let p = payload(Body::Text(crate::payload::TextData {
+            value: "hello".into(),
+        }));
+        assert!(p.icon.is_none());
+        assert!(p.status.is_none());
+        assert!(p.format.is_none());
+        assert!(matches!(p.body, Body::Text(t) if t.value == "hello"));
+    }
+
+    #[test]
+    fn project_from_url_rejects_userinfo_that_contains_a_slash() {
+        // A userinfo chunk with a slash can't be a real `user(:token)?` credential pair; the
+        // https-userinfo arm bails out instead of mistaking the embedded slash for the start
+        // of the project path.
+        assert!(project_from_url("https://a/b@gitlab.com/group/proj", "gitlab.com").is_none());
+    }
+
+    #[test]
+    fn resolve_project_falls_back_to_the_cwd_git_remote() {
+        // With no explicit `project`, resolution walks the cwd's git remote. The suite runs
+        // inside splashboard's own repo, whose `origin` lives on github.com — passing that
+        // host lets the generic prefix parser recover `unhappychoice/splashboard` from the
+        // remote URL, exercising the `Some(path) => Ok(path)` arm.
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::current_dir().unwrap();
+        std::env::set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let resolved = resolve_project(None, "github.com");
+        std::env::set_current_dir(previous).unwrap();
+        let path = resolved.expect("cwd repo remote should resolve a project");
+        assert_eq!(path.as_str(), "unhappychoice/splashboard");
+    }
+
+    #[test]
     fn parse_options_surfaces_serde_failures() {
         #[derive(Debug, Default, serde::Deserialize)]
         #[serde(deny_unknown_fields)]

--- a/src/fetcher/gitlab/pipeline_status.rs
+++ b/src/fetcher/gitlab/pipeline_status.rs
@@ -242,6 +242,8 @@ fn cache_extra(ctx: &FetchContext) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     fn pipeline(status: &str) -> Pipeline {
@@ -382,5 +384,135 @@ mod tests {
         };
         let keys: Vec<&str> = e.items.iter().map(|i| i.key.as_str()).collect();
         assert_eq!(keys, vec!["status", "branch", "sha", "duration"]);
+    }
+
+    #[test]
+    fn sample_badge_and_text_carry_the_passing_headline() {
+        let Some(Body::Badge(b)) = GitlabPipelineStatus.sample_body(Shape::Badge) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Ok);
+        assert_eq!(b.label, "main · passing");
+        let Some(Body::Text(t)) = GitlabPipelineStatus.sample_body(Shape::Text) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "main · passing");
+    }
+
+    #[test]
+    fn sample_body_returns_none_for_unsupported_shape() {
+        assert!(GitlabPipelineStatus.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn metadata_methods_have_content() {
+        let fetcher = GitlabPipelineStatus;
+        assert_eq!(fetcher.name(), "gitlab_pipeline_status");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("GitLab"));
+        assert_eq!(fetcher.refresh_interval(), 60 * 5);
+    }
+
+    #[test]
+    fn option_schemas_lists_host_project_and_branch() {
+        let names: Vec<&str> = GitlabPipelineStatus
+            .option_schemas()
+            .iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, vec!["host", "project", "branch"]);
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_project_option() {
+        let fetcher = GitlabPipelineStatus;
+        let a = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/c\"").unwrap()),
+            ..Default::default()
+        });
+        assert!(a.starts_with("gitlab_pipeline_status-"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_varies_with_host_and_branch_options() {
+        let fetcher = GitlabPipelineStatus;
+        let base = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.one.org\"\nproject = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let other_host = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.two.org\"\nproject = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let with_branch = fetcher.cache_key(&FetchContext {
+            options: Some(
+                toml::from_str("host = \"git.one.org\"\nproject = \"a/b\"\nbranch = \"dev\"")
+                    .unwrap(),
+            ),
+            ..Default::default()
+        });
+        assert_ne!(base, other_host);
+        assert_ne!(base, with_branch);
+    }
+
+    #[test]
+    fn cache_key_with_no_options_falls_back_to_remote_resolution() {
+        // No `project` option: `cache_extra` walks the cwd git remote, which here is a GitHub
+        // repo, so the gitlab.com lookup yields nothing and the key still resolves cleanly.
+        let key = GitlabPipelineStatus.cache_key(&FetchContext::default());
+        assert!(key.starts_with("gitlab_pipeline_status-"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_option_keys_before_network_request() {
+        let err = GitlabPipelineStatus
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("bogus = 1").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid options")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_host_before_network_request() {
+        let err = GitlabPipelineStatus
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("host = \"https://evil.example\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid gitlab host")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_project_before_network_request() {
+        let err = GitlabPipelineStatus
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("project = \"not a path\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid project option")
+        ));
     }
 }

--- a/src/fetcher/gitlab/repo_issues.rs
+++ b/src/fetcher/gitlab/repo_issues.rs
@@ -137,6 +137,8 @@ fn cache_extra(ctx: &FetchContext) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -163,5 +165,109 @@ mod tests {
         for shape in LIST_SHAPES {
             assert!(fetcher.sample_body(*shape).is_some(), "missing {shape:?}");
         }
+        assert!(fetcher.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn metadata_methods_have_content() {
+        let fetcher = GitlabRepoIssues;
+        assert_eq!(fetcher.name(), "gitlab_repo_issues");
+        assert!(fetcher.description().contains("GitLab"));
+        assert_eq!(fetcher.refresh_interval(), 60 * 10);
+    }
+
+    #[test]
+    fn option_schemas_lists_host_project_and_limit() {
+        let names: Vec<&str> = GitlabRepoIssues
+            .option_schemas()
+            .iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, vec!["host", "project", "limit"]);
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_project_option() {
+        let fetcher = GitlabRepoIssues;
+        let a = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/c\"").unwrap()),
+            ..Default::default()
+        });
+        assert!(a.starts_with("gitlab_repo_issues-"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_varies_with_host_option() {
+        let fetcher = GitlabRepoIssues;
+        let a = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.one.org\"\nproject = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.two.org\"\nproject = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_with_no_options_falls_back_to_remote_resolution() {
+        // No `project` option: `cache_extra` walks the cwd git remote, which here is a GitHub
+        // repo, so the gitlab.com lookup yields nothing and the key still resolves cleanly.
+        let key = GitlabRepoIssues.cache_key(&FetchContext::default());
+        assert!(key.starts_with("gitlab_repo_issues-"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_option_keys_before_network_request() {
+        let err = GitlabRepoIssues
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("bogus = 1").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid options")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_host_before_network_request() {
+        let err = GitlabRepoIssues
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("host = \"https://evil.example\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid gitlab host")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_project_before_network_request() {
+        let err = GitlabRepoIssues
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("project = \"not a path\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid project option")
+        ));
     }
 }

--- a/src/fetcher/gitlab/repo_stars.rs
+++ b/src/fetcher/gitlab/repo_stars.rs
@@ -193,6 +193,8 @@ fn cache_extra(ctx: &FetchContext) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -281,5 +283,122 @@ mod tests {
             panic!("expected text fallback");
         };
         assert_eq!(t.value, "★ 5");
+    }
+
+    #[test]
+    fn sample_text_block_lists_emoji_prefixed_counter_lines() {
+        let Some(Body::TextBlock(b)) = GitlabRepoStars.sample_body(Shape::TextBlock) else {
+            panic!("expected text block");
+        };
+        assert_eq!(b.lines, vec!["★ 142", "🍴 9", "🔓 7"]);
+    }
+
+    #[test]
+    fn sample_body_returns_none_for_unsupported_shape() {
+        assert!(GitlabRepoStars.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn metadata_methods_have_content() {
+        let fetcher = GitlabRepoStars;
+        assert_eq!(fetcher.name(), "gitlab_repo_stars");
+        assert_eq!(fetcher.safety(), Safety::Safe);
+        assert!(fetcher.description().contains("GitLab"));
+        assert_eq!(fetcher.refresh_interval(), 60 * 60);
+    }
+
+    #[test]
+    fn option_schemas_lists_host_and_project() {
+        let names: Vec<&str> = GitlabRepoStars
+            .option_schemas()
+            .iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, vec!["host", "project"]);
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_project_option() {
+        let fetcher = GitlabRepoStars;
+        let a = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("project = \"a/c\"").unwrap()),
+            ..Default::default()
+        });
+        assert!(a.starts_with("gitlab_repo_stars-"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_varies_with_host_option() {
+        let fetcher = GitlabRepoStars;
+        let a = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.one.org\"\nproject = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        let b = fetcher.cache_key(&FetchContext {
+            options: Some(toml::from_str("host = \"git.two.org\"\nproject = \"a/b\"").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_key_with_no_options_falls_back_to_remote_resolution() {
+        // No `project` option: `cache_extra` walks the cwd git remote, which here is a GitHub
+        // repo, so the gitlab.com lookup yields nothing and the key still resolves cleanly.
+        let key = GitlabRepoStars.cache_key(&FetchContext::default());
+        assert!(key.starts_with("gitlab_repo_stars-"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_option_keys_before_network_request() {
+        let err = GitlabRepoStars
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("bogus = 1").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid options")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_host_before_network_request() {
+        let err = GitlabRepoStars
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("host = \"https://evil.example\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid gitlab host")
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_project_before_network_request() {
+        let err = GitlabRepoStars
+            .fetch(&FetchContext {
+                options: Some(toml::from_str("project = \"not a path\"").unwrap()),
+                timeout: Duration::from_secs(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(m) if m.contains("invalid project option")
+        ));
     }
 }

--- a/src/fetcher/huggingface_trending.rs
+++ b/src/fetcher/huggingface_trending.rs
@@ -584,6 +584,21 @@ mod tests {
     }
 
     #[test]
+    fn render_sync_text_block_lists_one_rank_prefixed_line_per_entry() {
+        let entries = vec![
+            entry("meta-llama/Llama-3.1", 0, 3200, Some(2_100_000)),
+            entry("author/repo", 1, 100, None),
+        ];
+        let body = render_sync(&entries, Kind::Models, Shape::TextBlock);
+        let Body::TextBlock(b) = body else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 2);
+        assert_eq!(b.lines[0], "#1 meta-llama/Llama-3.1  ♥ 3.2k  ↓ 2.1M");
+        assert_eq!(b.lines[1], "#2 author/repo  ♥ 100");
+    }
+
+    #[test]
     fn render_sync_linked_text_block_uses_kind_aware_url() {
         let body = render_sync(
             &[entry("author/repo", 0, 100, None)],

--- a/src/fetcher/huggingface_trending.rs
+++ b/src/fetcher/huggingface_trending.rs
@@ -461,6 +461,9 @@ struct HfProfile {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
     use std::time::Duration as StdDuration;
 
     use super::*;
@@ -694,5 +697,110 @@ mod tests {
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("unknown field"));
+    }
+
+    fn serve_once(status: &str, body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    #[tokio::test]
+    async fn get_json_deserializes_success_body() {
+        let (url, server) = serve_once("200 OK", r#"[{"id":"meta/llama","likes":3}]"#);
+        let entries: Vec<ApiEntry> = get_json(&url).await.unwrap();
+        server.join().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "meta/llama");
+        assert_eq!(entries[0].likes, Some(3));
+    }
+
+    #[tokio::test]
+    async fn get_json_surfaces_non_success_status() {
+        let (url, server) = serve_once("503 Service Unavailable", "");
+        let err = get_json::<Vec<ApiEntry>>(&url).await.unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg == "huggingface 503 Service Unavailable"
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_json_surfaces_json_parse_errors() {
+        let (url, server) = serve_once("200 OK", "not-json");
+        let err = get_json::<Vec<ApiEntry>>(&url).await.unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.starts_with("huggingface json parse:")
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_json_rejects_oversized_body() {
+        let body = "x".repeat(MAX_BYTES + 1);
+        let (url, server) = serve_once("200 OK", &body);
+        let err = get_json::<Vec<ApiEntry>>(&url).await.unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("huggingface response too large")
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_json_surfaces_request_failures() {
+        let err = get_json::<Vec<ApiEntry>>("not-a-url").await.unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("huggingface request failed")
+        ));
+    }
+
+    #[tokio::test]
+    async fn render_for_shape_delegates_non_image_shapes_to_render_sync() {
+        let body = render_for_shape(
+            &[entry("author/repo", 0, 100, None)],
+            Kind::Models,
+            Shape::Text,
+        )
+        .await;
+        assert!(matches!(body, Body::Text(_)));
+    }
+
+    #[tokio::test]
+    async fn render_for_shape_builds_image_list_without_avatar_for_idless_entries() {
+        let body = render_for_shape(
+            &[entry("no_slash", 0, 5, None)],
+            Kind::Models,
+            Shape::ImageLinkedList,
+        )
+        .await;
+        let Body::ImageLinkedList(d) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items.len(), 1);
+        assert!(d.items[0].thumbnail_path.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_thumbnails_returns_none_for_authorless_and_empty_inputs() {
+        assert!(resolve_thumbnails(&[]).await.is_empty());
+        let resolved = resolve_thumbnails(&[entry("no_slash", 0, 0, None)]).await;
+        assert_eq!(resolved, vec![None]);
     }
 }

--- a/src/fetcher/lastfm/charts.rs
+++ b/src/fetcher/lastfm/charts.rs
@@ -497,6 +497,45 @@ mod tests {
         assert_ne!(artists, bars);
     }
 
+    /// `render_body` is the shape dispatcher between `fetch` and the shared `top` body builders.
+    /// Drive every declared shape plus a shape outside `SHAPES` so the `_ => text_body` fallback
+    /// arm is exercised. `sample_rows()` carries no `image_url`, so `ImageLinkedList` resolves its
+    /// thumbnails to `None` without any network I/O.
+    #[tokio::test]
+    async fn render_body_dispatches_every_shape() {
+        let rows = sample_rows();
+        let k = Kind::Artists;
+        assert!(matches!(
+            render_body(&rows, k, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, k, Shape::ImageLinkedList).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, k, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, k, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, k, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, k, Shape::Bars).await,
+            Body::Bars(_)
+        ));
+        // `Shape::Text` is not an explicit arm — it lands in the `_ => text_body` fallback.
+        assert!(matches!(
+            render_body(&rows, k, Shape::Text).await,
+            Body::Text(_)
+        ));
+    }
+
     #[tokio::test]
     async fn fetch_rejects_unknown_options_before_network() {
         let err = LastfmCharts

--- a/src/fetcher/lastfm/client.rs
+++ b/src/fetcher/lastfm/client.rs
@@ -108,7 +108,19 @@ fn parse_api_error(bytes: &[u8]) -> Option<FetchError> {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use serde::Deserialize;
+
     use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct TestPayload {
+        ok: bool,
+    }
 
     #[test]
     fn build_url_includes_method_api_key_and_format() {
@@ -189,5 +201,106 @@ mod tests {
     #[test]
     fn http_reuses_the_same_client() {
         assert!(std::ptr::eq(http(), http()));
+    }
+
+    #[test]
+    fn parse_json_deserializes_success_body() {
+        let payload: TestPayload = parse_local("200 OK", r#"{"ok":true}"#).unwrap();
+        assert!(payload.ok);
+    }
+
+    #[test]
+    fn parse_json_surfaces_non_success_status() {
+        let err = parse_local::<TestPayload>("503 Service Unavailable", "").unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg == "lastfm 503 Service Unavailable"
+        ));
+    }
+
+    #[test]
+    fn parse_json_surfaces_json_parse_errors() {
+        let err = parse_local::<TestPayload>("200 OK", "not-json").unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.starts_with("lastfm json parse:")
+        ));
+    }
+
+    #[test]
+    fn parse_json_rejects_oversized_body() {
+        let body = "x".repeat(MAX_BYTES + 1);
+        let err = parse_local::<TestPayload>("200 OK", &body).unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("lastfm response too large")
+        ));
+    }
+
+    #[test]
+    fn parse_json_surfaces_lastfm_error_envelope_on_a_200() {
+        // Last.fm tunnels errors through HTTP 200 + `{"error":N,...}`; `parse_json` must catch
+        // that envelope before the caller's deserializer ever sees the bytes.
+        let err = parse_local::<TestPayload>("200 OK", r#"{"error":6,"message":"User not found"}"#)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg)
+                if msg.contains("lastfm error 6") && msg.contains("User not found")
+        ));
+    }
+
+    #[test]
+    fn get_json_fails_fast_when_api_key_missing() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LASTFM_API_KEY").ok();
+        unsafe { std::env::remove_var("LASTFM_API_KEY") };
+        let err = run_async(get_json::<TestPayload>("user.getInfo", &[])).unwrap_err();
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("LASTFM_API_KEY", v) };
+        }
+        assert!(matches!(err, FetchError::Failed(msg) if msg == "LASTFM_API_KEY not set"));
+    }
+
+    /// Serves `body` from a one-shot local server, drives a real `reqwest` request through the
+    /// shared `http()` client, and hands the resulting `Response` to `parse_json` — exercising
+    /// the body-size, status, error-envelope, and deserialization branches without network.
+    fn parse_local<T: DeserializeOwned>(status: &str, body: &str) -> Result<T, FetchError> {
+        let (url, server) = serve_once(status, body);
+        let result = run_async(async {
+            let res = http().get(&url).send().await.unwrap();
+            parse_json::<T>(res).await
+        });
+        server.join().unwrap();
+        result
+    }
+
+    fn serve_once(status: &str, body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
     }
 }

--- a/src/fetcher/lastfm/scrobbles_today.rs
+++ b/src/fetcher/lastfm/scrobbles_today.rs
@@ -862,4 +862,97 @@ mod tests {
             .unwrap_err();
         assert!(format!("{err}").contains("`user ="));
     }
+
+    fn rich_snapshot() -> Snapshot {
+        snapshot(
+            Some(track("Live", "Now Artist", None)),
+            vec![
+                track("First", "Artist A", Some(1_682_158_530)),
+                track("Second", "Artist B", None),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn render_body_dispatches_each_shape_to_its_builder() {
+        let snap = rich_snapshot();
+        for &shape in SHAPES {
+            let body = render_body(&snap, shape).await;
+            assert_eq!(crate::render::shape_of(&body), shape, "shape {shape:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn render_body_falls_back_to_text_for_unsupported_shape() {
+        let body = render_body(&rich_snapshot(), Shape::Ratio).await;
+        let Body::Text(t) = body else {
+            panic!("expected text fallback");
+        };
+        assert!(t.value.starts_with("♪ Live"));
+    }
+
+    #[test]
+    fn text_body_wraps_the_headline() {
+        let snap = snapshot(None, vec![track("Only", "A", Some(0))]);
+        let Body::Text(t) = text_body(&snap) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "1 scrobble today");
+    }
+
+    #[test]
+    fn text_block_body_lists_now_playing_then_history() {
+        let Body::TextBlock(b) = text_block_body(&rich_snapshot()) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 3);
+        assert!(b.lines[0].starts_with("♪ Live"));
+        assert!(b.lines[1].starts_with("10:15"));
+        assert!(b.lines[1].contains("First"));
+        assert!(b.lines[2].starts_with("--:--"));
+    }
+
+    #[test]
+    fn markdown_body_prepends_now_playing_bullet() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&rich_snapshot()) else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.starts_with("- ▶ **Live**"));
+        assert!(m.value.contains("- **First** — Artist A"));
+    }
+
+    #[test]
+    fn entries_body_lists_history_tracks_without_status() {
+        let snap = snapshot(None, vec![track("Hist", "Artist", Some(0))]);
+        let Body::Entries(e) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert_eq!(e.items[0].key, "Hist");
+        assert_eq!(e.items[0].value.as_deref(), Some("Artist"));
+        assert!(e.items[0].status.is_none());
+    }
+
+    #[test]
+    fn collect_rows_for_image_orders_now_playing_first_and_timestamps_history() {
+        let snap = rich_snapshot();
+        let rows = collect_rows_for_image(&snap);
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].1.starts_with("♪ Live"));
+        assert_eq!(rows[0].2.as_deref(), Some("now playing"));
+        assert_eq!(rows[1].1, "First");
+        assert_eq!(rows[1].2.as_deref(), Some("10:15 · Artist A"));
+        assert_eq!(rows[2].2.as_deref(), Some("Artist B"));
+    }
+
+    #[tokio::test]
+    async fn image_linked_body_builds_rows_with_empty_thumbnails_offline() {
+        let Body::ImageLinkedList(d) = image_linked_body(&rich_snapshot()).await else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items.len(), 3);
+        assert!(d.items[0].title.starts_with("♪ Live"));
+        assert_eq!(d.items[0].subtitle.as_deref(), Some("now playing"));
+        assert!(d.items.iter().all(|i| i.thumbnail_path.is_none()));
+    }
 }

--- a/src/fetcher/lastfm/top.rs
+++ b/src/fetcher/lastfm/top.rs
@@ -468,4 +468,89 @@ mod tests {
         assert!(s.contains("Artist"));
         assert!(s.contains("42 plays"));
     }
+
+    #[test]
+    fn period_deserialises_every_renamed_param_string() {
+        #[derive(Deserialize)]
+        struct Wrap {
+            period: Period,
+        }
+        for (param, expected) in [
+            ("1month", Period::OneMonth),
+            ("3month", Period::ThreeMonth),
+            ("6month", Period::SixMonth),
+            ("12month", Period::TwelveMonth),
+            ("overall", Period::Overall),
+        ] {
+            let raw: toml::Value = toml::from_str(&format!("period = \"{param}\"")).unwrap();
+            let parsed: Wrap = raw.try_into().unwrap();
+            assert_eq!(parsed.period, expected);
+        }
+    }
+
+    #[test]
+    fn text_body_wraps_headline_in_text_shape() {
+        let rows = vec![row(1, "Artist", None, 100)];
+        let Body::Text(t) = text_body(&rows, "empty") else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, "#1 Artist  (100 plays)");
+
+        let Body::Text(empty) = text_body(&[], "quiet window") else {
+            panic!("expected text");
+        };
+        assert_eq!(empty.value, "quiet window");
+    }
+
+    #[test]
+    fn text_block_body_emits_one_line_per_row() {
+        let rows = vec![row(1, "A", None, 100), row(2, "B", None, 50)];
+        let Body::TextBlock(b) = text_block_body(&rows, "empty") else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 2);
+        assert!(b.lines[0].starts_with("#1 A"));
+        assert!(b.lines[1].contains("50 plays"));
+    }
+
+    #[test]
+    fn text_block_body_falls_back_to_single_empty_line() {
+        let Body::TextBlock(b) = text_block_body(&[], "quiet") else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines, vec!["quiet".to_string()]);
+    }
+
+    #[test]
+    fn markdown_body_renders_a_bullet_per_row() {
+        let rows = vec![row(1, "Track", Some("Artist"), 42)];
+        let Body::MarkdownTextBlock(m) = markdown_body(&rows, "quiet") else {
+            panic!("expected markdown");
+        };
+        assert_eq!(m.value, "- **#1 Track — Artist** — 42 plays");
+    }
+
+    #[test]
+    fn entries_body_emits_placeholder_row_when_empty() {
+        let Body::Entries(e) = entries_body(&[]) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert_eq!(e.items[0].key, "—");
+        assert_eq!(e.items[0].value.as_deref(), Some("no scrobbles yet"));
+    }
+
+    #[tokio::test]
+    async fn image_linked_body_maps_rows_to_items_without_thumbnails() {
+        let rows = vec![row(1, "Track", Some("Artist"), 42), row(2, "Solo", None, 7)];
+        let Body::ImageLinkedList(d) = image_linked_body(&rows).await else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items.len(), 2);
+        assert_eq!(d.items[0].title, "#1 Track");
+        assert!(d.items[0].thumbnail_path.is_none());
+        assert_eq!(d.items[0].subtitle.as_deref(), Some("Artist  ·  42 plays"));
+        assert_eq!(d.items[1].subtitle.as_deref(), Some("7 plays"));
+        assert!(d.items[1].url.is_some());
+    }
 }

--- a/src/fetcher/lastfm/top_albums.rs
+++ b/src/fetcher/lastfm/top_albums.rs
@@ -420,6 +420,57 @@ mod tests {
         assert_ne!(seven, overall);
     }
 
+    /// `render_body` is the shape dispatcher between `fetch` and the shared `top` body builders.
+    /// Drive every declared shape plus a shape outside `SHAPES` so the `_ => text_body` fallback
+    /// arm is exercised. `sample_rows()` carries no `image_url`, so `ImageLinkedList` resolves its
+    /// thumbnails to `None` without any network I/O.
+    #[tokio::test]
+    async fn render_body_dispatches_every_shape() {
+        let rows = sample_rows();
+        let p = Period::SevenDay;
+        assert!(matches!(
+            render_body(&rows, p, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::ImageLinkedList).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Ratio).await,
+            Body::Ratio(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::NumberSeries).await,
+            Body::NumberSeries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Bars).await,
+            Body::Bars(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Badge).await,
+            Body::Badge(_)
+        ));
+        // `Shape::Text` is not an explicit arm — it lands in the `_ => text_body` fallback.
+        assert!(matches!(
+            render_body(&rows, p, Shape::Text).await,
+            Body::Text(_)
+        ));
+    }
+
     #[tokio::test]
     async fn fetch_requires_user_option() {
         let err = LastfmTopAlbums

--- a/src/fetcher/lastfm/top_artists.rs
+++ b/src/fetcher/lastfm/top_artists.rs
@@ -435,6 +435,57 @@ mod tests {
         assert_ne!(seven, bars);
     }
 
+    /// `render_body` is the shape dispatcher between `fetch` and the shared `top` body builders.
+    /// Drive every declared shape plus a shape outside `SHAPES` so the `_ => text_body` fallback
+    /// arm is exercised. `sample_rows()` carries no `image_url`, so `ImageLinkedList` resolves its
+    /// thumbnails to `None` without any network I/O.
+    #[tokio::test]
+    async fn render_body_dispatches_every_shape() {
+        let rows = sample_rows();
+        let p = Period::SevenDay;
+        assert!(matches!(
+            render_body(&rows, p, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::ImageLinkedList).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Ratio).await,
+            Body::Ratio(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::NumberSeries).await,
+            Body::NumberSeries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Bars).await,
+            Body::Bars(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Badge).await,
+            Body::Badge(_)
+        ));
+        // `Shape::Text` is not an explicit arm — it lands in the `_ => text_body` fallback.
+        assert!(matches!(
+            render_body(&rows, p, Shape::Text).await,
+            Body::Text(_)
+        ));
+    }
+
     #[tokio::test]
     async fn fetch_requires_user_option() {
         let err = LastfmTopArtists

--- a/src/fetcher/lastfm/top_tracks.rs
+++ b/src/fetcher/lastfm/top_tracks.rs
@@ -428,6 +428,57 @@ mod tests {
         assert_ne!(seven, month);
     }
 
+    /// `render_body` is the shape dispatcher between `fetch` and the shared `top` body builders.
+    /// Drive every declared shape plus a shape outside `SHAPES` so the `_ => text_body` fallback
+    /// arm is exercised. `sample_rows()` carries no `image_url`, so `ImageLinkedList` resolves its
+    /// thumbnails to `None` without any network I/O.
+    #[tokio::test]
+    async fn render_body_dispatches_every_shape() {
+        let rows = sample_rows();
+        let p = Period::SevenDay;
+        assert!(matches!(
+            render_body(&rows, p, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::ImageLinkedList).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Ratio).await,
+            Body::Ratio(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::NumberSeries).await,
+            Body::NumberSeries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Bars).await,
+            Body::Bars(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, p, Shape::Badge).await,
+            Body::Badge(_)
+        ));
+        // `Shape::Text` is not an explicit arm — it lands in the `_ => text_body` fallback.
+        assert!(matches!(
+            render_body(&rows, p, Shape::Text).await,
+            Body::Text(_)
+        ));
+    }
+
     #[tokio::test]
     async fn fetch_requires_user_option() {
         let err = LastfmTopTracks

--- a/src/fetcher/news/mod.rs
+++ b/src/fetcher/news/mod.rs
@@ -219,6 +219,9 @@ fn resolve_feed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
     use std::time::Duration;
 
     fn ctx(shape: Option<Shape>, options: Option<toml::Value>) -> FetchContext {
@@ -538,6 +541,197 @@ mod tests {
             err,
             FetchError::Failed(ref msg)
                 if msg.contains("unknown feed key") && msg.contains("definitely-not-a-feed")
+        ));
+    }
+
+    const RSS_FIXTURE: &str = r#"<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Local Test</title>
+    <link>https://example.com</link>
+    <description>x</description>
+    <item>
+      <title>First story</title>
+      <link>https://example.com/1</link>
+      <pubDate>Sun, 26 Apr 2026 09:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Second story</title>
+      <link>https://example.com/2</link>
+      <pubDate>Fri, 24 Apr 2026 11:30:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Third story</title>
+      <link>https://example.com/3</link>
+      <pubDate>Wed, 22 Apr 2026 08:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>"#;
+
+    /// Serves exactly one HTTP response on a random loopback port, then closes. Lets `fetch`
+    /// exercise the real `feed::fetch_bytes` / `feed::parse_feed` path without a live network.
+    fn serve_once(
+        status: &str,
+        content_type: &str,
+        body: &[u8],
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let content_type = content_type.to_owned();
+        let body = body.to_vec();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let header = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(header.as_bytes()).unwrap();
+            stream.write_all(&body).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    /// Builds a `&'static NewsSource` whose single feed URL points at a caller-provided address.
+    /// The `news_*` family hardcodes `&'static str` feed URLs, so a feed served from a random
+    /// `serve_once` port has to be leaked to satisfy the lifetime. Leaking in a unit test is
+    /// bounded — the process exits when the run ends.
+    fn leak_local_source(url: &str) -> &'static NewsSource {
+        let feed_url: &'static str = String::leak(url.to_owned());
+        let feeds: &'static [NewsFeed] = Vec::leak(vec![NewsFeed {
+            key: "main",
+            url: feed_url,
+            label: "Main",
+        }]);
+        Box::leak(Box::new(NewsSource {
+            name: "news_test_local",
+            display: "Local Test",
+            category: NewsCategory::General,
+            description: "test-only source served from a local HTTP listener",
+            feeds,
+        }))
+    }
+
+    /// Happy path: no shape set → `fetch` defaults to `LinkedTextBlock`, parses the served RSS,
+    /// and emits one linked row per item. Covers the `Url::parse` success arm, the count clamp,
+    /// `feed::fetch_bytes`, `feed::parse_feed`, and the `other =>` shape branch of `fetch`.
+    #[tokio::test]
+    async fn fetch_parses_local_feed_into_default_linked_block() {
+        let (url, server) = serve_once("200 OK", "application/rss+xml", RSS_FIXTURE.as_bytes());
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let payload = f.fetch(&ctx(None, None)).await.unwrap();
+        server.join().unwrap();
+        assert!(matches!(
+            &payload.body,
+            Body::LinkedTextBlock(b)
+                if b.items.len() == 3
+                    && b.items[0].text.contains("First story")
+                    && b.items[0].url.as_deref() == Some("https://example.com/1")
+        ));
+    }
+
+    /// A non-default `Shape` still flows through the `other =>` arm — `render_body` picks the
+    /// `TextBlock` projection.
+    #[tokio::test]
+    async fn fetch_renders_text_block_shape() {
+        let (url, server) = serve_once("200 OK", "application/rss+xml", RSS_FIXTURE.as_bytes());
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let payload = f.fetch(&ctx(Some(Shape::TextBlock), None)).await.unwrap();
+        server.join().unwrap();
+        assert!(matches!(&payload.body, Body::TextBlock(t) if t.lines.len() == 3));
+    }
+
+    /// The `count` option flows into the clamp + `take(count)`, capping the rendered rows.
+    #[tokio::test]
+    async fn fetch_count_option_caps_rendered_rows() {
+        let (url, server) = serve_once("200 OK", "application/rss+xml", RSS_FIXTURE.as_bytes());
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let payload = f
+            .fetch(&ctx(
+                Some(Shape::LinkedTextBlock),
+                Some(parse_opts("count = 1")),
+            ))
+            .await
+            .unwrap();
+        server.join().unwrap();
+        assert!(matches!(&payload.body, Body::LinkedTextBlock(b) if b.items.len() == 1));
+    }
+
+    /// `Shape::ImageLinkedList` routes to `feed::render_image_linked`; the fixture carries no
+    /// thumbnails, so every row resolves with `thumbnail_path == None` and no image is fetched.
+    #[tokio::test]
+    async fn fetch_renders_image_linked_shape_without_thumbnails() {
+        let (url, server) = serve_once("200 OK", "application/rss+xml", RSS_FIXTURE.as_bytes());
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let payload = f
+            .fetch(&ctx(Some(Shape::ImageLinkedList), None))
+            .await
+            .unwrap();
+        server.join().unwrap();
+        assert!(matches!(
+            &payload.body,
+            Body::ImageLinkedList(d)
+                if d.items.len() == 3 && d.items[0].thumbnail_path.is_none()
+        ));
+    }
+
+    /// `Shape::Image` routes to `feed::render_image_body`; with no resolvable thumbnail the body
+    /// is an empty-path `Image` placeholder.
+    #[tokio::test]
+    async fn fetch_renders_image_shape_with_empty_path() {
+        let (url, server) = serve_once("200 OK", "application/rss+xml", RSS_FIXTURE.as_bytes());
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let payload = f.fetch(&ctx(Some(Shape::Image), None)).await.unwrap();
+        server.join().unwrap();
+        assert!(matches!(&payload.body, Body::Image(img) if img.path.is_empty()));
+    }
+
+    /// A non-feed response body surfaces `feed::parse_feed`'s labelled error through `fetch`.
+    #[tokio::test]
+    async fn fetch_surfaces_parse_error_from_non_feed_body() {
+        let (url, server) = serve_once("200 OK", "text/plain", b"not a feed");
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let err = f
+            .fetch(&ctx(Some(Shape::LinkedTextBlock), None))
+            .await
+            .unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("news_test_local parse")
+        ));
+    }
+
+    /// A non-success HTTP status surfaces `feed::fetch_bytes`'s `{label} {status}` error.
+    #[tokio::test]
+    async fn fetch_surfaces_http_status_error() {
+        let (url, server) = serve_once("500 Internal Server Error", "text/plain", b"oops");
+        let f = NewsFeedFetcher {
+            source: leak_local_source(&url),
+        };
+        let err = f
+            .fetch(&ctx(Some(Shape::LinkedTextBlock), None))
+            .await
+            .unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("news_test_local 500")
         ));
     }
 

--- a/src/fetcher/steam/charts.rs
+++ b/src/fetcher/steam/charts.rs
@@ -296,4 +296,149 @@ mod tests {
         let err = parse_options::<Options>(Some(&raw)).unwrap_err();
         assert!(err.contains("invalid options"));
     }
+
+    fn sample_rows() -> Vec<GameRow> {
+        vec![
+            GameRow {
+                rank: 1,
+                appid: 730,
+                name: "Counter-Strike 2".into(),
+                value: 1_500_000,
+                value_label: "1.5M peak".into(),
+            },
+            GameRow {
+                rank: 2,
+                appid: 570,
+                name: "Dota 2".into(),
+                value: 600_000,
+                value_label: "600k peak".into(),
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn render_body_dispatches_each_shape_to_its_body_variant() {
+        let rows = sample_rows();
+        assert!(matches!(
+            render_body(&rows, Shape::Bars).await,
+            Body::Bars(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, Shape::NumberSeries).await,
+            Body::NumberSeries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, Shape::Badge).await,
+            Body::Badge(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn render_body_text_arm_is_the_catch_all_fallback() {
+        // `Shape::Text` is not an explicit match arm — it exercises the `_ =>` branch.
+        let rows = sample_rows();
+        let Body::Text(t) = render_body(&rows, Shape::Text).await else {
+            panic!("expected text body");
+        };
+        assert!(t.value.contains("Counter-Strike 2"));
+    }
+
+    #[tokio::test]
+    async fn render_body_image_shapes_resolve_without_network_on_empty_rows() {
+        assert!(matches!(
+            render_body(&[], Shape::ImageLinkedList).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&[], Shape::Image).await,
+            Body::Image(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_names_is_empty_when_no_ranks_supplied() {
+        assert!(resolve_names(&[]).await.is_empty());
+    }
+
+    #[test]
+    fn appdetail_semaphore_returns_one_shared_instance() {
+        let a = appdetail_semaphore();
+        let b = appdetail_semaphore();
+        assert!(std::sync::Arc::ptr_eq(&a, &b));
+        assert!(a.available_permits() <= APPDETAIL_CONCURRENCY);
+    }
+
+    fn ctx(options: Option<toml::Value>) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            timeout: std::time::Duration::from_secs(1),
+            options,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_options() {
+        let f = SteamCharts;
+        let base = f.cache_key(&ctx(None));
+        assert!(base.starts_with("steam_charts-"));
+
+        let opts = toml::Value::try_from(serde_json::json!({"count": 5})).unwrap();
+        assert_ne!(f.cache_key(&ctx(Some(opts))), base);
+    }
+
+    #[test]
+    fn charts_response_parses_ranks_with_peak_count() {
+        let raw = r#"{"response":{"ranks":[{"rank":1,"appid":730,"peak_in_game":1500000}]}}"#;
+        let parsed: ChartsResponse = serde_json::from_str(raw).unwrap();
+        let ranks = parsed.response.ranks.unwrap();
+        assert_eq!(ranks.len(), 1);
+        assert_eq!(ranks[0].appid, 730);
+        assert_eq!(ranks[0].peak_in_game, 1_500_000);
+    }
+
+    #[test]
+    fn charts_body_defaults_ranks_to_none_when_field_absent() {
+        let parsed: ChartsResponse = serde_json::from_str(r#"{"response":{}}"#).unwrap();
+        assert!(parsed.response.ranks.is_none());
+    }
+
+    #[test]
+    fn raw_rank_defaults_peak_in_game_to_zero_when_omitted() {
+        let parsed: RawRank = serde_json::from_str(r#"{"rank":3,"appid":440}"#).unwrap();
+        assert_eq!(parsed.peak_in_game, 0);
+    }
+
+    #[test]
+    fn app_details_response_keeps_data_on_success_and_drops_it_on_failure() {
+        let raw = r#"{"730":{"success":true,"data":{"name":"Counter-Strike 2"}},"9999":{"success":false}}"#;
+        let parsed: AppDetailsResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            parsed.0["730"].data.as_ref().unwrap().name,
+            "Counter-Strike 2"
+        );
+        assert!(parsed.0["9999"].data.is_none());
+    }
+
+    #[test]
+    fn app_details_data_defaults_name_to_empty_string() {
+        let parsed: AppDetailsData = serde_json::from_str("{}").unwrap();
+        assert!(parsed.name.is_empty());
+    }
 }

--- a/src/fetcher/steam/client.rs
+++ b/src/fetcher/steam/client.rs
@@ -138,7 +138,19 @@ async fn parse_json<T: DeserializeOwned>(res: reqwest::Response) -> Result<T, Fe
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use serde::Deserialize;
+
     use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct TestPayload {
+        ok: bool,
+    }
 
     #[test]
     fn resolve_api_key_fails_with_clear_message_when_unset() {
@@ -217,5 +229,101 @@ mod tests {
     #[test]
     fn http_reuses_the_same_client() {
         assert!(std::ptr::eq(http(), http()));
+    }
+
+    #[test]
+    fn request_json_deserializes_success_body() {
+        let (url, server) = serve_once("200 OK", r#"{"ok":true}"#);
+        let payload: TestPayload = run_async(request_json(&url)).unwrap();
+        server.join().unwrap();
+        assert!(payload.ok);
+    }
+
+    #[test]
+    fn request_json_surfaces_non_success_status() {
+        let (url, server) = serve_once("503 Service Unavailable", "");
+        let err = run_async(request_json::<TestPayload>(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg == "steam 503 Service Unavailable"
+        ));
+    }
+
+    #[test]
+    fn request_json_surfaces_json_parse_errors() {
+        let (url, server) = serve_once("200 OK", "not-json");
+        let err = run_async(request_json::<TestPayload>(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.starts_with("steam json parse:")
+        ));
+    }
+
+    #[test]
+    fn request_json_rejects_oversized_body() {
+        let body = "x".repeat(MAX_BYTES + 1);
+        let (url, server) = serve_once("200 OK", &body);
+        let err = run_async(request_json::<TestPayload>(&url)).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("steam response too large")
+        ));
+    }
+
+    #[test]
+    fn request_json_surfaces_request_failures() {
+        let err = run_async(request_json::<TestPayload>("not-a-url")).unwrap_err();
+        assert!(matches!(
+            err,
+            FetchError::Failed(msg) if msg.contains("steam request failed")
+        ));
+    }
+
+    #[test]
+    fn get_json_fails_fast_when_api_key_missing() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("STEAM_API_KEY").ok();
+        unsafe { std::env::remove_var("STEAM_API_KEY") };
+        let err = run_async(get_json::<TestPayload>(
+            "ISteamUser/GetPlayerSummaries/v2/",
+            &[],
+        ))
+        .unwrap_err();
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("STEAM_API_KEY", v) };
+        }
+        assert!(matches!(err, FetchError::Failed(msg) if msg == "STEAM_API_KEY not set"));
+    }
+
+    fn serve_once(status: &str, body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
     }
 }

--- a/src/fetcher/steam/games.rs
+++ b/src/fetcher/steam/games.rs
@@ -353,4 +353,133 @@ mod tests {
         };
         assert_eq!(m.value, "_quiet_");
     }
+
+    #[test]
+    fn text_block_body_emits_single_empty_label_line_on_empty_input() {
+        let Body::TextBlock(b) = text_block_body(&[], "no games yet") else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines, vec!["no games yet".to_string()]);
+    }
+
+    #[test]
+    fn text_block_body_lists_one_line_per_row() {
+        let rows = vec![
+            row(1, 730, "CS2", 60, "60h"),
+            row(2, 570, "Dota 2", 30, "30h"),
+        ];
+        let Body::TextBlock(b) = text_block_body(&rows, "empty") else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 2);
+        assert_eq!(b.lines[0], "#1 CS2  60h");
+    }
+
+    #[test]
+    fn entries_body_emits_dash_placeholder_row_on_empty_input() {
+        let Body::Entries(e) = entries_body(&[], "no games yet") else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert_eq!(e.items[0].key, "—");
+        assert_eq!(e.items[0].value.as_deref(), Some("no games yet"));
+    }
+
+    /// Hash a URL the same way `thumbnails` content-addresses its cache, so a pre-seeded file
+    /// at `<hash>.png` makes `download_to_cache` resolve via `existing_cached` — exercising the
+    /// non-empty `image_*_body` arms without any network I/O.
+    fn thumbnail_hash(url: &str) -> String {
+        use sha2::{Digest, Sha256};
+        Sha256::digest(url.as_bytes())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    fn restore_home(previous: Option<String>) {
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
+                None => std::env::remove_var("SPLASHBOARD_HOME"),
+            }
+        }
+    }
+
+    /// Drive an async body builder to completion on a fresh current-thread runtime. Sync so the
+    /// `TEST_ENV_LOCK` guard is never held across an `.await` (clippy `await_holding_lock`).
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn image_linked_body_resolves_cached_thumbnails_without_network() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var("SPLASHBOARD_HOME").ok();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("SPLASHBOARD_HOME", dir.path()) };
+
+        let rows = vec![
+            row(1, 730, "CS2", 60, "60h"),
+            row(2, 570, "Dota 2", 30, "30h"),
+        ];
+        let thumbs = dir.path().join("cache").join("thumbnails");
+        std::fs::create_dir_all(&thumbs).unwrap();
+        for r in &rows {
+            let file = thumbs.join(format!("{}.png", thumbnail_hash(&r.header_image())));
+            std::fs::write(&file, b"\x89PNG\r\n\x1a\n").unwrap();
+        }
+
+        let body = block_on(image_linked_body(&rows));
+        restore_home(previous);
+
+        let Body::ImageLinkedList(d) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(d.items.len(), 2);
+        assert_eq!(d.items[0].title, "#1 CS2");
+        assert_eq!(
+            d.items[0].url.as_deref(),
+            Some(rows[0].store_url().as_str())
+        );
+        assert_eq!(d.items[0].subtitle.as_deref(), Some("60h"));
+        assert!(
+            d.items[0]
+                .thumbnail_path
+                .as_deref()
+                .is_some_and(|p| p.ends_with(".png"))
+        );
+    }
+
+    #[test]
+    fn image_body_resolves_top_cached_thumbnail_without_network() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var("SPLASHBOARD_HOME").ok();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("SPLASHBOARD_HOME", dir.path()) };
+
+        let rows = vec![
+            row(1, 730, "CS2", 60, "60h"),
+            row(2, 570, "Dota 2", 30, "30h"),
+        ];
+        let thumbs = dir.path().join("cache").join("thumbnails");
+        std::fs::create_dir_all(&thumbs).unwrap();
+        let file = thumbs.join(format!("{}.png", thumbnail_hash(&rows[0].header_image())));
+        std::fs::write(&file, b"\x89PNG\r\n\x1a\n").unwrap();
+
+        let body = block_on(image_body(&rows));
+        restore_home(previous);
+
+        let Body::Image(img) = body else {
+            panic!("expected image");
+        };
+        assert!(img.path.ends_with(".png"));
+    }
 }

--- a/src/fetcher/steam/games.rs
+++ b/src/fetcher/steam/games.rs
@@ -396,11 +396,25 @@ mod tests {
             .collect()
     }
 
-    fn restore_home(previous: Option<String>) {
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
-                None => std::env::remove_var("SPLASHBOARD_HOME"),
+    /// RAII guard: points `SPLASHBOARD_HOME` at a temp dir and restores it on drop, so a
+    /// panic mid-test can't leak the override into later tests sharing the process env.
+    struct SplashHomeGuard(Option<String>);
+
+    impl SplashHomeGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let previous = std::env::var("SPLASHBOARD_HOME").ok();
+            unsafe { std::env::set_var("SPLASHBOARD_HOME", path) };
+            Self(previous)
+        }
+    }
+
+    impl Drop for SplashHomeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
+                    None => std::env::remove_var("SPLASHBOARD_HOME"),
+                }
             }
         }
     }
@@ -420,9 +434,8 @@ mod tests {
         let _lock = crate::paths::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        let previous = std::env::var("SPLASHBOARD_HOME").ok();
         let dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("SPLASHBOARD_HOME", dir.path()) };
+        let _home = SplashHomeGuard::set(dir.path());
 
         let rows = vec![
             row(1, 730, "CS2", 60, "60h"),
@@ -436,7 +449,6 @@ mod tests {
         }
 
         let body = block_on(image_linked_body(&rows));
-        restore_home(previous);
 
         let Body::ImageLinkedList(d) = body else {
             panic!("expected image_linked_list");
@@ -461,9 +473,8 @@ mod tests {
         let _lock = crate::paths::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        let previous = std::env::var("SPLASHBOARD_HOME").ok();
         let dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("SPLASHBOARD_HOME", dir.path()) };
+        let _home = SplashHomeGuard::set(dir.path());
 
         let rows = vec![
             row(1, 730, "CS2", 60, "60h"),
@@ -475,7 +486,6 @@ mod tests {
         std::fs::write(&file, b"\x89PNG\r\n\x1a\n").unwrap();
 
         let body = block_on(image_body(&rows));
-        restore_home(previous);
 
         let Body::Image(img) = body else {
             panic!("expected image");

--- a/src/fetcher/steam/owned_games.rs
+++ b/src/fetcher/steam/owned_games.rs
@@ -390,4 +390,109 @@ mod tests {
         let opts: Options = parse_options(Some(&raw)).unwrap();
         assert_eq!(opts.sort, Some(Sort::Recent));
     }
+
+    #[tokio::test]
+    async fn render_body_dispatches_each_shape_to_its_body_variant() {
+        let games = sample_games();
+        let rows = rows_from_games(&games, Sort::Playtime, 10);
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Bars, Sort::Playtime).await,
+            Body::Bars(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Entries, Sort::Playtime).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::TextBlock, Sort::Playtime).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::MarkdownTextBlock, Sort::Playtime).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::LinkedTextBlock, Sort::Playtime).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::NumberSeries, Sort::Playtime).await,
+            Body::NumberSeries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Ratio, Sort::Playtime).await,
+            Body::Ratio(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Badge, Sort::Recent).await,
+            Body::Badge(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn render_body_text_arm_is_the_catch_all_library_summary() {
+        // `Shape::Text` has no explicit match arm — it exercises the `_ =>` branch.
+        let games = sample_games();
+        let rows = rows_from_games(&games, Sort::Playtime, 10);
+        let body = render_body(&rows, &games, Shape::Text, Sort::Playtime).await;
+        assert!(matches!(&body, Body::Text(t) if t.value.contains("owned games")));
+    }
+
+    #[tokio::test]
+    async fn render_body_image_shapes_resolve_without_network_on_empty_rows() {
+        assert!(matches!(
+            render_body(&[], &[], Shape::ImageLinkedList, Sort::Playtime).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&[], &[], Shape::Image, Sort::Playtime).await,
+            Body::Image(_)
+        ));
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_options() {
+        let f = SteamOwnedGames;
+        let base = f.cache_key(&FetchContext::default());
+        assert!(base.starts_with("steam_owned_games-"));
+        let with_opts = f.cache_key(&FetchContext {
+            options: Some(toml::from_str("count = 5").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(base, with_opts);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_any_network() {
+        let f = SteamOwnedGames;
+        let ctx = FetchContext {
+            options: Some(toml::from_str("bogus = 1").unwrap()),
+            ..Default::default()
+        };
+        let err = f.fetch(&ctx).await.unwrap_err();
+        assert!(matches!(err, FetchError::Failed(m) if m.contains("invalid options")));
+    }
+
+    #[test]
+    fn sort_label_describes_the_ranking_axis() {
+        assert_eq!(Sort::Playtime.label(), "all-time");
+        assert_eq!(Sort::Recent.label(), "recent");
+    }
+
+    #[test]
+    fn text_summary_falls_back_to_empty_label_when_no_rows() {
+        let Body::Text(t) = text_body_with_summary(&[], &[]) else {
+            panic!("expected text body");
+        };
+        assert_eq!(t.value, EMPTY_LABEL);
+    }
+
+    #[test]
+    fn relative_label_emits_raw_ts_for_out_of_chrono_range_timestamps() {
+        // A timestamp millions of years in the past is older than 30 days (→ the `_` arm)
+        // and outside chrono's representable range (→ `timestamp_opt` yields None).
+        let now = 1_750_000_000_i64;
+        let label = relative_label(now, -9_000_000_000_000_000);
+        assert_eq!(label, "ts:-9000000000000000");
+    }
 }

--- a/src/fetcher/steam/player_summary.rs
+++ b/src/fetcher/steam/player_summary.rs
@@ -777,6 +777,29 @@ mod tests {
         (format!("http://{addr}/avatar.png"), handle)
     }
 
+    /// RAII guard: points `SPLASHBOARD_HOME` at a temp dir and restores it on drop, so a
+    /// panic mid-test can't leak the override into later tests sharing the process env.
+    struct SplashHomeGuard(Option<String>);
+
+    impl SplashHomeGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let previous = std::env::var("SPLASHBOARD_HOME").ok();
+            unsafe { std::env::set_var("SPLASHBOARD_HOME", path) };
+            Self(previous)
+        }
+    }
+
+    impl Drop for SplashHomeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("SPLASHBOARD_HOME", value),
+                    None => std::env::remove_var("SPLASHBOARD_HOME"),
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn image_bodies_resolve_avatar_through_thumbnail_cache() {
@@ -784,8 +807,7 @@ mod tests {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        let previous = std::env::var("SPLASHBOARD_HOME").ok();
-        unsafe { std::env::set_var("SPLASHBOARD_HOME", tmp.path()) };
+        let _home = SplashHomeGuard::set(tmp.path());
 
         let (url, server) = serve_png_once();
         let snap = Snapshot {
@@ -802,11 +824,6 @@ mod tests {
         let Body::Image(img) = render_body(&snap, Shape::Image).await else {
             panic!("expected image");
         };
-
-        match previous {
-            Some(v) => unsafe { std::env::set_var("SPLASHBOARD_HOME", v) },
-            None => unsafe { std::env::remove_var("SPLASHBOARD_HOME") },
-        }
 
         let thumb = list.items[0]
             .thumbnail_path

--- a/src/fetcher/steam/player_summary.rs
+++ b/src/fetcher/steam/player_summary.rs
@@ -545,5 +545,211 @@ mod tests {
         assert_eq!(subtitle(&snap), "Lv 25 · online");
         snap.level = None;
         assert_eq!(subtitle(&snap), "online");
+        snap.current_game = Some("Portal 2".into());
+        assert_eq!(subtitle(&snap), "in Portal 2");
+    }
+
+    fn ctx(options: Option<toml::Value>) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            timeout: std::time::Duration::from_secs(1),
+            options,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fetcher_exposes_refresh_interval_description_and_option_schema() {
+        let f = SteamPlayerSummary;
+        assert!(f.refresh_interval() > 0);
+        assert!(!f.description().is_empty());
+        assert_eq!(f.option_schemas().len(), 1);
+        assert_eq!(f.option_schemas()[0].name, "steam_id");
+        assert_eq!(f.shapes().len(), SHAPES.len());
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_options() {
+        let f = SteamPlayerSummary;
+        let base = f.cache_key(&ctx(None));
+        assert!(base.starts_with("steam_player_summary-"));
+
+        let opts = toml::Value::try_from(serde_json::json!({"steam_id": "123"})).unwrap();
+        assert_ne!(f.cache_key(&ctx(Some(opts))), base);
+    }
+
+    #[test]
+    fn options_struct_rejects_unknown_keys() {
+        let raw = toml::Value::try_from(serde_json::json!({"unknown": 1})).unwrap();
+        assert!(parse_options::<Options>(Some(&raw)).is_err());
+    }
+
+    #[test]
+    fn persona_state_from_code_maps_each_status_code_when_not_in_game() {
+        assert_eq!(PersonaState::from_code(1, false), PersonaState::Online);
+        assert_eq!(PersonaState::from_code(2, false), PersonaState::Busy);
+        assert_eq!(PersonaState::from_code(3, false), PersonaState::Away);
+        assert_eq!(PersonaState::from_code(4, false), PersonaState::Snooze);
+        assert_eq!(
+            PersonaState::from_code(5, false),
+            PersonaState::LookingToTrade
+        );
+        assert_eq!(
+            PersonaState::from_code(6, false),
+            PersonaState::LookingToPlay
+        );
+        assert_eq!(PersonaState::from_code(0, false), PersonaState::Offline);
+        assert_eq!(PersonaState::from_code(99, false), PersonaState::Offline);
+    }
+
+    #[test]
+    fn text_body_wraps_the_headline() {
+        let snap = sample(PersonaState::Online, None);
+        let Body::Text(t) = text_body(&snap) else {
+            panic!("expected text");
+        };
+        assert_eq!(t.value, headline(&snap));
+    }
+
+    #[test]
+    fn text_block_body_carries_the_lines() {
+        let snap = sample(PersonaState::Online, None);
+        let Body::TextBlock(b) = text_block_body(&snap) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines, lines(&snap));
+        assert_eq!(b.lines[0], "Robin");
+    }
+
+    #[test]
+    fn lines_reports_playing_game_instead_of_last_seen_when_in_game() {
+        let snap = sample(PersonaState::InGame, Some("Half-Life"));
+        let ls = lines(&snap);
+        assert!(ls.iter().any(|l| l == "Playing: Half-Life"));
+        assert!(!ls.iter().any(|l| l.starts_with("Last seen:")));
+    }
+
+    #[test]
+    fn entries_body_adds_playing_row_when_in_a_game() {
+        let snap = sample(PersonaState::InGame, Some("Team Fortress 2"));
+        let Body::Entries(e) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        let playing = e.items.iter().find(|i| i.key == "playing").unwrap();
+        assert_eq!(playing.value.as_deref(), Some("Team Fortress 2"));
+        assert!(e.items.iter().any(|i| i.key == "last seen"));
+    }
+
+    #[test]
+    fn badge_body_uses_state_label_when_not_in_a_game() {
+        let snap = sample(PersonaState::Away, None);
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert_eq!(b.label, "away");
+    }
+
+    #[test]
+    fn format_last_logoff_falls_back_to_raw_ts_for_out_of_range_input() {
+        let s = format_last_logoff(i64::MAX);
+        assert_eq!(s, format!("ts:{}", i64::MAX));
+    }
+
+    fn no_avatar(state: PersonaState, game: Option<&str>) -> Snapshot {
+        Snapshot {
+            avatar_url: None,
+            ..sample(state, game)
+        }
+    }
+
+    #[tokio::test]
+    async fn render_body_dispatches_each_shape_to_its_body_variant() {
+        let snap = no_avatar(PersonaState::Online, None);
+        assert!(matches!(
+            render_body(&snap, Shape::Text).await,
+            Body::Text(_)
+        ));
+        assert!(matches!(
+            render_body(&snap, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&snap, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&snap, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&snap, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&snap, Shape::Badge).await,
+            Body::Badge(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn render_body_image_shapes_resolve_without_network_when_avatar_absent() {
+        let snap = no_avatar(PersonaState::Online, None);
+        assert!(matches!(
+            render_body(&snap, Shape::Image).await,
+            Body::Image(_)
+        ));
+        let Body::Image(img) = render_body(&snap, Shape::Image).await else {
+            panic!("expected image");
+        };
+        assert!(img.path.is_empty());
+
+        let Body::ImageLinkedList(list) = render_body(&snap, Shape::ImageLinkedList).await else {
+            panic!("expected image_linked_list");
+        };
+        assert_eq!(list.items.len(), 1);
+        assert!(list.items[0].thumbnail_path.is_none());
+        assert_eq!(list.items[0].title, "Robin");
+    }
+
+    #[tokio::test]
+    async fn render_body_unlisted_shape_falls_back_to_text() {
+        // `Shape::Ratio` is not in SHAPES, so it exercises the `_ =>` catch-all arm.
+        let snap = no_avatar(PersonaState::Online, None);
+        assert!(matches!(
+            render_body(&snap, Shape::Ratio).await,
+            Body::Text(_)
+        ));
+    }
+
+    #[test]
+    fn player_summaries_response_parses_first_player_and_defaults_missing_fields() {
+        let raw =
+            r#"{"response":{"players":[{"steamid":"1","personaname":"Gabe","personastate":1}]}}"#;
+        let parsed: PlayerSummariesResponse = serde_json::from_str(raw).unwrap();
+        let player = &parsed.response.players[0];
+        assert_eq!(player.personaname, "Gabe");
+        assert_eq!(player.personastate, 1);
+        assert!(player.profileurl.is_empty());
+        assert!(player.avatarfull.is_empty());
+        assert!(player.lastlogoff.is_none());
+        assert!(player.gameid.is_none());
+        assert!(player.gameextrainfo.is_none());
+    }
+
+    #[test]
+    fn player_summaries_body_defaults_players_to_empty_when_absent() {
+        let parsed: PlayerSummariesResponse = serde_json::from_str(r#"{"response":{}}"#).unwrap();
+        assert!(parsed.response.players.is_empty());
+    }
+
+    #[test]
+    fn steam_level_response_reads_level_and_defaults_to_none_when_absent() {
+        let with_level: SteamLevelResponse =
+            serde_json::from_str(r#"{"response":{"player_level":42}}"#).unwrap();
+        assert_eq!(with_level.response.player_level, Some(42));
+
+        let without: SteamLevelResponse = serde_json::from_str(r#"{"response":{}}"#).unwrap();
+        assert!(without.response.player_level.is_none());
     }
 }

--- a/src/fetcher/steam/player_summary.rs
+++ b/src/fetcher/steam/player_summary.rs
@@ -752,4 +752,68 @@ mod tests {
         let without: SteamLevelResponse = serde_json::from_str(r#"{"response":{}}"#).unwrap();
         assert!(without.response.player_level.is_none());
     }
+
+    /// One-shot local HTTP server that answers a single request with a tiny PNG, so the avatar
+    /// download path can be exercised without reaching the real network.
+    fn serve_png_once() -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request);
+            let body: &[u8] = b"\x89PNG\r\n\x1a\navatar-bytes";
+            let header = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: image/png\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(header.as_bytes()).unwrap();
+            stream.write_all(body).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{addr}/avatar.png"), handle)
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn image_bodies_resolve_avatar_through_thumbnail_cache() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let previous = std::env::var("SPLASHBOARD_HOME").ok();
+        unsafe { std::env::set_var("SPLASHBOARD_HOME", tmp.path()) };
+
+        let (url, server) = serve_png_once();
+        let snap = Snapshot {
+            avatar_url: Some(url),
+            ..sample(PersonaState::Online, None)
+        };
+
+        // `image_linked_body` performs the one network download; `image_body` then resolves the
+        // same avatar URL from the on-disk cache without a second request.
+        let Body::ImageLinkedList(list) = render_body(&snap, Shape::ImageLinkedList).await else {
+            panic!("expected image_linked_list");
+        };
+        server.join().unwrap();
+        let Body::Image(img) = render_body(&snap, Shape::Image).await else {
+            panic!("expected image");
+        };
+
+        match previous {
+            Some(v) => unsafe { std::env::set_var("SPLASHBOARD_HOME", v) },
+            None => unsafe { std::env::remove_var("SPLASHBOARD_HOME") },
+        }
+
+        let thumb = list.items[0]
+            .thumbnail_path
+            .as_deref()
+            .expect("avatar should resolve to a cached path");
+        assert!(thumb.ends_with(".png"));
+        assert_eq!(list.items[0].title, "Robin");
+        assert_eq!(img.path, thumb);
+    }
 }

--- a/src/fetcher/steam/recently_played.rs
+++ b/src/fetcher/steam/recently_played.rs
@@ -281,4 +281,86 @@ mod tests {
         assert_eq!(opts.steam_id.as_deref(), Some("76561197960287930"));
         assert_eq!(opts.count, Some(10));
     }
+
+    #[tokio::test]
+    async fn render_body_dispatches_each_shape_to_its_body_variant() {
+        let games = sample_games();
+        let rows = rows_from_games(&games);
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Bars).await,
+            Body::Bars(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Entries).await,
+            Body::Entries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::TextBlock).await,
+            Body::TextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::MarkdownTextBlock).await,
+            Body::MarkdownTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::LinkedTextBlock).await,
+            Body::LinkedTextBlock(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::NumberSeries).await,
+            Body::NumberSeries(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Ratio).await,
+            Body::Ratio(_)
+        ));
+        assert!(matches!(
+            render_body(&rows, &games, Shape::Badge).await,
+            Body::Badge(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn render_body_text_arm_is_the_catch_all_weekly_summary() {
+        // `Shape::Text` has no explicit match arm — it exercises the `_ =>` branch.
+        let games = sample_games();
+        let rows = rows_from_games(&games);
+        let body = render_body(&rows, &games, Shape::Text).await;
+        assert!(matches!(&body, Body::Text(t) if t.value.contains("2 games this week")));
+    }
+
+    #[tokio::test]
+    async fn render_body_image_shapes_resolve_without_network_on_empty_rows() {
+        assert!(matches!(
+            render_body(&[], &[], Shape::ImageLinkedList).await,
+            Body::ImageLinkedList(_)
+        ));
+        assert!(matches!(
+            render_body(&[], &[], Shape::Image).await,
+            Body::Image(_)
+        ));
+    }
+
+    #[test]
+    fn cache_key_is_name_prefixed_and_varies_with_options() {
+        let f = SteamRecentlyPlayed;
+        let base = f.cache_key(&FetchContext::default());
+        assert!(base.starts_with("steam_recently_played-"));
+        let with_opts = f.cache_key(&FetchContext {
+            options: Some(toml::from_str("count = 10").unwrap()),
+            ..Default::default()
+        });
+        assert_ne!(base, with_opts);
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_unknown_options_before_any_network() {
+        let f = SteamRecentlyPlayed;
+        let ctx = FetchContext {
+            options: Some(toml::from_str("bogus = 1").unwrap()),
+            ..Default::default()
+        };
+        let err = f.fetch(&ctx).await.unwrap_err();
+        assert!(matches!(err, FetchError::Failed(m) if m.contains("invalid options")));
+    }
 }

--- a/src/fetcher/wikipedia/trending.rs
+++ b/src/fetcher/wikipedia/trending.rs
@@ -440,6 +440,40 @@ mod tests {
         }
     }
 
+    /// Minimal one-shot HTTP server so the `/page/summary` thumbnail lookup can be exercised
+    /// without reaching the real `*.wikipedia.org` host. Returns the base URL (no trailing
+    /// slash, suitable as a `rest_base`) and the server thread handle.
+    fn serve_once(status: &str, body: &str) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _ = stream.read(&mut [0_u8; 1024]);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    /// A local address with nothing listening — every request fails fast with connection
+    /// refused, exercising the error arm without a real network round-trip.
+    fn dead_base() -> String {
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        format!("http://{addr}")
+    }
+
     #[test]
     fn access_as_path_covers_all_variants() {
         assert_eq!(Access::All.as_path(), "all-access");
@@ -707,5 +741,48 @@ mod tests {
         };
         assert!(t.value.contains("Quokka"));
         assert!(t.value.contains("412.0k"));
+    }
+
+    /// The `ImageLinkedList` arm drives the whole thumbnail-resolution chain
+    /// (`resolve_thumbnails` → `collect_thumbnail_urls` → `download_many`). An empty article
+    /// slice exercises every entry point of that chain without a single HTTP call — the
+    /// per-article `fetch_thumbnail_url` loop body is simply never entered.
+    #[tokio::test]
+    async fn render_for_shape_image_linked_list_handles_empty_articles_without_network() {
+        let body = render_for_shape(&[], Shape::ImageLinkedList, "en").await;
+        let Body::ImageLinkedList(data) = body else {
+            panic!("expected image_linked_list");
+        };
+        assert!(data.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_thumbnail_url_extracts_source_from_summary_response() {
+        let (base, server) = serve_once(
+            "200 OK",
+            r#"{"title":"Quokka","thumbnail":{"source":"https://upload.wikimedia.org/quokka.jpg"}}"#,
+        );
+        let resolved = fetch_thumbnail_url(&base, "Quokka").await;
+        server.join().unwrap();
+        assert_eq!(
+            resolved.as_deref(),
+            Some("https://upload.wikimedia.org/quokka.jpg")
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_thumbnail_url_is_none_when_summary_omits_thumbnail() {
+        let (base, server) = serve_once("200 OK", r#"{"title":"Quokka"}"#);
+        let resolved = fetch_thumbnail_url(&base, "Quokka").await;
+        server.join().unwrap();
+        assert!(resolved.is_none());
+    }
+
+    /// A failed `/page/summary` lookup must not sink the row — `fetch_thumbnail_url` swallows
+    /// the error via `.ok()?` and silently yields `None`.
+    #[tokio::test]
+    async fn fetch_thumbnail_url_is_none_when_request_fails() {
+        let resolved = fetch_thumbnail_url(&dead_base(), "Quokka").await;
+        assert!(resolved.is_none());
     }
 }

--- a/src/fetcher/wikipedia/trending.rs
+++ b/src/fetcher/wikipedia/trending.rs
@@ -667,4 +667,45 @@ mod tests {
             .unwrap_err();
         assert!(format!("{err}").contains("unknown field"));
     }
+
+    #[test]
+    fn render_sync_text_block_lists_one_article_line_each() {
+        let body = render_sync(
+            &[article("Quokka", 412_000), article("Apollo_11", 287_000)],
+            Shape::TextBlock,
+        );
+        let Body::TextBlock(t) = body else {
+            panic!("expected text_block");
+        };
+        assert_eq!(t.lines[0], "412.0k views  Quokka");
+        assert_eq!(t.lines[1], "287.0k views  Apollo 11");
+    }
+
+    #[test]
+    fn build_summary_url_appends_title_to_rest_base() {
+        let base = rest_api_base("en");
+        let url = build_summary_url(&base, "Apollo_11");
+        assert_eq!(
+            url,
+            "https://en.wikipedia.org/api/rest_v1/page/summary/Apollo_11"
+        );
+    }
+
+    #[test]
+    fn build_summary_url_percent_encodes_reserved_chars() {
+        let base = rest_api_base("ja");
+        let url = build_summary_url(&base, "Hello#world");
+        assert!(url.ends_with("/page/summary/Hello%23world"), "url: {url}");
+        assert!(url.starts_with("https://ja.wikipedia.org/"), "url: {url}");
+    }
+
+    #[tokio::test]
+    async fn render_for_shape_non_image_shape_renders_synchronously() {
+        let body = render_for_shape(&[article("Quokka", 412_000)], Shape::Text, "en").await;
+        let Body::Text(t) = body else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("Quokka"));
+        assert!(t.value.contains("412.0k"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1257,6 +1257,127 @@ PATH = "/tmp/ignored"
         assert_eq!(cache_path, expected);
     }
 
+    fn project_dashboard(fetcher: &str) -> String {
+        format!(
+            "[[widget]]\nid = \"x\"\nfetcher = \"{fetcher}\"\nrender = \"text_plain\"\n\n\
+             [[row]]\nheight = {{ length = 3 }}\n[[row.child]]\nwidget = \"x\"\n"
+        )
+    }
+
+    /// `clear_one` resolves the dashboard via `resolve_dashboard_source()`; from the crate root
+    /// (a git repo root with no per-dir dashboard) that yields `Project`, so the command reads
+    /// `project.dashboard.toml` under `SPLASHBOARD_HOME`.
+    fn write_project_dashboard(home: &Path, fetcher: &str) {
+        write_file(
+            &home.join("project.dashboard.toml"),
+            &project_dashboard(fetcher),
+        );
+    }
+
+    fn clear_one_cache_paths(cache_dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        let registry = super::Registry::with_builtins();
+        let fetcher = registry.get_cached("basic_static").unwrap();
+        let key = fetcher.cache_key(&super::FetchContext {
+            widget_id: "x".into(),
+            format: None,
+            timeout: std::time::Duration::from_secs(0),
+            file_format: None,
+            shape: Some(fetcher.default_shape()),
+            options: None,
+            timezone: None,
+            locale: None,
+        });
+        let sanitized = splashboard::cache::sanitize(&key);
+        (
+            cache_dir.join(format!("{sanitized}.json")),
+            cache_dir.join(format!("{sanitized}.lock")),
+        )
+    }
+
+    #[test]
+    fn clear_one_errors_when_widget_id_absent_from_config() {
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        write_project_dashboard(home.path(), "basic_static");
+        let err = super::clear_one(cache.path(), "ghost", false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert!(
+            err.to_string().contains("no widget 'ghost'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn clear_one_errors_when_widget_uses_realtime_fetcher() {
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        // `clock` is a realtime fetcher, so it is absent from the cached-fetcher registry —
+        // `clear_one` cannot derive a disk cache key for it.
+        write_project_dashboard(home.path(), "clock");
+        let err = super::clear_one(cache.path(), "x", false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert!(
+            err.to_string().contains("realtime"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn clear_one_reports_no_entry_when_cache_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        write_project_dashboard(home.path(), "basic_static");
+        // No cache files written: both the entry and lock paths miss with `NotFound`, so the
+        // command still succeeds and prints the "had no cache entry" diagnostic.
+        super::clear_one(cache.path(), "x", false).unwrap();
+    }
+
+    #[test]
+    fn clear_one_removes_existing_entry_and_lock_files() {
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        write_project_dashboard(home.path(), "basic_static");
+        let (entry, lock) = clear_one_cache_paths(cache.path());
+        write_file(&entry, "{}");
+        write_file(&lock, "");
+        super::clear_one(cache.path(), "x", false).unwrap();
+        assert!(!entry.exists(), "entry file should be removed");
+        assert!(!lock.exists(), "lock file should be removed");
+    }
+
+    #[test]
+    fn clear_one_json_mode_removes_files_and_succeeds() {
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        write_project_dashboard(home.path(), "basic_static");
+        let (entry, lock) = clear_one_cache_paths(cache.path());
+        write_file(&entry, "{}");
+        write_file(&lock, "");
+        super::clear_one(cache.path(), "x", true).unwrap();
+        assert!(!entry.exists(), "entry file should be removed in json mode");
+        assert!(!lock.exists(), "lock file should be removed in json mode");
+    }
+
     #[test]
     fn collect_cache_rows_returns_empty_for_missing_dir() {
         // `cache list` against a never-used cache should print "(empty)", not error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1589,6 +1589,64 @@ PATH = "/tmp/ignored"
     }
 
     #[test]
+    fn run_cache_path_subcommand_resolves_dir_under_splashboard_home() {
+        let home = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        super::run_cache(super::CacheSubcommand::Path).unwrap();
+    }
+
+    #[test]
+    fn run_cache_list_subcommand_treats_missing_cache_dir_as_empty() {
+        let home = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        // `<SPLASHBOARD_HOME>/cache` does not exist yet — both modes must still succeed.
+        super::run_cache(super::CacheSubcommand::List { json: false }).unwrap();
+        super::run_cache(super::CacheSubcommand::List { json: true }).unwrap();
+    }
+
+    #[test]
+    fn run_cache_clear_subcommand_removes_seeded_entry_and_lock_files() {
+        let home = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        let cache_dir = home.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("w.json"), r#"{}"#).unwrap();
+        std::fs::write(cache_dir.join("w.lock"), "").unwrap();
+
+        super::run_cache(super::CacheSubcommand::Clear {
+            widget_id: None,
+            yes: true,
+            json: true,
+        })
+        .unwrap();
+
+        assert!(!cache_dir.join("w.json").exists());
+        assert!(!cache_dir.join("w.lock").exists());
+    }
+
+    #[test]
+    fn run_cache_clear_with_widget_id_dispatches_to_clear_one() {
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(vec![(
+            "SPLASHBOARD_HOME",
+            Some(home.path().display().to_string()),
+        )]);
+        write_project_dashboard(home.path(), "basic_static");
+        // No cache files seeded — `clear_one` still succeeds with the "no entry" diagnostic.
+        super::run_cache_clear(cache.path(), Some("x".into()), false, false).unwrap();
+    }
+
+    #[test]
     fn run_list_trusted_and_revoke_round_trip_store_entries() {
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(vec![(

--- a/src/render/animated_figlet_morph.rs
+++ b/src/render/animated_figlet_morph.rs
@@ -404,7 +404,16 @@ mod tests {
         let body = text_body();
         let registry = Registry::with_builtins();
         let theme = Theme::default();
-        let elapsed = elapsed_since_start_ms().max(1);
+        // The fade-OUT branch only runs once process uptime clears the 260ms fade window;
+        // before that `render_morph` takes the fade-IN branch instead. Park until uptime is
+        // past it so this test deterministically exercises the crossfade-out path that a fast
+        // suite would otherwise skip. Process uptime is monotonic, so once past 320ms a render
+        // with `phase_len = uptime + 200` is guaranteed to land inside phase 0's fade-out zone.
+        process_start();
+        while elapsed_since_start_ms() < 320 {
+            thread::sleep(Duration::from_millis(20));
+        }
+        let elapsed = elapsed_since_start_ms();
         let phase_len = elapsed.saturating_add(200);
         let duration_ms = phase_len as u64 * DEFAULT_SEQUENCE.len() as u64;
         let opts = RenderOptions {

--- a/src/render/animated_splitflap.rs
+++ b/src/render/animated_splitflap.rs
@@ -363,4 +363,60 @@ mod tests {
         let registry = Registry::with_builtins();
         let _ = render_to_buffer_with_spec(&payload, Some(&spec), &registry, 40, 10);
     }
+
+    #[test]
+    fn apply_flap_skips_a_zero_sized_area() {
+        let backend = TestBackend::new(4, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let zero = Rect {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 0,
+                };
+                apply_flap(frame, zero, 0, 1_000, &Theme::default());
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert!((0..2).all(|y| line_text(&buf, y).trim().is_empty()));
+    }
+
+    #[test]
+    fn apply_flap_leaves_settled_cells_untouched_past_the_window() {
+        let backend = TestBackend::new(3, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                frame.render_widget(Paragraph::new("AB "), area);
+                // elapsed == total: every cell has already settled, so each one takes the
+                // `elapsed_ms >= settle_at` continue and keeps its original glyph.
+                apply_flap(frame, area, 1_000, 1_000, &Theme::default());
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert_eq!(buf.cell((0, 0)).unwrap().symbol(), "A");
+        assert_eq!(buf.cell((1, 0)).unwrap().symbol(), "B");
+    }
+
+    #[test]
+    fn apply_flap_ignores_cells_outside_the_buffer() {
+        let backend = TestBackend::new(3, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                // Area deliberately larger than the 3x1 buffer: the out-of-range cells
+                // resolve to no cell and take the `else { continue }` arm without panicking.
+                let oversized = Rect {
+                    x: 0,
+                    y: 0,
+                    width: 12,
+                    height: 4,
+                };
+                apply_flap(frame, oversized, 0, 1_000, &Theme::default());
+            })
+            .unwrap();
+    }
 }

--- a/src/render/chart_histogram.rs
+++ b/src/render/chart_histogram.rs
@@ -292,6 +292,34 @@ mod tests {
     }
 
     #[test]
+    fn render_histogram_draws_nothing_for_an_empty_series() {
+        // `render_payload` short-circuits empty bodies upstream, so the renderer's own
+        // `data.values.is_empty()` guard is only reachable by calling `render_histogram`
+        // directly — exercise it and confirm the buffer is left blank.
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let backend = TestBackend::new(20, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_histogram(
+                    frame,
+                    frame.area(),
+                    &NumberSeriesData { values: vec![] },
+                    &RenderOptions::default(),
+                    &Theme::default(),
+                );
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let content: String = (0..6).map(|y| line_text(&buf, y)).collect();
+        assert!(
+            content.trim().is_empty(),
+            "an empty series should leave the buffer blank: {content:?}"
+        );
+    }
+
+    #[test]
     fn single_value_collapses_to_first_bucket() {
         let counts = bucket_counts(&[42, 42, 42, 42], 5);
         assert_eq!(counts, vec![4, 0, 0, 0, 0]);
@@ -479,6 +507,12 @@ mod tests {
     #[test]
     fn boost_to_visible_no_op_when_height_zero() {
         assert_eq!(boost_to_visible(vec![1, 5, 1], 0), vec![1, 5, 1]);
+    }
+
+    #[test]
+    fn boost_to_visible_no_op_when_every_count_is_zero() {
+        // All-zero counts → peak is zero → nothing to lift, the slice passes straight through.
+        assert_eq!(boost_to_visible(vec![0, 0, 0], 4), vec![0, 0, 0]);
     }
 
     #[test]

--- a/src/render/chart_sparkline.rs
+++ b/src/render/chart_sparkline.rs
@@ -331,4 +331,63 @@ mod tests {
         assert_eq!(buf.cell((1, 2)).unwrap().symbol(), ZERO_BASELINE);
         assert_eq!(buf.cell((2, 2)).unwrap().symbol(), ZERO_BASELINE);
     }
+
+    #[test]
+    fn render_ignores_a_non_number_series_body() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let mut terminal = Terminal::new(TestBackend::new(10, 3)).unwrap();
+        let body = Body::Text(crate::payload::TextData { value: "x".into() });
+        let opts = RenderOptions::default();
+        let theme = Theme::default();
+        let registry = Registry::with_builtins();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                ChartSparklineRenderer.render(frame, area, &body, &opts, &theme, &registry);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert!(
+            (0..buf.area.height).all(|y| line_text(&buf, y).trim().is_empty()),
+            "a non-NumberSeries body must leave the slot untouched"
+        );
+    }
+
+    #[test]
+    fn line_style_handles_empty_values() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W =
+            toml::from_str(r#"render = { type = "chart_sparkline", style = "line" }"#).unwrap();
+        let buf = render_to_buffer_with_spec(&payload(vec![]), Some(&w.render), &registry, 10, 3);
+        assert!((0..buf.area.height).all(|y| line_text(&buf, y).trim().is_empty()));
+    }
+
+    /// `render_sparkline` always truncates the value window to the chart width before calling
+    /// these helpers, so their out-of-range guards (zero-sized area, an over-long slice, a
+    /// mid/bottom row past the buffer) are defence-in-depth — exercise them directly.
+    #[test]
+    fn line_and_baseline_helpers_guard_out_of_range_inputs() {
+        use ratatui::{Terminal, backend::TestBackend};
+        let mut terminal = Terminal::new(TestBackend::new(4, 3)).unwrap();
+        let theme = Theme::default();
+        terminal
+            .draw(|frame| {
+                // Each clause of the degenerate-area short-circuit.
+                draw_line_series(frame, Rect::new(0, 0, 0, 3), &[1, 2], &theme);
+                draw_line_series(frame, Rect::new(0, 0, 4, 0), &[1, 2], &theme);
+                draw_line_series(frame, Rect::new(0, 0, 4, 3), &[], &theme);
+                draw_zero_baseline(frame, Rect::new(0, 0, 4, 0), &[0, 0], &theme);
+                // A slice longer than the area width hits the in-loop break.
+                draw_line_series(frame, Rect::new(0, 0, 2, 3), &[1, 2, 3, 4], &theme);
+                draw_zero_baseline(frame, Rect::new(0, 0, 2, 3), &[0, 0, 0, 0], &theme);
+                // A mid/bottom row past the buffer makes `cell_mut` return `None`.
+                draw_line_series(frame, Rect::new(0, 0, 4, 20), &[0, 7], &theme);
+                draw_zero_baseline(frame, Rect::new(0, 0, 4, 20), &[0, 0], &theme);
+            })
+            .unwrap();
+    }
 }

--- a/src/render/grid_table.rs
+++ b/src/render/grid_table.rs
@@ -183,8 +183,10 @@ fn to_row<'a>(item: &'a Entry, aligns: [Alignment; 2], theme: &Theme) -> Row<'a>
 
 #[cfg(test)]
 mod tests {
+    use ratatui::{Terminal, backend::TestBackend};
+
     use super::*;
-    use crate::payload::{EntriesData, Entry, Payload, Status};
+    use crate::payload::{EntriesData, Entry, Payload, Status, TextData};
     use crate::render::test_utils::{line_text, render_to_buffer, render_to_buffer_with_spec};
     use crate::render::{Registry, RenderSpec};
 
@@ -236,5 +238,52 @@ mod tests {
         assert!(row.contains("stars: 1.2k"), "row: {row:?}");
         assert!(row.contains("license: MIT"), "row: {row:?}");
         assert!(row.contains('·'), "separator missing: {row:?}");
+    }
+
+    #[test]
+    fn inline_layout_honours_right_alignment() {
+        let registry = Registry::with_builtins();
+        #[derive(serde::Deserialize)]
+        struct W {
+            render: RenderSpec,
+        }
+        let w: W = toml::from_str(
+            r#"render = { type = "grid_table", layout = "inline", align = "right" }"#,
+        )
+        .unwrap();
+        let p = payload(vec![Entry {
+            key: "stars".into(),
+            value: Some("1.2k".into()),
+            status: None,
+        }]);
+        let buf = render_to_buffer_with_spec(&p, Some(&w.render), &registry, 60, 1);
+        let row = line_text(&buf, 0);
+        // Right-aligned: content sits flush against the right edge, leaving leading padding.
+        assert!(row.starts_with(' '), "expected leading padding: {row:?}");
+        assert!(row.ends_with("stars: 1.2k"), "row: {row:?}");
+    }
+
+    #[test]
+    fn render_ignores_a_non_entries_body() {
+        // The runtime guards shape mismatches upstream, but the renderer must also no-op
+        // gracefully (not panic) if a non-`Entries` body reaches it directly.
+        let mut terminal = Terminal::new(TestBackend::new(20, 3)).unwrap();
+        let theme = Theme::default();
+        let registry = Registry::with_builtins();
+        let opts = RenderOptions::default();
+        let body = Body::Text(TextData {
+            value: "ignored".into(),
+        });
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                GridTableRenderer.render(f, area, &body, &opts, &theme, &registry);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert!(
+            line_text(&buf, 0).trim().is_empty(),
+            "non-entries body should draw nothing",
+        );
     }
 }

--- a/src/render/list_cards.rs
+++ b/src/render/list_cards.rs
@@ -568,4 +568,89 @@ mod tests {
         let row0 = row_text(&buf, 0);
         assert_eq!(row0.find('a'), Some(6));
     }
+
+    #[test]
+    fn natural_height_returns_one_for_non_image_linked_body() {
+        // A renderer is only ever dispatched its accepted shape, but `natural_height` keeps a
+        // defensive fallback for a mismatched body — exercise that arm directly.
+        let registry = Registry::with_builtins();
+        let renderer = ListCardsRenderer;
+        let body = Body::Text(crate::payload::TextData {
+            value: "not a card list".into(),
+        });
+        assert_eq!(
+            renderer.natural_height(&body, &RenderOptions::default(), 40, &registry),
+            1,
+        );
+    }
+
+    #[test]
+    fn render_cards_ignores_zero_sized_area() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let data = ImageLinkedListData {
+            items: vec![item("dropped", None, None)],
+        };
+        let opts = RenderOptions::default();
+        let theme = Theme::default();
+        let mut terminal = Terminal::new(TestBackend::new(10, 3)).unwrap();
+        terminal
+            .draw(|f| {
+                // Zero width and zero height must both no-op before any cell write.
+                render_cards(
+                    f,
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: 0,
+                        height: 3,
+                    },
+                    &data,
+                    &opts,
+                    &theme,
+                );
+                render_cards(
+                    f,
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: 10,
+                        height: 0,
+                    },
+                    &data,
+                    &opts,
+                    &theme,
+                );
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        assert!((0..3).all(|y| row_text(buf, y).trim().is_empty()));
+    }
+
+    #[test]
+    fn card_with_thumbnail_path_runs_thumbnail_draw_path() {
+        let registry = Registry::with_builtins();
+        let spec = RenderSpec::Short("list_cards".into());
+        let card = ImageLinkedItem {
+            title: "with thumb".into(),
+            url: None,
+            thumbnail_path: Some("/nonexistent/splashboard-test-thumb.png".into()),
+            subtitle: None,
+        };
+        // A non-empty `thumbnail_path` drives `draw_card` into `draw_thumbnail`; the missing
+        // file makes the image load fail and the error is swallowed, so the render still
+        // completes and the title column stays populated.
+        let buf = render_to_buffer_with_spec(&payload(vec![card]), Some(&spec), &registry, 40, 3);
+        assert!(row_text(&buf, 0).contains("with thumb"));
+    }
+
+    #[test]
+    fn draw_text_skips_zero_dimensions() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 3));
+        let card = item("title", None, Some("subtitle"));
+        let theme = Theme::default();
+        draw_text(&mut buf, 0, 0, 0, 3, &card, &theme);
+        draw_text(&mut buf, 0, 0, 10, 0, &card, &theme);
+        assert!((0..3).all(|y| row_text(&buf, y).trim().is_empty()));
+    }
 }

--- a/src/render/list_links.rs
+++ b/src/render/list_links.rs
@@ -407,4 +407,77 @@ mod tests {
         });
         assert!(!osc8_suppressed());
     }
+
+    #[test]
+    fn render_links_short_circuits_on_zero_dimension_area() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let data = LinkedTextBlockData {
+            items: vec![line("alpha", Some("https://example.com"))],
+        };
+        let opts = RenderOptions::default();
+        let theme = Theme::default();
+        let mut terminal = Terminal::new(TestBackend::new(10, 2)).unwrap();
+        terminal
+            .draw(|f| {
+                // A zero-width and a zero-height area both hit the early return —
+                // neither writes a cell.
+                render_links(&mut *f, Rect::new(0, 0, 0, 2), &data, &opts, &theme);
+                render_links(&mut *f, Rect::new(0, 0, 10, 0), &data, &opts, &theme);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert!(cells_concat(&buf, 0).trim().is_empty());
+    }
+
+    #[test]
+    fn write_row_is_a_no_op_when_nothing_is_drawn() {
+        // `max_width = 0` makes `set_stringn` draw zero cells, so `drawn == 0`.
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+        write_row(
+            &mut buf,
+            0,
+            0,
+            0,
+            &line("hello", Some("https://example.com")),
+            Style::default(),
+        );
+        assert!(cells_concat(&buf, 0).trim().is_empty());
+    }
+
+    #[test]
+    fn write_row_skips_osc8_wrap_under_suppression() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        without_osc8(|| {
+            write_row(
+                &mut buf,
+                0,
+                0,
+                20,
+                &line("hello", Some("https://example.com")),
+                Style::default(),
+            );
+        });
+        let row = cells_concat(&buf, 0);
+        assert!(row.contains("hello"), "plain text still renders: {row:?}");
+        assert!(
+            !row.contains("\x1b]8;;"),
+            "OSC 8 wrap must be suppressed: {row:?}",
+        );
+    }
+
+    #[test]
+    fn wrap_osc8_is_a_no_op_under_suppression() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        buf.set_string(0, 0, "hello", Style::default());
+        without_osc8(|| {
+            wrap_osc8(&mut buf, 0, 0, 5, "https://example.com", Style::default());
+        });
+        let row = cells_concat(&buf, 0);
+        assert!(
+            !row.contains("\x1b]8;;"),
+            "wrap_osc8 must skip wrapping under suppression: {row:?}",
+        );
+        assert!(row.contains("hello"));
+    }
 }

--- a/src/render/list_ranking.rs
+++ b/src/render/list_ranking.rs
@@ -497,4 +497,39 @@ mod tests {
         assert_eq!(display_width("🥇"), 2);
         assert_eq!(display_width("10."), 3);
     }
+
+    #[test]
+    fn fit_label_covers_pad_truncate_and_zero_width_branches() {
+        // Zero width collapses to empty regardless of the label.
+        assert_eq!(fit_label("anything", 0), "");
+        // A label that fits is right-padded with spaces to the column width.
+        assert_eq!(fit_label("ab", 5), "ab   ");
+        // Width 1 has no room for content beside the ellipsis, so it is the ellipsis alone.
+        assert_eq!(fit_label("hello", 1), "…");
+        // A longer label keeps `width - 1` chars and appends a single ellipsis.
+        assert_eq!(fit_label("hello", 3), "he…");
+    }
+
+    #[test]
+    fn pad_left_prepends_spaces_only_when_shorter_than_width() {
+        assert_eq!(pad_left("9", 4), "   9");
+        // Already at or past the width is returned unchanged.
+        assert_eq!(pad_left("142", 3), "142");
+        assert_eq!(pad_left("longer", 2), "longer");
+    }
+
+    #[test]
+    fn align_rect_offsets_for_center_and_right_and_passes_through_otherwise() {
+        let area = Rect::new(2, 1, 20, 3);
+        // Center places the block in the middle of the spare width.
+        assert_eq!(align_rect(area, 10, Some("center")).x, 2 + 5);
+        // Right pushes it flush against the trailing edge.
+        let right = align_rect(area, 10, Some("right"));
+        assert_eq!(right.x, 2 + 10);
+        assert_eq!(right.width, 10);
+        // No align hint, zero content, or content wider than the area all return the area as-is.
+        assert_eq!(align_rect(area, 10, None), area);
+        assert_eq!(align_rect(area, 0, Some("center")), area);
+        assert_eq!(align_rect(area, 99, Some("right")), area);
+    }
 }

--- a/src/render/media_image.rs
+++ b/src/render/media_image.rs
@@ -368,6 +368,52 @@ mod tests {
     }
 
     #[test]
+    fn draw_thumbnail_skips_zero_sized_area() {
+        // Defence-in-depth guard: a zero-width or zero-height cell returns `Ok` before any
+        // image load, so a degenerate layout slot can't surface a spurious `[image: …]` error.
+        // Only reachable by calling `draw_thumbnail` directly — the public render path never
+        // hands a renderer a zero-sized area.
+        let backend = TestBackend::new(8, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let zero_width = Rect {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 4,
+                };
+                let zero_height = Rect {
+                    x: 0,
+                    y: 0,
+                    width: 8,
+                    height: 0,
+                };
+                assert!(
+                    draw_thumbnail(
+                        frame,
+                        zero_width,
+                        "/does/not/exist.png",
+                        None,
+                        &Theme::default(),
+                    )
+                    .is_ok()
+                );
+                assert!(
+                    draw_thumbnail(
+                        frame,
+                        zero_height,
+                        "/does/not/exist.png",
+                        Some("cover"),
+                        &Theme::default(),
+                    )
+                    .is_ok()
+                );
+            })
+            .unwrap();
+    }
+
+    #[test]
     fn padding_shrinks_area_uniformly() {
         let area = Rect {
             x: 0,

--- a/src/render/text_ascii.rs
+++ b/src/render/text_ascii.rs
@@ -518,4 +518,45 @@ mod tests {
             8
         );
     }
+
+    #[test]
+    fn figlet_wrapped_returns_raw_input_when_font_cannot_render_it() {
+        // figlet_rs `convert` yields `None` for an empty string and for input whose every
+        // character is absent from the font (e.g. C0 control codes). `figlet_wrapped` then
+        // falls back to the raw input rather than emitting a silently-empty cell.
+        assert_eq!(figlet_wrapped("", None, 200, 200), "");
+        assert_eq!(figlet_wrapped("\u{1}\u{2}", None, 200, 200), "\u{1}\u{2}");
+    }
+
+    #[test]
+    fn blocks_width_and_pixel_name_fall_back_for_unrecognised_pixel_size() {
+        // `blocks_width` only special-cases the three sizes `parse_pixel_size` can produce;
+        // any other `tui-big-text` variant takes the conservative 4-cols-per-glyph fallback.
+        assert_eq!(blocks_width("hi", PixelSize::HalfHeight), 8);
+        assert_eq!(pixel_name(PixelSize::HalfHeight), "other");
+    }
+
+    #[test]
+    fn render_draws_nothing_for_a_non_text_body() {
+        // The renderer accepts `Text` only; `render_payload` already gates shape mismatches,
+        // but the `if let Body::Text` guard inside `render` is the defence-in-depth that must
+        // neither panic nor draw if it is ever handed another body directly.
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut terminal = Terminal::new(TestBackend::new(20, 4)).unwrap();
+        let body = Body::TextBlock(TextBlockData {
+            lines: vec!["ignored".into()],
+        });
+        let registry = Registry::with_builtins();
+        let theme = Theme::default();
+        let opts = RenderOptions::default();
+        terminal
+            .draw(|f| TextAsciiRenderer.render(f, f.area(), &body, &opts, &theme, &registry))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        assert!(
+            (0..buf.area.width).all(|x| buf.cell((x, 0)).unwrap().symbol() == " "),
+            "a non-text body must leave the cell blank",
+        );
+    }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2929,6 +2929,54 @@ mod tests {
     }
 
     #[test]
+    fn cache_keys_for_returns_empty_when_no_cached_widgets() {
+        let registry = Registry::with_builtins();
+        // `clock` is a realtime fetcher and `mystery_fetcher` is unregistered, so neither
+        // resolves through `get_cached` — `cache_keys_for` filters both out.
+        let widgets = vec![
+            widget("realtime", "clock"),
+            widget("unknown", "mystery_fetcher"),
+        ];
+        let keys = cache_keys_for(&widgets, &registry, &General::default(), &HashMap::new());
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn cache_keys_for_derives_one_distinct_key_per_cached_widget() {
+        let registry = Registry::with_builtins();
+        // Two cached `basic_static` widgets with different params, plus a realtime widget
+        // that must not contribute a key.
+        let widgets = vec![
+            static_widget("first", "one"),
+            static_widget("second", "two"),
+            widget("clock", "clock"),
+        ];
+        let keys = cache_keys_for(&widgets, &registry, &General::default(), &HashMap::new());
+        assert_eq!(keys.len(), 2, "realtime widget must be excluded");
+        assert_ne!(
+            keys[0], keys[1],
+            "differing params must yield distinct cache keys"
+        );
+    }
+
+    #[test]
+    fn cache_keys_for_matches_the_key_load_entries_reads() {
+        let registry = Registry::with_builtins();
+        let widgets = vec![static_widget("greeting", "Hello!")];
+        let keys = cache_keys_for(&widgets, &registry, &General::default(), &HashMap::new());
+        let expected = registry
+            .get_cached("basic_static")
+            .unwrap()
+            .cache_key(&fetch_context(
+                &widgets[0],
+                &General::default(),
+                None,
+                Duration::from_secs(0),
+            ));
+        assert_eq!(keys, vec![expected]);
+    }
+
+    #[test]
     fn render_specs_collect_only_widgets_with_explicit_renderers() {
         let widgets = vec![
             widget_with_render("plain", "clock", None),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1874,6 +1874,21 @@ mod tests {
     }
 
     #[test]
+    fn finalize_splash_shows_the_cursor_for_the_shell() {
+        // ratatui hides the cursor while drawing; `finalize_splash` must hand it back visible
+        // so the shell prompt printed after the splash gets one. `TestBackend` tracks cursor
+        // visibility in its `Debug` output, so an explicit hide followed by `finalize_splash`
+        // proves the show-cursor call is the thing that flips it back.
+        let backend = TestBackend::new(20, 3);
+        let mut terminal = make_terminal(backend, 3).unwrap();
+        terminal.hide_cursor().unwrap();
+        assert!(format!("{:?}", terminal.backend()).contains("cursor: false"));
+
+        finalize_splash(&mut terminal);
+        assert!(format!("{:?}", terminal.backend()).contains("cursor: true"));
+    }
+
+    #[test]
     fn copy_rows_copies_vertical_slice() {
         let mut src = Buffer::empty(Rect::new(0, 0, 4, 4));
         src.set_string(0, 0, "AAAA", Style::default());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1697,6 +1697,68 @@ mod tests {
     }
 
     #[test]
+    fn next_refresh_secs_is_none_for_a_realtime_only_dashboard() {
+        assert_eq!(next_refresh_secs(&HashMap::new()), None);
+    }
+
+    #[test]
+    fn next_refresh_secs_saturates_to_zero_for_a_long_stale_entry() {
+        let mut entries = HashMap::new();
+        entries.insert(
+            "a".into(),
+            CacheEntry {
+                refreshed_at: 0,
+                ttl_seconds: 60,
+                kind: CacheEntryKind::Ok,
+                payload: text_payload("x"),
+            },
+        );
+        assert_eq!(next_refresh_secs(&entries), Some(0));
+    }
+
+    #[test]
+    fn next_refresh_secs_reports_remaining_ttl_for_a_fresh_entry() {
+        let mut entries = HashMap::new();
+        entries.insert("a".into(), CacheEntry::new(text_payload("x"), 600));
+        let remaining = next_refresh_secs(&entries).expect("fresh entry has a countdown");
+        assert!(
+            (595..=600).contains(&remaining),
+            "expected ~600s remaining, got {remaining}"
+        );
+    }
+
+    #[test]
+    fn next_refresh_secs_takes_the_soonest_across_entries() {
+        let mut entries = HashMap::new();
+        entries.insert(
+            "stale".into(),
+            CacheEntry {
+                refreshed_at: 0,
+                ttl_seconds: 60,
+                kind: CacheEntryKind::Ok,
+                payload: text_payload("x"),
+            },
+        );
+        entries.insert("fresh".into(), CacheEntry::new(text_payload("y"), 600));
+        assert_eq!(
+            next_refresh_secs(&entries),
+            Some(0),
+            "min wins: the stale entry is due before the fresh one"
+        );
+    }
+
+    #[test]
+    fn fmt_duration_compact_picks_a_unit_per_magnitude() {
+        assert_eq!(fmt_duration_compact(0), "0s");
+        assert_eq!(fmt_duration_compact(45), "45s");
+        assert_eq!(fmt_duration_compact(59), "59s");
+        assert_eq!(fmt_duration_compact(60), "1m");
+        assert_eq!(fmt_duration_compact(3599), "59m");
+        assert_eq!(fmt_duration_compact(3600), "1h");
+        assert_eq!(fmt_duration_compact(7200), "2h");
+    }
+
+    #[test]
     fn draw_frame_hint_lands_on_bottom_row_when_clipping() {
         let root = single_widget_tree("x");
         let mut payloads = HashMap::new();

--- a/xtask/src/html_snapshot.rs
+++ b/xtask/src/html_snapshot.rs
@@ -537,4 +537,24 @@ mod tests {
         assert_eq!(color_hex(Color::Indexed(9)), "currentColor");
         assert_eq!(color_hex(Color::Reset), "currentColor");
     }
+
+    #[test]
+    fn color_hex_maps_every_ansi16_named_color() {
+        assert_eq!(color_hex(Color::Black), "#000000");
+        assert_eq!(color_hex(Color::Red), "#aa0000");
+        assert_eq!(color_hex(Color::Green), "#00aa00");
+        assert_eq!(color_hex(Color::Yellow), "#aa5500");
+        assert_eq!(color_hex(Color::Blue), "#0000aa");
+        assert_eq!(color_hex(Color::Magenta), "#aa00aa");
+        assert_eq!(color_hex(Color::Cyan), "#00aaaa");
+        assert_eq!(color_hex(Color::Gray), "#aaaaaa");
+        assert_eq!(color_hex(Color::DarkGray), "#555555");
+        assert_eq!(color_hex(Color::LightRed), "#ff5555");
+        assert_eq!(color_hex(Color::LightGreen), "#55ff55");
+        assert_eq!(color_hex(Color::LightYellow), "#ffff55");
+        assert_eq!(color_hex(Color::LightBlue), "#5555ff");
+        assert_eq!(color_hex(Color::LightMagenta), "#ff55ff");
+        assert_eq!(color_hex(Color::LightCyan), "#55ffff");
+        assert_eq!(color_hex(Color::White), "#ffffff");
+    }
 }

--- a/xtask/src/preset_index.rs
+++ b/xtask/src/preset_index.rs
@@ -55,17 +55,21 @@ pub fn run(out_dir: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn run_writes_an_entry_for_every_template() {
+    fn unique_temp_dir(tag: &str) -> std::path::PathBuf {
         use std::time::{SystemTime, UNIX_EPOCH};
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let dir = std::env::temp_dir().join(format!(
-            "splashboard-preset-index-{unique}-{}",
+        std::env::temp_dir().join(format!(
+            "splashboard-preset-index-{tag}-{unique}-{}",
             std::process::id()
-        ));
+        ))
+    }
+
+    #[test]
+    fn run_writes_an_entry_for_every_template() {
+        let dir = unique_temp_dir("write");
 
         run(&dir).unwrap();
         let body = fs::read_to_string(dir.join("_presets.json")).unwrap();
@@ -76,6 +80,36 @@ mod tests {
             assert_eq!(entry["slug"], template.name);
             assert_eq!(entry["description"], template.description);
         }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_surfaces_create_dir_failure() {
+        // A regular file where a directory component is expected — `create_dir_all` on a
+        // child path fails, and `run` should surface it with the `create` context.
+        let blocker = unique_temp_dir("create-fail");
+        fs::write(&blocker, "not a directory").unwrap();
+
+        let err = run(&blocker.join("child")).unwrap_err();
+        assert!(
+            err.to_string().contains("create"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_file(&blocker);
+    }
+
+    #[test]
+    fn run_surfaces_write_failure() {
+        // Pre-create the index path as a directory so `fs::write` cannot replace it — `run`
+        // should surface the failure with the `write` context.
+        let dir = unique_temp_dir("write-fail");
+        fs::create_dir_all(&dir).unwrap();
+        fs::create_dir(dir.join("_presets.json")).unwrap();
+
+        let err = run(&dir).unwrap_err();
+        assert!(err.to_string().contains("write"), "unexpected error: {err}");
+
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/xtask/src/snapshots.rs
+++ b/xtask/src/snapshots.rs
@@ -309,7 +309,7 @@ mod tests {
         [
             (Shape::Text, "clock"),
             (Shape::TextBlock, "git_recent_commits"),
-            (Shape::MarkdownTextBlock, "basic_static"),
+            (Shape::MarkdownTextBlock, "basic_links"),
             (Shape::LinkedTextBlock, "rss"),
             (Shape::Entries, "system_monitor_host"),
             (Shape::Ratio, "clock_ratio"),

--- a/xtask/src/themes.rs
+++ b/xtask/src/themes.rs
@@ -150,6 +150,14 @@ mod tests {
     }
 
     #[test]
+    fn pretty_name_keeps_empty_underscore_segments_as_blank_words() {
+        // A leading / trailing `_` yields an empty `split('_')` segment whose `chars().next()`
+        // is `None`, exercising the `None => String::new()` arm rather than the capitalize path.
+        assert_eq!(pretty_name("foo_"), "Foo ");
+        assert_eq!(pretty_name("_bar"), " Bar");
+    }
+
+    #[test]
     fn ordered_slugs_lists_default_first_then_remaining_known_themes() {
         let order = ordered_slugs();
         assert_eq!(order[0], "default");
@@ -172,5 +180,95 @@ mod tests {
         for slug in presets::KNOWN {
             let _ = theme_for(slug);
         }
+    }
+
+    #[test]
+    fn theme_for_falls_back_to_default_for_unknown_slug() {
+        // `presets::by_name` misses → `unwrap_or_default()` materialises the default theme
+        // rather than panicking, so a stale slug in the gallery still renders something.
+        let _ = theme_for("not-a-real-theme");
+    }
+
+    fn unique_temp_dir(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "splashboard-themes-{tag}-{unique}-{}",
+            std::process::id()
+        ))
+    }
+
+    /// A minimal one-widget dashboard written to a temp file — enough for
+    /// `render_config_html_with_theme` to parse, lay out, and snapshot without network or disk
+    /// fetchers. Returns the path so the caller can pass it to `render_one` as the demo config.
+    fn write_demo_dashboard(tag: &str) -> std::path::PathBuf {
+        let path = unique_temp_dir(tag).with_extension("toml");
+        fs::write(
+            &path,
+            r#"
+[[widget]]
+id = "hello"
+fetcher = "basic_static"
+format = "Hi"
+render = "list_plain"
+
+[[row]]
+height = { length = 1 }
+  [[row.child]]
+  widget = "hello"
+"#,
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn render_one_writes_theme_html_and_returns_entry() {
+        let demo = write_demo_dashboard("render-ok");
+        let out_dir = unique_temp_dir("render-ok-out");
+        fs::create_dir_all(&out_dir).unwrap();
+
+        let entry = render_one("nord", &demo, &out_dir, 20, 6).unwrap();
+        assert_eq!(entry.slug, "nord");
+        assert_eq!(entry.name, "Nord");
+        assert!(matches!(entry.kind, ThemeKind::Dark));
+
+        let html = fs::read_to_string(out_dir.join("nord.html")).unwrap();
+        assert!(html.starts_with("<pre"), "unexpected html: {html}");
+
+        let _ = fs::remove_file(&demo);
+        let _ = fs::remove_dir_all(&out_dir);
+    }
+
+    #[test]
+    fn render_one_surfaces_render_failure_from_missing_demo_config() {
+        // A demo path that doesn't exist makes `render_config_html_with_theme`'s `read_to_string`
+        // fail; `render_one` should propagate that error rather than writing a stray html file.
+        let missing = unique_temp_dir("render-missing").with_extension("toml");
+        let out_dir = unique_temp_dir("render-missing-out");
+        fs::create_dir_all(&out_dir).unwrap();
+
+        let err = render_one("nord", &missing, &out_dir, 20, 6).unwrap_err();
+        assert!(err.to_string().contains("read"), "unexpected error: {err}");
+
+        let _ = fs::remove_dir_all(&out_dir);
+    }
+
+    #[test]
+    fn render_one_surfaces_write_failure_when_output_path_is_a_directory() {
+        // Pre-create `nord.html` as a directory so `fs::write` cannot replace it — `render_one`
+        // should surface the failure with its `write` context after a successful render.
+        let demo = write_demo_dashboard("render-write-fail");
+        let out_dir = unique_temp_dir("render-write-fail-out");
+        fs::create_dir_all(out_dir.join("nord.html")).unwrap();
+
+        let err = render_one("nord", &demo, &out_dir, 20, 6).unwrap_err();
+        assert!(err.to_string().contains("write"), "unexpected error: {err}");
+
+        let _ = fs::remove_file(&demo);
+        let _ = fs::remove_dir_all(&out_dir);
     }
 }


### PR DESCRIPTION
Autonomous coverage-improvement loop. Each iteration measures baseline line coverage with `cargo llvm-cov`, picks one under-tested target (low-coverage file, untested branch, or public API), and adds tests only — no production-code changes.

Quality gate: `cargo test`, `cargo clippy`, and `cargo fmt` must all pass before any commit. Coverage only goes up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Extensive test suite expansions** across multiple modules with comprehensive coverage for edge cases, error handling, and core functionality including cache operations, rendering behaviors, shape dispatch, HTTP error scenarios, and configuration validation.
* **New integration test helpers** and local HTTP server utilities to support offline testing of network-dependent features.
* **Added async test coverage** for fetcher and rendering operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->