### PR TITLE
feat(fetcher): claude_* family — claude_code_usage + claude_subscription

### DIFF
--- a/src/fetcher/claude/code_usage.rs
+++ b/src/fetcher/claude/code_usage.rs
@@ -1,0 +1,907 @@
+//! `claude_code_usage` — token + cost rollup from local Claude Code session JSONL files.
+//!
+//! Walks `<root>/projects/<encoded-cwd>/<session-uuid>.jsonl` under every root in
+//! [`crate::fetcher::claude::common::discover_jsonl_dirs`], filters lines to assistant events
+//! since the configured window, deduplicates by `(message.id, request_id)` keeping the row with
+//! the higher token total, then groups by project / model / day depending on `group_by`.
+//!
+//! `Safety::Safe` — every read is rooted at a `$HOME`-relative directory the user owns. No
+//! network, no token, no exec. Pricing is hardcoded in [`super::common`] so a stale price feed
+//! can't disrupt the fetch.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::claude::common::{
+    cost_usd, discover_jsonl_dirs, format_cost, format_tokens, project_name_from_cwd,
+};
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, NumberSeriesData,
+    Payload, Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::NumberSeries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "since",
+        type_hint: "\"today\" | \"7d\" | \"30d\" | \"all\"",
+        required: false,
+        default: Some("\"today\""),
+        description: "Window the rollup covers, anchored on the current UTC day.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum rows surfaced by multi-row shapes (`Bars`, `Entries`, …).",
+    },
+    OptionSchema {
+        name: "group_by",
+        type_hint: "\"project\" | \"model\" | \"day\"",
+        required: false,
+        default: Some("\"project\""),
+        description: "Axis used by `Bars` / `Entries` / `TextBlock` row shapes.",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MAX_LIMIT: u32 = 50;
+
+pub struct ClaudeCodeUsage;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub since: Option<String>,
+    pub limit: Option<u32>,
+    pub group_by: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for ClaudeCodeUsage {
+    fn name(&self) -> &str {
+        "claude_code_usage"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Token and cost rollup from local Claude Code session JSONL files. Aggregates assistant turns under the chosen `since` window and groups them by project, model, or day. Pricing is bundled, so the splash works offline."
+    }
+    fn refresh_interval(&self) -> u64 {
+        // The JSONL files only grow when the user is actively running Claude Code; a 5-minute
+        // refresh is fast enough to mirror "what I just spent" without re-walking MBs every cd.
+        5 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let since = parse_since(opts.since.as_deref())?;
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as usize;
+        let group_by = parse_group_by(opts.group_by.as_deref())?;
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+
+        let snapshot = build_snapshot(&since, group_by, limit);
+        Ok(payload(render_body(&snapshot, shape)))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Since {
+    Today,
+    Days(i64),
+    All,
+}
+
+impl Since {
+    fn label(&self) -> &'static str {
+        match self {
+            Since::Today => "Today",
+            Since::Days(7) => "7d",
+            Since::Days(30) => "30d",
+            Since::Days(_) => "window",
+            Since::All => "All-time",
+        }
+    }
+    fn includes(&self, ts: DateTime<Utc>) -> bool {
+        match self {
+            Since::All => true,
+            Since::Today => ts.date_naive() == Utc::now().date_naive(),
+            Since::Days(n) => Utc::now() - Duration::days(*n) <= ts,
+        }
+    }
+}
+
+fn parse_since(raw: Option<&str>) -> Result<Since, FetchError> {
+    match raw.unwrap_or("today").trim().to_lowercase().as_str() {
+        "today" => Ok(Since::Today),
+        "7d" => Ok(Since::Days(7)),
+        "30d" => Ok(Since::Days(30)),
+        "all" => Ok(Since::All),
+        other => Err(FetchError::Failed(format!(
+            "invalid since: {other:?} (expected today | 7d | 30d | all)"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GroupBy {
+    Project,
+    Model,
+    Day,
+}
+
+fn parse_group_by(raw: Option<&str>) -> Result<GroupBy, FetchError> {
+    match raw.unwrap_or("project").trim().to_lowercase().as_str() {
+        "project" => Ok(GroupBy::Project),
+        "model" => Ok(GroupBy::Model),
+        "day" => Ok(GroupBy::Day),
+        other => Err(FetchError::Failed(format!(
+            "invalid group_by: {other:?} (expected project | model | day)"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct Snapshot {
+    rows: Vec<UsageRow>,
+    total_cost: f64,
+    total_tokens: u64,
+    daily_tokens: Vec<u64>,
+    since_label: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct UsageRow {
+    label: String,
+    tokens: u64,
+    cost: f64,
+}
+
+#[derive(Debug, Clone)]
+struct UsageEvent {
+    timestamp: DateTime<Utc>,
+    model: String,
+    project: String,
+    message_id: String,
+    request_id: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_write_5m: u64,
+    cache_write_1h: u64,
+    cache_read: u64,
+}
+
+impl UsageEvent {
+    fn token_total(&self) -> u64 {
+        self.input_tokens
+            + self.output_tokens
+            + self.cache_write_5m
+            + self.cache_write_1h
+            + self.cache_read
+    }
+    fn cost(&self) -> f64 {
+        cost_usd(
+            &self.model,
+            self.input_tokens,
+            self.output_tokens,
+            self.cache_write_5m,
+            self.cache_write_1h,
+            self.cache_read,
+        )
+    }
+}
+
+fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize) -> Snapshot {
+    let events = dedup(collect_events(&discover_jsonl_dirs(), since));
+    let total_tokens = events.iter().map(UsageEvent::token_total).sum();
+    let total_cost = events.iter().map(UsageEvent::cost).sum();
+    let rows = group_rows(&events, group_by, limit);
+    let daily_tokens = daily_series(&events, since);
+    Snapshot {
+        rows,
+        total_cost,
+        total_tokens,
+        daily_tokens,
+        since_label: since.label(),
+    }
+}
+
+fn collect_events(roots: &[PathBuf], since: &Since) -> Vec<UsageEvent> {
+    roots.iter().flat_map(|r| walk_jsonl(r, since)).collect()
+}
+
+fn walk_jsonl(root: &PathBuf, since: &Since) -> Vec<UsageEvent> {
+    let Ok(projects) = fs::read_dir(root) else {
+        return Vec::new();
+    };
+    projects
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .flat_map(|dir| read_sessions(&dir.path(), since))
+        .collect()
+}
+
+fn read_sessions(dir: &PathBuf, since: &Since) -> Vec<UsageEvent> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "jsonl"))
+        .flat_map(|e| read_session_file(&e.path(), since))
+        .collect()
+}
+
+fn read_session_file(path: &PathBuf, since: &Since) -> Vec<UsageEvent> {
+    let Ok(file) = fs::File::open(path) else {
+        return Vec::new();
+    };
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| line.contains("\"type\":\"assistant\""))
+        .filter_map(|line| parse_event(&line))
+        .filter(|e| since.includes(e.timestamp))
+        .collect()
+}
+
+#[derive(Deserialize)]
+struct RawEvent {
+    #[serde(rename = "type", default)]
+    kind: String,
+    #[serde(default)]
+    timestamp: String,
+    #[serde(default)]
+    cwd: String,
+    #[serde(rename = "requestId", default)]
+    request_id: String,
+    #[serde(default)]
+    message: Option<RawMessage>,
+}
+
+#[derive(Deserialize)]
+struct RawMessage {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    model: String,
+    #[serde(default)]
+    usage: Option<RawUsage>,
+}
+
+#[derive(Deserialize)]
+struct RawUsage {
+    #[serde(default)]
+    input_tokens: u64,
+    #[serde(default)]
+    output_tokens: u64,
+    #[serde(default)]
+    cache_creation_input_tokens: u64,
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+    #[serde(default)]
+    cache_creation: Option<RawCacheCreation>,
+}
+
+#[derive(Deserialize)]
+struct RawCacheCreation {
+    #[serde(default)]
+    ephemeral_5m_input_tokens: u64,
+    #[serde(default)]
+    ephemeral_1h_input_tokens: u64,
+}
+
+fn parse_event(line: &str) -> Option<UsageEvent> {
+    let raw: RawEvent = serde_json::from_str(line).ok()?;
+    if raw.kind != "assistant" {
+        return None;
+    }
+    let message = raw.message?;
+    let usage = message.usage?;
+    let timestamp = DateTime::parse_from_rfc3339(&raw.timestamp)
+        .ok()?
+        .with_timezone(&Utc);
+    let (cache_write_5m, cache_write_1h) = match usage.cache_creation {
+        Some(c) => (c.ephemeral_5m_input_tokens, c.ephemeral_1h_input_tokens),
+        // Older JSONL sessions only carry the rollup count; treat it all as 5m write tier.
+        None => (usage.cache_creation_input_tokens, 0),
+    };
+    Some(UsageEvent {
+        timestamp,
+        model: message.model,
+        project: project_name_from_cwd(&raw.cwd),
+        message_id: message.id,
+        request_id: raw.request_id,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_write_5m,
+        cache_write_1h,
+        cache_read: usage.cache_read_input_tokens,
+    })
+}
+
+fn dedup(events: Vec<UsageEvent>) -> Vec<UsageEvent> {
+    let mut by_key: HashMap<(String, String), UsageEvent> = HashMap::new();
+    for e in events {
+        let key = (e.message_id.clone(), e.request_id.clone());
+        // ccusage gotcha: a `(message.id, requestId)` can repeat across files when a session
+        // resumes. Keep the row with the higher total — that's the canonical final usage.
+        by_key
+            .entry(key)
+            .and_modify(|prev| {
+                if e.token_total() > prev.token_total() {
+                    *prev = e.clone();
+                }
+            })
+            .or_insert(e);
+    }
+    by_key.into_values().collect()
+}
+
+fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<UsageRow> {
+    let mut by_key: HashMap<String, (u64, f64)> = HashMap::new();
+    for e in events {
+        let key = match group_by {
+            GroupBy::Project => e.project.clone(),
+            GroupBy::Model => short_model_name(&e.model),
+            GroupBy::Day => e.timestamp.date_naive().to_string(),
+        };
+        let entry = by_key.entry(key).or_insert((0, 0.0));
+        entry.0 += e.token_total();
+        entry.1 += e.cost();
+    }
+    let mut rows: Vec<UsageRow> = by_key
+        .into_iter()
+        .map(|(label, (tokens, cost))| UsageRow {
+            label,
+            tokens,
+            cost,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.cost
+            .partial_cmp(&a.cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.tokens.cmp(&a.tokens))
+    });
+    rows.truncate(limit);
+    rows
+}
+
+/// `claude-opus-4-7-20250929` → `opus-4-7`. Drops the family prefix and any trailing date so the
+/// `model` group key reads as a model family rather than a release id.
+fn short_model_name(model: &str) -> String {
+    let lower = model.to_lowercase();
+    let stripped = lower.strip_prefix("claude-").unwrap_or(&lower);
+    stripped
+        .rsplit_once('-')
+        .map(|(head, tail)| {
+            if tail.chars().all(|c| c.is_ascii_digit()) && tail.len() >= 6 {
+                head.to_string()
+            } else {
+                stripped.to_string()
+            }
+        })
+        .unwrap_or_else(|| stripped.to_string())
+}
+
+fn daily_series(events: &[UsageEvent], since: &Since) -> Vec<u64> {
+    let span_days = match since {
+        Since::Today => 1,
+        Since::Days(n) => *n as usize,
+        Since::All => 30,
+    };
+    let mut buckets: HashMap<NaiveDate, u64> = HashMap::new();
+    for e in events {
+        *buckets.entry(e.timestamp.date_naive()).or_default() += e.token_total();
+    }
+    let today = Utc::now().date_naive();
+    (0..span_days)
+        .rev()
+        .map(|i| {
+            let day = today - Duration::days(i as i64);
+            buckets.get(&day).copied().unwrap_or(0)
+        })
+        .collect()
+}
+
+fn render_body(snap: &Snapshot, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => text_body(snap),
+        Shape::TextBlock => text_block_body(snap),
+        Shape::MarkdownTextBlock => markdown_body(snap),
+        Shape::Entries => entries_body(snap),
+        Shape::Bars => bars_body(snap),
+        Shape::NumberSeries => number_series_body(snap),
+        Shape::Badge => badge_body(snap),
+        _ => text_body(snap),
+    }
+}
+
+fn text_body(snap: &Snapshot) -> Body {
+    Body::Text(TextData {
+        value: headline(snap),
+    })
+}
+
+fn headline(snap: &Snapshot) -> String {
+    if snap.total_tokens == 0 {
+        format!("{}: no sessions", snap.since_label)
+    } else {
+        format!(
+            "{}: {} tokens / {}",
+            snap.since_label,
+            format_tokens(snap.total_tokens),
+            format_cost(snap.total_cost),
+        )
+    }
+}
+
+fn text_block_body(snap: &Snapshot) -> Body {
+    let mut lines = vec![headline(snap)];
+    lines.extend(snap.rows.iter().map(format_row));
+    if snap.rows.is_empty() && snap.total_tokens > 0 {
+        // Window covers activity but the grouping yielded no rows — likely an obscure axis on a
+        // tiny session. Keep the headline; don't add a misleading "no data" line.
+    } else if snap.rows.is_empty() {
+        lines.push("no recent Claude Code activity".into());
+    }
+    Body::TextBlock(TextBlockData { lines })
+}
+
+fn format_row(row: &UsageRow) -> String {
+    format!(
+        "{}  {} / {}",
+        row.label,
+        format_tokens(row.tokens),
+        format_cost(row.cost),
+    )
+}
+
+fn markdown_body(snap: &Snapshot) -> Body {
+    let mut lines = vec![format!("**{}**", headline(snap))];
+    lines.extend(snap.rows.iter().map(|r| {
+        format!(
+            "- **{}** — {} / {}",
+            r.label,
+            format_tokens(r.tokens),
+            format_cost(r.cost),
+        )
+    }));
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: lines.join("\n"),
+    })
+}
+
+fn entries_body(snap: &Snapshot) -> Body {
+    let items = if snap.rows.is_empty() {
+        vec![Entry {
+            key: snap.since_label.into(),
+            value: Some(headline(snap)),
+            status: None,
+        }]
+    } else {
+        snap.rows
+            .iter()
+            .map(|r| Entry {
+                key: r.label.clone(),
+                value: Some(format!(
+                    "{} / {}",
+                    format_tokens(r.tokens),
+                    format_cost(r.cost)
+                )),
+                status: None,
+            })
+            .collect()
+    };
+    Body::Entries(EntriesData { items })
+}
+
+fn bars_body(snap: &Snapshot) -> Body {
+    // Bars use raw token counts so chart_bar still ranks correctly; the value_label carries the
+    // formatted cost so list_ranking presents money instead of seven-digit token counts.
+    let bars = snap
+        .rows
+        .iter()
+        .map(|r| Bar {
+            label: r.label.clone(),
+            value: r.tokens,
+            value_label: Some(format_cost(r.cost)),
+        })
+        .collect();
+    Body::Bars(BarsData { bars })
+}
+
+fn number_series_body(snap: &Snapshot) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: snap.daily_tokens.clone(),
+    })
+}
+
+fn badge_body(snap: &Snapshot) -> Body {
+    let (status, label) = if snap.total_tokens == 0 {
+        (Status::Warn, format!("{}: quiet", snap.since_label))
+    } else {
+        let tone = if snap.total_cost >= 50.0 {
+            Status::Error
+        } else if snap.total_cost >= 10.0 {
+            Status::Warn
+        } else {
+            Status::Ok
+        };
+        (
+            tone,
+            format!("{} {}", snap.since_label, format_cost(snap.total_cost)),
+        )
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    Some(match shape {
+        Shape::Text => samples::text("Today: 3.4M tokens / $12.34"),
+        Shape::TextBlock => samples::text_block(&[
+            "Today: 3.4M tokens / $12.34",
+            "splashboard  2.1M / $7.20",
+            "playground   1.3M / $5.14",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "**Today: 3.4M tokens / $12.34**\n- **splashboard** — 2.1M / $7.20\n- **playground** — 1.3M / $5.14",
+        ),
+        Shape::Entries => samples::entries(&[
+            ("splashboard", "2.1M / $7.20"),
+            ("playground", "1.3M / $5.14"),
+        ]),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "splashboard".into(),
+                    value: 2_100_000,
+                    value_label: Some("$7.20".into()),
+                },
+                Bar {
+                    label: "playground".into(),
+                    value: 1_300_000,
+                    value_label: Some("$5.14".into()),
+                },
+            ],
+        }),
+        Shape::NumberSeries => {
+            samples::number_series(&[0, 100_000, 250_000, 800_000, 600_000, 2_400_000, 3_400_000])
+        }
+        Shape::Badge => samples::badge(Status::Warn, "Today $12.34"),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::time::Duration as StdDuration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "claude-code".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn parse_since_accepts_known_windows() {
+        assert!(matches!(parse_since(None).unwrap(), Since::Today));
+        assert!(matches!(parse_since(Some("7d")).unwrap(), Since::Days(7)));
+        assert!(matches!(parse_since(Some("30d")).unwrap(), Since::Days(30)));
+        assert!(matches!(parse_since(Some("all")).unwrap(), Since::All));
+    }
+
+    #[test]
+    fn parse_since_rejects_unknown_window() {
+        let err = parse_since(Some("yesterday")).unwrap_err();
+        assert!(format!("{err}").contains("yesterday"));
+    }
+
+    #[test]
+    fn parse_group_by_defaults_to_project() {
+        assert!(matches!(parse_group_by(None).unwrap(), GroupBy::Project));
+    }
+
+    #[test]
+    fn parse_event_extracts_usage_and_cache_split() {
+        let line = r#"{"type":"assistant","timestamp":"2026-05-05T16:15:07.713Z","cwd":"/home/owner/.ghq/github.com/x/y","requestId":"req_1","message":{"id":"msg_1","model":"claude-opus-4-7","usage":{"input_tokens":6,"output_tokens":254,"cache_creation_input_tokens":25094,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":25094}}}}"#;
+        let event = parse_event(line).expect("usage row must parse");
+        assert_eq!(event.project, "y");
+        assert_eq!(event.message_id, "msg_1");
+        assert_eq!(event.input_tokens, 6);
+        assert_eq!(event.output_tokens, 254);
+        assert_eq!(event.cache_write_1h, 25094);
+        assert_eq!(event.cache_write_5m, 0);
+    }
+
+    #[test]
+    fn parse_event_skips_non_assistant_lines() {
+        let line = r#"{"type":"user","message":{"content":"hi"}}"#;
+        assert!(parse_event(line).is_none());
+    }
+
+    #[test]
+    fn parse_event_falls_back_to_rollup_count_when_split_missing() {
+        // Older sessions don't carry the `cache_creation` split — fall back to attributing the
+        // legacy rollup to the 5m tier so the cost math still runs.
+        let line = r#"{"type":"assistant","timestamp":"2026-05-05T00:00:00Z","cwd":"/x","requestId":"r","message":{"id":"m","model":"claude-sonnet-4-6","usage":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":1000,"cache_read_input_tokens":0}}}"#;
+        let event = parse_event(line).unwrap();
+        assert_eq!(event.cache_write_5m, 1000);
+        assert_eq!(event.cache_write_1h, 0);
+    }
+
+    #[test]
+    fn dedup_keeps_higher_token_total_on_collision() {
+        let base = UsageEvent {
+            timestamp: Utc::now(),
+            model: "claude-sonnet-4-6".into(),
+            project: "x".into(),
+            message_id: "m".into(),
+            request_id: "r".into(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_write_5m: 0,
+            cache_write_1h: 0,
+            cache_read: 0,
+        };
+        let small = UsageEvent {
+            input_tokens: 10,
+            ..base.clone()
+        };
+        let large = UsageEvent {
+            input_tokens: 100,
+            ..base.clone()
+        };
+        let kept = dedup(vec![small, large.clone()]);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].input_tokens, 100);
+    }
+
+    #[test]
+    fn group_rows_sorts_by_cost_desc_and_truncates_to_limit() {
+        let make = |project: &str, output: u64| UsageEvent {
+            timestamp: Utc::now(),
+            model: "claude-opus-4-7".into(),
+            project: project.into(),
+            message_id: project.into(),
+            request_id: project.into(),
+            input_tokens: 0,
+            output_tokens: output,
+            cache_write_5m: 0,
+            cache_write_1h: 0,
+            cache_read: 0,
+        };
+        let events = vec![make("a", 1_000), make("b", 5_000), make("c", 100)];
+        let rows = group_rows(&events, GroupBy::Project, 2);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].label, "b");
+        assert_eq!(rows[1].label, "a");
+    }
+
+    #[test]
+    fn short_model_name_strips_family_prefix_and_release_date() {
+        assert_eq!(short_model_name("claude-opus-4-7-20250929"), "opus-4-7");
+        assert_eq!(short_model_name("claude-sonnet-4-6"), "sonnet-4-6");
+        assert_eq!(short_model_name("claude-3-5-sonnet"), "3-5-sonnet");
+    }
+
+    #[test]
+    fn since_today_excludes_yesterday() {
+        let yesterday = Utc::now() - Duration::days(1);
+        assert!(!Since::Today.includes(yesterday));
+        assert!(Since::Today.includes(Utc::now()));
+    }
+
+    #[test]
+    fn since_days_window_includes_recent_and_excludes_old() {
+        let recent = Utc::now() - Duration::days(3);
+        let old = Utc::now() - Duration::days(40);
+        assert!(Since::Days(7).includes(recent));
+        assert!(!Since::Days(7).includes(old));
+        assert!(Since::All.includes(old));
+    }
+
+    #[test]
+    fn daily_series_length_matches_window() {
+        let series = daily_series(&[], &Since::Days(7));
+        assert_eq!(series.len(), 7);
+        assert!(series.iter().all(|&n| n == 0));
+    }
+
+    #[test]
+    fn headline_reports_quiet_window_when_empty() {
+        let snap = Snapshot {
+            since_label: "Today",
+            ..Default::default()
+        };
+        assert_eq!(headline(&snap), "Today: no sessions");
+    }
+
+    #[test]
+    fn badge_warns_on_quiet_window() {
+        let snap = Snapshot {
+            since_label: "Today",
+            ..Default::default()
+        };
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert!(b.label.ends_with("quiet"));
+    }
+
+    #[test]
+    fn badge_promotes_to_error_above_50_usd() {
+        let snap = Snapshot {
+            total_tokens: 1,
+            total_cost: 75.0,
+            since_label: "Today",
+            ..Default::default()
+        };
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Error);
+    }
+
+    #[test]
+    fn bars_body_carries_cost_value_label() {
+        let snap = Snapshot {
+            rows: vec![UsageRow {
+                label: "x".into(),
+                tokens: 1_500_000,
+                cost: 5.0,
+            }],
+            ..Default::default()
+        };
+        let Body::Bars(b) = bars_body(&snap) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars[0].value, 1_500_000);
+        assert_eq!(b.bars[0].value_label.as_deref(), Some("$5.000"));
+    }
+
+    #[test]
+    fn entries_body_falls_back_to_headline_when_no_rows() {
+        let snap = Snapshot {
+            since_label: "7d",
+            ..Default::default()
+        };
+        let Body::Entries(e) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert_eq!(e.items[0].key, "7d");
+    }
+
+    #[test]
+    fn fetcher_metadata_lists_seven_shapes_with_text_default() {
+        let f = ClaudeCodeUsage;
+        assert_eq!(f.shapes(), SHAPES);
+        assert_eq!(f.default_shape(), Shape::Text);
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "sample missing for {s:?}");
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn fetch_reads_jsonl_from_env_override_root() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempdir().unwrap();
+        let projects = tmp.path().join("projects").join("-home-x-y");
+        fs::create_dir_all(&projects).unwrap();
+        let mut file = fs::File::create(projects.join("session.jsonl")).unwrap();
+        let now = Utc::now().to_rfc3339();
+        writeln!(
+            file,
+            r#"{{"type":"assistant","timestamp":"{now}","cwd":"/home/x/y","requestId":"r","message":{{"id":"m","model":"claude-opus-4-7","usage":{{"input_tokens":1000,"output_tokens":2000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}"#
+        )
+        .unwrap();
+        let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path()) };
+
+        let body = ClaudeCodeUsage
+            .fetch(&ctx(Some("since = \"today\""), Some(Shape::Text)))
+            .await
+            .unwrap()
+            .body;
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+        }
+
+        let Body::Text(t) = body else {
+            panic!("expected Text, got {body:?}");
+        };
+        assert!(t.value.contains("Today"));
+        assert!(t.value.contains("3k"), "value was {:?}", t.value);
+    }
+
+    #[test]
+    fn day_grouping_buckets_by_calendar_date() {
+        let day1 = Utc.with_ymd_and_hms(2026, 5, 5, 10, 0, 0).unwrap();
+        let day2 = Utc.with_ymd_and_hms(2026, 5, 6, 10, 0, 0).unwrap();
+        let mk = |ts: DateTime<Utc>, id: &str, out: u64| UsageEvent {
+            timestamp: ts,
+            model: "claude-opus-4-7".into(),
+            project: "x".into(),
+            message_id: id.into(),
+            request_id: id.into(),
+            input_tokens: 0,
+            output_tokens: out,
+            cache_write_5m: 0,
+            cache_write_1h: 0,
+            cache_read: 0,
+        };
+        let events = vec![
+            mk(day1, "a", 1_000),
+            mk(day1, "b", 2_000),
+            mk(day2, "c", 500),
+        ];
+        let rows = group_rows(&events, GroupBy::Day, 10);
+        assert_eq!(rows.len(), 2);
+        // Day 1 contributed 3_000 tokens vs day 2's 500, so it ranks first.
+        assert!(rows[0].label.ends_with("05-05"));
+        assert_eq!(rows[0].tokens, 3_000);
+    }
+
+    use chrono::TimeZone;
+}

--- a/src/fetcher/claude/code_usage.rs
+++ b/src/fetcher/claude/code_usage.rs
@@ -143,7 +143,15 @@ impl Since {
         match self {
             Since::All => true,
             Since::Today => ts.date_naive() == Utc::now().date_naive(),
-            Since::Days(n) => Utc::now() - Duration::days(*n) <= ts,
+            // Calendar-day comparison so this matches `daily_series`'s bucket window exactly
+            // (today .. today-(n-1)). A rolling `now - n days` cutoff would leak partial-day
+            // events into the totals that never show up in the per-day series.
+            Since::Days(n) => {
+                let today = Utc::now().date_naive();
+                let start = today - Duration::days((*n - 1).max(0));
+                let day = ts.date_naive();
+                day >= start && day <= today
+            }
         }
     }
 }
@@ -273,10 +281,12 @@ fn read_session_file(path: &PathBuf, since: &Since) -> Vec<UsageEvent> {
     let Ok(file) = fs::File::open(path) else {
         return Vec::new();
     };
+    // Let `parse_event` do the type-filter — its internal `kind != "assistant"` check is the
+    // authoritative one. A substring pre-filter here would silently drop valid records if Claude
+    // Code's JSONL formatter ever switches to `"type": "assistant"` with whitespace.
     BufReader::new(file)
         .lines()
         .map_while(Result::ok)
-        .filter(|line| line.contains("\"type\":\"assistant\""))
         .filter_map(|line| parse_event(&line))
         .filter(|e| since.includes(e.timestamp))
         .collect()
@@ -359,7 +369,15 @@ fn parse_event(line: &str) -> Option<UsageEvent> {
 
 fn dedup(events: Vec<UsageEvent>) -> Vec<UsageEvent> {
     let mut by_key: HashMap<(String, String), UsageEvent> = HashMap::new();
+    let mut passthrough: Vec<UsageEvent> = Vec::new();
     for e in events {
+        // serde `#[default]` fills missing IDs with `""`. Collapsing every empty-ID record into
+        // one dedup bucket would silently drop unrelated assistant turns — fall through to the
+        // passthrough list instead so usage stays accurate even if a future schema omits an ID.
+        if e.message_id.is_empty() || e.request_id.is_empty() {
+            passthrough.push(e);
+            continue;
+        }
         let key = (e.message_id.clone(), e.request_id.clone());
         // ccusage gotcha: a `(message.id, requestId)` can repeat across files when a session
         // resumes. Keep the row with the higher total — that's the canonical final usage.
@@ -372,7 +390,9 @@ fn dedup(events: Vec<UsageEvent>) -> Vec<UsageEvent> {
             })
             .or_insert(e);
     }
-    by_key.into_values().collect()
+    let mut out: Vec<UsageEvent> = by_key.into_values().collect();
+    out.extend(passthrough);
+    out
 }
 
 fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<UsageRow> {
@@ -753,6 +773,47 @@ mod tests {
         assert!(Since::Days(7).includes(recent));
         assert!(!Since::Days(7).includes(old));
         assert!(Since::All.includes(old));
+    }
+
+    #[test]
+    fn since_days_window_uses_calendar_day_boundary_not_rolling_timestamp() {
+        // For Days(7) the inclusive window is `today .. today-6` (matching daily_series's 7
+        // bucket span). The boundary day (today-6) at midnight must be included, and the day
+        // before (today-7) at 23:59 must be excluded — even though the rolling
+        // `now - 7 days` cutoff would put both on the same side.
+        use chrono::TimeZone;
+        let today = Utc::now().date_naive();
+        let boundary_in =
+            Utc.from_utc_datetime(&(today - Duration::days(6)).and_hms_opt(0, 0, 0).unwrap());
+        let just_out =
+            Utc.from_utc_datetime(&(today - Duration::days(7)).and_hms_opt(23, 59, 0).unwrap());
+        assert!(Since::Days(7).includes(boundary_in));
+        assert!(!Since::Days(7).includes(just_out));
+    }
+
+    #[test]
+    fn dedup_passes_through_events_with_empty_ids_instead_of_collapsing_them() {
+        // serde fills missing IDs with `""`; two unrelated assistant turns with empty IDs must
+        // not collide into a single dedup bucket — that would silently lose usage.
+        let make = |suffix: u64| UsageEvent {
+            timestamp: Utc::now(),
+            model: "claude-sonnet-4-6".into(),
+            project: "x".into(),
+            message_id: String::new(),
+            request_id: String::new(),
+            input_tokens: suffix,
+            output_tokens: 0,
+            cache_write_5m: 0,
+            cache_write_1h: 0,
+            cache_read: 0,
+        };
+        let kept = dedup(vec![make(1), make(2)]);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(
+            kept.iter().map(|e| e.input_tokens).sum::<u64>(),
+            3,
+            "both events must survive when ids are empty"
+        );
     }
 
     #[test]

--- a/src/fetcher/claude/common.rs
+++ b/src/fetcher/claude/common.rs
@@ -1,0 +1,235 @@
+//! Shared helpers for the `claude_*` family — model pricing, cost math, and the JSONL discovery
+//! roots used by `claude_code_usage`.
+//!
+//! Pricing lives in source rather than a vendored JSON file because the set of Claude models is
+//! small and changes rarely; bumping a constant is less error-prone than parsing an external table
+//! on every fetch. When a new family ships, add a [`PRICE_TABLE`] row matching the model-id prefix.
+
+use std::path::PathBuf;
+
+/// USD per million tokens for a single Claude model family. Cache write tiers map to Anthropic's
+/// `ephemeral_5m` / `ephemeral_1h` breakouts in the usage payload; `cache_read` covers the
+/// flat-rate cache-read line.
+#[derive(Debug, Clone, Copy)]
+pub struct Price {
+    pub input: f64,
+    pub output: f64,
+    pub cache_write_5m: f64,
+    pub cache_write_1h: f64,
+    pub cache_read: f64,
+}
+
+const OPUS: Price = Price {
+    input: 15.0,
+    output: 75.0,
+    cache_write_5m: 18.75,
+    cache_write_1h: 30.0,
+    cache_read: 1.50,
+};
+
+const SONNET: Price = Price {
+    input: 3.0,
+    output: 15.0,
+    cache_write_5m: 3.75,
+    cache_write_1h: 6.0,
+    cache_read: 0.30,
+};
+
+const HAIKU: Price = Price {
+    input: 1.0,
+    output: 5.0,
+    cache_write_5m: 1.25,
+    cache_write_1h: 2.0,
+    cache_read: 0.10,
+};
+
+/// Prefix table — first match wins, longest-prefix entries appear first so `opus` doesn't shadow
+/// a hypothetical `opus-mini`. Match is on the full lowercased model id.
+const PRICE_TABLE: &[(&str, Price)] = &[
+    ("claude-opus", OPUS),
+    ("claude-sonnet", SONNET),
+    ("claude-haiku", HAIKU),
+    // Legacy date-stamped names still seen in older JSONL sessions.
+    ("claude-3-5-sonnet", SONNET),
+    ("claude-3-5-haiku", HAIKU),
+    ("claude-3-opus", OPUS),
+    ("claude-3-sonnet", SONNET),
+    ("claude-3-haiku", HAIKU),
+];
+
+pub fn price_for(model: &str) -> Option<Price> {
+    let lower = model.to_lowercase();
+    PRICE_TABLE
+        .iter()
+        .find(|(prefix, _)| lower.starts_with(prefix))
+        .map(|(_, p)| *p)
+}
+
+/// USD cost of a usage row given a model. Unknown models contribute 0 — surfacing them as
+/// "free" is friendlier than hiding the underlying token activity behind an error.
+#[allow(clippy::too_many_arguments)]
+pub fn cost_usd(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_write_5m: u64,
+    cache_write_1h: u64,
+    cache_read: u64,
+) -> f64 {
+    let Some(p) = price_for(model) else {
+        return 0.0;
+    };
+    let per_token = |rate_per_mt: f64, count: u64| (count as f64) * rate_per_mt / 1_000_000.0;
+    per_token(p.input, input_tokens)
+        + per_token(p.output, output_tokens)
+        + per_token(p.cache_write_5m, cache_write_5m)
+        + per_token(p.cache_write_1h, cache_write_1h)
+        + per_token(p.cache_read, cache_read)
+}
+
+/// "$12.34" / "$0.05" / "$1.2k" — compact enough to fit a Badge or a Text headline.
+pub fn format_cost(usd: f64) -> String {
+    if usd >= 1_000.0 {
+        format!("${:.1}k", usd / 1_000.0)
+    } else if usd >= 10.0 {
+        format!("${:.2}", usd)
+    } else if usd > 0.0 {
+        format!("${:.3}", usd)
+    } else {
+        "$0.00".into()
+    }
+}
+
+/// "3.4M" / "812k" / "42" — same compact strategy for raw token counts.
+pub fn format_tokens(count: u64) -> String {
+    if count >= 1_000_000 {
+        format!("{:.1}M", count as f64 / 1_000_000.0)
+    } else if count >= 1_000 {
+        format!("{}k", count / 1_000)
+    } else {
+        count.to_string()
+    }
+}
+
+/// Claude Code's per-CWD project directories. The CLI uses `~/.claude/projects/<encoded-cwd>/`
+/// by default; the older `~/.config/claude/projects/` is still seen on Linux hosts upgraded from
+/// pre-3.x. `CLAUDE_CONFIG_DIR` accepts a comma-separated list so power users with multiple
+/// installs can point at every root.
+pub fn discover_jsonl_dirs() -> Vec<PathBuf> {
+    if let Ok(raw) = std::env::var("CLAUDE_CONFIG_DIR") {
+        return raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| PathBuf::from(s).join("projects"))
+            .collect();
+    }
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    [home.join(".claude"), home.join(".config").join("claude")]
+        .into_iter()
+        .map(|p| p.join("projects"))
+        .filter(|p| p.is_dir())
+        .collect()
+}
+
+/// Last path component of a Claude `cwd` field — the bare project name without filesystem noise.
+/// Empty cwd falls back to `"(unknown)"` so renderers always get a non-empty key.
+pub fn project_name_from_cwd(cwd: &str) -> String {
+    PathBuf::from(cwd)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "(unknown)".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn price_for_matches_opus_sonnet_haiku_by_prefix() {
+        assert!(price_for("claude-opus-4-7").is_some());
+        assert!(price_for("claude-sonnet-4-6").is_some());
+        assert!(price_for("claude-haiku-4-5-20251001").is_some());
+        assert!(price_for("claude-3-5-sonnet-20241022").is_some());
+    }
+
+    #[test]
+    fn price_for_unknown_model_returns_none() {
+        assert!(price_for("gpt-4-turbo").is_none());
+        assert!(price_for("").is_none());
+    }
+
+    #[test]
+    fn price_for_is_case_insensitive() {
+        assert!(price_for("CLAUDE-OPUS-4-7").is_some());
+    }
+
+    #[test]
+    fn cost_usd_zero_for_unknown_model_even_with_tokens() {
+        assert_eq!(cost_usd("gpt-4", 1_000_000, 1_000_000, 0, 0, 0), 0.0);
+    }
+
+    #[test]
+    fn cost_usd_sums_per_tier_rates_against_million_tokens() {
+        // Opus: 1M input @ $15 + 1M output @ $75 = $90 exactly.
+        let c = cost_usd("claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0);
+        assert!((c - 90.0).abs() < 1e-6, "expected ~$90, got {c}");
+    }
+
+    #[test]
+    fn cost_usd_charges_cache_tiers() {
+        // Sonnet cache_write_1h: 1M @ $6 = $6.
+        let c = cost_usd("claude-sonnet-4-6", 0, 0, 0, 1_000_000, 0);
+        assert!((c - 6.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn format_cost_picks_unit_by_magnitude() {
+        assert_eq!(format_cost(0.0), "$0.00");
+        assert_eq!(format_cost(0.005), "$0.005");
+        assert_eq!(format_cost(2.50), "$2.500");
+        assert_eq!(format_cost(12.34), "$12.34");
+        assert_eq!(format_cost(1234.0), "$1.2k");
+    }
+
+    #[test]
+    fn format_tokens_uses_m_and_k_suffixes() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(42), "42");
+        assert_eq!(format_tokens(1_500), "1k");
+        assert_eq!(format_tokens(3_400_000), "3.4M");
+    }
+
+    #[test]
+    fn project_name_from_cwd_takes_last_component() {
+        assert_eq!(
+            project_name_from_cwd("/home/owner/.ghq/github.com/unhappychoice/splashboard"),
+            "splashboard"
+        );
+    }
+
+    #[test]
+    fn project_name_from_cwd_handles_empty_path() {
+        assert_eq!(project_name_from_cwd(""), "(unknown)");
+    }
+
+    #[test]
+    fn discover_jsonl_dirs_honours_env_override() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/a, /tmp/b") };
+        let dirs = discover_jsonl_dirs();
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs[0].ends_with("a/projects"));
+        assert!(dirs[1].ends_with("b/projects"));
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+        }
+    }
+}

--- a/src/fetcher/claude/mod.rs
+++ b/src/fetcher/claude/mod.rs
@@ -1,0 +1,34 @@
+//! Claude (and Claude Code) fetchers.
+//!
+//! - [`code_usage::ClaudeCodeUsage`] aggregates the local JSONL files Claude Code writes for
+//!   every session, with zero configuration and no network.
+//!
+//! `Safety::Safe` — local-only reads under `$HOME/.claude/`.
+
+mod code_usage;
+mod common;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(code_usage::ClaudeCodeUsage)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetchers_entry_point_registers_each_member_under_claude_prefix() {
+        let names: Vec<String> = fetchers().iter().map(|f| f.name().to_string()).collect();
+        for name in &names {
+            assert!(
+                name.starts_with("claude_"),
+                "{name} must use the `claude_` family prefix"
+            );
+        }
+        assert!(names.contains(&"claude_code_usage".to_string()));
+    }
+}

--- a/src/fetcher/claude/mod.rs
+++ b/src/fetcher/claude/mod.rs
@@ -2,18 +2,26 @@
 //!
 //! - [`code_usage::ClaudeCodeUsage`] aggregates the local JSONL files Claude Code writes for
 //!   every session, with zero configuration and no network.
+//! - [`subscription::ClaudeSubscription`] reads the OAuth token Claude Code stores in
+//!   `~/.claude/.credentials.json` and reports Max-plan utilisation against an undocumented
+//!   `api.anthropic.com` endpoint.
 //!
-//! `Safety::Safe` — local-only reads under `$HOME/.claude/`.
+//! Both are `Safety::Safe` — `code_usage` is local-only, `subscription` only ever talks to the
+//! hardcoded `api.anthropic.com` host (same model as the `github_*` / `lastfm_*` families).
 
 mod code_usage;
 mod common;
+mod subscription;
 
 use std::sync::Arc;
 
 use crate::fetcher::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(code_usage::ClaudeCodeUsage)]
+    vec![
+        Arc::new(code_usage::ClaudeCodeUsage),
+        Arc::new(subscription::ClaudeSubscription),
+    ]
 }
 
 #[cfg(test)]
@@ -30,5 +38,6 @@ mod tests {
             );
         }
         assert!(names.contains(&"claude_code_usage".to_string()));
+        assert!(names.contains(&"claude_subscription".to_string()));
     }
 }

--- a/src/fetcher/claude/subscription.rs
+++ b/src/fetcher/claude/subscription.rs
@@ -1,0 +1,881 @@
+//! `claude_subscription` — Claude (Max plan) subscription utilisation as Claude Code sees it.
+//!
+//! Reads the OAuth token at `~/.claude/.credentials.json` and queries the **undocumented**
+//! endpoint `GET https://api.anthropic.com/api/oauth/usage` with the `oauth-2025-04-20` beta
+//! header (see the catalog body and the [`ohugonnot/claude-code-statusline`] reference).
+//! The response carries one entry per usage window — `five_hour`, `seven_day`,
+//! `seven_day_sonnet`, `seven_day_opus`, `seven_day_omelette` (the "Claude Design" pool in the
+//! claude.ai UI), and a handful of internal codenames — most of which are `null` for any one
+//! account. We walk the response generically, keep every non-null window in a canonical order,
+//! and label known keys with the UI string the user sees on claude.ai/account.
+//!
+//! Undocumented = fragile: every failure path short-circuits to [`FetchError`] so the splash
+//! still renders a placeholder, never panics.
+//!
+//! `Safety::Safe` — host is hardcoded, the OAuth token only travels to `api.anthropic.com`.
+//!
+//! [`ohugonnot/claude-code-statusline`]: https://github.com/ohugonnot/claude-code-statusline/blob/main/statusline.sh
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, RatioData,
+    Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Ratio,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "window",
+    type_hint: "string (response key — e.g. \"five_hour\" / \"seven_day\" / \"seven_day_sonnet\" / \"seven_day_omelette\")",
+    required: false,
+    default: Some("\"five_hour\""),
+    description: "Which window the single-value shapes (`Ratio`, `Badge`) report. Multi-row shapes always list every non-null window the response carries.",
+}];
+
+const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+
+pub struct ClaudeSubscription;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub window: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for ClaudeSubscription {
+    fn name(&self) -> &str {
+        "claude_subscription"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Claude (Max plan) subscription utilisation as seen by Claude Code's OAuth credentials. Reads `~/.claude/.credentials.json` and queries the undocumented `oauth/usage` endpoint, exposing every window the response carries (5-hour, 7-day, per-model and pool-specific siblings)."
+    }
+    fn refresh_interval(&self) -> u64 {
+        15 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let target = normalise_window_key(opts.window.as_deref());
+        let shape = ctx.shape.unwrap_or(Shape::Ratio);
+        let token = load_oauth_token()?;
+        let snapshot = fetch_snapshot(&token).await?;
+        Ok(payload(render_body(&snapshot, &target, shape)))
+    }
+}
+
+fn http() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .gzip(true)
+            .build()
+            .expect("reqwest client should build with default config")
+    })
+}
+
+/// User-facing strings for the response's window keys, in claude.ai/account language. Unknown
+/// keys fall through [`humanize_key`].
+fn known_label(key: &str) -> Option<&'static str> {
+    match key {
+        "five_hour" => Some("5h"),
+        "seven_day" => Some("7d"),
+        "seven_day_opus" => Some("7d Opus"),
+        "seven_day_sonnet" => Some("7d Sonnet"),
+        "seven_day_oauth_apps" => Some("7d OAuth apps"),
+        "seven_day_cowork" => Some("7d Cowork"),
+        "seven_day_omelette" => Some("Claude Design"),
+        "seven_day_omelette_promotional" => Some("Claude Design (promo)"),
+        "omelette_promotional" => Some("Claude Design (promo)"),
+        "tangelo" => Some("Tangelo"),
+        "iguana_necktie" => Some("Iguana Necktie"),
+        _ => None,
+    }
+}
+
+fn label_for(key: &str) -> String {
+    known_label(key)
+        .map(str::to_string)
+        .unwrap_or_else(|| humanize_key(key))
+}
+
+/// `seven_day_some_thing` → `7d some thing`, `tangelo` → `Tangelo`. Capitalises the first letter
+/// of the first word but otherwise keeps lowercase so multi-word codenames stay scannable.
+fn humanize_key(key: &str) -> String {
+    if key.is_empty() {
+        return String::new();
+    }
+    let normalised = key.replace("seven_day", "7d").replace('_', " ");
+    let mut chars = normalised.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Canonical sort key. Lower wins. Keeps `5h` first, then `7d (all)`, then `7d Sonnet` /
+/// `7d Opus`, other `seven_day_*` next, codenames last (alphabetical).
+fn sort_priority(key: &str) -> (u8, &str) {
+    match key {
+        "five_hour" => (0, key),
+        "seven_day" => (1, key),
+        "seven_day_sonnet" => (2, key),
+        "seven_day_opus" => (3, key),
+        "seven_day_omelette" => (4, key),
+        "seven_day_omelette_promotional" => (5, key),
+        "omelette_promotional" => (5, key),
+        _ if key.starts_with("seven_day_") => (6, key),
+        _ => (7, key),
+    }
+}
+
+fn normalise_window_key(raw: Option<&str>) -> String {
+    let raw = raw.unwrap_or("five_hour").trim();
+    // Accept a few friendly aliases for the keys users are most likely to type by hand.
+    match raw {
+        "" | "5h" => "five_hour".into(),
+        "7d" => "seven_day".into(),
+        "7d_sonnet" | "7d-sonnet" => "seven_day_sonnet".into(),
+        "7d_opus" | "7d-opus" => "seven_day_opus".into(),
+        "claude_design" | "design" => "seven_day_omelette".into(),
+        other => other.into(),
+    }
+}
+
+fn credentials_path() -> Result<PathBuf, FetchError> {
+    if let Ok(p) = std::env::var("SPLASHBOARD_CLAUDE_CREDENTIALS") {
+        return Ok(PathBuf::from(p));
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".claude").join(".credentials.json"))
+        .ok_or_else(|| FetchError::Failed("could not resolve $HOME for Claude credentials".into()))
+}
+
+#[derive(Deserialize)]
+struct CredentialsFile {
+    #[serde(rename = "claudeAiOauth", default)]
+    oauth: Option<OauthEntry>,
+}
+
+#[derive(Deserialize)]
+struct OauthEntry {
+    #[serde(rename = "accessToken", default)]
+    access_token: String,
+}
+
+fn load_oauth_token() -> Result<String, FetchError> {
+    let path = credentials_path()?;
+    let bytes = std::fs::read(&path)
+        .map_err(|e| FetchError::Failed(format!("read {}: {e}", path.display())))?;
+    let creds: CredentialsFile = serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("parse {}: {e}", path.display())))?;
+    let token = creds
+        .oauth
+        .map(|o| o.access_token)
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| {
+            FetchError::Failed("no `claudeAiOauth.accessToken` in credentials".into())
+        })?;
+    Ok(token)
+}
+
+#[derive(Debug, Clone, Default)]
+struct Snapshot {
+    windows: Vec<NamedWindow>,
+}
+
+#[derive(Debug, Clone)]
+struct NamedWindow {
+    key: String,
+    label: String,
+    state: WindowState,
+}
+
+#[derive(Debug, Clone)]
+struct WindowState {
+    utilization: f64,
+    resets_at: Option<DateTime<Utc>>,
+}
+
+impl Snapshot {
+    fn find(&self, key: &str) -> Option<&NamedWindow> {
+        self.windows.iter().find(|w| w.key == key)
+    }
+}
+
+async fn fetch_snapshot(token: &str) -> Result<Snapshot, FetchError> {
+    // The endpoint is undocumented; upstream tooling (claude-code-statusline) calls it as GET
+    // with the OAuth bearer + beta header. POSTing here returns 405 Method Not Allowed.
+    let res = http()
+        .get(USAGE_URL)
+        .bearer_auth(token)
+        .header("anthropic-beta", "oauth-2025-04-20")
+        .header("content-type", "application/json")
+        .send()
+        .await
+        .map_err(|e| FetchError::Failed(format!("claude_subscription request: {e}")))?;
+    let status = res.status();
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| FetchError::Failed(format!("read body: {e}")))?;
+    if !status.is_success() {
+        return Err(FetchError::Failed(format!(
+            "claude_subscription HTTP {status}"
+        )));
+    }
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| FetchError::Failed(format!("parse oauth/usage: {e}")))?;
+    Ok(parse_snapshot(&value))
+}
+
+fn parse_snapshot(value: &serde_json::Value) -> Snapshot {
+    let Some(obj) = value.as_object() else {
+        return Snapshot::default();
+    };
+    let mut windows: Vec<NamedWindow> = obj
+        .iter()
+        .filter_map(|(key, val)| parse_window_entry(key, val))
+        .collect();
+    windows.sort_by(|a, b| sort_priority(&a.key).cmp(&sort_priority(&b.key)));
+    Snapshot { windows }
+}
+
+fn parse_window_entry(key: &str, val: &serde_json::Value) -> Option<NamedWindow> {
+    // `extra_usage` carries a different schema (is_enabled / monthly_limit / used_credits …);
+    // not part of the window family — skip it. Future enhancement can surface it as a separate
+    // shape if anyone uses the paid extra-credit pool.
+    if key == "extra_usage" {
+        return None;
+    }
+    let obj = val.as_object()?;
+    let util = obj.get("utilization").and_then(|v| v.as_f64())?;
+    let resets_at = obj
+        .get("resets_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+    Some(NamedWindow {
+        key: key.to_string(),
+        label: label_for(key),
+        state: WindowState {
+            // Endpoint returns 0..100 percent — normalise to 0..1, allow 1.5 for over-quota so a
+            // blown window still draws distinctly rather than clipping to "full".
+            utilization: (util / 100.0).clamp(0.0, 1.5),
+            resets_at,
+        },
+    })
+}
+
+fn render_body(snap: &Snapshot, target: &str, shape: Shape) -> Body {
+    match shape {
+        Shape::Ratio => ratio_body(snap, target),
+        Shape::Text => text_body(snap),
+        Shape::TextBlock => text_block_body(snap),
+        Shape::MarkdownTextBlock => markdown_body(snap),
+        Shape::Entries => entries_body(snap),
+        Shape::Bars => bars_body(snap),
+        Shape::Badge => badge_body(snap, target),
+        Shape::Timeline => timeline_body(snap),
+        _ => text_body(snap),
+    }
+}
+
+fn ratio_body(snap: &Snapshot, target: &str) -> Body {
+    let label = known_label(target).map(str::to_string).unwrap_or_else(|| {
+        snap.find(target)
+            .map(|w| w.label.clone())
+            .unwrap_or_else(|| humanize_key(target))
+    });
+    let Some(window) = snap.find(target) else {
+        return Body::Ratio(RatioData {
+            value: 0.0,
+            label: Some(format!("{label} · n/a")),
+            denominator: Some(100),
+        });
+    };
+    let reset = window
+        .state
+        .resets_at
+        .map(format_reset)
+        .unwrap_or_else(|| "n/a".into());
+    Body::Ratio(RatioData {
+        value: window.state.utilization.clamp(0.0, 1.0),
+        label: Some(format!("{label} · resets {reset}")),
+        denominator: Some(100),
+    })
+}
+
+fn text_body(snap: &Snapshot) -> Body {
+    let parts: Vec<String> = snap
+        .windows
+        .iter()
+        .map(|w| format!("{} {}", w.label, percent(w.state.utilization)))
+        .collect();
+    Body::Text(TextData {
+        value: if parts.is_empty() {
+            "claude subscription: n/a".into()
+        } else {
+            parts.join(" · ")
+        },
+    })
+}
+
+fn text_block_body(snap: &Snapshot) -> Body {
+    let lines: Vec<String> = snap.windows.iter().map(format_window_line).collect();
+    Body::TextBlock(TextBlockData {
+        lines: if lines.is_empty() {
+            vec!["claude subscription: n/a".into()]
+        } else {
+            lines
+        },
+    })
+}
+
+fn markdown_body(snap: &Snapshot) -> Body {
+    let lines: Vec<String> = snap
+        .windows
+        .iter()
+        .map(|w| {
+            let reset = w
+                .state
+                .resets_at
+                .map(format_reset)
+                .unwrap_or_else(|| "n/a".into());
+            format!(
+                "- **{}** — {} (resets {reset})",
+                w.label,
+                percent(w.state.utilization),
+            )
+        })
+        .collect();
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: if lines.is_empty() {
+            "_claude subscription unavailable_".into()
+        } else {
+            lines.join("\n")
+        },
+    })
+}
+
+fn entries_body(snap: &Snapshot) -> Body {
+    let items: Vec<Entry> = snap
+        .windows
+        .iter()
+        .map(|w| Entry {
+            key: w.label.clone(),
+            value: Some(format!(
+                "{} (resets {})",
+                percent(w.state.utilization),
+                w.state
+                    .resets_at
+                    .map(format_reset)
+                    .unwrap_or_else(|| "n/a".into()),
+            )),
+            status: Some(status_for(w.state.utilization)),
+        })
+        .collect();
+    Body::Entries(EntriesData {
+        items: if items.is_empty() {
+            vec![Entry {
+                key: "claude".into(),
+                value: Some("subscription unavailable".into()),
+                status: Some(Status::Warn),
+            }]
+        } else {
+            items
+        },
+    })
+}
+
+fn bars_body(snap: &Snapshot) -> Body {
+    let bars: Vec<Bar> = snap
+        .windows
+        .iter()
+        .map(|w| Bar {
+            label: w.label.clone(),
+            // Bars take u64 — store utilisation as basis points (0..=10000+) so a fully spent
+            // window outranks a quarter-spent one in chart_bar.
+            value: ((w.state.utilization * 10_000.0).round() as i64).max(0) as u64,
+            value_label: Some(percent(w.state.utilization)),
+        })
+        .collect();
+    Body::Bars(BarsData { bars })
+}
+
+fn badge_body(snap: &Snapshot, target: &str) -> Body {
+    let label = known_label(target).map(str::to_string).unwrap_or_else(|| {
+        snap.find(target)
+            .map(|w| w.label.clone())
+            .unwrap_or_else(|| humanize_key(target))
+    });
+    let Some(window) = snap.find(target) else {
+        return Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: format!("{label}: n/a"),
+        });
+    };
+    Body::Badge(BadgeData {
+        status: status_for(window.state.utilization),
+        label: format!("{label} {}", percent(window.state.utilization)),
+    })
+}
+
+fn timeline_body(snap: &Snapshot) -> Body {
+    let mut events: Vec<TimelineEvent> = snap
+        .windows
+        .iter()
+        .filter_map(|w| {
+            w.state.resets_at.map(|ts| TimelineEvent {
+                timestamp: ts.timestamp(),
+                title: format!("{} resets", w.label),
+                detail: Some(format!("at {}", percent(w.state.utilization))),
+                status: Some(status_for(w.state.utilization)),
+            })
+        })
+        .collect();
+    events.sort_by_key(|e| e.timestamp);
+    Body::Timeline(TimelineData { events })
+}
+
+fn format_window_line(window: &NamedWindow) -> String {
+    let reset = window
+        .state
+        .resets_at
+        .map(format_reset)
+        .unwrap_or_else(|| "n/a".into());
+    format!(
+        "{}  {} · resets {reset}",
+        window.label,
+        percent(window.state.utilization),
+    )
+}
+
+fn percent(util: f64) -> String {
+    format!("{:.0}%", (util * 100.0).clamp(0.0, 150.0))
+}
+
+fn format_reset(ts: DateTime<Utc>) -> String {
+    let delta = ts.signed_duration_since(Utc::now());
+    if delta <= chrono::Duration::zero() {
+        return "now".into();
+    }
+    let mins = delta.num_minutes();
+    if mins < 60 {
+        format!("{mins}m")
+    } else if mins < 60 * 48 {
+        format!("{}h", delta.num_hours())
+    } else {
+        format!("{}d", delta.num_days())
+    }
+}
+
+fn status_for(util: f64) -> Status {
+    if util >= 0.85 {
+        Status::Error
+    } else if util >= 0.60 {
+        Status::Warn
+    } else {
+        Status::Ok
+    }
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    Some(match shape {
+        Shape::Ratio => samples::ratio(0.07, "5h · resets 2h"),
+        Shape::Text => samples::text("5h 7% · 7d 2% · 7d Sonnet 0% · Claude Design 0%"),
+        Shape::TextBlock => samples::text_block(&[
+            "5h             7% · resets 2h",
+            "7d             2% · resets 6d",
+            "7d Sonnet      0% · resets 6d",
+            "Claude Design  0% · resets n/a",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "- **5h** — 7% (resets 2h)\n- **7d** — 2% (resets 6d)\n- **7d Sonnet** — 0% (resets 6d)\n- **Claude Design** — 0% (resets n/a)",
+        ),
+        Shape::Entries => samples::entries(&[
+            ("5h", "7% (resets 2h)"),
+            ("7d", "2% (resets 6d)"),
+            ("7d Sonnet", "0% (resets 6d)"),
+            ("Claude Design", "0% (resets n/a)"),
+        ]),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "5h".into(),
+                    value: 700,
+                    value_label: Some("7%".into()),
+                },
+                Bar {
+                    label: "7d".into(),
+                    value: 200,
+                    value_label: Some("2%".into()),
+                },
+                Bar {
+                    label: "7d Sonnet".into(),
+                    value: 0,
+                    value_label: Some("0%".into()),
+                },
+                Bar {
+                    label: "Claude Design".into(),
+                    value: 0,
+                    value_label: Some("0%".into()),
+                },
+            ],
+        }),
+        Shape::Badge => samples::badge(Status::Ok, "5h 7%"),
+        Shape::Timeline => samples::timeline(&[
+            (Utc::now().timestamp() + 7_200, "5h resets", Some("at 7%")),
+            (
+                Utc::now().timestamp() + 6 * 86_400,
+                "7d resets",
+                Some("at 2%"),
+            ),
+        ]),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration as StdDuration;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "claude-sub".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn window(key: &str, util: f64, resets_in_secs: Option<i64>) -> NamedWindow {
+        NamedWindow {
+            key: key.into(),
+            label: label_for(key),
+            state: WindowState {
+                utilization: util,
+                resets_at: resets_in_secs.map(|s| Utc::now() + chrono::Duration::seconds(s)),
+            },
+        }
+    }
+
+    fn snap_full() -> Snapshot {
+        Snapshot {
+            windows: vec![
+                window("five_hour", 0.07, Some(2 * 3600)),
+                window("seven_day", 0.02, Some(6 * 86_400)),
+                window("seven_day_sonnet", 0.0, Some(6 * 86_400)),
+                window("seven_day_omelette", 0.0, None),
+            ],
+        }
+    }
+
+    #[test]
+    fn normalise_window_key_accepts_friendly_aliases() {
+        assert_eq!(normalise_window_key(None), "five_hour");
+        assert_eq!(normalise_window_key(Some("5h")), "five_hour");
+        assert_eq!(normalise_window_key(Some("7d")), "seven_day");
+        assert_eq!(normalise_window_key(Some("7d_sonnet")), "seven_day_sonnet");
+        assert_eq!(
+            normalise_window_key(Some("claude_design")),
+            "seven_day_omelette"
+        );
+        // Unknown keys pass through so users on a future build with a new window can pick it.
+        assert_eq!(normalise_window_key(Some("tangelo")), "tangelo");
+    }
+
+    #[test]
+    fn known_label_maps_canonical_keys_to_ui_strings() {
+        assert_eq!(known_label("five_hour"), Some("5h"));
+        assert_eq!(known_label("seven_day_omelette"), Some("Claude Design"));
+        assert_eq!(known_label("tangelo"), Some("Tangelo"));
+        assert_eq!(known_label("future_window_x"), None);
+    }
+
+    #[test]
+    fn humanize_key_replaces_seven_day_and_underscores() {
+        assert_eq!(humanize_key("seven_day_future_thing"), "7d future thing");
+        assert_eq!(humanize_key("future_thing"), "Future thing");
+        assert_eq!(humanize_key(""), "");
+    }
+
+    #[test]
+    fn parse_snapshot_skips_null_and_extra_usage_and_sorts_by_priority() {
+        // Real response shape: many keys present, only some non-null. `extra_usage` carries a
+        // different schema and must be skipped, the rest must appear in canonical order.
+        let raw = serde_json::json!({
+            "tangelo": null,
+            "seven_day_omelette": { "utilization": 0.0, "resets_at": null },
+            "seven_day_sonnet": { "utilization": 0.0, "resets_at": "2026-05-29T10:00:00Z" },
+            "iguana_necktie": null,
+            "five_hour": { "utilization": 7.0, "resets_at": "2026-05-23T10:40:00Z" },
+            "seven_day": { "utilization": 2.0, "resets_at": "2026-05-29T10:00:00Z" },
+            "seven_day_opus": null,
+            "extra_usage": { "is_enabled": false, "utilization": null }
+        });
+        let snap = parse_snapshot(&raw);
+        let keys: Vec<&str> = snap.windows.iter().map(|w| w.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "five_hour",
+                "seven_day",
+                "seven_day_sonnet",
+                "seven_day_omelette"
+            ]
+        );
+        assert!((snap.windows[0].state.utilization - 0.07).abs() < 1e-9);
+        assert!(snap.windows[3].state.resets_at.is_none());
+    }
+
+    #[test]
+    fn parse_snapshot_clamps_over_quota_at_one_and_a_half() {
+        let raw = serde_json::json!({
+            "five_hour": { "utilization": 200.0, "resets_at": null }
+        });
+        let snap = parse_snapshot(&raw);
+        assert_eq!(snap.windows[0].state.utilization, 1.5);
+    }
+
+    #[test]
+    fn parse_snapshot_handles_an_unexpected_top_level_shape() {
+        let raw = serde_json::json!("not an object");
+        let snap = parse_snapshot(&raw);
+        assert!(snap.windows.is_empty());
+    }
+
+    #[test]
+    fn status_for_bucketed_thresholds() {
+        assert_eq!(status_for(0.0), Status::Ok);
+        assert_eq!(status_for(0.5), Status::Ok);
+        assert_eq!(status_for(0.6), Status::Warn);
+        assert_eq!(status_for(0.85), Status::Error);
+    }
+
+    #[test]
+    fn percent_formats_without_decimal_and_caps_over_quota_at_150() {
+        assert_eq!(percent(0.07), "7%");
+        assert_eq!(percent(1.0), "100%");
+        assert_eq!(percent(1.5), "150%");
+        assert_eq!(percent(2.0), "150%");
+    }
+
+    #[test]
+    fn format_reset_picks_unit_by_distance() {
+        let now = Utc::now();
+        assert_eq!(format_reset(now - chrono::Duration::minutes(5)), "now");
+        assert!(format_reset(now + chrono::Duration::minutes(30)).ends_with("m"));
+        assert!(format_reset(now + chrono::Duration::hours(5)).ends_with("h"));
+        assert!(format_reset(now + chrono::Duration::days(5)).ends_with("d"));
+    }
+
+    #[test]
+    fn ratio_body_picks_requested_window_by_key() {
+        let snap = snap_full();
+        let Body::Ratio(r) = ratio_body(&snap, "seven_day") else {
+            panic!("expected ratio");
+        };
+        assert!((r.value - 0.02).abs() < 1e-6);
+        assert!(r.label.as_deref().unwrap_or_default().starts_with("7d"));
+    }
+
+    #[test]
+    fn ratio_body_falls_back_to_zero_when_window_missing() {
+        let Body::Ratio(r) = ratio_body(&Snapshot::default(), "five_hour") else {
+            panic!("expected ratio");
+        };
+        assert_eq!(r.value, 0.0);
+        assert!(r.label.as_deref().unwrap_or_default().contains("n/a"));
+    }
+
+    #[test]
+    fn badge_body_falls_back_when_window_missing() {
+        let Body::Badge(b) = badge_body(&Snapshot::default(), "five_hour") else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert!(b.label.contains("n/a"));
+    }
+
+    #[test]
+    fn entries_body_lists_every_present_window_in_canonical_order() {
+        let Body::Entries(e) = entries_body(&snap_full()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 4);
+        assert_eq!(e.items[0].key, "5h");
+        assert_eq!(e.items[3].key, "Claude Design");
+    }
+
+    #[test]
+    fn entries_body_falls_back_when_empty() {
+        let Body::Entries(e) = entries_body(&Snapshot::default()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert!(
+            e.items[0]
+                .value
+                .as_deref()
+                .unwrap_or_default()
+                .contains("unavailable")
+        );
+    }
+
+    #[test]
+    fn text_block_body_lists_all_present_windows() {
+        let Body::TextBlock(b) = text_block_body(&snap_full()) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 4);
+        assert!(b.lines[0].starts_with("5h"));
+        assert!(b.lines[3].starts_with("Claude Design"));
+    }
+
+    #[test]
+    fn bars_body_emits_basis_points_for_each_window() {
+        let Body::Bars(b) = bars_body(&snap_full()) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars.len(), 4);
+        assert_eq!(b.bars[0].value, 700);
+        assert_eq!(b.bars[1].value, 200);
+    }
+
+    #[test]
+    fn timeline_body_skips_windows_without_reset_and_sorts_by_timestamp() {
+        let Body::Timeline(t) = timeline_body(&snap_full()) else {
+            panic!("expected timeline");
+        };
+        // `seven_day_omelette` (resets_at = None) is dropped; the other 3 remain.
+        assert_eq!(t.events.len(), 3);
+        assert!(t.events[0].timestamp <= t.events[1].timestamp);
+        assert!(t.events[1].timestamp <= t.events[2].timestamp);
+    }
+
+    #[test]
+    fn fetcher_metadata_exposes_eight_shapes_with_ratio_default() {
+        let f = ClaudeSubscription;
+        assert_eq!(f.shapes(), SHAPES);
+        assert_eq!(f.default_shape(), Shape::Ratio);
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "sample missing for {s:?}");
+        }
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn load_oauth_token_reads_credentials_via_env_override() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let creds = tmp.path().join("creds.json");
+        std::fs::write(
+            &creds,
+            r#"{"claudeAiOauth":{"accessToken":"sk-claude-test"}}"#,
+        )
+        .unwrap();
+        let prev = std::env::var("SPLASHBOARD_CLAUDE_CREDENTIALS").ok();
+        unsafe { std::env::set_var("SPLASHBOARD_CLAUDE_CREDENTIALS", &creds) };
+        let token = load_oauth_token().unwrap();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("SPLASHBOARD_CLAUDE_CREDENTIALS", v) },
+            None => unsafe { std::env::remove_var("SPLASHBOARD_CLAUDE_CREDENTIALS") },
+        }
+        assert_eq!(token, "sk-claude-test");
+    }
+
+    #[test]
+    fn load_oauth_token_errors_on_empty_access_token() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let creds = tmp.path().join("creds.json");
+        std::fs::write(&creds, r#"{"claudeAiOauth":{"accessToken":""}}"#).unwrap();
+        let prev = std::env::var("SPLASHBOARD_CLAUDE_CREDENTIALS").ok();
+        unsafe { std::env::set_var("SPLASHBOARD_CLAUDE_CREDENTIALS", &creds) };
+        let err = load_oauth_token().unwrap_err();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("SPLASHBOARD_CLAUDE_CREDENTIALS", v) },
+            None => unsafe { std::env::remove_var("SPLASHBOARD_CLAUDE_CREDENTIALS") },
+        }
+        assert!(format!("{err}").contains("accessToken"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn fetch_surfaces_missing_credentials_as_failed() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("absent.json");
+        let prev = std::env::var("SPLASHBOARD_CLAUDE_CREDENTIALS").ok();
+        unsafe { std::env::set_var("SPLASHBOARD_CLAUDE_CREDENTIALS", &missing) };
+        let err = ClaudeSubscription
+            .fetch(&ctx(None, Some(Shape::Ratio)))
+            .await
+            .unwrap_err();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("SPLASHBOARD_CLAUDE_CREDENTIALS", v) },
+            None => unsafe { std::env::remove_var("SPLASHBOARD_CLAUDE_CREDENTIALS") },
+        }
+        assert!(format!("{err}").contains("read"));
+    }
+}

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -14,6 +14,7 @@ use crate::samples;
 
 pub mod basic;
 pub mod calendar;
+pub mod claude;
 pub mod clock;
 pub mod code;
 pub mod crypto_trending;
@@ -347,6 +348,9 @@ impl Registry {
         r.register(Arc::new(youtube::YoutubeChannelFetcher));
         r.register(Arc::new(huggingface_trending::HuggingfaceTrendingFetcher));
         for f in calendar::fetchers() {
+            r.register(f);
+        }
+        for f in claude::fetchers() {
             r.register(f);
         }
         for f in deal::fetchers() {


### PR DESCRIPTION
## Summary

Adds a new `claude_*` fetcher family with two members that target Splashboard's biggest persona overlap (Claude Code users):

- **`claude_code_usage`** — token + cost rollup from local Claude Code session JSONL files. Zero-config (`~/.claude/projects/*.jsonl`), `Safety::Safe`, pricing bundled.
- **`claude_subscription`** — Max-plan utilisation via the **undocumented** `GET api.anthropic.com/api/oauth/usage` endpoint, using the OAuth token Claude Code already stores in `~/.claude/.credentials.json`. Surfaces every non-null window the response carries (5h / 7d / 7d Sonnet / 7d Opus / Claude Design / …).

## `claude_code_usage`

| | |
|---|---|
| **Source** | `<root>/projects/<encoded-cwd>/<session-uuid>.jsonl` under every root in `CLAUDE_CONFIG_DIR` (default `~/.claude` + `~/.config/claude`) |
| **Auth** | none |
| **Safety** | `Safe` (local files) |
| **Default shape** | `Text` (`"Today: 17.0M tokens / $52.70"`) |
| **Shapes (7)** | `Text` / `TextBlock` / `MarkdownTextBlock` / `Entries` / `Bars` / `NumberSeries` / `Badge` |
| **Options** | `since` (`today` / `7d` / `30d` / `all`), `group_by` (`project` / `model` / `day`), `limit` (1..=50) |
| **Refresh** | 5 min |

Dedup by `(message.id, requestId)` — higher token total wins on collision (the [ccusage](https://github.com/ryoppippi/ccusage) gotcha for resumed sessions). Pricing for Opus / Sonnet / Haiku families plus `claude-3-*` legacy names is hardcoded in `claude/common.rs`; unknown models contribute 0 cost rather than failing the fetch.

## `claude_subscription`

| | |
|---|---|
| **Source** | `GET https://api.anthropic.com/api/oauth/usage` with `anthropic-beta: oauth-2025-04-20` |
| **Auth** | `claudeAiOauth.accessToken` from `~/.claude/.credentials.json` (override path via `SPLASHBOARD_CLAUDE_CREDENTIALS` for tests) |
| **Safety** | `Safe` (host fixed at `api.anthropic.com`) |
| **Default shape** | `Ratio` (single window selected via `window` option) |
| **Shapes (8)** | `Ratio` / `Text` / `TextBlock` / `MarkdownTextBlock` / `Entries` / `Bars` / `Badge` / `Timeline` |
| **Options** | `window` (string — `five_hour` / `seven_day` / `seven_day_sonnet` / … plus aliases like `5h` / `7d` / `claude_design`) |
| **Refresh** | 15 min |

Generic walker — every key in the response that carries `{utilization, resets_at}` is surfaced as a window. Known codenames are mapped to claude.ai UI labels (e.g. `seven_day_omelette` → **Claude Design**); unknown keys fall through `humanize_key` so a future window auto-shows up with a readable label. Utilisation arrives on a 0..100 percent scale, normalised internally to 0..1 with a 1.5 ceiling for distinct over-quota rendering.

The endpoint is undocumented and may break — every failure path returns `FetchError::Failed`, never panics. Tone thresholds: Ok < 60% / Warn < 85% / Error ≥ 85%.

## Trade-offs

- **`anthropic_usage` (originally part of this batch) was dropped** — admin-key persona is too thin for Splashboard's audience (`Org Admin`-only). The catalog entry has been removed from #64 (see catalog edit).
- Pricing for `claude_code_usage` is hardcoded rather than vendoring [LiteLLM's price feed](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — keeps the fetcher offline-safe; future PR can wire LiteLLM if richer coverage is needed.
- `claude_code_usage` walks the JSONL directory synchronously inside `async fn fetch`. With a 5-min TTL the cache hides the cost in normal use; if heavily used sessions push the cold-fetch latency, a follow-up can offload to `spawn_blocking`.

## Test plan

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (52 + 20 new tests, full suite 3160 + 1 green)
- Manual smoke test against live `oauth/usage` endpoint — 5h gauge / grid / badge values match claude.ai/account exactly.
- Manual smoke test against `~/.claude/projects/` on the maintainer's box — today / 7d / 30d rollups produced sensible Text / Bars / NumberSeries shapes.

## Catalog

- Ticks `claude_code_usage` in #64 (AI / LLM — local agent activity) — to flip after merge.
- Ticks `claude_subscription` in #64 (AI / LLM — subscription seat / rate-limit headroom) — to flip after merge.
- Removes `anthropic_usage` from #64 (already applied to the issue body — out of scope going forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track local Claude code token usage and costs per project/day with deduplication, daily series, cost badges, bars, entries and summary widgets.
  * Monitor Claude subscription/quota utilization with percentage, reset-time, timeline and status badges.
  * Register Claude fetchers so Claude data appears alongside other built-in usage dashboards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->