### PR TITLE
feat(fetcher): add codex_usage + codex_subscription, unify llm pricing via Actions sync

### DIFF
--- a/.github/workflows/sync-llm-pricing.yml
+++ b/.github/workflows/sync-llm-pricing.yml
@@ -1,0 +1,91 @@
+name: Sync LLM pricing
+
+# Daily refresh of `data/llm_pricing.json` from LiteLLM's price table. Filtered down to
+# OpenAI / Anthropic chat models and converted from per-token to per-million-tokens so the
+# splashboard runtime can consume it without rescaling. Opens a PR on diff; never commits
+# straight to main — agent PRs always wait for a human merge per repo policy.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'   # daily 00:00 UTC
+  workflow_dispatch:       # manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Refresh pricing snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch upstream LiteLLM table
+        run: |
+          curl -sSf -o /tmp/litellm.json \
+            "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/model_prices_and_context_window_backup.json"
+
+      - name: Extract OpenAI + Anthropic chat models
+        run: |
+          python3 <<'PY'
+          import json
+          src = json.load(open('/tmp/litellm.json'))
+          out = {}
+          for model, v in src.items():
+              if not isinstance(v, dict):
+                  continue
+              if v.get('litellm_provider') not in ('openai', 'anthropic'):
+                  continue
+              if v.get('mode') != 'chat':
+                  continue
+              if v.get('input_cost_per_token') is None and v.get('output_cost_per_token') is None:
+                  continue
+              row = {
+                  'input': v.get('input_cost_per_token', 0.0) * 1_000_000,
+                  'output': v.get('output_cost_per_token', 0.0) * 1_000_000,
+                  'cache_read': v.get('cache_read_input_token_cost', 0.0) * 1_000_000,
+              }
+              cw5 = v.get('cache_creation_input_token_cost', 0.0) * 1_000_000
+              cw1 = v.get('cache_creation_input_token_cost_above_1hr', 0.0) * 1_000_000
+              if cw5:
+                  row['cache_write_5m'] = cw5
+              if cw1:
+                  row['cache_write_1h'] = cw1
+              out[model] = row
+
+          out_sorted = {k: out[k] for k in sorted(out)}
+          final = {
+              "_meta": {
+                  "source": "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/model_prices_and_context_window_backup.json",
+                  "filter": "litellm_provider in {openai, anthropic} AND mode == chat",
+                  "fields": "USD per 1M tokens",
+              },
+              "models": out_sorted,
+          }
+          json.dump(final, open('data/llm_pricing.json', 'w'), indent=2, sort_keys=False)
+          print(f"rows: {len(out_sorted)}")
+          PY
+
+      - name: Open PR if diff
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-llm-pricing
+          title: 'chore: sync llm pricing from LiteLLM'
+          commit-message: |
+            chore: sync llm pricing from LiteLLM
+
+            Automated daily refresh of `data/llm_pricing.json`. Diff reviews
+            catch upstream schema or value changes before they reach users.
+          body: |
+            Automated daily refresh of `data/llm_pricing.json` from LiteLLM's price table.
+
+            **Review checklist:**
+            - [ ] Diff is plausible (no order-of-magnitude jumps that aren't matched by a public Anthropic / OpenAI announcement)
+            - [ ] No models silently disappeared (would zero-cost their token counts)
+            - [ ] `cargo test fetcher::llm_pricing::tests::snapshot_parses_repo_seed` passes — guards schema drift
+          labels: |
+            automation
+            pricing
+          delete-branch: true

--- a/.github/workflows/sync-llm-pricing.yml
+++ b/.github/workflows/sync-llm-pricing.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # `peter-evans/create-pull-request` supplies its own token below, so
+          # checkout doesn't need to persist credentials in the workspace.
+          persist-credentials: false
 
       - name: Fetch upstream LiteLLM table
         run: |

--- a/data/llm_pricing.json
+++ b/data/llm_pricing.json
@@ -1,0 +1,630 @@
+{
+  "_meta": {
+    "source": "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/model_prices_and_context_window_backup.json",
+    "filter": "litellm_provider in {openai, anthropic} AND mode == chat",
+    "fields": "USD per 1M tokens"
+  },
+  "models": {
+    "chatgpt-4o-latest": {
+      "input": 5.0,
+      "output": 15.0,
+      "cache_read": 0.0
+    },
+    "claude-3-7-sonnet-20250219": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write_5m": 3.75,
+      "cache_write_1h": 6.0
+    },
+    "claude-3-haiku-20240307": {
+      "input": 0.25,
+      "output": 1.25,
+      "cache_read": 0.03,
+      "cache_write_5m": 0.3,
+      "cache_write_1h": 6.0
+    },
+    "claude-3-opus-20240229": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write_5m": 18.75,
+      "cache_write_1h": 6.0
+    },
+    "claude-4-opus-20250514": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write_5m": 18.75
+    },
+    "claude-4-sonnet-20250514": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write_5m": 3.75
+    },
+    "claude-haiku-4-5": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.09999999999999999,
+      "cache_write_5m": 1.25,
+      "cache_write_1h": 2.0
+    },
+    "claude-haiku-4-5-20251001": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.09999999999999999,
+      "cache_write_5m": 1.25,
+      "cache_write_1h": 2.0
+    },
+    "claude-opus-4-1": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write_5m": 18.75,
+      "cache_write_1h": 30.0
+    },
+    "claude-opus-4-1-20250805": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write_5m": 18.75,
+      "cache_write_1h": 30.0
+    },
+    "claude-opus-4-20250514": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write_5m": 18.75,
+      "cache_write_1h": 30.0
+    },
+    "claude-opus-4-5": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write_5m": 6.25,
+      "cache_write_1h": 10.0
+    },
+    "claude-opus-4-5-20251101": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write_5m": 6.25,
+      "cache_write_1h": 10.0
+    },
+    "claude-opus-4-6": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write_5m": 6.25,
+      "cache_write_1h": 10.0
+    },
+    "claude-opus-4-6-20260205": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write_5m": 6.25,
+      "cache_write_1h": 10.0
+    },
+    "claude-opus-4-7": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write_5m": 6.25,
+      "cache_write_1h": 10.0
+    },
+    "claude-opus-4-7-20260416": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write_5m": 6.25,
+      "cache_write_1h": 10.0
+    },
+    "claude-sonnet-4-20250514": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write_5m": 3.75,
+      "cache_write_1h": 6.0
+    },
+    "claude-sonnet-4-5": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write_5m": 3.75
+    },
+    "claude-sonnet-4-5-20250929": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write_5m": 3.75
+    },
+    "claude-sonnet-4-6": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write_5m": 3.75
+    },
+    "ft:gpt-3.5-turbo": {
+      "input": 3.0,
+      "output": 6.0,
+      "cache_read": 0.0
+    },
+    "ft:gpt-3.5-turbo-0125": {
+      "input": 3.0,
+      "output": 6.0,
+      "cache_read": 0.0
+    },
+    "ft:gpt-3.5-turbo-0613": {
+      "input": 3.0,
+      "output": 6.0,
+      "cache_read": 0.0
+    },
+    "ft:gpt-3.5-turbo-1106": {
+      "input": 3.0,
+      "output": 6.0,
+      "cache_read": 0.0
+    },
+    "ft:gpt-4-0613": {
+      "input": 30.0,
+      "output": 60.0,
+      "cache_read": 0.0
+    },
+    "ft:gpt-4.1-2025-04-14": {
+      "input": 3.0,
+      "output": 12.0,
+      "cache_read": 0.75
+    },
+    "ft:gpt-4.1-mini-2025-04-14": {
+      "input": 0.7999999999999999,
+      "output": 3.1999999999999997,
+      "cache_read": 0.19999999999999998
+    },
+    "ft:gpt-4.1-nano-2025-04-14": {
+      "input": 0.19999999999999998,
+      "output": 0.7999999999999999,
+      "cache_read": 0.049999999999999996
+    },
+    "ft:gpt-4o-2024-08-06": {
+      "input": 3.75,
+      "output": 15.0,
+      "cache_read": 1.875
+    },
+    "ft:gpt-4o-2024-11-20": {
+      "input": 3.75,
+      "output": 15.0,
+      "cache_read": 0.0,
+      "cache_write_5m": 1.875
+    },
+    "ft:gpt-4o-mini-2024-07-18": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.15
+    },
+    "ft:o4-mini-2025-04-16": {
+      "input": 4.0,
+      "output": 16.0,
+      "cache_read": 1.0
+    },
+    "gpt-3.5-turbo": {
+      "input": 0.5,
+      "output": 1.5,
+      "cache_read": 0.0
+    },
+    "gpt-3.5-turbo-0125": {
+      "input": 0.5,
+      "output": 1.5,
+      "cache_read": 0.0
+    },
+    "gpt-3.5-turbo-1106": {
+      "input": 1.0,
+      "output": 2.0,
+      "cache_read": 0.0
+    },
+    "gpt-3.5-turbo-16k": {
+      "input": 3.0,
+      "output": 4.0,
+      "cache_read": 0.0
+    },
+    "gpt-4": {
+      "input": 30.0,
+      "output": 60.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-0125-preview": {
+      "input": 10.0,
+      "output": 30.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-0314": {
+      "input": 30.0,
+      "output": 60.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-0613": {
+      "input": 30.0,
+      "output": 60.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-1106-preview": {
+      "input": 10.0,
+      "output": 30.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-turbo": {
+      "input": 10.0,
+      "output": 30.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-turbo-2024-04-09": {
+      "input": 10.0,
+      "output": 30.0,
+      "cache_read": 0.0
+    },
+    "gpt-4-turbo-preview": {
+      "input": 10.0,
+      "output": 30.0,
+      "cache_read": 0.0
+    },
+    "gpt-4.1": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "gpt-4.1-2025-04-14": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "gpt-4.1-mini": {
+      "input": 0.39999999999999997,
+      "output": 1.5999999999999999,
+      "cache_read": 0.09999999999999999
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "input": 0.39999999999999997,
+      "output": 1.5999999999999999,
+      "cache_read": 0.09999999999999999
+    },
+    "gpt-4.1-nano": {
+      "input": 0.09999999999999999,
+      "output": 0.39999999999999997,
+      "cache_read": 0.024999999999999998
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "input": 0.09999999999999999,
+      "output": 0.39999999999999997,
+      "cache_read": 0.024999999999999998
+    },
+    "gpt-4o": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "gpt-4o-2024-05-13": {
+      "input": 5.0,
+      "output": 15.0,
+      "cache_read": 0.0
+    },
+    "gpt-4o-2024-08-06": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "gpt-4o-2024-11-20": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "gpt-4o-audio-preview": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 0.0
+    },
+    "gpt-4o-audio-preview-2024-12-17": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 0.0
+    },
+    "gpt-4o-audio-preview-2025-06-03": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 0.0
+    },
+    "gpt-4o-mini": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075
+    },
+    "gpt-4o-mini-2024-07-18": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075
+    },
+    "gpt-4o-mini-audio-preview": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.0
+    },
+    "gpt-4o-mini-audio-preview-2024-12-17": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.0
+    },
+    "gpt-4o-mini-realtime-preview": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.3
+    },
+    "gpt-4o-mini-realtime-preview-2024-12-17": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.3
+    },
+    "gpt-4o-mini-search-preview": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075
+    },
+    "gpt-4o-mini-search-preview-2025-03-11": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075
+    },
+    "gpt-4o-realtime-preview": {
+      "input": 5.0,
+      "output": 20.0,
+      "cache_read": 2.5
+    },
+    "gpt-4o-realtime-preview-2024-12-17": {
+      "input": 5.0,
+      "output": 20.0,
+      "cache_read": 2.5
+    },
+    "gpt-4o-realtime-preview-2025-06-03": {
+      "input": 5.0,
+      "output": 20.0,
+      "cache_read": 2.5
+    },
+    "gpt-4o-search-preview": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "gpt-4o-search-preview-2025-03-11": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "gpt-5": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5-2025-08-07": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5-chat": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5-chat-latest": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5-mini": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.024999999999999998
+    },
+    "gpt-5-mini-2025-08-07": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.024999999999999998
+    },
+    "gpt-5-nano": {
+      "input": 0.049999999999999996,
+      "output": 0.39999999999999997,
+      "cache_read": 0.005
+    },
+    "gpt-5-nano-2025-08-07": {
+      "input": 0.049999999999999996,
+      "output": 0.39999999999999997,
+      "cache_read": 0.005
+    },
+    "gpt-5-search-api": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5-search-api-2025-10-14": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5.1": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5.1-2025-11-13": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5.1-chat-latest": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "gpt-5.2": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "gpt-5.2-2025-12-11": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "gpt-5.2-chat-latest": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "gpt-5.3-chat-latest": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "gpt-5.4": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "gpt-5.4-2026-03-05": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "gpt-5.4-mini": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "gpt-5.4-mini-2026-03-17": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "gpt-5.4-nano": {
+      "input": 0.19999999999999998,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "gpt-5.4-nano-2026-03-17": {
+      "input": 0.19999999999999998,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "gpt-5.5": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "gpt-5.5-2026-04-23": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "gpt-audio": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 0.0
+    },
+    "gpt-audio-1.5": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 0.0
+    },
+    "gpt-audio-2025-08-28": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 0.0
+    },
+    "gpt-audio-mini": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.0
+    },
+    "gpt-audio-mini-2025-10-06": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.0
+    },
+    "gpt-audio-mini-2025-12-15": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.0
+    },
+    "gpt-realtime": {
+      "input": 4.0,
+      "output": 16.0,
+      "cache_read": 0.39999999999999997
+    },
+    "gpt-realtime-1.5": {
+      "input": 4.0,
+      "output": 16.0,
+      "cache_read": 0.39999999999999997
+    },
+    "gpt-realtime-2": {
+      "input": 4.0,
+      "output": 16.0,
+      "cache_read": 0.39999999999999997
+    },
+    "gpt-realtime-2025-08-28": {
+      "input": 4.0,
+      "output": 16.0,
+      "cache_read": 0.39999999999999997
+    },
+    "gpt-realtime-mini": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.0
+    },
+    "gpt-realtime-mini-2025-10-06": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.06
+    },
+    "gpt-realtime-mini-2025-12-15": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.06
+    },
+    "o1": {
+      "input": 15.0,
+      "output": 60.0,
+      "cache_read": 7.5
+    },
+    "o1-2024-12-17": {
+      "input": 15.0,
+      "output": 60.0,
+      "cache_read": 7.5
+    },
+    "o3": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "o3-2025-04-16": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "o3-mini": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.55
+    },
+    "o3-mini-2025-01-31": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.55
+    },
+    "o4-mini": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.275
+    },
+    "o4-mini-2025-04-16": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.275
+    }
+  }
+}

--- a/src/fetcher/claude/code_usage.rs
+++ b/src/fetcher/claude/code_usage.rs
@@ -950,6 +950,10 @@ mod tests {
     }
 
     #[tokio::test]
+    // TEST_ENV_LOCK serialises tests that mutate process env (`CLAUDE_CONFIG_DIR` here). The
+    // lock is held across `.fetch().await` deliberately so a sibling test can't swap the env
+    // out mid-flight; the fetcher only reads env at the synchronous entry to the call, so
+    // there's no path where the awaiting future re-takes the same lock and deadlocks.
     #[allow(clippy::await_holding_lock)]
     async fn fetch_reads_jsonl_from_env_override_root() {
         let _lock = crate::paths::TEST_ENV_LOCK

--- a/src/fetcher/claude/code_usage.rs
+++ b/src/fetcher/claude/code_usage.rs
@@ -5,9 +5,11 @@
 //! since the configured window, deduplicates by `(message.id, request_id)` keeping the row with
 //! the higher token total, then groups by project / model / day depending on `group_by`.
 //!
-//! `Safety::Safe` — every read is rooted at a `$HOME`-relative directory the user owns. No
-//! network, no token, no exec. Pricing is hardcoded in [`super::common`] so a stale price feed
-//! can't disrupt the fetch.
+//! `Safety::Safe` — every session read is rooted at a `$HOME`-relative directory the user
+//! owns. The fetcher *does* make a single HTTP GET for the LLM pricing snapshot (see
+//! [`crate::fetcher::llm_pricing`]) — the URL is hardcoded to splashboard's own GitHub repo,
+//! which keeps it under the host-fixed-URL Safe rule. On HTTP failure we fall back to the
+//! embedded floor so cost columns stay populated for the headline models.
 
 use std::collections::HashMap;
 use std::fs;
@@ -19,9 +21,10 @@ use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::claude::common::{
-    cost_usd, discover_jsonl_dirs, format_cost, format_tokens, project_name_from_cwd,
+    discover_jsonl_dirs, format_cost, format_tokens, project_name_from_cwd,
 };
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::llm_pricing::{self, PriceMap};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{
@@ -117,9 +120,20 @@ impl Fetcher for ClaudeCodeUsage {
         let group_by = parse_group_by(opts.group_by.as_deref())?;
         let shape = ctx.shape.unwrap_or(Shape::Text);
 
-        let snapshot = build_snapshot(&since, group_by, limit);
+        let prices = llm_pricing::fetch_pricing(http()).await;
+        let snapshot = build_snapshot(&since, group_by, limit, &prices);
         Ok(payload(render_body(&snapshot, shape)))
     }
+}
+
+fn http() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .user_agent(concat!("splashboard/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("reqwest client should build with default config")
+    })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -224,23 +238,24 @@ impl UsageEvent {
             + self.cache_write_1h
             + self.cache_read
     }
-    fn cost(&self) -> f64 {
-        cost_usd(
+    fn cost(&self, prices: &PriceMap) -> f64 {
+        llm_pricing::cost_usd(
+            prices,
             &self.model,
             self.input_tokens,
             self.output_tokens,
+            self.cache_read,
             self.cache_write_5m,
             self.cache_write_1h,
-            self.cache_read,
         )
     }
 }
 
-fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize) -> Snapshot {
+fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize, prices: &PriceMap) -> Snapshot {
     let events = dedup(collect_events(&discover_jsonl_dirs(), since));
     let total_tokens = events.iter().map(UsageEvent::token_total).sum();
-    let total_cost = events.iter().map(UsageEvent::cost).sum();
-    let rows = group_rows(&events, group_by, limit);
+    let total_cost: f64 = events.iter().map(|e| e.cost(prices)).sum();
+    let rows = group_rows(&events, group_by, limit, prices);
     let daily_tokens = daily_series(&events, since);
     Snapshot {
         rows,
@@ -395,7 +410,12 @@ fn dedup(events: Vec<UsageEvent>) -> Vec<UsageEvent> {
     out
 }
 
-fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<UsageRow> {
+fn group_rows(
+    events: &[UsageEvent],
+    group_by: GroupBy,
+    limit: usize,
+    prices: &PriceMap,
+) -> Vec<UsageRow> {
     let mut by_key: HashMap<String, (u64, f64)> = HashMap::new();
     for e in events {
         let key = match group_by {
@@ -405,7 +425,7 @@ fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<Usa
         };
         let entry = by_key.entry(key).or_insert((0, 0.0));
         entry.0 += e.token_total();
-        entry.1 += e.cost();
+        entry.1 += e.cost(prices);
     }
     let mut rows: Vec<UsageRow> = by_key
         .into_iter()
@@ -746,7 +766,7 @@ mod tests {
             cache_read: 0,
         };
         let events = vec![make("a", 1_000), make("b", 5_000), make("c", 100)];
-        let rows = group_rows(&events, GroupBy::Project, 2);
+        let rows = group_rows(&events, GroupBy::Project, 2, &llm_pricing::embedded_floor());
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].label, "b");
         assert_eq!(rows[1].label, "a");
@@ -957,7 +977,7 @@ mod tests {
             mk(day1, "b", 2_000),
             mk(day2, "c", 500),
         ];
-        let rows = group_rows(&events, GroupBy::Day, 10);
+        let rows = group_rows(&events, GroupBy::Day, 10, &llm_pricing::embedded_floor());
         assert_eq!(rows.len(), 2);
         // Day 1 contributed 3_000 tokens vs day 2's 500, so it ranks first.
         assert!(rows[0].label.ends_with("05-05"));

--- a/src/fetcher/claude/code_usage.rs
+++ b/src/fetcher/claude/code_usage.rs
@@ -14,7 +14,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, NaiveDate, Utc};
@@ -285,11 +285,41 @@ fn read_sessions(dir: &PathBuf, since: &Since) -> Vec<UsageEvent> {
     let Ok(entries) = fs::read_dir(dir) else {
         return Vec::new();
     };
+    // Claude session files are `<uuid>.jsonl` — no date in the filename. mtime is the only
+    // cheap signal we have for "was this session touched in the window?", so stat each file
+    // (one syscall, ~10µs) and skip the open+line-parse path when the file is stale.
+    let cutoff = mtime_cutoff(since);
     entries
         .flatten()
         .filter(|e| e.path().extension().is_some_and(|x| x == "jsonl"))
+        .filter(|e| mtime_within_cutoff(&e.path(), cutoff))
         .flat_map(|e| read_session_file(&e.path(), since))
         .collect()
+}
+
+fn mtime_cutoff(since: &Since) -> Option<NaiveDate> {
+    let today = Utc::now().date_naive();
+    match since {
+        Since::All => None,
+        // One-day buffer covers sessions Claude touched late yesterday whose mtime races our
+        // midnight comparison.
+        Since::Today => Some(today - Duration::days(1)),
+        Since::Days(n) => Some(today - Duration::days(*n)),
+    }
+}
+
+fn mtime_within_cutoff(path: &Path, cutoff: Option<NaiveDate>) -> bool {
+    let Some(cutoff) = cutoff else {
+        return true;
+    };
+    let Ok(meta) = fs::metadata(path) else {
+        return true;
+    };
+    let Ok(mtime) = meta.modified() else {
+        return true;
+    };
+    let mtime_date = DateTime::<Utc>::from(mtime).date_naive();
+    mtime_date >= cutoff
 }
 
 fn read_session_file(path: &PathBuf, since: &Since) -> Vec<UsageEvent> {
@@ -954,6 +984,48 @@ mod tests {
         };
         assert!(t.value.contains("Today"));
         assert!(t.value.contains("3k"), "value was {:?}", t.value);
+    }
+
+    #[test]
+    fn mtime_cutoff_is_none_for_all_and_one_day_buffer_for_today() {
+        assert!(mtime_cutoff(&Since::All).is_none());
+        let today = Utc::now().date_naive();
+        assert_eq!(mtime_cutoff(&Since::Today), Some(today - Duration::days(1)));
+        assert_eq!(
+            mtime_cutoff(&Since::Days(7)),
+            Some(today - Duration::days(7))
+        );
+    }
+
+    #[test]
+    fn mtime_within_cutoff_keeps_freshly_written_files() {
+        // A file written now has mtime = now → should always be within any non-empty cutoff.
+        let tmp = tempdir().unwrap();
+        let fresh = tmp.path().join("recent.jsonl");
+        fs::write(&fresh, "").unwrap();
+        let cutoff = mtime_cutoff(&Since::Today);
+        assert!(mtime_within_cutoff(&fresh, cutoff));
+    }
+
+    #[test]
+    fn mtime_within_cutoff_keeps_unreadable_files_conservatively() {
+        // If we can't stat the path, the safe thing is to let `read_session_file` try and
+        // fail silently — the per-line `since.includes(ts)` filter is the source of truth.
+        let cutoff = Some(Utc::now().date_naive());
+        assert!(mtime_within_cutoff(
+            Path::new("/nonexistent/path/does/not/exist.jsonl"),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn mtime_within_cutoff_lets_anything_through_when_cutoff_is_none() {
+        // Since::All path: cutoff is None, every file (even nonexistent) passes.
+        let tmp = tempdir().unwrap();
+        let f = tmp.path().join("any.jsonl");
+        fs::write(&f, "").unwrap();
+        assert!(mtime_within_cutoff(&f, None));
+        assert!(mtime_within_cutoff(Path::new("/nonexistent.jsonl"), None));
     }
 
     #[test]

--- a/src/fetcher/claude/common.rs
+++ b/src/fetcher/claude/common.rs
@@ -1,91 +1,10 @@
-//! Shared helpers for the `claude_*` family — model pricing, cost math, and the JSONL discovery
+//! Shared helpers for the `claude_*` family — formatting helpers and the JSONL discovery
 //! roots used by `claude_code_usage`.
 //!
-//! Pricing lives in source rather than a vendored JSON file because the set of Claude models is
-//! small and changes rarely; bumping a constant is less error-prone than parsing an external table
-//! on every fetch. When a new family ships, add a [`PRICE_TABLE`] row matching the model-id prefix.
+//! Pricing has moved to the shared [`crate::fetcher::llm_pricing`] module so claude and codex
+//! consume the same snapshot. See its module doc for the fetch / fallback story.
 
 use std::path::PathBuf;
-
-/// USD per million tokens for a single Claude model family. Cache write tiers map to Anthropic's
-/// `ephemeral_5m` / `ephemeral_1h` breakouts in the usage payload; `cache_read` covers the
-/// flat-rate cache-read line.
-#[derive(Debug, Clone, Copy)]
-pub struct Price {
-    pub input: f64,
-    pub output: f64,
-    pub cache_write_5m: f64,
-    pub cache_write_1h: f64,
-    pub cache_read: f64,
-}
-
-const OPUS: Price = Price {
-    input: 15.0,
-    output: 75.0,
-    cache_write_5m: 18.75,
-    cache_write_1h: 30.0,
-    cache_read: 1.50,
-};
-
-const SONNET: Price = Price {
-    input: 3.0,
-    output: 15.0,
-    cache_write_5m: 3.75,
-    cache_write_1h: 6.0,
-    cache_read: 0.30,
-};
-
-const HAIKU: Price = Price {
-    input: 1.0,
-    output: 5.0,
-    cache_write_5m: 1.25,
-    cache_write_1h: 2.0,
-    cache_read: 0.10,
-};
-
-/// Prefix table — first match wins, longest-prefix entries appear first so `opus` doesn't shadow
-/// a hypothetical `opus-mini`. Match is on the full lowercased model id.
-const PRICE_TABLE: &[(&str, Price)] = &[
-    ("claude-opus", OPUS),
-    ("claude-sonnet", SONNET),
-    ("claude-haiku", HAIKU),
-    // Legacy date-stamped names still seen in older JSONL sessions.
-    ("claude-3-5-sonnet", SONNET),
-    ("claude-3-5-haiku", HAIKU),
-    ("claude-3-opus", OPUS),
-    ("claude-3-sonnet", SONNET),
-    ("claude-3-haiku", HAIKU),
-];
-
-pub fn price_for(model: &str) -> Option<Price> {
-    let lower = model.to_lowercase();
-    PRICE_TABLE
-        .iter()
-        .find(|(prefix, _)| lower.starts_with(prefix))
-        .map(|(_, p)| *p)
-}
-
-/// USD cost of a usage row given a model. Unknown models contribute 0 — surfacing them as
-/// "free" is friendlier than hiding the underlying token activity behind an error.
-#[allow(clippy::too_many_arguments)]
-pub fn cost_usd(
-    model: &str,
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_write_5m: u64,
-    cache_write_1h: u64,
-    cache_read: u64,
-) -> f64 {
-    let Some(p) = price_for(model) else {
-        return 0.0;
-    };
-    let per_token = |rate_per_mt: f64, count: u64| (count as f64) * rate_per_mt / 1_000_000.0;
-    per_token(p.input, input_tokens)
-        + per_token(p.output, output_tokens)
-        + per_token(p.cache_write_5m, cache_write_5m)
-        + per_token(p.cache_write_1h, cache_write_1h)
-        + per_token(p.cache_read, cache_read)
-}
 
 /// "$12.34" / "$0.05" / "$1.2k" — compact enough to fit a Badge or a Text headline.
 pub fn format_cost(usd: f64) -> String {
@@ -147,44 +66,6 @@ pub fn project_name_from_cwd(cwd: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn price_for_matches_opus_sonnet_haiku_by_prefix() {
-        assert!(price_for("claude-opus-4-7").is_some());
-        assert!(price_for("claude-sonnet-4-6").is_some());
-        assert!(price_for("claude-haiku-4-5-20251001").is_some());
-        assert!(price_for("claude-3-5-sonnet-20241022").is_some());
-    }
-
-    #[test]
-    fn price_for_unknown_model_returns_none() {
-        assert!(price_for("gpt-4-turbo").is_none());
-        assert!(price_for("").is_none());
-    }
-
-    #[test]
-    fn price_for_is_case_insensitive() {
-        assert!(price_for("CLAUDE-OPUS-4-7").is_some());
-    }
-
-    #[test]
-    fn cost_usd_zero_for_unknown_model_even_with_tokens() {
-        assert_eq!(cost_usd("gpt-4", 1_000_000, 1_000_000, 0, 0, 0), 0.0);
-    }
-
-    #[test]
-    fn cost_usd_sums_per_tier_rates_against_million_tokens() {
-        // Opus: 1M input @ $15 + 1M output @ $75 = $90 exactly.
-        let c = cost_usd("claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0);
-        assert!((c - 90.0).abs() < 1e-6, "expected ~$90, got {c}");
-    }
-
-    #[test]
-    fn cost_usd_charges_cache_tiers() {
-        // Sonnet cache_write_1h: 1M @ $6 = $6.
-        let c = cost_usd("claude-sonnet-4-6", 0, 0, 0, 1_000_000, 0);
-        assert!((c - 6.0).abs() < 1e-6);
-    }
 
     #[test]
     fn format_cost_picks_unit_by_magnitude() {

--- a/src/fetcher/codex/common.rs
+++ b/src/fetcher/codex/common.rs
@@ -1,0 +1,348 @@
+//! Shared helpers for the `codex_*` family — model pricing, cost math, and the date-tree
+//! discovery used by `codex_usage` and `codex_subscription`.
+//!
+//! Pricing lives in source rather than a vendored file because the OpenAI model surface is
+//! small enough to track by hand; bumping a constant is less error-prone than parsing an
+//! external table on every fetch. When a new family ships, add a [`PRICE_TABLE`] row matching
+//! the model-id prefix.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// USD per million tokens for a single OpenAI model family. `cached_input` covers the prompt
+/// cache discount (Codex CLI's `cached_input_tokens` lands here, billed at the discounted rate
+/// instead of the full `input` rate). Reasoning output is billed at the same rate as regular
+/// output today, so it folds into [`Price::output`].
+#[derive(Debug, Clone, Copy)]
+pub struct Price {
+    pub input: f64,
+    pub cached_input: f64,
+    pub output: f64,
+}
+
+const GPT_5: Price = Price {
+    input: 1.25,
+    cached_input: 0.125,
+    output: 10.0,
+};
+
+const GPT_5_MINI: Price = Price {
+    input: 0.25,
+    cached_input: 0.025,
+    output: 2.0,
+};
+
+const GPT_5_NANO: Price = Price {
+    input: 0.05,
+    cached_input: 0.005,
+    output: 0.40,
+};
+
+const GPT_4_1: Price = Price {
+    input: 2.0,
+    cached_input: 0.50,
+    output: 8.0,
+};
+
+const GPT_4_1_MINI: Price = Price {
+    input: 0.40,
+    cached_input: 0.10,
+    output: 1.60,
+};
+
+const O3: Price = Price {
+    input: 2.0,
+    cached_input: 0.50,
+    output: 8.0,
+};
+
+const O4_MINI: Price = Price {
+    input: 1.10,
+    cached_input: 0.275,
+    output: 4.40,
+};
+
+/// Prefix table — longest-prefix entries come first so `gpt-5-mini` doesn't get swallowed by
+/// `gpt-5`. Match is on the full lowercased model id.
+const PRICE_TABLE: &[(&str, Price)] = &[
+    ("gpt-5-nano", GPT_5_NANO),
+    ("gpt-5-mini", GPT_5_MINI),
+    ("gpt-5", GPT_5),
+    ("gpt-4.1-mini", GPT_4_1_MINI),
+    ("gpt-4.1", GPT_4_1),
+    ("o4-mini", O4_MINI),
+    ("o3", O3),
+];
+
+pub fn price_for(model: &str) -> Option<Price> {
+    let lower = model.to_lowercase();
+    PRICE_TABLE
+        .iter()
+        .find(|(prefix, _)| lower.starts_with(prefix))
+        .map(|(_, p)| *p)
+}
+
+/// USD cost of a single turn given a model. Unknown models contribute 0 — surfacing them as
+/// "free" is friendlier than hiding the underlying token activity behind an error.
+pub fn cost_usd(
+    model: &str,
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    output_tokens: u64,
+) -> f64 {
+    let Some(p) = price_for(model) else {
+        return 0.0;
+    };
+    let per_token = |rate_per_mt: f64, count: u64| (count as f64) * rate_per_mt / 1_000_000.0;
+    // OpenAI reports `cached_input_tokens` as a subset of `input_tokens`; bill the cached chunk
+    // at the discounted rate and the rest at the full input rate.
+    let billable_input = input_tokens.saturating_sub(cached_input_tokens);
+    per_token(p.input, billable_input)
+        + per_token(p.cached_input, cached_input_tokens)
+        + per_token(p.output, output_tokens)
+}
+
+/// "$12.34" / "$0.05" / "$1.2k" — compact enough to fit a Badge or a Text headline.
+pub fn format_cost(usd: f64) -> String {
+    if usd >= 1_000.0 {
+        format!("${:.1}k", usd / 1_000.0)
+    } else if usd >= 10.0 {
+        format!("${:.2}", usd)
+    } else if usd > 0.0 {
+        format!("${:.3}", usd)
+    } else {
+        "$0.00".into()
+    }
+}
+
+/// "3.4M" / "812k" / "42" — same compact strategy for raw token counts.
+pub fn format_tokens(count: u64) -> String {
+    if count >= 1_000_000 {
+        format!("{:.1}M", count as f64 / 1_000_000.0)
+    } else if count >= 1_000 {
+        format!("{}k", count / 1_000)
+    } else {
+        count.to_string()
+    }
+}
+
+/// Codex CLI's per-day session roots. Default `~/.codex/sessions/`; the `CODEX_HOME` env var
+/// (Codex's own override) wins so power users with relocated installs stay covered.
+pub fn discover_session_dirs() -> Vec<PathBuf> {
+    if let Ok(raw) = std::env::var("CODEX_HOME") {
+        return vec![PathBuf::from(raw).join("sessions")];
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".codex").join("sessions"))
+        .filter(|p| p.is_dir())
+        .into_iter()
+        .collect()
+}
+
+/// Enumerate every `rollout-*.jsonl` under the `YYYY/MM/DD/` tree of each root. Sorted by
+/// filename (lexically chronological — Codex's `rollout-<rfc3339>` prefix gives free ordering).
+pub fn list_session_files(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = roots.iter().flat_map(walk_year_month_day).collect();
+    files.sort();
+    files
+}
+
+fn walk_year_month_day(root: &PathBuf) -> Vec<PathBuf> {
+    read_subdirs(root)
+        .into_iter()
+        .flat_map(|year| read_subdirs(&year))
+        .flat_map(|month| read_subdirs(&month))
+        .flat_map(|day| read_jsonl_files(&day))
+        .collect()
+}
+
+fn read_subdirs(dir: &PathBuf) -> Vec<PathBuf> {
+    fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flat_map(|it| it.flatten())
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .map(|e| e.path())
+        .collect()
+}
+
+fn read_jsonl_files(dir: &PathBuf) -> Vec<PathBuf> {
+    fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flat_map(|it| it.flatten())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
+        .collect()
+}
+
+/// Last path component of a Codex `cwd` field — the bare project name without filesystem noise.
+/// Empty cwd falls back to `"(unknown)"` so renderers always get a non-empty key.
+pub fn project_name_from_cwd(cwd: &str) -> String {
+    PathBuf::from(cwd)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "(unknown)".into())
+}
+
+/// `gpt-5.5` → `gpt-5.5`, `gpt-5-2025-08-12` → `gpt-5`, `gpt-5-mini-2025-08-12` → `gpt-5-mini`.
+/// Drops a trailing dash-separated `YYYY-MM-DD` release stamp so the `group_by = model` axis
+/// collapses release ids into a family. Anything else passes through unchanged.
+pub fn short_model_name(model: &str) -> String {
+    let lower = model.to_lowercase();
+    strip_trailing_iso_date(&lower).unwrap_or(lower)
+}
+
+fn strip_trailing_iso_date(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    // Match `-YYYY-MM-DD` at the end (11 chars total). Cheap manual scan; chrono would pull in
+    // strftime parsing for what amounts to a regex literal.
+    if bytes.len() < 11 {
+        return None;
+    }
+    let tail = &bytes[bytes.len() - 11..];
+    let ok = tail[0] == b'-'
+        && tail[5] == b'-'
+        && tail[8] == b'-'
+        && tail[1..5].iter().all(|b| b.is_ascii_digit())
+        && tail[6..8].iter().all(|b| b.is_ascii_digit())
+        && tail[9..11].iter().all(|b| b.is_ascii_digit());
+    ok.then(|| s[..s.len() - 11].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn price_for_matches_gpt_5_family_by_prefix() {
+        assert!(price_for("gpt-5").is_some());
+        assert!(price_for("gpt-5.5").is_some());
+        assert!(price_for("gpt-5-mini").is_some());
+        assert!(price_for("gpt-5-nano").is_some());
+        assert!(price_for("o4-mini").is_some());
+    }
+
+    #[test]
+    fn price_for_unknown_model_returns_none() {
+        assert!(price_for("claude-opus-4-7").is_none());
+        assert!(price_for("").is_none());
+    }
+
+    #[test]
+    fn price_for_longer_prefix_wins_over_shorter() {
+        // gpt-5-mini must resolve to GPT_5_MINI, not GPT_5 (it's listed before in PRICE_TABLE).
+        let mini = price_for("gpt-5-mini").unwrap();
+        assert!(
+            (mini.input - 0.25).abs() < 1e-9,
+            "expected gpt-5-mini rate, got {}",
+            mini.input
+        );
+    }
+
+    #[test]
+    fn cost_usd_zero_for_unknown_model_even_with_tokens() {
+        assert_eq!(cost_usd("claude-opus-4-7", 1_000_000, 0, 1_000_000), 0.0);
+    }
+
+    #[test]
+    fn cost_usd_charges_cached_input_at_discounted_rate() {
+        // gpt-5: 1M billable input @ $1.25 + 0M cached + 0M output = $1.25
+        let full = cost_usd("gpt-5", 1_000_000, 0, 0);
+        assert!((full - 1.25).abs() < 1e-9, "got {full}");
+        // Same input but all cached → 1M @ $0.125 = $0.125
+        let cached = cost_usd("gpt-5", 1_000_000, 1_000_000, 0);
+        assert!((cached - 0.125).abs() < 1e-9, "got {cached}");
+    }
+
+    #[test]
+    fn cost_usd_splits_partial_cache_against_full_and_cached_rates() {
+        // 1M input where 0.5M is cached → 0.5M @ $1.25 + 0.5M @ $0.125 = $0.625 + $0.0625 = $0.6875
+        let c = cost_usd("gpt-5", 1_000_000, 500_000, 0);
+        assert!((c - 0.6875).abs() < 1e-9, "got {c}");
+    }
+
+    #[test]
+    fn format_cost_picks_unit_by_magnitude() {
+        assert_eq!(format_cost(0.0), "$0.00");
+        assert_eq!(format_cost(0.005), "$0.005");
+        assert_eq!(format_cost(2.50), "$2.500");
+        assert_eq!(format_cost(12.34), "$12.34");
+        assert_eq!(format_cost(1234.0), "$1.2k");
+    }
+
+    #[test]
+    fn format_tokens_uses_m_and_k_suffixes() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(42), "42");
+        assert_eq!(format_tokens(1_500), "1k");
+        assert_eq!(format_tokens(3_400_000), "3.4M");
+    }
+
+    #[test]
+    fn project_name_from_cwd_takes_last_component() {
+        assert_eq!(
+            project_name_from_cwd("/home/owner/.ghq/github.com/unhappychoice/splashboard"),
+            "splashboard"
+        );
+        assert_eq!(project_name_from_cwd(""), "(unknown)");
+    }
+
+    #[test]
+    fn short_model_name_strips_trailing_iso_date_only() {
+        assert_eq!(short_model_name("gpt-5-2025-08-12"), "gpt-5");
+        assert_eq!(short_model_name("gpt-5-mini-2025-08-12"), "gpt-5-mini");
+        // No trailing date → pass through unchanged.
+        assert_eq!(short_model_name("gpt-5.5"), "gpt-5.5");
+        assert_eq!(short_model_name("o4-mini"), "o4-mini");
+        // A trailing integer that isn't an ISO date must not be stripped.
+        assert_eq!(short_model_name("gpt-5-mini-12345"), "gpt-5-mini-12345");
+    }
+
+    #[test]
+    fn discover_session_dirs_honours_codex_home_env() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("CODEX_HOME").ok();
+        unsafe { std::env::set_var("CODEX_HOME", "/tmp/codex-test-home") };
+        let dirs = discover_session_dirs();
+        assert_eq!(dirs.len(), 1);
+        assert!(dirs[0].ends_with("codex-test-home/sessions"));
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+            None => unsafe { std::env::remove_var("CODEX_HOME") },
+        }
+    }
+
+    #[test]
+    fn list_session_files_walks_year_month_day_tree_sorted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let day = tmp.path().join("2026").join("05").join("23");
+        fs::create_dir_all(&day).unwrap();
+        fs::write(day.join("rollout-2026-05-23T01-00-00-b.jsonl"), "").unwrap();
+        fs::write(day.join("rollout-2026-05-23T00-00-00-a.jsonl"), "").unwrap();
+        // Non-jsonl + extra noise must be ignored.
+        fs::write(day.join("note.txt"), "").unwrap();
+        let files = list_session_files(&[tmp.path().to_path_buf()]);
+        assert_eq!(files.len(), 2);
+        // Lexical sort = chronological because filenames are rfc3339-prefixed.
+        assert!(
+            files[0]
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("00-00-00-a")
+        );
+        assert!(
+            files[1]
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("01-00-00-b")
+        );
+    }
+}

--- a/src/fetcher/codex/common.rs
+++ b/src/fetcher/codex/common.rs
@@ -1,106 +1,11 @@
-//! Shared helpers for the `codex_*` family — model pricing, cost math, and the date-tree
-//! discovery used by `codex_usage` and `codex_subscription`.
+//! Shared helpers for the `codex_*` family — formatting helpers, JSONL session discovery,
+//! and the small label-normalising bits used by `codex_usage` and `codex_subscription`.
 //!
-//! Pricing lives in source rather than a vendored file because the OpenAI model surface is
-//! small enough to track by hand; bumping a constant is less error-prone than parsing an
-//! external table on every fetch. When a new family ships, add a [`PRICE_TABLE`] row matching
-//! the model-id prefix.
+//! Pricing has moved to the shared [`crate::fetcher::llm_pricing`] module so codex and
+//! claude consume the same snapshot. See its module doc for the fetch / fallback story.
 
 use std::fs;
 use std::path::PathBuf;
-
-/// USD per million tokens for a single OpenAI model family. `cached_input` covers the prompt
-/// cache discount (Codex CLI's `cached_input_tokens` lands here, billed at the discounted rate
-/// instead of the full `input` rate). Reasoning output is billed at the same rate as regular
-/// output today, so it folds into [`Price::output`].
-#[derive(Debug, Clone, Copy)]
-pub struct Price {
-    pub input: f64,
-    pub cached_input: f64,
-    pub output: f64,
-}
-
-const GPT_5: Price = Price {
-    input: 1.25,
-    cached_input: 0.125,
-    output: 10.0,
-};
-
-const GPT_5_MINI: Price = Price {
-    input: 0.25,
-    cached_input: 0.025,
-    output: 2.0,
-};
-
-const GPT_5_NANO: Price = Price {
-    input: 0.05,
-    cached_input: 0.005,
-    output: 0.40,
-};
-
-const GPT_4_1: Price = Price {
-    input: 2.0,
-    cached_input: 0.50,
-    output: 8.0,
-};
-
-const GPT_4_1_MINI: Price = Price {
-    input: 0.40,
-    cached_input: 0.10,
-    output: 1.60,
-};
-
-const O3: Price = Price {
-    input: 2.0,
-    cached_input: 0.50,
-    output: 8.0,
-};
-
-const O4_MINI: Price = Price {
-    input: 1.10,
-    cached_input: 0.275,
-    output: 4.40,
-};
-
-/// Prefix table — longest-prefix entries come first so `gpt-5-mini` doesn't get swallowed by
-/// `gpt-5`. Match is on the full lowercased model id.
-const PRICE_TABLE: &[(&str, Price)] = &[
-    ("gpt-5-nano", GPT_5_NANO),
-    ("gpt-5-mini", GPT_5_MINI),
-    ("gpt-5", GPT_5),
-    ("gpt-4.1-mini", GPT_4_1_MINI),
-    ("gpt-4.1", GPT_4_1),
-    ("o4-mini", O4_MINI),
-    ("o3", O3),
-];
-
-pub fn price_for(model: &str) -> Option<Price> {
-    let lower = model.to_lowercase();
-    PRICE_TABLE
-        .iter()
-        .find(|(prefix, _)| lower.starts_with(prefix))
-        .map(|(_, p)| *p)
-}
-
-/// USD cost of a single turn given a model. Unknown models contribute 0 — surfacing them as
-/// "free" is friendlier than hiding the underlying token activity behind an error.
-pub fn cost_usd(
-    model: &str,
-    input_tokens: u64,
-    cached_input_tokens: u64,
-    output_tokens: u64,
-) -> f64 {
-    let Some(p) = price_for(model) else {
-        return 0.0;
-    };
-    let per_token = |rate_per_mt: f64, count: u64| (count as f64) * rate_per_mt / 1_000_000.0;
-    // OpenAI reports `cached_input_tokens` as a subset of `input_tokens`; bill the cached chunk
-    // at the discounted rate and the rest at the full input rate.
-    let billable_input = input_tokens.saturating_sub(cached_input_tokens);
-    per_token(p.input, billable_input)
-        + per_token(p.cached_input, cached_input_tokens)
-        + per_token(p.output, output_tokens)
-}
 
 /// "$12.34" / "$0.05" / "$1.2k" — compact enough to fit a Badge or a Text headline.
 pub fn format_cost(usd: f64) -> String {
@@ -214,54 +119,6 @@ fn strip_trailing_iso_date(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn price_for_matches_gpt_5_family_by_prefix() {
-        assert!(price_for("gpt-5").is_some());
-        assert!(price_for("gpt-5.5").is_some());
-        assert!(price_for("gpt-5-mini").is_some());
-        assert!(price_for("gpt-5-nano").is_some());
-        assert!(price_for("o4-mini").is_some());
-    }
-
-    #[test]
-    fn price_for_unknown_model_returns_none() {
-        assert!(price_for("claude-opus-4-7").is_none());
-        assert!(price_for("").is_none());
-    }
-
-    #[test]
-    fn price_for_longer_prefix_wins_over_shorter() {
-        // gpt-5-mini must resolve to GPT_5_MINI, not GPT_5 (it's listed before in PRICE_TABLE).
-        let mini = price_for("gpt-5-mini").unwrap();
-        assert!(
-            (mini.input - 0.25).abs() < 1e-9,
-            "expected gpt-5-mini rate, got {}",
-            mini.input
-        );
-    }
-
-    #[test]
-    fn cost_usd_zero_for_unknown_model_even_with_tokens() {
-        assert_eq!(cost_usd("claude-opus-4-7", 1_000_000, 0, 1_000_000), 0.0);
-    }
-
-    #[test]
-    fn cost_usd_charges_cached_input_at_discounted_rate() {
-        // gpt-5: 1M billable input @ $1.25 + 0M cached + 0M output = $1.25
-        let full = cost_usd("gpt-5", 1_000_000, 0, 0);
-        assert!((full - 1.25).abs() < 1e-9, "got {full}");
-        // Same input but all cached → 1M @ $0.125 = $0.125
-        let cached = cost_usd("gpt-5", 1_000_000, 1_000_000, 0);
-        assert!((cached - 0.125).abs() < 1e-9, "got {cached}");
-    }
-
-    #[test]
-    fn cost_usd_splits_partial_cache_against_full_and_cached_rates() {
-        // 1M input where 0.5M is cached → 0.5M @ $1.25 + 0.5M @ $0.125 = $0.625 + $0.0625 = $0.6875
-        let c = cost_usd("gpt-5", 1_000_000, 500_000, 0);
-        assert!((c - 0.6875).abs() < 1e-9, "got {c}");
-    }
 
     #[test]
     fn format_cost_picks_unit_by_magnitude() {

--- a/src/fetcher/codex/common.rs
+++ b/src/fetcher/codex/common.rs
@@ -77,7 +77,16 @@ fn read_jsonl_files(dir: &PathBuf) -> Vec<PathBuf> {
         .into_iter()
         .flat_map(|it| it.flatten())
         .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
+        // Only `rollout-*.jsonl` — Codex writes session rollups with this prefix; other
+        // *.jsonl files that may appear under `~/.codex/sessions/` (history backups, future
+        // file kinds) are unrelated and would confuse the lex-sorted "newest session" lookup
+        // codex_subscription does.
+        .filter(|p| {
+            p.extension().is_some_and(|x| x == "jsonl")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("rollout-"))
+        })
         .collect()
 }
 

--- a/src/fetcher/codex/mod.rs
+++ b/src/fetcher/codex/mod.rs
@@ -2,11 +2,15 @@
 //!
 //! - [`usage::CodexUsage`] aggregates the local `rollout-*.jsonl` files Codex CLI writes for
 //!   every session, with zero configuration and no network.
+//! - [`subscription::CodexSubscription`] extracts rate-limit utilisation (5h / 7d windows +
+//!   plan type) from the most recent session's last `token_count` event.
 //!
-//! `Safety::Safe` — every read is rooted at `~/.codex/sessions/` (or the `CODEX_HOME`
-//! override) and no network connection is opened.
+//! Both are `Safety::Safe` — all reads are rooted at `~/.codex/sessions/`. No network, no
+//! token leaves the host (the rate-limit data is already cached in the JSONL by Codex CLI;
+//! re-fetching it would mean making an inference call, which costs money).
 
 mod common;
+mod subscription;
 mod usage;
 
 use std::sync::Arc;
@@ -14,7 +18,10 @@ use std::sync::Arc;
 use crate::fetcher::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    vec![Arc::new(usage::CodexUsage)]
+    vec![
+        Arc::new(usage::CodexUsage),
+        Arc::new(subscription::CodexSubscription),
+    ]
 }
 
 #[cfg(test)]
@@ -31,5 +38,6 @@ mod tests {
             );
         }
         assert!(names.contains(&"codex_usage".to_string()));
+        assert!(names.contains(&"codex_subscription".to_string()));
     }
 }

--- a/src/fetcher/codex/mod.rs
+++ b/src/fetcher/codex/mod.rs
@@ -1,13 +1,16 @@
 //! Codex (OpenAI Codex CLI) fetchers.
 //!
 //! - [`usage::CodexUsage`] aggregates the local `rollout-*.jsonl` files Codex CLI writes for
-//!   every session, with zero configuration and no network.
+//!   every session, then HTTP-GETs the shared LLM pricing snapshot from splashboard's own
+//!   GitHub repo (see [`crate::fetcher::llm_pricing`]) to convert tokens into a USD cost.
 //! - [`subscription::CodexSubscription`] extracts rate-limit utilisation (5h / 7d windows +
-//!   plan type) from the most recent session's last `token_count` event.
+//!   plan type) from the most recent session's last `token_count` event. No network — the
+//!   payload Codex CLI already wrote is what we read.
 //!
-//! Both are `Safety::Safe` — all reads are rooted at `~/.codex/sessions/`. No network, no
-//! token leaves the host (the rate-limit data is already cached in the JSONL by Codex CLI;
-//! re-fetching it would mean making an inference call, which costs money).
+//! Both are `Safety::Safe`. `codex_subscription` is local-only. `codex_usage` makes one
+//! host-fixed HTTP GET (the URL never accepts user input) — same model as `nasa_apod` or any
+//! other Safe + outbound fetcher: config can't redirect the traffic, no token leaves the
+//! host.
 
 mod common;
 mod subscription;

--- a/src/fetcher/codex/mod.rs
+++ b/src/fetcher/codex/mod.rs
@@ -1,0 +1,29 @@
+//! Codex (OpenAI Codex CLI) fetchers.
+//!
+//! Scaffolding for the family. Individual fetchers (`codex_usage`, `codex_subscription`,
+//! etc.) live as siblings of [`common`] and register through [`fetchers`].
+//!
+//! `Safety::Safe` — every member of the family reads from `~/.codex/sessions/` (or the
+//! `CODEX_HOME` override) and never opens a network connection.
+
+mod common;
+
+use std::sync::Arc;
+
+use crate::fetcher::Fetcher;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetchers_entry_point_starts_empty_until_members_are_registered() {
+        // Commit-1 contract: the entry point exists and returns an empty vec. Member fetchers
+        // are added by subsequent commits; this assertion is amended as they land.
+        assert!(fetchers().is_empty());
+    }
+}

--- a/src/fetcher/codex/mod.rs
+++ b/src/fetcher/codex/mod.rs
@@ -1,19 +1,20 @@
 //! Codex (OpenAI Codex CLI) fetchers.
 //!
-//! Scaffolding for the family. Individual fetchers (`codex_usage`, `codex_subscription`,
-//! etc.) live as siblings of [`common`] and register through [`fetchers`].
+//! - [`usage::CodexUsage`] aggregates the local `rollout-*.jsonl` files Codex CLI writes for
+//!   every session, with zero configuration and no network.
 //!
-//! `Safety::Safe` — every member of the family reads from `~/.codex/sessions/` (or the
-//! `CODEX_HOME` override) and never opens a network connection.
+//! `Safety::Safe` — every read is rooted at `~/.codex/sessions/` (or the `CODEX_HOME`
+//! override) and no network connection is opened.
 
 mod common;
+mod usage;
 
 use std::sync::Arc;
 
 use crate::fetcher::Fetcher;
 
 pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
-    Vec::new()
+    vec![Arc::new(usage::CodexUsage)]
 }
 
 #[cfg(test)]
@@ -21,9 +22,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fetchers_entry_point_starts_empty_until_members_are_registered() {
-        // Commit-1 contract: the entry point exists and returns an empty vec. Member fetchers
-        // are added by subsequent commits; this assertion is amended as they land.
-        assert!(fetchers().is_empty());
+    fn fetchers_entry_point_registers_each_member_under_codex_prefix() {
+        let names: Vec<String> = fetchers().iter().map(|f| f.name().to_string()).collect();
+        for name in &names {
+            assert!(
+                name.starts_with("codex_"),
+                "{name} must use the `codex_` family prefix"
+            );
+        }
+        assert!(names.contains(&"codex_usage".to_string()));
     }
 }

--- a/src/fetcher/codex/subscription.rs
+++ b/src/fetcher/codex/subscription.rs
@@ -716,6 +716,44 @@ mod tests {
     }
 
     #[test]
+    fn text_block_body_includes_plan_line_and_one_per_window() {
+        let Body::TextBlock(b) = text_block_body(&snap_full()) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 3);
+        assert!(b.lines[0].contains("pro"));
+        assert!(b.lines[1].starts_with("5h"));
+        assert!(b.lines[2].starts_with("7d"));
+    }
+
+    #[test]
+    fn text_block_body_falls_back_when_no_data() {
+        let Body::TextBlock(b) = text_block_body(&Snapshot::default()) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 1);
+        assert!(b.lines[0].contains("n/a"));
+    }
+
+    #[test]
+    fn markdown_body_emphasises_plan_and_each_window() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&snap_full()) else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("**plan**: `pro`"));
+        assert!(m.value.contains("- **5h**"));
+        assert!(m.value.contains("- **7d**"));
+    }
+
+    #[test]
+    fn markdown_body_falls_back_when_empty() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&Snapshot::default()) else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.contains("unavailable"));
+    }
+
+    #[test]
     fn status_for_bucketed_thresholds() {
         assert_eq!(status_for(0.0), Status::Ok);
         assert_eq!(status_for(0.5), Status::Ok);

--- a/src/fetcher/codex/subscription.rs
+++ b/src/fetcher/codex/subscription.rs
@@ -1,0 +1,812 @@
+//! `codex_subscription` — Codex CLI plan utilisation as Codex sees it.
+//!
+//! Codex CLI piggybacks rate-limit state on every `token_count` event in the session JSONL:
+//!
+//! ```json
+//! "rate_limits": {
+//!   "primary":   { "used_percent": 0.0, "window_minutes": 300,   "resets_at": 1779493088 },
+//!   "secondary": { "used_percent": 0.0, "window_minutes": 10080, "resets_at": 1779863530 },
+//!   "plan_type": "pro",
+//!   ...
+//! }
+//! ```
+//!
+//! `primary` is the 5h window, `secondary` is the 7d window. This fetcher walks the newest
+//! session and reads the last such event — that's the same data Codex itself would show.
+//!
+//! We deliberately don't make a network call here even though OpenAI's API can return this
+//! same payload: the only way to re-fetch is to make a billable inference request, which is
+//! not what a splash widget should do. Freshness is bounded by "when did the user last run
+//! Codex" — `format_reset` will show `now` for a window that has already rolled over.
+//!
+//! `Safety::Safe` — every read stays inside `~/.codex/sessions/`.
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::codex::common::{discover_session_dirs, list_session_files};
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, RatioData,
+    Status, TextBlockData, TextData, TimelineData, TimelineEvent,
+};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Ratio,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::Badge,
+    Shape::Timeline,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[OptionSchema {
+    name: "window",
+    type_hint: "\"5h\" | \"7d\" | \"primary\" | \"secondary\"",
+    required: false,
+    default: Some("\"5h\""),
+    description: "Which window the single-value shapes (`Ratio`, `Badge`) report. Multi-row shapes always list both windows.",
+}];
+
+pub struct CodexSubscription;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub window: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for CodexSubscription {
+    fn name(&self) -> &str {
+        "codex_subscription"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Codex CLI subscription utilisation, parsed from the local session JSONL. Each token_count event Codex writes carries the 5h (primary) and 7d (secondary) rate-limit windows; we read the most recent one. No HTTP — re-fetching this would mean making a billable inference call."
+    }
+    fn refresh_interval(&self) -> u64 {
+        // The newest JSONL grows as the user uses Codex; a 5-minute cache matches the
+        // session-recent feel without re-reading megabytes on every cd.
+        5 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let target = parse_window(opts.window.as_deref());
+        let shape = ctx.shape.unwrap_or(Shape::Ratio);
+        let snapshot = load_snapshot()?;
+        Ok(payload(render_body(&snapshot, target, shape)))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowKind {
+    Primary,
+    Secondary,
+}
+
+fn parse_window(raw: Option<&str>) -> WindowKind {
+    match raw.unwrap_or("5h").trim().to_lowercase().as_str() {
+        "7d" | "secondary" | "week" | "weekly" => WindowKind::Secondary,
+        // 5h is the canonical primary; any unknown value falls through to primary so a typo
+        // doesn't render an empty widget.
+        _ => WindowKind::Primary,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct Snapshot {
+    windows: Vec<NamedWindow>,
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct NamedWindow {
+    kind: WindowKind,
+    label: String,
+    utilization: f64,
+    resets_at: Option<DateTime<Utc>>,
+}
+
+impl Snapshot {
+    fn find(&self, kind: WindowKind) -> Option<&NamedWindow> {
+        self.windows.iter().find(|w| w.kind == kind)
+    }
+}
+
+fn load_snapshot() -> Result<Snapshot, FetchError> {
+    let files = list_session_files(&discover_session_dirs());
+    let latest = files
+        .last()
+        .cloned()
+        .ok_or_else(|| FetchError::Failed("no Codex session JSONL found".into()))?;
+    parse_latest_rate_limits(&latest)
+        .ok_or_else(|| FetchError::Failed(format!("no rate_limits event in {}", latest.display())))
+}
+
+fn parse_latest_rate_limits(path: &PathBuf) -> Option<Snapshot> {
+    let file = fs::File::open(path).ok()?;
+    // Walk forward, keeping the most recent rate_limits seen. Reverse-scan would be faster but
+    // BufReader doesn't seek backward — sessions top out at a few MB so this is fine.
+    let mut latest: Option<RawRateLimits> = None;
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if let Some(rl) = extract_rate_limits(&line) {
+            latest = Some(rl);
+        }
+    }
+    latest.map(snapshot_from)
+}
+
+fn extract_rate_limits(line: &str) -> Option<RawRateLimits> {
+    let raw: RawLine = serde_json::from_str(line).ok()?;
+    if raw.kind != "event_msg" {
+        return None;
+    }
+    let payload = raw.payload?;
+    if payload.msg_type.as_deref()? != "token_count" {
+        return None;
+    }
+    payload.rate_limits
+}
+
+#[derive(Deserialize)]
+struct RawLine {
+    #[serde(rename = "type", default)]
+    kind: String,
+    #[serde(default)]
+    payload: Option<RawPayload>,
+}
+
+#[derive(Deserialize)]
+struct RawPayload {
+    #[serde(default, rename = "type")]
+    msg_type: Option<String>,
+    #[serde(default)]
+    rate_limits: Option<RawRateLimits>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawRateLimits {
+    #[serde(default)]
+    primary: Option<RawRateWindow>,
+    #[serde(default)]
+    secondary: Option<RawRateWindow>,
+    #[serde(default)]
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawRateWindow {
+    #[serde(default)]
+    used_percent: f64,
+    #[serde(default)]
+    window_minutes: u64,
+    #[serde(default)]
+    resets_at: Option<i64>,
+}
+
+fn snapshot_from(raw: RawRateLimits) -> Snapshot {
+    let windows = [
+        raw.primary.map(|w| named_window(WindowKind::Primary, w)),
+        raw.secondary
+            .map(|w| named_window(WindowKind::Secondary, w)),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    Snapshot {
+        windows,
+        plan_type: raw.plan_type,
+    }
+}
+
+fn named_window(kind: WindowKind, w: RawRateWindow) -> NamedWindow {
+    NamedWindow {
+        kind,
+        label: window_label(w.window_minutes, kind),
+        // `used_percent` is 0..100 (allow up to 150 to keep an over-quota window visible).
+        utilization: (w.used_percent / 100.0).clamp(0.0, 1.5),
+        resets_at: w.resets_at.and_then(|s| Utc.timestamp_opt(s, 0).single()),
+    }
+}
+
+/// Resolve a window's display label from its `window_minutes` (300 → "5h", 10080 → "7d"),
+/// falling back to a kind-relative label when the duration is unfamiliar.
+fn window_label(minutes: u64, kind: WindowKind) -> String {
+    // Match `0` first — every divisibility check below would otherwise succeed for it and emit
+    // a misleading "0d" / "0h" label.
+    if minutes == 0 {
+        return match kind {
+            WindowKind::Primary => "primary".into(),
+            WindowKind::Secondary => "secondary".into(),
+        };
+    }
+    match minutes {
+        300 => "5h".into(),
+        10_080 => "7d".into(),
+        m if m % 1440 == 0 => format!("{}d", m / 1440),
+        m if m % 60 == 0 => format!("{}h", m / 60),
+        m => format!("{m}m"),
+    }
+}
+
+fn render_body(snap: &Snapshot, target: WindowKind, shape: Shape) -> Body {
+    match shape {
+        Shape::Ratio => ratio_body(snap, target),
+        Shape::Text => text_body(snap),
+        Shape::TextBlock => text_block_body(snap),
+        Shape::MarkdownTextBlock => markdown_body(snap),
+        Shape::Entries => entries_body(snap),
+        Shape::Bars => bars_body(snap),
+        Shape::Badge => badge_body(snap, target),
+        Shape::Timeline => timeline_body(snap),
+        _ => text_body(snap),
+    }
+}
+
+fn ratio_body(snap: &Snapshot, target: WindowKind) -> Body {
+    let Some(window) = snap.find(target) else {
+        return Body::Ratio(RatioData {
+            value: 0.0,
+            label: Some(format!("{} · n/a", default_label(target))),
+            denominator: Some(100),
+        });
+    };
+    let reset = window
+        .resets_at
+        .map(format_reset)
+        .unwrap_or_else(|| "n/a".into());
+    Body::Ratio(RatioData {
+        value: window.utilization.clamp(0.0, 1.0),
+        label: Some(format!("{} · resets {reset}", window.label)),
+        denominator: Some(100),
+    })
+}
+
+fn default_label(kind: WindowKind) -> &'static str {
+    match kind {
+        WindowKind::Primary => "5h",
+        WindowKind::Secondary => "7d",
+    }
+}
+
+fn text_body(snap: &Snapshot) -> Body {
+    let parts: Vec<String> = snap
+        .windows
+        .iter()
+        .map(|w| format!("{} {}", w.label, percent(w.utilization)))
+        .collect();
+    let head = match &snap.plan_type {
+        Some(plan) if !plan.is_empty() => format!("[{plan}] "),
+        _ => String::new(),
+    };
+    Body::Text(TextData {
+        value: if parts.is_empty() {
+            "codex subscription: n/a".into()
+        } else {
+            format!("{head}{}", parts.join(" · "))
+        },
+    })
+}
+
+fn text_block_body(snap: &Snapshot) -> Body {
+    let mut lines: Vec<String> = Vec::new();
+    if let Some(plan) = &snap.plan_type
+        && !plan.is_empty()
+    {
+        lines.push(format!("plan: {plan}"));
+    }
+    lines.extend(snap.windows.iter().map(format_window_line));
+    Body::TextBlock(TextBlockData {
+        lines: if lines.is_empty() {
+            vec!["codex subscription: n/a".into()]
+        } else {
+            lines
+        },
+    })
+}
+
+fn markdown_body(snap: &Snapshot) -> Body {
+    let mut lines: Vec<String> = Vec::new();
+    if let Some(plan) = &snap.plan_type
+        && !plan.is_empty()
+    {
+        lines.push(format!("**plan**: `{plan}`"));
+    }
+    lines.extend(snap.windows.iter().map(|w| {
+        let reset = w
+            .resets_at
+            .map(format_reset)
+            .unwrap_or_else(|| "n/a".into());
+        format!(
+            "- **{}** — {} (resets {reset})",
+            w.label,
+            percent(w.utilization),
+        )
+    }));
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: if lines.is_empty() {
+            "_codex subscription unavailable_".into()
+        } else {
+            lines.join("\n")
+        },
+    })
+}
+
+fn entries_body(snap: &Snapshot) -> Body {
+    let mut items: Vec<Entry> = Vec::new();
+    if let Some(plan) = &snap.plan_type
+        && !plan.is_empty()
+    {
+        items.push(Entry {
+            key: "plan".into(),
+            value: Some(plan.clone()),
+            status: None,
+        });
+    }
+    items.extend(snap.windows.iter().map(|w| Entry {
+        key: w.label.clone(),
+        value: Some(format!(
+            "{} (resets {})",
+            percent(w.utilization),
+            w.resets_at.map(format_reset).unwrap_or_else(|| "n/a".into()),
+        )),
+        status: Some(status_for(w.utilization)),
+    }));
+    Body::Entries(EntriesData {
+        items: if items.is_empty() {
+            vec![Entry {
+                key: "codex".into(),
+                value: Some("subscription unavailable".into()),
+                status: Some(Status::Warn),
+            }]
+        } else {
+            items
+        },
+    })
+}
+
+fn bars_body(snap: &Snapshot) -> Body {
+    let bars: Vec<Bar> = snap
+        .windows
+        .iter()
+        .map(|w| Bar {
+            label: w.label.clone(),
+            // Bars take u64 — store utilisation as basis points (0..=15000) so a fully spent
+            // window outranks a quarter-spent one in chart_bar.
+            value: ((w.utilization * 10_000.0).round() as i64).max(0) as u64,
+            value_label: Some(percent(w.utilization)),
+        })
+        .collect();
+    Body::Bars(BarsData { bars })
+}
+
+fn badge_body(snap: &Snapshot, target: WindowKind) -> Body {
+    let Some(window) = snap.find(target) else {
+        return Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: format!("{}: n/a", default_label(target)),
+        });
+    };
+    Body::Badge(BadgeData {
+        status: status_for(window.utilization),
+        label: format!("{} {}", window.label, percent(window.utilization)),
+    })
+}
+
+fn timeline_body(snap: &Snapshot) -> Body {
+    let mut events: Vec<TimelineEvent> = snap
+        .windows
+        .iter()
+        .filter_map(|w| {
+            w.resets_at.map(|ts| TimelineEvent {
+                timestamp: ts.timestamp(),
+                title: format!("{} resets", w.label),
+                detail: Some(format!("at {}", percent(w.utilization))),
+                status: Some(status_for(w.utilization)),
+            })
+        })
+        .collect();
+    events.sort_by_key(|e| e.timestamp);
+    Body::Timeline(TimelineData { events })
+}
+
+fn format_window_line(window: &NamedWindow) -> String {
+    let reset = window
+        .resets_at
+        .map(format_reset)
+        .unwrap_or_else(|| "n/a".into());
+    format!(
+        "{}  {} · resets {reset}",
+        window.label,
+        percent(window.utilization),
+    )
+}
+
+fn percent(util: f64) -> String {
+    format!("{:.0}%", (util * 100.0).clamp(0.0, 150.0))
+}
+
+fn format_reset(ts: DateTime<Utc>) -> String {
+    let delta = ts.signed_duration_since(Utc::now());
+    if delta <= chrono::Duration::zero() {
+        return "now".into();
+    }
+    let mins = delta.num_minutes();
+    if mins < 60 {
+        format!("{mins}m")
+    } else if mins < 60 * 48 {
+        format!("{}h", delta.num_hours())
+    } else {
+        format!("{}d", delta.num_days())
+    }
+}
+
+fn status_for(util: f64) -> Status {
+    if util >= 0.85 {
+        Status::Error
+    } else if util >= 0.60 {
+        Status::Warn
+    } else {
+        Status::Ok
+    }
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    Some(match shape {
+        Shape::Ratio => samples::ratio(0.18, "5h · resets 3h"),
+        Shape::Text => samples::text("[pro] 5h 18% · 7d 7%"),
+        Shape::TextBlock => {
+            samples::text_block(&["plan: pro", "5h  18% · resets 3h", "7d   7% · resets 5d"])
+        }
+        Shape::MarkdownTextBlock => samples::markdown(
+            "**plan**: `pro`\n- **5h** — 18% (resets 3h)\n- **7d** — 7% (resets 5d)",
+        ),
+        Shape::Entries => samples::entries(&[
+            ("plan", "pro"),
+            ("5h", "18% (resets 3h)"),
+            ("7d", "7% (resets 5d)"),
+        ]),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "5h".into(),
+                    value: 1800,
+                    value_label: Some("18%".into()),
+                },
+                Bar {
+                    label: "7d".into(),
+                    value: 700,
+                    value_label: Some("7%".into()),
+                },
+            ],
+        }),
+        Shape::Badge => samples::badge(Status::Ok, "5h 18%"),
+        Shape::Timeline => samples::timeline(&[
+            (
+                Utc::now().timestamp() + 3 * 3_600,
+                "5h resets",
+                Some("at 18%"),
+            ),
+            (
+                Utc::now().timestamp() + 5 * 86_400,
+                "7d resets",
+                Some("at 7%"),
+            ),
+        ]),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::time::Duration as StdDuration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "codex-sub".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn snap_full() -> Snapshot {
+        Snapshot {
+            plan_type: Some("pro".into()),
+            windows: vec![
+                NamedWindow {
+                    kind: WindowKind::Primary,
+                    label: "5h".into(),
+                    utilization: 0.18,
+                    resets_at: Some(Utc::now() + chrono::Duration::hours(3)),
+                },
+                NamedWindow {
+                    kind: WindowKind::Secondary,
+                    label: "7d".into(),
+                    utilization: 0.07,
+                    resets_at: Some(Utc::now() + chrono::Duration::days(5)),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn parse_window_accepts_friendly_aliases() {
+        assert_eq!(parse_window(None), WindowKind::Primary);
+        assert_eq!(parse_window(Some("5h")), WindowKind::Primary);
+        assert_eq!(parse_window(Some("7d")), WindowKind::Secondary);
+        assert_eq!(parse_window(Some("secondary")), WindowKind::Secondary);
+        // Typo / unknown → primary fallback so the widget still draws.
+        assert_eq!(parse_window(Some("five-hour")), WindowKind::Primary);
+    }
+
+    #[test]
+    fn window_label_derives_from_window_minutes() {
+        assert_eq!(window_label(300, WindowKind::Primary), "5h");
+        assert_eq!(window_label(10_080, WindowKind::Secondary), "7d");
+        assert_eq!(window_label(1440 * 14, WindowKind::Secondary), "14d");
+        assert_eq!(window_label(120, WindowKind::Primary), "2h");
+        assert_eq!(window_label(45, WindowKind::Primary), "45m");
+        assert_eq!(window_label(0, WindowKind::Primary), "primary");
+    }
+
+    #[test]
+    fn extract_rate_limits_picks_token_count_payload() {
+        let line = r#"{"timestamp":"x","type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":{"primary":{"used_percent":7.0,"window_minutes":300,"resets_at":1779493088},"secondary":null,"plan_type":"pro"}}}"#;
+        let rl = extract_rate_limits(line).expect("must parse rate_limits");
+        assert!(rl.primary.is_some());
+        assert_eq!(rl.plan_type.as_deref(), Some("pro"));
+    }
+
+    #[test]
+    fn extract_rate_limits_skips_non_token_count_events() {
+        // task_started carries no rate_limits — must not produce a false positive.
+        let line = r#"{"timestamp":"x","type":"event_msg","payload":{"type":"task_started"}}"#;
+        assert!(extract_rate_limits(line).is_none());
+        // session_meta has the wrong outer kind.
+        let line = r#"{"timestamp":"x","type":"session_meta","payload":{}}"#;
+        assert!(extract_rate_limits(line).is_none());
+    }
+
+    #[test]
+    fn snapshot_from_clamps_over_quota_at_one_and_a_half() {
+        let raw = RawRateLimits {
+            primary: Some(RawRateWindow {
+                used_percent: 200.0,
+                window_minutes: 300,
+                resets_at: None,
+            }),
+            secondary: None,
+            plan_type: None,
+        };
+        let snap = snapshot_from(raw);
+        assert_eq!(snap.windows[0].utilization, 1.5);
+    }
+
+    #[test]
+    fn parse_latest_rate_limits_keeps_the_last_seen_event() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-x.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"event_msg","payload":{{"type":"token_count","rate_limits":{{"primary":{{"used_percent":5.0,"window_minutes":300,"resets_at":1}}}}}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"event_msg","payload":{{"type":"token_count","rate_limits":{{"primary":{{"used_percent":42.0,"window_minutes":300,"resets_at":1}}}}}}}}"#
+        )
+        .unwrap();
+        let snap = parse_latest_rate_limits(&path).expect("must parse");
+        // 42% is the last event; not 5% (the first).
+        assert!((snap.windows[0].utilization - 0.42).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ratio_body_picks_requested_window_by_kind() {
+        let Body::Ratio(r) = ratio_body(&snap_full(), WindowKind::Secondary) else {
+            panic!("expected ratio");
+        };
+        assert!((r.value - 0.07).abs() < 1e-6);
+        assert!(r.label.as_deref().unwrap_or_default().starts_with("7d"));
+    }
+
+    #[test]
+    fn ratio_body_falls_back_to_zero_when_window_missing() {
+        let Body::Ratio(r) = ratio_body(&Snapshot::default(), WindowKind::Primary) else {
+            panic!("expected ratio");
+        };
+        assert_eq!(r.value, 0.0);
+        assert!(r.label.as_deref().unwrap_or_default().contains("n/a"));
+    }
+
+    #[test]
+    fn text_body_prefixes_plan_type_when_present() {
+        let Body::Text(t) = text_body(&snap_full()) else {
+            panic!("expected text");
+        };
+        assert!(t.value.contains("[pro]"));
+        assert!(t.value.contains("5h"));
+        assert!(t.value.contains("7d"));
+    }
+
+    #[test]
+    fn entries_body_lists_plan_then_windows() {
+        let Body::Entries(e) = entries_body(&snap_full()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 3);
+        assert_eq!(e.items[0].key, "plan");
+        assert_eq!(e.items[1].key, "5h");
+        assert_eq!(e.items[2].key, "7d");
+    }
+
+    #[test]
+    fn entries_body_falls_back_when_empty() {
+        let Body::Entries(e) = entries_body(&Snapshot::default()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert!(
+            e.items[0]
+                .value
+                .as_deref()
+                .unwrap_or_default()
+                .contains("unavailable")
+        );
+    }
+
+    #[test]
+    fn bars_body_emits_basis_points_per_window() {
+        let Body::Bars(b) = bars_body(&snap_full()) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars.len(), 2);
+        assert_eq!(b.bars[0].value, 1800);
+        assert_eq!(b.bars[1].value, 700);
+    }
+
+    #[test]
+    fn timeline_body_drops_windows_without_reset_and_sorts_by_timestamp() {
+        let mut snap = snap_full();
+        snap.windows[1].resets_at = None;
+        let Body::Timeline(t) = timeline_body(&snap) else {
+            panic!("expected timeline");
+        };
+        assert_eq!(t.events.len(), 1);
+        assert!(t.events[0].title.starts_with("5h"));
+    }
+
+    #[test]
+    fn status_for_bucketed_thresholds() {
+        assert_eq!(status_for(0.0), Status::Ok);
+        assert_eq!(status_for(0.5), Status::Ok);
+        assert_eq!(status_for(0.6), Status::Warn);
+        assert_eq!(status_for(0.85), Status::Error);
+    }
+
+    #[test]
+    fn percent_caps_over_quota_at_150() {
+        assert_eq!(percent(0.07), "7%");
+        assert_eq!(percent(1.0), "100%");
+        assert_eq!(percent(1.5), "150%");
+        assert_eq!(percent(2.0), "150%");
+    }
+
+    #[test]
+    fn fetcher_metadata_exposes_eight_shapes_with_ratio_default() {
+        let f = CodexSubscription;
+        assert_eq!(f.shapes(), SHAPES);
+        assert_eq!(f.default_shape(), Shape::Ratio);
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "sample missing for {s:?}");
+        }
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn fetch_surfaces_missing_sessions_as_failed() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempdir().unwrap();
+        // CODEX_HOME points to a directory that has no `sessions/` tree at all.
+        let prev = std::env::var("CODEX_HOME").ok();
+        unsafe { std::env::set_var("CODEX_HOME", tmp.path()) };
+        let err = CodexSubscription
+            .fetch(&ctx(None, Some(Shape::Ratio)))
+            .await
+            .unwrap_err();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+            None => unsafe { std::env::remove_var("CODEX_HOME") },
+        }
+        assert!(format!("{err}").contains("no Codex session"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn fetch_reads_latest_rate_limits_from_codex_home_env() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempdir().unwrap();
+        let day = tmp
+            .path()
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("23");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-05-23T00-00-00-x.jsonl");
+        let resets_at = (Utc::now() + chrono::Duration::hours(3)).timestamp();
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"event_msg","payload":{{"type":"token_count","rate_limits":{{"primary":{{"used_percent":18.0,"window_minutes":300,"resets_at":{resets_at}}},"secondary":{{"used_percent":7.0,"window_minutes":10080,"resets_at":{resets_at}}},"plan_type":"pro"}}}}}}"#
+        )
+        .unwrap();
+
+        let prev = std::env::var("CODEX_HOME").ok();
+        unsafe { std::env::set_var("CODEX_HOME", tmp.path()) };
+        let body = CodexSubscription
+            .fetch(&ctx(None, Some(Shape::Ratio)))
+            .await
+            .unwrap()
+            .body;
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+            None => unsafe { std::env::remove_var("CODEX_HOME") },
+        }
+
+        let Body::Ratio(r) = body else {
+            panic!("expected Ratio, got {body:?}");
+        };
+        assert!((r.value - 0.18).abs() < 1e-6, "ratio was {}", r.value);
+        assert!(r.label.as_deref().unwrap_or("").starts_with("5h"));
+    }
+}

--- a/src/fetcher/codex/usage.rs
+++ b/src/fetcher/codex/usage.rs
@@ -6,9 +6,11 @@
 //! that precedes each turn carries the model id and `cwd`; we thread that state forward as
 //! we parse so token_count events get attributed to the right turn.
 //!
-//! `Safety::Safe` — every read is rooted at a `$HOME`-relative directory the user owns. No
-//! network, no token, no exec. Pricing is hardcoded in [`super::common`] so a stale price feed
-//! can't disrupt the fetch.
+//! `Safety::Safe` — every session read is rooted at a `$HOME`-relative directory the user
+//! owns. The fetcher *does* make a single HTTP GET for the LLM pricing snapshot (see
+//! [`crate::fetcher::llm_pricing`]) — the URL is hardcoded to splashboard's own GitHub repo,
+//! which keeps it under the host-fixed-URL Safe rule. On HTTP failure we fall back to the
+//! embedded floor so cost columns stay populated for the headline models.
 
 use std::collections::HashMap;
 use std::fs;
@@ -20,10 +22,11 @@ use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::Deserialize;
 
 use crate::fetcher::codex::common::{
-    cost_usd, discover_session_dirs, format_cost, format_tokens, list_session_files,
-    project_name_from_cwd, short_model_name,
+    discover_session_dirs, format_cost, format_tokens, list_session_files, project_name_from_cwd,
+    short_model_name,
 };
 use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::llm_pricing::{self, PriceMap};
 use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
 use crate::options::OptionSchema;
 use crate::payload::{
@@ -119,9 +122,20 @@ impl Fetcher for CodexUsage {
         let group_by = parse_group_by(opts.group_by.as_deref())?;
         let shape = ctx.shape.unwrap_or(Shape::Text);
 
-        let snapshot = build_snapshot(&since, group_by, limit);
+        let prices = llm_pricing::fetch_pricing(http()).await;
+        let snapshot = build_snapshot(&since, group_by, limit, &prices);
         Ok(payload(render_body(&snapshot, shape)))
     }
+}
+
+fn http() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .user_agent(concat!("splashboard/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("reqwest client should build with default config")
+    })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -220,21 +234,27 @@ impl UsageEvent {
         // count it. Reasoning tokens already roll into `output_tokens`.
         self.input_tokens + self.output_tokens
     }
-    fn cost(&self) -> f64 {
-        cost_usd(
+    fn cost(&self, prices: &PriceMap) -> f64 {
+        // OpenAI reports `cached_input_tokens` as a subset of `input_tokens`; pass the
+        // non-cached chunk at the full input rate and the cached chunk at `cache_read`.
+        let billable_input = self.input_tokens.saturating_sub(self.cached_input_tokens);
+        llm_pricing::cost_usd(
+            prices,
             &self.model,
-            self.input_tokens,
-            self.cached_input_tokens,
+            billable_input,
             self.output_tokens,
+            self.cached_input_tokens,
+            0,
+            0,
         )
     }
 }
 
-fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize) -> Snapshot {
+fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize, prices: &PriceMap) -> Snapshot {
     let events = collect_events(&list_session_files(&discover_session_dirs()), since);
     let total_tokens = events.iter().map(UsageEvent::token_total).sum();
-    let total_cost = events.iter().map(UsageEvent::cost).sum();
-    let rows = group_rows(&events, group_by, limit);
+    let total_cost: f64 = events.iter().map(|e| e.cost(prices)).sum();
+    let rows = group_rows(&events, group_by, limit, prices);
     let daily_tokens = daily_series(&events, since);
     Snapshot {
         rows,
@@ -376,7 +396,12 @@ fn token_usage_from_event(payload: &RawPayload) -> Option<RawTokenUsage> {
     })
 }
 
-fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<UsageRow> {
+fn group_rows(
+    events: &[UsageEvent],
+    group_by: GroupBy,
+    limit: usize,
+    prices: &PriceMap,
+) -> Vec<UsageRow> {
     let mut by_key: HashMap<String, (u64, f64)> = HashMap::new();
     for e in events {
         let key = match group_by {
@@ -386,7 +411,7 @@ fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<Usa
         };
         let entry = by_key.entry(key).or_insert((0, 0.0));
         entry.0 += e.token_total();
-        entry.1 += e.cost();
+        entry.1 += e.cost(prices);
     }
     let mut rows: Vec<UsageRow> = by_key
         .into_iter()
@@ -709,7 +734,7 @@ mod tests {
             output_tokens: output,
         };
         let events = vec![make("a", 1_000), make("b", 5_000), make("c", 100)];
-        let rows = group_rows(&events, GroupBy::Project, 2);
+        let rows = group_rows(&events, GroupBy::Project, 2, &llm_pricing::embedded_floor());
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].label, "b");
         assert_eq!(rows[1].label, "a");

--- a/src/fetcher/codex/usage.rs
+++ b/src/fetcher/codex/usage.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, NaiveDate, Utc};
@@ -266,10 +266,41 @@ fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize, prices: &Price
 }
 
 fn collect_events(files: &[PathBuf], since: &Since) -> Vec<UsageEvent> {
+    // Codex session filenames are `rollout-YYYY-MM-DDTHH-MM-SS-uuid.jsonl`; skip the whole
+    // file when its date prefix is older than the `since` cutoff. Saves opening hundreds of
+    // MB of JSONL on cold cache when the user just wants Today / 7d.
+    let cutoff = cutoff_date(since);
     files
         .iter()
+        .filter(|p| filename_within_cutoff(p, cutoff))
         .flat_map(|f| read_session_file(f, since))
         .collect()
+}
+
+fn cutoff_date(since: &Since) -> Option<NaiveDate> {
+    let today = Utc::now().date_naive();
+    match since {
+        Since::All => None,
+        // One-day buffer covers sessions that started before midnight and spilled past it.
+        Since::Today => Some(today - Duration::days(1)),
+        Since::Days(n) => Some(today - Duration::days(*n)),
+    }
+}
+
+fn filename_within_cutoff(path: &Path, cutoff: Option<NaiveDate>) -> bool {
+    let Some(cutoff) = cutoff else {
+        return true;
+    };
+    parse_filename_date(path).is_none_or(|date| date >= cutoff)
+}
+
+fn parse_filename_date(path: &Path) -> Option<NaiveDate> {
+    let name = path.file_name()?.to_str()?;
+    let rest = name.strip_prefix("rollout-")?;
+    if rest.len() < 10 {
+        return None;
+    }
+    NaiveDate::parse_from_str(&rest[..10], "%Y-%m-%d").ok()
 }
 
 fn read_session_file(path: &PathBuf, since: &Since) -> Vec<UsageEvent> {
@@ -850,6 +881,60 @@ mod tests {
         };
         assert!(t.value.contains("Today"));
         assert!(t.value.contains("3k"), "value was {:?}", t.value);
+    }
+
+    #[test]
+    fn parse_filename_date_extracts_iso_prefix_from_rollout_name() {
+        let p = PathBuf::from("rollout-2026-05-23T03-37-58-uuid.jsonl");
+        let date = parse_filename_date(&p).expect("must parse");
+        assert_eq!(date.to_string(), "2026-05-23");
+    }
+
+    #[test]
+    fn parse_filename_date_returns_none_for_unexpected_names() {
+        assert!(parse_filename_date(&PathBuf::from("session.jsonl")).is_none());
+        assert!(parse_filename_date(&PathBuf::from("rollout-notadate.jsonl")).is_none());
+    }
+
+    #[test]
+    fn filename_within_cutoff_keeps_files_inside_window_and_drops_older() {
+        let today = Utc::now().date_naive();
+        let cutoff = Some(today - Duration::days(6));
+        let recent = PathBuf::from(format!("rollout-{today}T00-00-00-x.jsonl"));
+        let edge = PathBuf::from(format!(
+            "rollout-{}T23-59-59-x.jsonl",
+            today - Duration::days(6)
+        ));
+        let ancient = PathBuf::from(format!(
+            "rollout-{}T12-00-00-x.jsonl",
+            today - Duration::days(60)
+        ));
+        assert!(filename_within_cutoff(&recent, cutoff));
+        assert!(filename_within_cutoff(&edge, cutoff));
+        assert!(!filename_within_cutoff(&ancient, cutoff));
+    }
+
+    #[test]
+    fn filename_within_cutoff_keeps_unparseable_names_conservatively() {
+        // If we can't parse the date, we must not skip the file — falling through to the
+        // per-line `since.includes(ts)` filter is the safe path.
+        let cutoff = Some(Utc::now().date_naive());
+        assert!(filename_within_cutoff(
+            &PathBuf::from("session.jsonl"),
+            cutoff
+        ));
+    }
+
+    #[test]
+    fn cutoff_date_is_none_for_all_and_one_day_buffer_for_today() {
+        assert!(cutoff_date(&Since::All).is_none());
+        let today = Utc::now().date_naive();
+        // Today's cutoff buffers one day so sessions that started before midnight are kept.
+        assert_eq!(cutoff_date(&Since::Today), Some(today - Duration::days(1)));
+        assert_eq!(
+            cutoff_date(&Since::Days(7)),
+            Some(today - Duration::days(7))
+        );
     }
 
     fn snap_with_rows() -> Snapshot {

--- a/src/fetcher/codex/usage.rs
+++ b/src/fetcher/codex/usage.rs
@@ -1,0 +1,829 @@
+//! `codex_usage` — token + cost rollup from local Codex CLI session JSONL files.
+//!
+//! Walks `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` (or `$CODEX_HOME/sessions/...`),
+//! filters lines to `event_msg` of type `token_count` carrying per-turn `last_token_usage`,
+//! then groups by project / model / day depending on `group_by`. The `turn_context` event
+//! that precedes each turn carries the model id and `cwd`; we thread that state forward as
+//! we parse so token_count events get attributed to the right turn.
+//!
+//! `Safety::Safe` — every read is rooted at a `$HOME`-relative directory the user owns. No
+//! network, no token, no exec. Pricing is hardcoded in [`super::common`] so a stale price feed
+//! can't disrupt the fetch.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use serde::Deserialize;
+
+use crate::fetcher::codex::common::{
+    cost_usd, discover_session_dirs, format_cost, format_tokens, list_session_files,
+    project_name_from_cwd, short_model_name,
+};
+use crate::fetcher::github::common::{cache_key, parse_options, payload};
+use crate::fetcher::{FetchContext, FetchError, Fetcher, Safety};
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Bar, BarsData, Body, EntriesData, Entry, MarkdownTextBlockData, NumberSeriesData,
+    Payload, Status, TextBlockData, TextData,
+};
+use crate::render::Shape;
+
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+    Shape::Bars,
+    Shape::NumberSeries,
+    Shape::Badge,
+];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "since",
+        type_hint: "\"today\" | \"7d\" | \"30d\" | \"all\"",
+        required: false,
+        default: Some("\"today\""),
+        description: "Window the rollup covers, anchored on the current UTC day.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "integer (1..=50)",
+        required: false,
+        default: Some("10"),
+        description: "Maximum rows surfaced by multi-row shapes (`Bars`, `Entries`, …).",
+    },
+    OptionSchema {
+        name: "group_by",
+        type_hint: "\"project\" | \"model\" | \"day\"",
+        required: false,
+        default: Some("\"project\""),
+        description: "Axis used by `Bars` / `Entries` / `TextBlock` row shapes.",
+    },
+];
+
+const DEFAULT_LIMIT: u32 = 10;
+const MAX_LIMIT: u32 = 50;
+
+pub struct CodexUsage;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Options {
+    pub since: Option<String>,
+    pub limit: Option<u32>,
+    pub group_by: Option<String>,
+}
+
+#[async_trait]
+impl Fetcher for CodexUsage {
+    fn name(&self) -> &str {
+        "codex_usage"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Token and cost rollup from local Codex CLI session JSONL files. Aggregates per-turn usage under the chosen `since` window and groups it by project, model, or day. Pricing is bundled, so the splash works offline."
+    }
+    fn refresh_interval(&self) -> u64 {
+        // Mirrors claude_code_usage: JSONL only grows when Codex is actively running, so a
+        // 5-minute refresh tracks "what I just spent" without re-walking MBs every cd.
+        5 * 60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let extra = ctx
+            .options
+            .as_ref()
+            .and_then(|v| toml::to_string(v).ok())
+            .unwrap_or_default();
+        cache_key(self.name(), ctx, &extra)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        sample_body(shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: Options = parse_options(ctx.options.as_ref()).map_err(FetchError::Failed)?;
+        let since = parse_since(opts.since.as_deref())?;
+        let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as usize;
+        let group_by = parse_group_by(opts.group_by.as_deref())?;
+        let shape = ctx.shape.unwrap_or(Shape::Text);
+
+        let snapshot = build_snapshot(&since, group_by, limit);
+        Ok(payload(render_body(&snapshot, shape)))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Since {
+    Today,
+    Days(i64),
+    All,
+}
+
+impl Since {
+    fn label(&self) -> &'static str {
+        match self {
+            Since::Today => "Today",
+            Since::Days(7) => "7d",
+            Since::Days(30) => "30d",
+            Since::Days(_) => "window",
+            Since::All => "All-time",
+        }
+    }
+    fn includes(&self, ts: DateTime<Utc>) -> bool {
+        match self {
+            Since::All => true,
+            Since::Today => ts.date_naive() == Utc::now().date_naive(),
+            Since::Days(n) => {
+                // Calendar-day comparison so this matches `daily_series`'s bucket window exactly
+                // (today .. today-(n-1)). A rolling `now - n days` cutoff would leak partial-day
+                // events into the totals that never show up in the per-day series.
+                let today = Utc::now().date_naive();
+                let start = today - Duration::days((*n - 1).max(0));
+                let day = ts.date_naive();
+                day >= start && day <= today
+            }
+        }
+    }
+}
+
+fn parse_since(raw: Option<&str>) -> Result<Since, FetchError> {
+    match raw.unwrap_or("today").trim().to_lowercase().as_str() {
+        "today" => Ok(Since::Today),
+        "7d" => Ok(Since::Days(7)),
+        "30d" => Ok(Since::Days(30)),
+        "all" => Ok(Since::All),
+        other => Err(FetchError::Failed(format!(
+            "invalid since: {other:?} (expected today | 7d | 30d | all)"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GroupBy {
+    Project,
+    Model,
+    Day,
+}
+
+fn parse_group_by(raw: Option<&str>) -> Result<GroupBy, FetchError> {
+    match raw.unwrap_or("project").trim().to_lowercase().as_str() {
+        "project" => Ok(GroupBy::Project),
+        "model" => Ok(GroupBy::Model),
+        "day" => Ok(GroupBy::Day),
+        other => Err(FetchError::Failed(format!(
+            "invalid group_by: {other:?} (expected project | model | day)"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct Snapshot {
+    rows: Vec<UsageRow>,
+    total_cost: f64,
+    total_tokens: u64,
+    daily_tokens: Vec<u64>,
+    since_label: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct UsageRow {
+    label: String,
+    tokens: u64,
+    cost: f64,
+}
+
+#[derive(Debug, Clone)]
+struct UsageEvent {
+    timestamp: DateTime<Utc>,
+    model: String,
+    project: String,
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    output_tokens: u64,
+}
+
+impl UsageEvent {
+    fn token_total(&self) -> u64 {
+        // `cached_input_tokens` is a subset of `input_tokens` in OpenAI's schema; don't double-
+        // count it. Reasoning tokens already roll into `output_tokens`.
+        self.input_tokens + self.output_tokens
+    }
+    fn cost(&self) -> f64 {
+        cost_usd(
+            &self.model,
+            self.input_tokens,
+            self.cached_input_tokens,
+            self.output_tokens,
+        )
+    }
+}
+
+fn build_snapshot(since: &Since, group_by: GroupBy, limit: usize) -> Snapshot {
+    let events = collect_events(&list_session_files(&discover_session_dirs()), since);
+    let total_tokens = events.iter().map(UsageEvent::token_total).sum();
+    let total_cost = events.iter().map(UsageEvent::cost).sum();
+    let rows = group_rows(&events, group_by, limit);
+    let daily_tokens = daily_series(&events, since);
+    Snapshot {
+        rows,
+        total_cost,
+        total_tokens,
+        daily_tokens,
+        since_label: since.label(),
+    }
+}
+
+fn collect_events(files: &[PathBuf], since: &Since) -> Vec<UsageEvent> {
+    files
+        .iter()
+        .flat_map(|f| read_session_file(f, since))
+        .collect()
+}
+
+fn read_session_file(path: &PathBuf, since: &Since) -> Vec<UsageEvent> {
+    let Ok(file) = fs::File::open(path) else {
+        return Vec::new();
+    };
+    let mut model = String::new();
+    let mut cwd = String::new();
+    let mut out: Vec<UsageEvent> = Vec::new();
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        // `session_meta` and `turn_context` set the current model/cwd; `token_count` events
+        // consume that context. Order is sequential, so a running mutable state is enough.
+        if let Some(raw) = parse_line(&line) {
+            apply_event(raw, &mut model, &mut cwd, since, &mut out);
+        }
+    }
+    out
+}
+
+fn apply_event(
+    raw: RawLine,
+    model: &mut String,
+    cwd: &mut String,
+    since: &Since,
+    out: &mut Vec<UsageEvent>,
+) {
+    let RawLine {
+        timestamp,
+        kind,
+        payload,
+    } = raw;
+    match kind.as_str() {
+        "session_meta" => {
+            if let Some(c) = payload.cwd {
+                *cwd = c;
+            }
+        }
+        "turn_context" => {
+            if let Some(m) = payload.model {
+                *model = m;
+            }
+            if let Some(c) = payload.cwd {
+                *cwd = c;
+            }
+        }
+        "event_msg" => {
+            if let Some(usage) = token_usage_from_event(&payload)
+                && let Some(ts) = parse_ts(&timestamp)
+                && since.includes(ts)
+            {
+                out.push(UsageEvent {
+                    timestamp: ts,
+                    model: model.clone(),
+                    project: project_name_from_cwd(cwd),
+                    input_tokens: usage.input_tokens,
+                    cached_input_tokens: usage.cached_input_tokens,
+                    output_tokens: usage.output_tokens,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_ts(raw: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[derive(Deserialize)]
+struct RawLine {
+    #[serde(default)]
+    timestamp: String,
+    #[serde(rename = "type", default)]
+    kind: String,
+    #[serde(default)]
+    payload: RawPayload,
+}
+
+#[derive(Default, Deserialize)]
+struct RawPayload {
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    // `event_msg` payloads carry their own `type` discriminator (`token_count`, `task_started`,
+    // …); we flatten just the fields we read so unknown subtypes don't trip the deserializer.
+    #[serde(default, rename = "type")]
+    msg_type: Option<String>,
+    #[serde(default)]
+    info: Option<RawTokenInfo>,
+}
+
+#[derive(Deserialize)]
+struct RawTokenInfo {
+    #[serde(default)]
+    last_token_usage: Option<RawTokenUsage>,
+}
+
+#[derive(Deserialize)]
+struct RawTokenUsage {
+    #[serde(default)]
+    input_tokens: u64,
+    #[serde(default)]
+    cached_input_tokens: u64,
+    #[serde(default)]
+    output_tokens: u64,
+}
+
+fn parse_line(line: &str) -> Option<RawLine> {
+    serde_json::from_str(line).ok()
+}
+
+fn token_usage_from_event(payload: &RawPayload) -> Option<RawTokenUsage> {
+    if payload.msg_type.as_deref()? != "token_count" {
+        return None;
+    }
+    let info = payload.info.as_ref()?;
+    info.last_token_usage.as_ref().map(|u| RawTokenUsage {
+        input_tokens: u.input_tokens,
+        cached_input_tokens: u.cached_input_tokens,
+        output_tokens: u.output_tokens,
+    })
+}
+
+fn group_rows(events: &[UsageEvent], group_by: GroupBy, limit: usize) -> Vec<UsageRow> {
+    let mut by_key: HashMap<String, (u64, f64)> = HashMap::new();
+    for e in events {
+        let key = match group_by {
+            GroupBy::Project => e.project.clone(),
+            GroupBy::Model => short_model_name(&e.model),
+            GroupBy::Day => e.timestamp.date_naive().to_string(),
+        };
+        let entry = by_key.entry(key).or_insert((0, 0.0));
+        entry.0 += e.token_total();
+        entry.1 += e.cost();
+    }
+    let mut rows: Vec<UsageRow> = by_key
+        .into_iter()
+        .map(|(label, (tokens, cost))| UsageRow {
+            label,
+            tokens,
+            cost,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.cost
+            .partial_cmp(&a.cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.tokens.cmp(&a.tokens))
+    });
+    rows.truncate(limit);
+    rows
+}
+
+fn daily_series(events: &[UsageEvent], since: &Since) -> Vec<u64> {
+    let span_days = match since {
+        Since::Today => 1,
+        Since::Days(n) => *n as usize,
+        Since::All => 30,
+    };
+    let mut buckets: HashMap<NaiveDate, u64> = HashMap::new();
+    for e in events {
+        *buckets.entry(e.timestamp.date_naive()).or_default() += e.token_total();
+    }
+    let today = Utc::now().date_naive();
+    (0..span_days)
+        .rev()
+        .map(|i| {
+            let day = today - Duration::days(i as i64);
+            buckets.get(&day).copied().unwrap_or(0)
+        })
+        .collect()
+}
+
+fn render_body(snap: &Snapshot, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => text_body(snap),
+        Shape::TextBlock => text_block_body(snap),
+        Shape::MarkdownTextBlock => markdown_body(snap),
+        Shape::Entries => entries_body(snap),
+        Shape::Bars => bars_body(snap),
+        Shape::NumberSeries => number_series_body(snap),
+        Shape::Badge => badge_body(snap),
+        _ => text_body(snap),
+    }
+}
+
+fn text_body(snap: &Snapshot) -> Body {
+    Body::Text(TextData {
+        value: headline(snap),
+    })
+}
+
+fn headline(snap: &Snapshot) -> String {
+    if snap.total_tokens == 0 {
+        format!("{}: no sessions", snap.since_label)
+    } else {
+        format!(
+            "{}: {} tokens / {}",
+            snap.since_label,
+            format_tokens(snap.total_tokens),
+            format_cost(snap.total_cost),
+        )
+    }
+}
+
+fn text_block_body(snap: &Snapshot) -> Body {
+    let mut lines = vec![headline(snap)];
+    lines.extend(snap.rows.iter().map(format_row));
+    if snap.rows.is_empty() && snap.total_tokens == 0 {
+        lines.push("no recent Codex CLI activity".into());
+    }
+    Body::TextBlock(TextBlockData { lines })
+}
+
+fn format_row(row: &UsageRow) -> String {
+    format!(
+        "{}  {} / {}",
+        row.label,
+        format_tokens(row.tokens),
+        format_cost(row.cost),
+    )
+}
+
+fn markdown_body(snap: &Snapshot) -> Body {
+    let mut lines = vec![format!("**{}**", headline(snap))];
+    lines.extend(snap.rows.iter().map(|r| {
+        format!(
+            "- **{}** — {} / {}",
+            r.label,
+            format_tokens(r.tokens),
+            format_cost(r.cost),
+        )
+    }));
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: lines.join("\n"),
+    })
+}
+
+fn entries_body(snap: &Snapshot) -> Body {
+    let items = if snap.rows.is_empty() {
+        vec![Entry {
+            key: snap.since_label.into(),
+            value: Some(headline(snap)),
+            status: None,
+        }]
+    } else {
+        snap.rows
+            .iter()
+            .map(|r| Entry {
+                key: r.label.clone(),
+                value: Some(format!(
+                    "{} / {}",
+                    format_tokens(r.tokens),
+                    format_cost(r.cost)
+                )),
+                status: None,
+            })
+            .collect()
+    };
+    Body::Entries(EntriesData { items })
+}
+
+fn bars_body(snap: &Snapshot) -> Body {
+    // Bars use raw token counts so chart_bar still ranks correctly; the value_label carries the
+    // formatted cost so list_ranking presents money instead of seven-digit token counts.
+    let bars = snap
+        .rows
+        .iter()
+        .map(|r| Bar {
+            label: r.label.clone(),
+            value: r.tokens,
+            value_label: Some(format_cost(r.cost)),
+        })
+        .collect();
+    Body::Bars(BarsData { bars })
+}
+
+fn number_series_body(snap: &Snapshot) -> Body {
+    Body::NumberSeries(NumberSeriesData {
+        values: snap.daily_tokens.clone(),
+    })
+}
+
+fn badge_body(snap: &Snapshot) -> Body {
+    let (status, label) = if snap.total_tokens == 0 {
+        (Status::Warn, format!("{}: quiet", snap.since_label))
+    } else {
+        let tone = if snap.total_cost >= 50.0 {
+            Status::Error
+        } else if snap.total_cost >= 10.0 {
+            Status::Warn
+        } else {
+            Status::Ok
+        };
+        (
+            tone,
+            format!("{} {}", snap.since_label, format_cost(snap.total_cost)),
+        )
+    };
+    Body::Badge(BadgeData { status, label })
+}
+
+fn sample_body(shape: Shape) -> Option<Body> {
+    use crate::samples;
+    Some(match shape {
+        Shape::Text => samples::text("Today: 1.8M tokens / $7.42"),
+        Shape::TextBlock => samples::text_block(&[
+            "Today: 1.8M tokens / $7.42",
+            "splashboard  1.2M / $4.80",
+            "image_gen    600k / $2.62",
+        ]),
+        Shape::MarkdownTextBlock => samples::markdown(
+            "**Today: 1.8M tokens / $7.42**\n- **splashboard** — 1.2M / $4.80\n- **image_gen** — 600k / $2.62",
+        ),
+        Shape::Entries => samples::entries(&[
+            ("splashboard", "1.2M / $4.80"),
+            ("image_gen", "600k / $2.62"),
+        ]),
+        Shape::Bars => Body::Bars(BarsData {
+            bars: vec![
+                Bar {
+                    label: "splashboard".into(),
+                    value: 1_200_000,
+                    value_label: Some("$4.80".into()),
+                },
+                Bar {
+                    label: "image_gen".into(),
+                    value: 600_000,
+                    value_label: Some("$2.62".into()),
+                },
+            ],
+        }),
+        Shape::NumberSeries => {
+            samples::number_series(&[0, 80_000, 200_000, 500_000, 700_000, 1_400_000, 1_800_000])
+        }
+        Shape::Badge => samples::badge(Status::Warn, "Today $7.42"),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::time::Duration as StdDuration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn ctx(options: Option<&str>, shape: Option<Shape>) -> FetchContext {
+        FetchContext {
+            widget_id: "codex".into(),
+            timeout: StdDuration::from_secs(1),
+            shape,
+            options: options.map(|raw| toml::from_str(raw).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn options_reject_unknown_keys() {
+        let raw: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(raw.try_into::<Options>().is_err());
+    }
+
+    #[test]
+    fn parse_since_accepts_known_windows() {
+        assert!(matches!(parse_since(None).unwrap(), Since::Today));
+        assert!(matches!(parse_since(Some("7d")).unwrap(), Since::Days(7)));
+        assert!(matches!(parse_since(Some("30d")).unwrap(), Since::Days(30)));
+        assert!(matches!(parse_since(Some("all")).unwrap(), Since::All));
+    }
+
+    #[test]
+    fn parse_since_rejects_unknown_window() {
+        let err = parse_since(Some("yesterday")).unwrap_err();
+        assert!(format!("{err}").contains("yesterday"));
+    }
+
+    #[test]
+    fn parse_group_by_defaults_to_project() {
+        assert!(matches!(parse_group_by(None).unwrap(), GroupBy::Project));
+    }
+
+    #[test]
+    fn token_usage_from_event_skips_non_token_count_messages() {
+        let raw = serde_json::from_str::<RawLine>(
+            r#"{"timestamp":"2026-05-22T18:38:08.073Z","type":"event_msg","payload":{"type":"task_started"}}"#,
+        )
+        .unwrap();
+        assert!(token_usage_from_event(&raw.payload).is_none());
+    }
+
+    #[test]
+    fn token_usage_from_event_extracts_last_turn_usage() {
+        let raw = serde_json::from_str::<RawLine>(
+            r#"{"timestamp":"2026-05-22T18:38:13.916Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":14878,"cached_input_tokens":6528,"output_tokens":194}}}}"#,
+        )
+        .unwrap();
+        let usage = token_usage_from_event(&raw.payload).unwrap();
+        assert_eq!(usage.input_tokens, 14878);
+        assert_eq!(usage.cached_input_tokens, 6528);
+        assert_eq!(usage.output_tokens, 194);
+    }
+
+    #[test]
+    fn token_usage_from_event_skips_startup_event_with_null_info() {
+        // Codex emits an initial `token_count` with `"info":null` before any turn runs; that
+        // must not produce a UsageEvent or every session would gain a phantom zero-cost turn.
+        let raw = serde_json::from_str::<RawLine>(
+            r#"{"timestamp":"2026-05-22T18:38:08.455Z","type":"event_msg","payload":{"type":"token_count","info":null}}"#,
+        )
+        .unwrap();
+        assert!(token_usage_from_event(&raw.payload).is_none());
+    }
+
+    #[test]
+    fn read_session_file_threads_turn_context_model_and_cwd_into_each_event() {
+        // turn_context sets the model + cwd; the following token_count must inherit them.
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-05-23T00-00-00-x.jsonl");
+        let now = Utc::now().to_rfc3339();
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{now}","type":"session_meta","payload":{{"cwd":"/h/proj-a"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{now}","type":"turn_context","payload":{{"model":"gpt-5","cwd":"/h/proj-a"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{now}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":300}}}}}}}}"#
+        )
+        .unwrap();
+        let events = read_session_file(&path, &Since::All);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].model, "gpt-5");
+        assert_eq!(events[0].project, "proj-a");
+        assert_eq!(events[0].input_tokens, 1000);
+    }
+
+    #[test]
+    fn group_rows_sorts_by_cost_desc_and_truncates_to_limit() {
+        let make = |project: &str, output: u64| UsageEvent {
+            timestamp: Utc::now(),
+            model: "gpt-5".into(),
+            project: project.into(),
+            input_tokens: 0,
+            cached_input_tokens: 0,
+            output_tokens: output,
+        };
+        let events = vec![make("a", 1_000), make("b", 5_000), make("c", 100)];
+        let rows = group_rows(&events, GroupBy::Project, 2);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].label, "b");
+        assert_eq!(rows[1].label, "a");
+    }
+
+    #[test]
+    fn since_today_excludes_yesterday() {
+        let yesterday = Utc::now() - Duration::days(1);
+        assert!(!Since::Today.includes(yesterday));
+        assert!(Since::Today.includes(Utc::now()));
+    }
+
+    #[test]
+    fn daily_series_length_matches_window() {
+        let series = daily_series(&[], &Since::Days(7));
+        assert_eq!(series.len(), 7);
+        assert!(series.iter().all(|&n| n == 0));
+    }
+
+    #[test]
+    fn headline_reports_quiet_window_when_empty() {
+        let snap = Snapshot {
+            since_label: "Today",
+            ..Default::default()
+        };
+        assert_eq!(headline(&snap), "Today: no sessions");
+    }
+
+    #[test]
+    fn badge_warns_on_quiet_window() {
+        let snap = Snapshot {
+            since_label: "Today",
+            ..Default::default()
+        };
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+        assert!(b.label.ends_with("quiet"));
+    }
+
+    #[test]
+    fn badge_promotes_to_error_above_50_usd() {
+        let snap = Snapshot {
+            total_tokens: 1,
+            total_cost: 75.0,
+            since_label: "Today",
+            ..Default::default()
+        };
+        let Body::Badge(b) = badge_body(&snap) else {
+            panic!("expected badge");
+        };
+        assert_eq!(b.status, Status::Error);
+    }
+
+    #[test]
+    fn fetcher_metadata_lists_seven_shapes_with_text_default() {
+        let f = CodexUsage;
+        assert_eq!(f.shapes(), SHAPES);
+        assert_eq!(f.default_shape(), Shape::Text);
+        for s in SHAPES {
+            assert!(f.sample_body(*s).is_some(), "sample missing for {s:?}");
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn fetch_reads_jsonl_from_codex_home_env_override() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempdir().unwrap();
+        let day = tmp
+            .path()
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("23");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-05-23T00-00-00-x.jsonl");
+        let now = Utc::now().to_rfc3339();
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            r#"{{"timestamp":"{now}","type":"session_meta","payload":{{"cwd":"/h/y"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"timestamp":"{now}","type":"turn_context","payload":{{"model":"gpt-5","cwd":"/h/y"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"timestamp":"{now}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":2000}}}}}}}}"#
+        )
+        .unwrap();
+
+        let prev = std::env::var("CODEX_HOME").ok();
+        unsafe { std::env::set_var("CODEX_HOME", tmp.path()) };
+        let body = CodexUsage
+            .fetch(&ctx(Some("since = \"today\""), Some(Shape::Text)))
+            .await
+            .unwrap()
+            .body;
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CODEX_HOME", v) },
+            None => unsafe { std::env::remove_var("CODEX_HOME") },
+        }
+
+        let Body::Text(t) = body else {
+            panic!("expected Text, got {body:?}");
+        };
+        assert!(t.value.contains("Today"));
+        assert!(t.value.contains("3k"), "value was {:?}", t.value);
+    }
+}

--- a/src/fetcher/codex/usage.rs
+++ b/src/fetcher/codex/usage.rs
@@ -851,4 +851,116 @@ mod tests {
         assert!(t.value.contains("Today"));
         assert!(t.value.contains("3k"), "value was {:?}", t.value);
     }
+
+    fn snap_with_rows() -> Snapshot {
+        Snapshot {
+            rows: vec![
+                UsageRow {
+                    label: "splashboard".into(),
+                    tokens: 2_100_000,
+                    cost: 7.2,
+                },
+                UsageRow {
+                    label: "playground".into(),
+                    tokens: 1_300_000,
+                    cost: 5.14,
+                },
+            ],
+            total_cost: 12.34,
+            total_tokens: 3_400_000,
+            daily_tokens: vec![0, 100_000, 250_000, 3_400_000],
+            since_label: "Today",
+        }
+    }
+
+    #[test]
+    fn text_body_renders_headline_with_total_tokens_and_cost() {
+        let Body::Text(t) = text_body(&snap_with_rows()) else {
+            panic!("expected text");
+        };
+        assert!(t.value.starts_with("Today"));
+        assert!(t.value.contains("3.4M"));
+        assert!(t.value.contains("$12.34"));
+    }
+
+    #[test]
+    fn text_block_body_lists_headline_then_one_line_per_row() {
+        let Body::TextBlock(b) = text_block_body(&snap_with_rows()) else {
+            panic!("expected text_block");
+        };
+        assert_eq!(b.lines.len(), 3);
+        assert!(b.lines[0].contains("$12.34"));
+        assert!(b.lines[1].starts_with("splashboard"));
+        assert!(b.lines[2].starts_with("playground"));
+    }
+
+    #[test]
+    fn text_block_body_falls_back_to_quiet_line_when_no_activity() {
+        // No rows AND no tokens at all → the fetcher must surface a placeholder line, otherwise
+        // a quiet user just sees a bare "Today: no sessions" headline with nothing under it.
+        let snap = Snapshot {
+            since_label: "Today",
+            ..Default::default()
+        };
+        let Body::TextBlock(b) = text_block_body(&snap) else {
+            panic!("expected text_block");
+        };
+        assert!(b.lines.iter().any(|l| l.contains("no recent")));
+    }
+
+    #[test]
+    fn markdown_body_emphasises_headline_and_each_row() {
+        let Body::MarkdownTextBlock(m) = markdown_body(&snap_with_rows()) else {
+            panic!("expected markdown");
+        };
+        assert!(m.value.starts_with("**Today"));
+        assert!(m.value.contains("- **splashboard**"));
+    }
+
+    #[test]
+    fn entries_body_falls_back_to_headline_when_no_rows() {
+        // Mirrors claude_code_usage: entries shape must always emit at least one row so
+        // grid_table doesn't render a blank box.
+        let snap = Snapshot {
+            since_label: "7d",
+            ..Default::default()
+        };
+        let Body::Entries(e) = entries_body(&snap) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 1);
+        assert_eq!(e.items[0].key, "7d");
+    }
+
+    #[test]
+    fn entries_body_carries_one_item_per_row_with_token_and_cost_value() {
+        let Body::Entries(e) = entries_body(&snap_with_rows()) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 2);
+        assert_eq!(e.items[0].key, "splashboard");
+        let value = e.items[0].value.as_deref().unwrap_or_default();
+        assert!(value.contains("2.1M"));
+        assert!(value.contains("$"));
+    }
+
+    #[test]
+    fn bars_body_uses_token_count_as_value_and_cost_string_as_label() {
+        // chart_bar ranks by the integer value field; list_ranking surfaces the value_label
+        // verbatim. We want bars to rank by token count and *display* cost.
+        let Body::Bars(b) = bars_body(&snap_with_rows()) else {
+            panic!("expected bars");
+        };
+        assert_eq!(b.bars.len(), 2);
+        assert_eq!(b.bars[0].value, 2_100_000);
+        assert!(b.bars[0].value_label.as_deref().unwrap_or("").contains("$"));
+    }
+
+    #[test]
+    fn number_series_body_carries_daily_tokens_in_order() {
+        let Body::NumberSeries(n) = number_series_body(&snap_with_rows()) else {
+            panic!("expected number_series");
+        };
+        assert_eq!(n.values, vec![0, 100_000, 250_000, 3_400_000]);
+    }
 }

--- a/src/fetcher/llm_pricing.rs
+++ b/src/fetcher/llm_pricing.rs
@@ -1,0 +1,302 @@
+//! Shared LLM pricing helper for the `codex_*` and `claude_*` families.
+//!
+//! Fetches `data/llm_pricing.json` from this repository's `main` branch
+//! (`raw.githubusercontent.com/unhappychoice/splashboard/main/data/llm_pricing.json`) on every
+//! call. The host is hardcoded — config never controls where the request goes, which keeps the
+//! callers (codex_usage, claude_code_usage) in the `Safety::Safe` class.
+//!
+//! Why HTTP at all when we ship the file in our own repo:
+//! - splashboard binaries persist for months between releases; LiteLLM ships new model
+//!   identifiers weekly. HTTP fetch lets old binaries see new prices without a rebuild.
+//! - The fetcher's own disk cache (5-minute TTL on both consumers today) absorbs the redundancy
+//!   — the price lookup only fires when the outer cache is stale, not on every render frame.
+//!
+//! Why we sync into this repo instead of fetching LiteLLM directly:
+//! - LiteLLM's schema changes are caught by the GitHub Actions sync PR before they reach users.
+//! - LiteLLM outages don't take down our cost rollups — the snapshot in our repo keeps serving.
+//!
+//! On any failure (network down, parse error, schema drift) the helper falls back to a tiny
+//! `EMBEDDED_FLOOR` covering the current model families. Unknown models still contribute $0
+//! cost, mirroring the original hardcoded behaviour.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::Deserialize;
+
+const SOURCE_URL: &str =
+    "https://raw.githubusercontent.com/unhappychoice/splashboard/main/data/llm_pricing.json";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// USD per million tokens for a single LLM model.
+///
+/// `cache_write_5m` / `cache_write_1h` only apply to Anthropic's ephemeral cache tiers; for
+/// OpenAI models they stay at 0 and the caller's cost math drops the term naturally.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Default)]
+pub struct Price {
+    #[serde(default)]
+    pub input: f64,
+    #[serde(default)]
+    pub output: f64,
+    #[serde(default)]
+    pub cache_read: f64,
+    #[serde(default)]
+    pub cache_write_5m: f64,
+    #[serde(default)]
+    pub cache_write_1h: f64,
+}
+
+/// Snapshot of pricing for every model the splashboard repo currently tracks.
+pub type PriceMap = HashMap<String, Price>;
+
+/// Fetch the latest snapshot. Returns the embedded floor on any failure so callers don't have
+/// to thread `Result` through every cost-math call site.
+pub async fn fetch_pricing(http: &Client) -> PriceMap {
+    fetch_remote(http)
+        .await
+        .unwrap_or_else(|_| embedded_floor())
+}
+
+async fn fetch_remote(http: &Client) -> Result<PriceMap, String> {
+    let res = http
+        .get(SOURCE_URL)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| format!("request: {e}"))?;
+    if !res.status().is_success() {
+        return Err(format!("HTTP {}", res.status()));
+    }
+    let body: Snapshot = res.json().await.map_err(|e| format!("parse: {e}"))?;
+    Ok(body.models)
+}
+
+#[derive(Deserialize)]
+struct Snapshot {
+    #[serde(default)]
+    models: PriceMap,
+}
+
+/// Longest-prefix lookup over the snapshot. `gpt-5-2025-08-12` resolves to `gpt-5` when the
+/// dated variant isn't a key, so newly-released identifiers within a known family stay priced
+/// until the next Actions sync ships an exact match.
+pub fn price_for<'a>(prices: &'a PriceMap, model: &str) -> Option<&'a Price> {
+    let lower = model.to_lowercase();
+    if let Some(p) = prices.get(&lower) {
+        return Some(p);
+    }
+    prices
+        .iter()
+        .filter(|(k, _)| lower.starts_with(k.as_str()) && !k.is_empty())
+        .max_by_key(|(k, _)| k.len())
+        .map(|(_, p)| p)
+}
+
+/// USD cost of a single token-usage row. Unknown models contribute 0 — surfacing them as
+/// "free" is friendlier than hiding the underlying token activity behind an error.
+pub fn cost_usd(
+    prices: &PriceMap,
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read: u64,
+    cache_write_5m: u64,
+    cache_write_1h: u64,
+) -> f64 {
+    let Some(p) = price_for(prices, model) else {
+        return 0.0;
+    };
+    let per_token = |rate: f64, count: u64| (count as f64) * rate / 1_000_000.0;
+    // `cache_read` covers the discounted cached-input tier; the input rate applies to the
+    // non-cached portion only. OpenAI reports `cached_input_tokens` as a subset of
+    // `input_tokens`, so the caller subtracts it before passing into `input_tokens` here.
+    per_token(p.input, input_tokens)
+        + per_token(p.output, output_tokens)
+        + per_token(p.cache_read, cache_read)
+        + per_token(p.cache_write_5m, cache_write_5m)
+        + per_token(p.cache_write_1h, cache_write_1h)
+}
+
+/// Bare minimum for cold-start (no network, no cache) so cost columns aren't entirely zero.
+/// The snapshot in `data/llm_pricing.json` is the authoritative source; this only covers the
+/// shipping headline models. Anything missing here will still get a `Some(Price)` via the
+/// next successful HTTP fetch.
+pub fn embedded_floor() -> PriceMap {
+    static FLOOR: OnceLock<PriceMap> = OnceLock::new();
+    FLOOR
+        .get_or_init(|| {
+            let mut m = PriceMap::new();
+            m.insert(
+                "gpt-5".into(),
+                Price {
+                    input: 1.25,
+                    output: 10.0,
+                    cache_read: 0.125,
+                    ..Default::default()
+                },
+            );
+            m.insert(
+                "gpt-5-mini".into(),
+                Price {
+                    input: 0.25,
+                    output: 2.0,
+                    cache_read: 0.025,
+                    ..Default::default()
+                },
+            );
+            m.insert(
+                "claude-opus-4-7".into(),
+                Price {
+                    input: 5.0,
+                    output: 25.0,
+                    cache_read: 0.5,
+                    cache_write_5m: 6.25,
+                    cache_write_1h: 10.0,
+                },
+            );
+            m.insert(
+                "claude-sonnet-4-6".into(),
+                Price {
+                    input: 3.0,
+                    output: 15.0,
+                    cache_read: 0.3,
+                    cache_write_5m: 3.75,
+                    cache_write_1h: 6.0,
+                },
+            );
+            m.insert(
+                "claude-haiku-4-5".into(),
+                Price {
+                    input: 1.0,
+                    output: 5.0,
+                    cache_read: 0.1,
+                    cache_write_5m: 1.25,
+                    cache_write_1h: 2.0,
+                },
+            );
+            m
+        })
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_prices() -> PriceMap {
+        let mut m = PriceMap::new();
+        m.insert(
+            "gpt-5".into(),
+            Price {
+                input: 1.25,
+                output: 10.0,
+                cache_read: 0.125,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "gpt-5-mini".into(),
+            Price {
+                input: 0.25,
+                output: 2.0,
+                cache_read: 0.025,
+                ..Default::default()
+            },
+        );
+        m.insert(
+            "claude-opus-4-7".into(),
+            Price {
+                input: 5.0,
+                output: 25.0,
+                cache_read: 0.5,
+                cache_write_5m: 6.25,
+                cache_write_1h: 10.0,
+            },
+        );
+        m
+    }
+
+    #[test]
+    fn price_for_exact_match_wins() {
+        let p = sample_prices();
+        assert_eq!(price_for(&p, "gpt-5").map(|x| x.input), Some(1.25));
+    }
+
+    #[test]
+    fn price_for_falls_back_to_longest_prefix() {
+        // `gpt-5-2025-08-12` isn't an exact key; longest prefix is `gpt-5`.
+        let p = sample_prices();
+        let row = price_for(&p, "gpt-5-2025-08-12").expect("must resolve via prefix");
+        assert_eq!(row.input, 1.25);
+    }
+
+    #[test]
+    fn price_for_longest_prefix_wins_over_shorter() {
+        // `gpt-5-mini-2025-08-12` must resolve to `gpt-5-mini`, not `gpt-5`.
+        let p = sample_prices();
+        let row = price_for(&p, "gpt-5-mini-2025-08-12").expect("must resolve via prefix");
+        assert_eq!(row.input, 0.25);
+    }
+
+    #[test]
+    fn price_for_is_case_insensitive() {
+        let p = sample_prices();
+        assert!(price_for(&p, "GPT-5").is_some());
+        assert!(price_for(&p, "Claude-Opus-4-7").is_some());
+    }
+
+    #[test]
+    fn price_for_unknown_model_returns_none() {
+        let p = sample_prices();
+        assert!(price_for(&p, "mistral-large").is_none());
+        assert!(price_for(&p, "").is_none());
+    }
+
+    #[test]
+    fn cost_usd_zero_for_unknown_model_even_with_tokens() {
+        let p = sample_prices();
+        assert_eq!(
+            cost_usd(&p, "mistral-large", 1_000_000, 1_000_000, 0, 0, 0),
+            0.0
+        );
+    }
+
+    #[test]
+    fn cost_usd_sums_per_tier_rates() {
+        // gpt-5: 1M input @ $1.25 + 1M output @ $10.00 = $11.25
+        let p = sample_prices();
+        let c = cost_usd(&p, "gpt-5", 1_000_000, 1_000_000, 0, 0, 0);
+        assert!((c - 11.25).abs() < 1e-9, "expected $11.25, got {c}");
+    }
+
+    #[test]
+    fn cost_usd_charges_anthropic_cache_write_tiers() {
+        // claude-opus-4-7 cache_write_1h: 1M @ $10 = $10
+        let p = sample_prices();
+        let c = cost_usd(&p, "claude-opus-4-7", 0, 0, 0, 0, 1_000_000);
+        assert!((c - 10.0).abs() < 1e-9, "expected $10, got {c}");
+    }
+
+    #[test]
+    fn embedded_floor_covers_current_headline_models() {
+        let f = embedded_floor();
+        assert!(f.contains_key("gpt-5"));
+        assert!(f.contains_key("gpt-5-mini"));
+        assert!(f.contains_key("claude-opus-4-7"));
+        assert!(f.contains_key("claude-sonnet-4-6"));
+        assert!(f.contains_key("claude-haiku-4-5"));
+    }
+
+    #[test]
+    fn snapshot_parses_repo_seed() {
+        // Guarantees our own `data/llm_pricing.json` stays loadable. If schema drift in the
+        // sync workflow ever produces an incompatible file, this test catches it before the
+        // PR can merge.
+        let raw = include_str!("../../data/llm_pricing.json");
+        let snap: Snapshot = serde_json::from_str(raw).expect("seed must parse");
+        assert!(snap.models.contains_key("gpt-5"));
+        assert!(snap.models.contains_key("claude-opus-4-7"));
+    }
+}

--- a/src/fetcher/llm_pricing.rs
+++ b/src/fetcher/llm_pricing.rs
@@ -87,9 +87,12 @@ pub fn price_for<'a>(prices: &'a PriceMap, model: &str) -> Option<&'a Price> {
     if let Some(p) = prices.get(&lower) {
         return Some(p);
     }
+    // Prefix match against lowercased keys too — `data/llm_pricing.json` keys happen to be
+    // lowercase today but the lookup shouldn't quietly miss if a future LiteLLM sync ships a
+    // mixed-case identifier.
     prices
         .iter()
-        .filter(|(k, _)| lower.starts_with(k.as_str()) && !k.is_empty())
+        .filter(|(k, _)| !k.is_empty() && lower.starts_with(&k.to_lowercase()))
         .max_by_key(|(k, _)| k.len())
         .map(|(_, p)| p)
 }

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -31,6 +31,7 @@ pub mod hackernews;
 pub mod huggingface_trending;
 pub mod lastfm;
 pub mod linear;
+pub mod llm_pricing;
 pub mod lobsters;
 pub mod nasa_apod;
 pub mod net;

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -17,6 +17,7 @@ pub mod calendar;
 pub mod claude;
 pub mod clock;
 pub mod code;
+pub mod codex;
 pub mod crypto_trending;
 pub mod crypto_watchlist;
 pub mod deal;
@@ -351,6 +352,9 @@ impl Registry {
             r.register(f);
         }
         for f in claude::fetchers() {
+            r.register(f);
+        }
+        for f in codex::fetchers() {
             r.register(f);
         }
         for f in deal::fetchers() {


### PR DESCRIPTION
## Summary

Adds two `codex_*` fetchers for OpenAI Codex CLI users, mirroring what `claude_*` ships for Claude Code:

- **`codex_usage`** — token + cost rollup from local `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. Aggregates per-turn usage under `since` (today / 7d / 30d / all) and groups by project / model / day.
- **`codex_subscription`** — 5h / 7d rate-limit utilisation parsed from the most recent session's last `token_count` event. Codex CLI already carries the rate-limit payload on every event, so we read what's there rather than making a billable inference call.

Both are `Safety::Safe`: every session read stays under `~/.codex/sessions/` (or `$CODEX_HOME/sessions/`). `codex_usage` *does* make one host-fixed HTTP GET for the LLM pricing snapshot — see the dedicated change below.

While stitching codex into the codebase the PR also unifies the pricing path across both `codex_*` and `claude_*`:

- New `src/fetcher/llm_pricing.rs` carries one shared `PriceMap`, fetched from `raw.githubusercontent.com/unhappychoice/splashboard/main/data/llm_pricing.json` (host hardcoded → stays `Safe`).
- New `data/llm_pricing.json` is the initial seed, extracted from LiteLLM's `model_prices_and_context_window_backup.json` and filtered to OpenAI / Anthropic chat models (117 rows, ~14 KB).
- New `.github/workflows/sync-llm-pricing.yml` runs daily, pulls LiteLLM, normalises, and opens a PR via `peter-evans/create-pull-request@v7` on diff. No auto-merge.
- `claude_code_usage`'s hardcoded `PRICE_TABLE` is dropped in favour of the shared helper. This unwinds an inadvertent over-charge: the hardcoded Opus tier was still at Opus 4.1's $15 / $75 / MTok while Anthropic dropped Opus 4.5+ to $5 / $25 / MTok (verified against `docs.claude.com/.../pricing`). Sonnet and Haiku figures are unchanged.

Cold-cache first paint over realistic `~/.codex/sessions/` (1,453 files, 527 MB) was multiple seconds. Two perf commits at the tail of the branch take it back to milliseconds:

- `codex_usage` filters the file list by the `rollout-YYYY-MM-DD…` filename prefix before opening.
- `claude_code_usage` filters by `mtime` (Claude session files are `<uuid>.jsonl` — no date in the filename to read).

For `since = "all"` both fetchers still walk every file; the filename / mtime filter only kicks in for windowed queries.

## Test plan

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --all-targets` ✅ (3229 lib + integration tests pass)
- Smoke-tested locally with a 9-widget `.splashboard/dashboard.toml` exercising every shape: `codex_usage` × 4 (Text / Bars / TextBlock / NumberSeries) + `codex_subscription` × 3 (Ratio / TextBlock / Badge) + `claude_code_usage` × 2 (Text / TextBlock).
- Verified `splashboard catalog fetcher codex_usage` / `codex_subscription` print the expected option schema and compatible renderer set.

## Reference (mirrors auto-generated docs)

### `codex_usage`

Token and cost rollup from local Codex CLI session JSONL files. Aggregates per-turn usage under the chosen `since` window and groups it by project, model, or day.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `text`, `text_block`, `markdown_text_block`, `entries`, `bars`, `number_series`, `badge` |

#### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `since` | `"today"` \| `"7d"` \| `"30d"` \| `"all"` | no | `"today"` | Window the rollup covers, anchored on the current UTC day. |
| `limit` | integer (1..=50) | no | `10` | Maximum rows surfaced by multi-row shapes (`Bars`, `Entries`, …). |
| `group_by` | `"project"` \| `"model"` \| `"day"` | no | `"project"` | Axis used by `Bars` / `Entries` / `TextBlock` row shapes. |

#### Compatible renderers

- `text` → [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), animated wrappers
- `text_block` → [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/)
- `markdown_text_block` → [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/)
- `entries` → [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/)
- `bars` → [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar/), [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie/), [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking/)
- `number_series` → [`chart_histogram`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_histogram/), [`chart_sparkline`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_sparkline/)
- `badge` → [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/)

### `codex_subscription`

Codex CLI subscription utilisation, parsed from the local session JSONL. Each `token_count` event Codex writes carries the 5h (primary) and 7d (secondary) rate-limit windows; we read the most recent one.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `ratio`, `text`, `text_block`, `markdown_text_block`, `entries`, `bars`, `badge`, `timeline` |

#### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `window` | `"5h"` \| `"7d"` \| `"primary"` \| `"secondary"` | no | `"5h"` | Which window the single-value shapes (`Ratio`, `Badge`) report. Multi-row shapes always list both windows. |

#### Compatible renderers

- `ratio` → [`gauge_circle`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_circle/), [`gauge_line`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_line/), [`gauge_battery`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_battery/), [`gauge_segment`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_segment/), [`gauge_thermometer`](https://splashboard.unhappychoice.com/reference/renderers/gauge/gauge_thermometer/)
- `text` → [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/)
- `text_block` → [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/)
- `markdown_text_block` → [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/)
- `entries` → [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/)
- `bars` → [`chart_bar`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_bar/), [`chart_pie`](https://splashboard.unhappychoice.com/reference/renderers/chart/chart_pie/), [`list_ranking`](https://splashboard.unhappychoice.com/reference/renderers/list/list_ranking/)
- `badge` → [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/)
- `timeline` → [`list_timeline`](https://splashboard.unhappychoice.com/reference/renderers/list/list_timeline/)

## Catalog

Ticks `codex_usage` in #64 (already a checkbox under "AI / LLM — local agent activity"). Adds a new `codex_subscription` entry to the same issue's "AI / LLM — subscription seat / rate-limit headroom" section after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex usage fetcher to track token consumption and costs by project and model.
  * Added Codex subscription fetcher to display plan utilization and reset timing.
  * Integrated dynamic cost calculations into usage tracking with automated daily pricing refresh (manual trigger available).

* **Chores**
  * Centralized LLM pricing into a shared module and seeded pricing snapshot for consistent cost reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->