### PR TITLE
test(fetcher/codex_usage): compute fixture path from today's date

### DIFF
--- a/src/fetcher/codex/usage.rs
+++ b/src/fetcher/codex/usage.rs
@@ -654,6 +654,7 @@ mod tests {
     use std::io::Write;
     use std::time::Duration as StdDuration;
 
+    use chrono::Datelike;
     use tempfile::tempdir;
 
     use super::*;
@@ -838,14 +839,18 @@ mod tests {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let tmp = tempdir().unwrap();
+        // Path components and filename must reflect today: the file-list filter in
+        // `list_session_files` drops anything whose filename date precedes the `since`
+        // cutoff, so a hardcoded date bitrots after that day passes.
+        let today = Utc::now().date_naive();
         let day = tmp
             .path()
             .join("sessions")
-            .join("2026")
-            .join("05")
-            .join("23");
+            .join(format!("{:04}", today.year()))
+            .join(format!("{:02}", today.month()))
+            .join(format!("{:02}", today.day()));
         fs::create_dir_all(&day).unwrap();
-        let path = day.join("rollout-2026-05-23T00-00-00-x.jsonl");
+        let path = day.join(format!("rollout-{today}T00-00-00-x.jsonl"));
         let now = Utc::now().to_rfc3339();
         let mut file = fs::File::create(&path).unwrap();
         writeln!(


### PR DESCRIPTION
## Summary

`fetcher::codex::usage::tests::fetch_reads_jsonl_from_codex_home_env_override` started failing on main today (2026-05-25) across all three CI runners.

The test fixture hardcoded the session directory and filename to `2026-05-23`. After bfc728f (`perf(fetcher/codex_usage): skip JSONL files outside the since window by filename`) the file-list step in `list_session_files` filters by filename date before opening the JSONL, dropping anything older than the `since="today"` cutoff (today - 1 day buffer). On 2026-05-25 that cutoff is `2026-05-24`, so the `2026-05-23` fixture file is filtered out, and the body comes back as `"Today: no sessions"` instead of `"Today: 3k"`.

Fix: compute the directory components and filename from `Utc::now()` so the fixture always lands inside the cutoff window. The inner JSONL timestamps were already using `Utc::now()`, only the path was static.

## Test plan

- `cargo test --lib fetcher::codex::usage::tests::fetch_reads_jsonl_from_codex_home_env_override` — passes locally
- `cargo fmt --all -- --check` — clean
- `cargo clippy --lib --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to use the current date dynamically instead of hardcoded date values, preventing test failures from becoming outdated as time passes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/splashboard/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->