### PR TITLE
feat(render,weather): PixelArt shape + media_pixel + weather sprites

### DIFF
--- a/src/fetcher/read_store.rs
+++ b/src/fetcher/read_store.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use crate::payload::{
     Bar, BarsData, Body, CalendarData, EntriesData, HeatmapData, ImageData, ImageLinkedListData,
-    NumberSeriesData, Payload, PointSeriesData, RatioData, TextBlockData, TextData,
+    NumberSeriesData, Payload, PixelArtData, PointSeriesData, RatioData, TextBlockData, TextData,
 };
 use crate::render::Shape;
 
@@ -22,6 +22,7 @@ const READ_STORE_SHAPES: &[Shape] = &[
     Shape::PointSeries,
     Shape::Bars,
     Shape::Image,
+    Shape::PixelArt,
     Shape::ImageLinkedList,
     Shape::Calendar,
     Shape::Heatmap,
@@ -178,6 +179,7 @@ fn from_json(text: &str, shape: Shape) -> Result<Body, FetchError> {
         Shape::PointSeries => parse_as!(PointSeriesData, PointSeries),
         Shape::Bars => parse_as!(BarsData, Bars),
         Shape::Image => parse_as!(ImageData, Image),
+        Shape::PixelArt => parse_as!(PixelArtData, PixelArt),
         Shape::ImageLinkedList => parse_as!(ImageLinkedListData, ImageLinkedList),
         Shape::Calendar => parse_as!(CalendarData, Calendar),
         Shape::Heatmap => parse_as!(HeatmapData, Heatmap),
@@ -205,6 +207,7 @@ fn from_toml(text: &str, shape: Shape) -> Result<Body, FetchError> {
         Shape::PointSeries => parse_as!(PointSeriesData, PointSeries),
         Shape::Bars => parse_as!(BarsData, Bars),
         Shape::Image => parse_as!(ImageData, Image),
+        Shape::PixelArt => parse_as!(PixelArtData, PixelArt),
         Shape::ImageLinkedList => parse_as!(ImageLinkedListData, ImageLinkedList),
         Shape::Calendar => parse_as!(CalendarData, Calendar),
         Shape::Heatmap => parse_as!(HeatmapData, Heatmap),
@@ -235,6 +238,10 @@ fn empty_body(shape: Shape) -> Body {
         }),
         Shape::Image => Body::Image(ImageData {
             path: String::new(),
+        }),
+        Shape::PixelArt => Body::PixelArt(PixelArtData {
+            pixels: Vec::new(),
+            label: None,
         }),
         Shape::ImageLinkedList => Body::ImageLinkedList(ImageLinkedListData { items: Vec::new() }),
         Shape::Calendar => Body::Calendar(CalendarData {
@@ -519,6 +526,18 @@ value = "main""#,
                 }),
             ),
             (
+                Shape::PixelArt,
+                r#"{"pixels":[[{"r":255,"g":0,"b":0,"a":255},{"r":0,"g":0,"b":0,"a":0}]],"label":"hi"}"#,
+                "label = \"hi\"\npixels = [[{r=255,g=0,b=0,a=255},{r=0,g=0,b=0,a=0}]]",
+                Body::PixelArt(PixelArtData {
+                    pixels: vec![vec![
+                        crate::payload::PixelColor::opaque(255, 0, 0),
+                        crate::payload::PixelColor::TRANSPARENT,
+                    ]],
+                    label: Some("hi".into()),
+                }),
+            ),
+            (
                 Shape::Calendar,
                 r#"{"year":2026,"month":4,"day":30,"events":[1,15]}"#,
                 "year = 2026\nmonth = 4\nday = 30\nevents = [1, 15]",
@@ -706,6 +725,13 @@ value = "main""#,
                 Shape::Image,
                 Body::Image(ImageData {
                     path: String::new(),
+                }),
+            ),
+            (
+                Shape::PixelArt,
+                Body::PixelArt(PixelArtData {
+                    pixels: Vec::new(),
+                    label: None,
                 }),
             ),
             (

--- a/src/fetcher/weather/mod.rs
+++ b/src/fetcher/weather/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 pub(crate) mod common;
 mod forecast;
 mod now;
+mod sprites;
 
 use super::Fetcher;
 

--- a/src/fetcher/weather/now.rs
+++ b/src/fetcher/weather/now.rs
@@ -21,6 +21,7 @@ use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::common::{
     API_BASE, Units, http, parse_options, payload, weather_badge, weather_description,
 };
+use super::sprites::sprite_for_code;
 
 const HOURLY_HOURS: usize = 24;
 
@@ -69,7 +70,7 @@ impl Fetcher for WeatherFetcher {
         Safety::Safe
     }
     fn description(&self) -> &'static str {
-        "Forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` / `Text` summarise current conditions; `PointSeries` carries the next 24h of hourly temperature (signed °C / °F); `NumberSeries` / `Bars` carry hourly precipitation in tenths of mm/inch; `Badge` flags severe weather codes (thunderstorm = error, freezing / snow / heavy rain = warn). Metric or imperial units, no API key required."
+        "Forecast for a fixed (latitude, longitude) via Open-Meteo. `Entries` / `Text` summarise current conditions; `PointSeries` carries the next 24h of hourly temperature (signed °C / °F); `NumberSeries` / `Bars` carry hourly precipitation in tenths of mm/inch; `Badge` flags severe weather codes (thunderstorm = error, freezing / snow / heavy rain = warn); `PixelArt` paints a 16×16 truecolor sprite of the current sky. Metric or imperial units, no API key required."
     }
     fn refresh_interval(&self) -> u64 {
         60 * 30
@@ -82,6 +83,7 @@ impl Fetcher for WeatherFetcher {
             Shape::NumberSeries,
             Shape::Bars,
             Shape::Badge,
+            Shape::PixelArt,
         ]
     }
     fn option_schemas(&self) -> &[OptionSchema] {
@@ -106,6 +108,7 @@ impl Fetcher for WeatherFetcher {
             Shape::NumberSeries => number_series(&sample.hourly),
             Shape::Bars => precipitation_bars(&sample.hourly),
             Shape::Badge => Body::Badge(weather_badge(sample.code)),
+            Shape::PixelArt => Body::PixelArt(sprite_for_code(sample.code)),
             _ => return None,
         })
     }
@@ -122,6 +125,7 @@ impl Fetcher for WeatherFetcher {
             Shape::NumberSeries => number_series(&report.hourly),
             Shape::Bars => precipitation_bars(&report.hourly),
             Shape::Badge => Body::Badge(weather_badge(report.code)),
+            Shape::PixelArt => Body::PixelArt(sprite_for_code(report.code)),
             _ => entries(&report),
         };
         Ok(payload(body))
@@ -531,6 +535,7 @@ mod tests {
                 Shape::NumberSeries,
                 Shape::Bars,
                 Shape::Badge,
+                Shape::PixelArt,
             ]
             .as_slice()
         );
@@ -545,6 +550,7 @@ mod tests {
                     | (Shape::NumberSeries, Body::NumberSeries(_))
                     | (Shape::Bars, Body::Bars(_))
                     | (Shape::Badge, Body::Badge(_))
+                    | (Shape::PixelArt, Body::PixelArt(_))
             ));
         }
         let text = fetcher

--- a/src/fetcher/weather/sprites.rs
+++ b/src/fetcher/weather/sprites.rs
@@ -246,23 +246,25 @@ const SPRITE_OVERCAST: &[&str] = &[
     "................",
 ];
 
+// Bands are two pixel rows thick so each one packs into a single half-block cell as solid
+// fog rather than a fg/bg pinstripe. Horizontal indent varies per band for a drifting feel.
 const SPRITE_FOG: &[&str] = &[
     "................",
     "................",
-    "..ffffffffffff..",
+    "..fffffffffff...",
+    "..fffffffffff...",
+    "................",
     "................",
     ".fffffffffffff..",
-    "................",
-    "..ffffffffffff..",
-    "................",
     ".fffffffffffff..",
     "................",
-    "..ffffffffffff..",
+    "................",
+    "...fffffffffff..",
+    "...fffffffffff..",
+    "................",
     "................",
     ".fffffffffffff..",
-    "................",
-    "..ffffffffffff..",
-    "................",
+    ".fffffffffffff..",
 ];
 
 const SPRITE_RAIN: &[&str] = &[

--- a/src/fetcher/weather/sprites.rs
+++ b/src/fetcher/weather/sprites.rs
@@ -1,0 +1,423 @@
+//! Bundled 16x16 weather sprites for the `weather` fetcher's `PixelArt` shape. Sprites are
+//! authored as ASCII grids — one character per pixel — paired with a palette mapping each
+//! character to an RGBA colour. Decoding happens once on first use and the resulting
+//! [`PixelArtData`] values are cached in process for the lifetime of the binary.
+//!
+//! Why ASCII-in-source vs. bundled PNG: the diff stays text-only, sprite edits show up cleanly
+//! in PR review, and there is no PNG decode at runtime beyond the constant-time palette lookup
+//! used here.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use crate::payload::{PixelArtData, PixelColor};
+
+use super::common::weather_description;
+
+pub const SPRITE_SIZE: usize = 16;
+
+pub struct SpriteCatalog {
+    pub clear: PixelArtData,
+    pub mostly_clear: PixelArtData,
+    pub partly_cloudy: PixelArtData,
+    pub overcast: PixelArtData,
+    pub fog: PixelArtData,
+    pub rain: PixelArtData,
+    pub snow: PixelArtData,
+    pub thunderstorm: PixelArtData,
+}
+
+pub fn catalog() -> &'static SpriteCatalog {
+    static CATALOG: OnceLock<SpriteCatalog> = OnceLock::new();
+    CATALOG.get_or_init(build_catalog)
+}
+
+/// Pick the sprite matching a WMO code (Open-Meteo's standard table). Falls back to `overcast`
+/// for codes outside the bundled set so the renderer always has something to draw.
+pub fn sprite_for_code(code: u16) -> PixelArtData {
+    let c = catalog();
+    let key = match code {
+        0 => &c.clear,
+        1 => &c.mostly_clear,
+        2 => &c.partly_cloudy,
+        3 => &c.overcast,
+        45 | 48 => &c.fog,
+        51..=57 | 61..=67 | 80..=82 => &c.rain,
+        71..=77 | 85 | 86 => &c.snow,
+        95..=99 => &c.thunderstorm,
+        _ => &c.overcast,
+    };
+    let mut sprite = key.clone();
+    let (_, label) = weather_description(code);
+    sprite.label = Some(label.into());
+    sprite
+}
+
+fn build_catalog() -> SpriteCatalog {
+    SpriteCatalog {
+        clear: decode(SPRITE_CLEAR, palette_clear()),
+        mostly_clear: decode(SPRITE_MOSTLY_CLEAR, palette_mostly_clear()),
+        partly_cloudy: decode(SPRITE_PARTLY_CLOUDY, palette_partly_cloudy()),
+        overcast: decode(SPRITE_OVERCAST, palette_overcast()),
+        fog: decode(SPRITE_FOG, palette_fog()),
+        rain: decode(SPRITE_RAIN, palette_rain()),
+        snow: decode(SPRITE_SNOW, palette_snow()),
+        thunderstorm: decode(SPRITE_THUNDERSTORM, palette_thunderstorm()),
+    }
+}
+
+fn decode(grid: &[&str], palette: HashMap<char, PixelColor>) -> PixelArtData {
+    let pixels = grid
+        .iter()
+        .map(|row| {
+            row.chars()
+                .map(|c| palette.get(&c).copied().unwrap_or(PixelColor::TRANSPARENT))
+                .collect()
+        })
+        .collect();
+    PixelArtData {
+        pixels,
+        label: None,
+    }
+}
+
+// ---- Palette helpers ----
+
+const SUN_RIM: PixelColor = PixelColor::opaque(255, 213, 79);
+const SUN_CORE: PixelColor = PixelColor::opaque(255, 167, 38);
+const CLOUD_EDGE: PixelColor = PixelColor::opaque(189, 195, 199);
+const CLOUD_FILL: PixelColor = PixelColor::opaque(236, 240, 241);
+const CLOUD_DARK: PixelColor = PixelColor::opaque(127, 140, 141);
+const RAINDROP: PixelColor = PixelColor::opaque(52, 152, 219);
+const SNOW: PixelColor = PixelColor::opaque(245, 245, 245);
+const BOLT: PixelColor = PixelColor::opaque(255, 235, 59);
+const FOG: PixelColor = PixelColor::opaque(176, 190, 197);
+
+fn palette_clear() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('Y', SUN_RIM),
+        ('O', SUN_CORE),
+    ])
+}
+
+fn palette_mostly_clear() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('Y', SUN_RIM),
+        ('O', SUN_CORE),
+        ('c', CLOUD_EDGE),
+        ('w', CLOUD_FILL),
+    ])
+}
+
+fn palette_partly_cloudy() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('Y', SUN_RIM),
+        ('O', SUN_CORE),
+        ('c', CLOUD_EDGE),
+        ('w', CLOUD_FILL),
+    ])
+}
+
+fn palette_overcast() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('c', CLOUD_EDGE),
+        ('w', CLOUD_FILL),
+        ('d', CLOUD_DARK),
+    ])
+}
+
+fn palette_fog() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('f', FOG),
+        ('w', CLOUD_FILL),
+    ])
+}
+
+fn palette_rain() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('c', CLOUD_EDGE),
+        ('w', CLOUD_FILL),
+        ('d', CLOUD_DARK),
+        ('r', RAINDROP),
+    ])
+}
+
+fn palette_snow() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('c', CLOUD_EDGE),
+        ('w', CLOUD_FILL),
+        ('d', CLOUD_DARK),
+        ('s', SNOW),
+    ])
+}
+
+fn palette_thunderstorm() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('c', CLOUD_EDGE),
+        ('w', CLOUD_FILL),
+        ('d', CLOUD_DARK),
+        ('b', BOLT),
+    ])
+}
+
+// ---- Sprite grids (16x16) ----
+
+const SPRITE_CLEAR: &[&str] = &[
+    "................",
+    "................",
+    ".....YYYYYY.....",
+    "...YYYOOOOYYY...",
+    "..YYOOOOOOOOYY..",
+    "..YOOOOOOOOOOY..",
+    ".YOOOOOOOOOOOOY.",
+    ".YOOOOOOOOOOOOY.",
+    ".YOOOOOOOOOOOOY.",
+    ".YOOOOOOOOOOOOY.",
+    "..YOOOOOOOOOOY..",
+    "..YYOOOOOOOOYY..",
+    "...YYYOOOOYYY...",
+    ".....YYYYYY.....",
+    "................",
+    "................",
+];
+
+const SPRITE_MOSTLY_CLEAR: &[&str] = &[
+    "................",
+    "....YYYY........",
+    "...YYOOYY.......",
+    "..YYOOOOYY......",
+    "..YOOOOOOY......",
+    "..YOOOOOOY......",
+    "...YOOOOY..ccc..",
+    "....YYYY..cwwwc.",
+    "........ccwwwwc.",
+    "........cwwwwwwc",
+    ".........ccwwwc.",
+    "..........ccc...",
+    "................",
+    "................",
+    "................",
+    "................",
+];
+
+const SPRITE_PARTLY_CLOUDY: &[&str] = &[
+    "................",
+    "................",
+    "....cccc........",
+    "...cwwwwc.......",
+    "..cwwwwwwc......",
+    ".cwwwwwwwwc.....",
+    ".cwwwwwwwwc.....",
+    ".cwwwwwwwwc.....",
+    "..cwwwwwwwccc...",
+    "...cccccccwwwc..",
+    "........cwwwwwc.",
+    "........cwwwwwc.",
+    ".........cwwwc..",
+    "..........ccc...",
+    "................",
+    "................",
+];
+
+const SPRITE_OVERCAST: &[&str] = &[
+    "................",
+    "................",
+    "....cccccc......",
+    "...cwwwwwwc.....",
+    "..cwwwwwwwwc....",
+    ".cwwwwwwwwwwc...",
+    ".cwwwwwwwwwwc...",
+    ".cwwwwwwwwwwccc.",
+    "..cccccccccwwwc.",
+    "...ddddddcwwwwc.",
+    "..ddwwwwwwwwwwc.",
+    ".ddwwwwwwwwwwc..",
+    ".dwwwwwwwwwwc...",
+    ".ddwwwwwwwwc....",
+    "..dddddddddd....",
+    "................",
+];
+
+const SPRITE_FOG: &[&str] = &[
+    "................",
+    "................",
+    "..ffffffffffff..",
+    "................",
+    ".fffffffffffff..",
+    "................",
+    "..ffffffffffff..",
+    "................",
+    ".fffffffffffff..",
+    "................",
+    "..ffffffffffff..",
+    "................",
+    ".fffffffffffff..",
+    "................",
+    "..ffffffffffff..",
+    "................",
+];
+
+const SPRITE_RAIN: &[&str] = &[
+    "................",
+    "....cccccc......",
+    "...cwwwwwwc.....",
+    "..cwwwwwwwwcc...",
+    ".cwwwwwwwwwwc...",
+    ".cwwwwwwwwwwc...",
+    ".dddddddddddd...",
+    "................",
+    "..r..r..r..r....",
+    ".r..r..r..r..r..",
+    "................",
+    "..r..r..r..r....",
+    ".r..r..r..r..r..",
+    "................",
+    "..r..r..r..r....",
+    "................",
+];
+
+const SPRITE_SNOW: &[&str] = &[
+    "................",
+    "....cccccc......",
+    "...cwwwwwwc.....",
+    "..cwwwwwwwwcc...",
+    ".cwwwwwwwwwwc...",
+    ".cwwwwwwwwwwc...",
+    ".dddddddddddd...",
+    "................",
+    "..s..s..s..s....",
+    ".s..s..s..s..s..",
+    "................",
+    "..s..s..s..s....",
+    ".s..s..s..s..s..",
+    "................",
+    "..s..s..s..s....",
+    "................",
+];
+
+const SPRITE_THUNDERSTORM: &[&str] = &[
+    "................",
+    "....cccccc......",
+    "...cwwwwwwc.....",
+    "..cwwwwwwwwcc...",
+    ".cwwwwwwwwwwc...",
+    ".cwwwwwwwwwwc...",
+    ".dddddddddddd...",
+    "................",
+    "......bbbb......",
+    ".....bbbb.......",
+    "....bbbb........",
+    "...bbbbbbb......",
+    "......bbb.......",
+    ".....bb.........",
+    "....bb..........",
+    "................",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_grid_is_16x16(grid: &[&str]) {
+        assert_eq!(grid.len(), SPRITE_SIZE, "row count");
+        for (i, row) in grid.iter().enumerate() {
+            assert_eq!(row.chars().count(), SPRITE_SIZE, "row {i} width");
+        }
+    }
+
+    #[test]
+    fn every_sprite_grid_is_16x16() {
+        for grid in [
+            SPRITE_CLEAR,
+            SPRITE_MOSTLY_CLEAR,
+            SPRITE_PARTLY_CLOUDY,
+            SPRITE_OVERCAST,
+            SPRITE_FOG,
+            SPRITE_RAIN,
+            SPRITE_SNOW,
+            SPRITE_THUNDERSTORM,
+        ] {
+            assert_grid_is_16x16(grid);
+        }
+    }
+
+    #[test]
+    fn decoded_catalog_has_uniform_dimensions() {
+        let c = catalog();
+        for sprite in [
+            &c.clear,
+            &c.mostly_clear,
+            &c.partly_cloudy,
+            &c.overcast,
+            &c.fog,
+            &c.rain,
+            &c.snow,
+            &c.thunderstorm,
+        ] {
+            assert_eq!(sprite.pixels.len(), SPRITE_SIZE);
+            for row in &sprite.pixels {
+                assert_eq!(row.len(), SPRITE_SIZE);
+            }
+        }
+    }
+
+    #[test]
+    fn sprite_for_code_maps_known_wmo_buckets() {
+        // Spot-check one code per bucket; weather_description's bucket table is the source of
+        // truth and is itself tested in common.rs.
+        for (code, expected_label) in [
+            (0u16, "clear"),
+            (1, "mostly clear"),
+            (2, "partly cloudy"),
+            (3, "overcast"),
+            (45, "fog"),
+            (61, "rain"),
+            (71, "snow"),
+            (95, "thunderstorm"),
+        ] {
+            let s = sprite_for_code(code);
+            assert_eq!(s.label.as_deref(), Some(expected_label), "WMO {code}");
+        }
+    }
+
+    #[test]
+    fn unknown_code_falls_back_to_overcast_sprite() {
+        let s = sprite_for_code(7777);
+        // Same pixel grid as the overcast sprite.
+        assert_eq!(s.pixels, catalog().overcast.pixels);
+    }
+
+    #[test]
+    fn palette_characters_only_use_declared_keys() {
+        // Walks every grid and confirms every non-transparent glyph has a palette entry. Catches
+        // typos like accidentally using `0` instead of `O` in a sprite.
+        let cases: &[(&[&str], HashMap<char, PixelColor>)] = &[
+            (SPRITE_CLEAR, palette_clear()),
+            (SPRITE_MOSTLY_CLEAR, palette_mostly_clear()),
+            (SPRITE_PARTLY_CLOUDY, palette_partly_cloudy()),
+            (SPRITE_OVERCAST, palette_overcast()),
+            (SPRITE_FOG, palette_fog()),
+            (SPRITE_RAIN, palette_rain()),
+            (SPRITE_SNOW, palette_snow()),
+            (SPRITE_THUNDERSTORM, palette_thunderstorm()),
+        ];
+        for (grid, palette) in cases {
+            for (y, row) in grid.iter().enumerate() {
+                for (x, ch) in row.chars().enumerate() {
+                    assert!(
+                        palette.contains_key(&ch),
+                        "char {ch:?} at ({x},{y}) has no palette entry"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -57,6 +57,11 @@ pub enum Body {
     Bars(BarsData),
     /// Path to an image on disk.
     Image(ImageData),
+    /// Small fixed-grid pixel-art sprite drawn cell-by-cell with truecolor half-blocks. Distinct
+    /// from `Image`: `Image` is a path the user (or fetcher) supplies, rendered through whatever
+    /// terminal-graphics protocol is available; `PixelArt` is inline RGBA data that always
+    /// renders with `▀` half-blocks and works in any terminal that supports truecolor.
+    PixelArt(PixelArtData),
     /// A month view anchored at a specific date, optionally with highlighted events. Calendar
     /// widget (and anything future that shows month-scale state) consumes this.
     Calendar(CalendarData),
@@ -229,6 +234,53 @@ pub struct Bar {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ImageData {
     pub path: String,
+}
+
+/// One pixel in a [`PixelArtData`] grid. `a = 0` means transparent — the renderer fills the
+/// terminal background through. Partial alpha is currently treated as opaque; the contract is
+/// "opaque or transparent" so the artist palette stays simple.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PixelColor {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    #[serde(default = "PixelColor::opaque_alpha")]
+    pub a: u8,
+}
+
+impl PixelColor {
+    pub const TRANSPARENT: Self = Self {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+    };
+
+    pub const fn opaque(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b, a: 255 }
+    }
+
+    pub fn is_transparent(self) -> bool {
+        self.a == 0
+    }
+
+    fn opaque_alpha() -> u8 {
+        255
+    }
+}
+
+/// A small fixed-grid pixel-art sprite, rendered cell-by-cell with truecolor half-blocks. Right
+/// for sprite-scale ambient widgets (weather icon, system mood face) that need full colour but
+/// don't want a terminal-graphics-protocol dependency. Distinct from [`ImageData`], which is a
+/// path to a real raster image rendered via ratatui-image. Rows must be the same length; the
+/// renderer treats jagged rows as an error payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PixelArtData {
+    /// Row-major grid; `pixels[0]` is the top row.
+    pub pixels: Vec<Vec<PixelColor>>,
+    /// Optional caption rendered under the sprite.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// 2D grid of intensities, row-major (`cells[row][col]`). The renderer picks a bucket per cell

--- a/src/render/media_pixel.rs
+++ b/src/render/media_pixel.rs
@@ -1,0 +1,463 @@
+//! `media_pixel` renderer — draws a [`PixelArtData`] grid as truecolor half-blocks (`▀`). One
+//! terminal cell carries two stacked pixels: the upper pixel becomes the cell foreground, the
+//! lower pixel becomes the cell background. Works on any terminal with 24-bit colour, with no
+//! dependency on kitty / sixel / iTerm2 graphics protocols (that's `media_image`'s job).
+//!
+//! Pixels with `a = 0` resolve to the theme background, so transparent regions blend with
+//! whatever the rest of the splash sits on.
+
+use ratatui::{
+    Frame,
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::Line,
+    widgets::{Paragraph, Widget},
+};
+
+use crate::options::OptionSchema;
+use crate::payload::{Body, PixelArtData, PixelColor};
+use crate::theme::{self, ColorKey, Theme};
+
+use super::{Registry, RenderOptions, Renderer, Shape};
+
+const HALF_BLOCK: &str = "\u{2580}"; // ▀ upper half block.
+
+const COLOR_KEYS: &[ColorKey] = &[theme::BG, theme::TEXT];
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "align",
+        type_hint: "\"left\" | \"center\" | \"right\"",
+        required: false,
+        default: Some("\"left\""),
+        description: "Horizontal placement of the sprite within the available cell.",
+    },
+    OptionSchema {
+        name: "max_width",
+        type_hint: "cells (u16)",
+        required: false,
+        default: Some("area width"),
+        description: "Upper bound on the rendered sprite width in cells. Overflow is clipped from the right.",
+    },
+    OptionSchema {
+        name: "max_height",
+        type_hint: "cells (u16)",
+        required: false,
+        default: Some("area height"),
+        description: "Upper bound on the rendered sprite height in cells (each cell = 2 pixel rows). Overflow is clipped from the bottom.",
+    },
+];
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    pub max_width: Option<u16>,
+    #[serde(default)]
+    pub max_height: Option<u16>,
+}
+
+pub struct MediaPixelRenderer;
+
+impl Renderer for MediaPixelRenderer {
+    fn name(&self) -> &str {
+        "media_pixel"
+    }
+    fn description(&self) -> &'static str {
+        "Draws a small pixel-art sprite cell-by-cell with truecolor half-blocks. Works in any terminal with 24-bit colour. Two stacked pixels fit into one cell, so a 16x16 sprite renders as 16 columns × 8 rows. Transparent pixels (`a = 0`) blend with the theme background."
+    }
+    fn accepts(&self) -> &[Shape] {
+        &[Shape::PixelArt]
+    }
+    fn color_keys(&self) -> &[ColorKey] {
+        COLOR_KEYS
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        body: &Body,
+        opts: &RenderOptions,
+        theme: &Theme,
+        _registry: &Registry,
+    ) {
+        if let Body::PixelArt(d) = body {
+            draw(frame, area, d, opts, theme);
+        }
+    }
+    fn natural_height(
+        &self,
+        body: &Body,
+        opts: &RenderOptions,
+        _max_width: u16,
+        _registry: &Registry,
+    ) -> u16 {
+        let Body::PixelArt(d) = body else {
+            return 1;
+        };
+        let specific: Options = opts.parse_specific();
+        let sprite_rows = pixel_grid_height(d);
+        let capped = specific
+            .max_height
+            .map_or(sprite_rows, |m| m.min(sprite_rows));
+        capped + label_height(d)
+    }
+}
+
+fn draw(frame: &mut Frame, area: Rect, data: &PixelArtData, opts: &RenderOptions, theme: &Theme) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    if !rows_are_uniform(data) {
+        frame.render_widget(
+            Paragraph::new("[pixel_art: jagged rows]")
+                .style(Style::default().fg(theme.status_error)),
+            area,
+        );
+        return;
+    }
+    let target = compute_target(area, data, opts);
+    let widget = SpriteWidget { data, theme };
+    frame.render_widget(widget, target.sprite);
+    if let (Some(label), Some(label_area)) = (data.label.as_deref(), target.label) {
+        let p = Paragraph::new(Line::from(label)).style(Style::default().fg(theme.text));
+        frame.render_widget(p, label_area);
+    }
+}
+
+struct SpriteTarget {
+    sprite: Rect,
+    label: Option<Rect>,
+}
+
+fn compute_target(area: Rect, data: &PixelArtData, opts: &RenderOptions) -> SpriteTarget {
+    let specific: Options = opts.parse_specific();
+    let sprite_w_natural = pixel_grid_width(data);
+    let sprite_h_natural = pixel_grid_height(data);
+    let lbl_h = label_height(data).min(area.height);
+    let available_h = area.height.saturating_sub(lbl_h);
+    let capped_w = specific
+        .max_width
+        .unwrap_or(sprite_w_natural)
+        .min(sprite_w_natural)
+        .min(area.width);
+    let capped_h = specific
+        .max_height
+        .unwrap_or(sprite_h_natural)
+        .min(sprite_h_natural)
+        .min(available_h);
+    let x_offset = match opts.align.as_deref() {
+        Some("center") => area.width.saturating_sub(capped_w) / 2,
+        Some("right") => area.width.saturating_sub(capped_w),
+        _ => 0,
+    };
+    let sprite = Rect {
+        x: area.x + x_offset,
+        y: area.y,
+        width: capped_w,
+        height: capped_h,
+    };
+    // Label spans the full row so multi-character captions don't truncate to the sprite's
+    // single-cell width — callers passing a 1-cell sprite still want "hi" to fit.
+    let label = (lbl_h > 0 && area.height >= sprite.height + lbl_h).then(|| Rect {
+        x: area.x,
+        y: area.y + sprite.height,
+        width: area.width,
+        height: lbl_h,
+    });
+    SpriteTarget { sprite, label }
+}
+
+fn pixel_grid_width(data: &PixelArtData) -> u16 {
+    data.pixels.first().map(|row| row.len() as u16).unwrap_or(0)
+}
+
+fn pixel_grid_height(data: &PixelArtData) -> u16 {
+    // Two pixel rows pack into one terminal cell (half-block), so divide by 2 rounding up.
+    (data.pixels.len() as u16).div_ceil(2)
+}
+
+fn label_height(data: &PixelArtData) -> u16 {
+    if data.label.as_deref().is_some_and(|s| !s.is_empty()) {
+        1
+    } else {
+        0
+    }
+}
+
+fn rows_are_uniform(data: &PixelArtData) -> bool {
+    let Some(first) = data.pixels.first() else {
+        return true;
+    };
+    let expected = first.len();
+    data.pixels.iter().all(|row| row.len() == expected)
+}
+
+struct SpriteWidget<'a> {
+    data: &'a PixelArtData,
+    theme: &'a Theme,
+}
+
+impl<'a> Widget for SpriteWidget<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        for cell_y in 0..area.height {
+            let pixel_y_top = cell_y as usize * 2;
+            let pixel_y_bot = pixel_y_top + 1;
+            for cell_x in 0..area.width {
+                let px = cell_x as usize;
+                let top = pixel_at(self.data, pixel_y_top, px);
+                let bot = pixel_at(self.data, pixel_y_bot, px);
+                let fg = resolve(top, self.theme);
+                let bg = resolve(bot, self.theme);
+                let pos = (area.x + cell_x, area.y + cell_y);
+                if let Some(c) = buf.cell_mut(pos) {
+                    c.set_symbol(HALF_BLOCK)
+                        .set_style(Style::default().fg(fg).bg(bg));
+                }
+            }
+        }
+    }
+}
+
+fn pixel_at(data: &PixelArtData, row: usize, col: usize) -> Option<PixelColor> {
+    data.pixels.get(row).and_then(|r| r.get(col)).copied()
+}
+
+fn resolve(pixel: Option<PixelColor>, theme: &Theme) -> Color {
+    match pixel {
+        Some(p) if !p.is_transparent() => Color::Rgb(p.r, p.g, p.b),
+        _ => theme.bg,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::{Payload, PixelArtData, PixelColor, TextData};
+    use crate::render::test_utils::render_to_buffer_with_spec;
+    use crate::render::{Registry, RenderSpec};
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn sprite_payload(data: PixelArtData) -> Payload {
+        Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: Body::PixelArt(data),
+        }
+    }
+
+    fn spec_default() -> RenderSpec {
+        RenderSpec::Short("media_pixel".into())
+    }
+
+    fn solid_red(rows: usize, cols: usize) -> PixelArtData {
+        let row: Vec<PixelColor> = (0..cols).map(|_| PixelColor::opaque(255, 0, 0)).collect();
+        PixelArtData {
+            pixels: (0..rows).map(|_| row.clone()).collect(),
+            label: None,
+        }
+    }
+
+    #[test]
+    fn renderer_contract_exposes_pixel_art_surface() {
+        let r = MediaPixelRenderer;
+        assert_eq!(r.name(), "media_pixel");
+        assert!(r.description().contains("truecolor"));
+        assert_eq!(r.accepts(), &[Shape::PixelArt]);
+        assert_eq!(r.color_keys().len(), 2);
+        let names: Vec<_> = r.option_schemas().iter().map(|s| s.name).collect();
+        assert_eq!(names, vec!["align", "max_width", "max_height"]);
+        assert!(!r.animates());
+    }
+
+    #[test]
+    fn renders_solid_red_as_truecolor_half_block() {
+        let buf = render_to_buffer_with_spec(
+            &sprite_payload(solid_red(4, 4)),
+            Some(&spec_default()),
+            &Registry::with_builtins(),
+            8,
+            4,
+        );
+        // Sprite is 4 cells wide × 2 cells tall (4 px / 2 px-per-cell). Cells (0,0)..(3,1) should
+        // carry the half-block glyph with both fg and bg in RGB red.
+        for y in 0..2u16 {
+            for x in 0..4u16 {
+                let cell = buf.cell((x, y)).unwrap();
+                assert_eq!(cell.symbol(), HALF_BLOCK, "cell ({x},{y}) glyph");
+                assert_eq!(cell.style().fg, Some(Color::Rgb(255, 0, 0)));
+                assert_eq!(cell.style().bg, Some(Color::Rgb(255, 0, 0)));
+            }
+        }
+    }
+
+    #[test]
+    fn transparent_pixel_resolves_to_theme_background() {
+        let data = PixelArtData {
+            pixels: vec![vec![PixelColor::TRANSPARENT, PixelColor::TRANSPARENT]],
+            label: None,
+        };
+        let buf = render_to_buffer_with_spec(
+            &sprite_payload(data),
+            Some(&spec_default()),
+            &Registry::with_builtins(),
+            4,
+            1,
+        );
+        let theme = Theme::default();
+        let cell = buf.cell((0, 0)).unwrap();
+        assert_eq!(cell.style().fg, Some(theme.bg));
+        assert_eq!(cell.style().bg, Some(theme.bg));
+    }
+
+    #[test]
+    fn odd_row_count_pads_bottom_pixel_with_theme_background() {
+        // 3 pixel rows = 2 cells tall; the second cell's bottom pixel is implied background.
+        let data = PixelArtData {
+            pixels: vec![
+                vec![PixelColor::opaque(10, 20, 30)],
+                vec![PixelColor::opaque(40, 50, 60)],
+                vec![PixelColor::opaque(70, 80, 90)],
+            ],
+            label: None,
+        };
+        let buf = render_to_buffer_with_spec(
+            &sprite_payload(data),
+            Some(&spec_default()),
+            &Registry::with_builtins(),
+            2,
+            2,
+        );
+        let theme = Theme::default();
+        let bottom_cell = buf.cell((0, 1)).unwrap();
+        assert_eq!(bottom_cell.style().fg, Some(Color::Rgb(70, 80, 90)));
+        assert_eq!(
+            bottom_cell.style().bg,
+            Some(theme.bg),
+            "missing pixel row falls back to theme bg"
+        );
+    }
+
+    #[test]
+    fn align_center_offsets_the_sprite() {
+        let buf = render_to_buffer_with_spec(
+            &sprite_payload(solid_red(2, 2)),
+            Some(&RenderSpec::Full {
+                type_name: "media_pixel".into(),
+                options: RenderOptions {
+                    align: Some("center".into()),
+                    ..RenderOptions::default()
+                },
+            }),
+            &Registry::with_builtins(),
+            10,
+            2,
+        );
+        // (10 - 2) / 2 = 4, so columns 4..=5 carry the sprite.
+        assert_eq!(
+            buf.cell((3, 0)).unwrap().symbol(),
+            " ",
+            "left of centred sprite should be blank"
+        );
+        let painted = buf.cell((4, 0)).unwrap();
+        assert_eq!(painted.symbol(), HALF_BLOCK);
+        assert_eq!(painted.style().fg, Some(Color::Rgb(255, 0, 0)));
+        assert_eq!(
+            buf.cell((6, 0)).unwrap().symbol(),
+            " ",
+            "right of centred sprite should be blank"
+        );
+    }
+
+    #[test]
+    fn label_renders_below_sprite_when_room_exists() {
+        let data = PixelArtData {
+            pixels: vec![
+                vec![PixelColor::opaque(1, 2, 3)],
+                vec![PixelColor::opaque(4, 5, 6)],
+            ],
+            label: Some("hi".into()),
+        };
+        let buf = render_to_buffer_with_spec(
+            &sprite_payload(data),
+            Some(&spec_default()),
+            &Registry::with_builtins(),
+            4,
+            3,
+        );
+        // Sprite uses 1 cell row; label sits at y=1.
+        let label_row: String = (0..4)
+            .map(|x| buf.cell((x, 1)).unwrap().symbol().to_string())
+            .collect();
+        assert!(label_row.starts_with("hi"));
+    }
+
+    #[test]
+    fn jagged_rows_render_in_band_error() {
+        let data = PixelArtData {
+            pixels: vec![
+                vec![PixelColor::opaque(1, 2, 3); 3],
+                vec![PixelColor::opaque(1, 2, 3); 2],
+            ],
+            label: None,
+        };
+        let buf = render_to_buffer_with_spec(
+            &sprite_payload(data),
+            Some(&spec_default()),
+            &Registry::with_builtins(),
+            30,
+            1,
+        );
+        let line: String = (0..30)
+            .map(|x| buf.cell((x, 0)).unwrap().symbol().to_string())
+            .collect();
+        assert!(line.contains("jagged"));
+    }
+
+    #[test]
+    fn ignores_non_pixel_art_body() {
+        let backend = TestBackend::new(6, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                MediaPixelRenderer.render(
+                    frame,
+                    frame.area(),
+                    &Body::Text(TextData {
+                        value: "ignored".into(),
+                    }),
+                    &RenderOptions::default(),
+                    &Theme::default(),
+                    &Registry::with_builtins(),
+                );
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        // Nothing was drawn — the body type mismatched the renderer's accepted shape, so it bails.
+        let content: String = (0..buf.area.height)
+            .flat_map(|y| (0..buf.area.width).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+        assert!(content.trim().is_empty());
+    }
+
+    #[test]
+    fn natural_height_combines_sprite_and_label() {
+        let data = PixelArtData {
+            pixels: vec![vec![PixelColor::opaque(0, 0, 0)]; 4],
+            label: Some("caption".into()),
+        };
+        let h = MediaPixelRenderer.natural_height(
+            &Body::PixelArt(data),
+            &RenderOptions::default(),
+            10,
+            &Registry::with_builtins(),
+        );
+        assert_eq!(h, 2 + 1, "4 px rows = 2 cells + 1-line label");
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -740,6 +740,7 @@ mod tests {
             "chart_histogram",
             "chart_pie",
             "media_image",
+            "media_pixel",
         ] {
             assert!(r.get(name).is_some(), "missing builtin renderer: {name}");
         }
@@ -759,6 +760,7 @@ mod tests {
             Shape::PointSeries,
             Shape::Bars,
             Shape::Image,
+            Shape::PixelArt,
             Shape::Calendar,
             Shape::Heatmap,
             Shape::Badge,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -42,6 +42,7 @@ mod list_ranking;
 mod list_timeline;
 pub mod loading;
 mod media_image;
+mod media_pixel;
 mod status_badge;
 mod text_ascii;
 mod text_markdown;
@@ -66,6 +67,7 @@ pub enum Shape {
     PointSeries,
     Bars,
     Image,
+    PixelArt,
     Calendar,
     Heatmap,
     Badge,
@@ -89,6 +91,7 @@ pub fn shape_of(body: &Body) -> Shape {
         Body::PointSeries(_) => Shape::PointSeries,
         Body::Bars(_) => Shape::Bars,
         Body::Image(_) => Shape::Image,
+        Body::PixelArt(_) => Shape::PixelArt,
         Body::Calendar(_) => Shape::Calendar,
         Body::Heatmap(_) => Shape::Heatmap,
         Body::Badge(_) => Shape::Badge,
@@ -113,6 +116,7 @@ impl Shape {
             Self::PointSeries => "point_series",
             Self::Bars => "bars",
             Self::Image => "image",
+            Self::PixelArt => "pixel_art",
             Self::Calendar => "calendar",
             Self::Heatmap => "heatmap",
             Self::Badge => "badge",
@@ -389,6 +393,7 @@ impl Registry {
         r.register(Arc::new(chart_histogram::ChartHistogramRenderer));
         r.register(Arc::new(chart_pie::ChartPieRenderer));
         r.register(Arc::new(media_image::MediaImageRenderer));
+        r.register(Arc::new(media_pixel::MediaPixelRenderer));
         r.register(Arc::new(grid_calendar::GridCalendarRenderer));
         r.register(Arc::new(grid_heatmap::GridHeatmapRenderer));
         r.register(Arc::new(list_timeline::ListTimelineRenderer));
@@ -424,6 +429,7 @@ pub fn default_renderer_for(shape: Shape) -> &'static str {
         Shape::PointSeries => "chart_line",
         Shape::Bars => "chart_bar",
         Shape::Image => "media_image",
+        Shape::PixelArt => "media_pixel",
         Shape::Calendar => "grid_calendar",
         Shape::Heatmap => "grid_heatmap",
         Shape::Badge => "status_badge",
@@ -537,6 +543,7 @@ pub fn is_empty_body(body: &Body) -> bool {
         Body::PointSeries(d) => d.series.iter().all(|s| s.points.is_empty()),
         Body::Bars(d) => d.bars.is_empty(),
         Body::Image(d) => d.path.is_empty(),
+        Body::PixelArt(d) => d.pixels.is_empty() || d.pixels.iter().all(|r| r.is_empty()),
         Body::Heatmap(d) => d.cells.is_empty() || d.cells.iter().all(|r| r.is_empty()),
         Body::Timeline(d) => d.events.is_empty(),
         // `Error` always carries a message — we want the user to see it, never collapse it to

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -13,8 +13,8 @@
 use crate::payload::{
     BadgeData, Bar, BarsData, Body, CalendarData, EntriesData, Entry, HeatmapData, ImageLinkedItem,
     ImageLinkedListData, LinkedLine, LinkedTextBlockData, MarkdownTextBlockData, NumberSeriesData,
-    PointSeries, PointSeriesData, RatioData, Status, TextBlockData, TextData, TimelineData,
-    TimelineEvent,
+    PixelArtData, PixelColor, PointSeries, PointSeriesData, RatioData, Status, TextBlockData,
+    TextData, TimelineData, TimelineEvent,
 };
 use crate::render::Shape;
 
@@ -49,6 +49,7 @@ pub fn canonical_sample(shape: Shape) -> Option<Body> {
         Shape::PointSeries => sine_points(),
         Shape::Bars => bars(&[("rust", 42), ("go", 28), ("ts", 17), ("py", 13)]),
         Shape::Image => return None,
+        Shape::PixelArt => pixel_art_sample(),
         Shape::Calendar => calendar(2026, 4, Some(22), &[10, 15, 30]),
         Shape::Heatmap => heatmap_grid(3, 7),
         Shape::Badge => badge(Status::Ok, "passing"),
@@ -192,6 +193,25 @@ pub fn sine_points() -> Body {
                 })
                 .collect(),
         }],
+    })
+}
+
+/// Tiny 4x4 sprite (a yellow-on-black smiley) used as the shape-level fallback for `PixelArt`.
+/// Fetchers that emit `PixelArt` should override `sample_body` with something representative;
+/// this is just the "this shape can render something" placeholder.
+pub fn pixel_art_sample() -> Body {
+    let bg = PixelColor::TRANSPARENT;
+    let fg = PixelColor::opaque(255, 213, 79);
+    let cheek = PixelColor::opaque(255, 99, 71);
+    let row = |cells: [PixelColor; 4]| cells.to_vec();
+    Body::PixelArt(PixelArtData {
+        pixels: vec![
+            row([bg, fg, fg, bg]),
+            row([fg, bg, bg, fg]),
+            row([fg, cheek, cheek, fg]),
+            row([bg, fg, fg, bg]),
+        ],
+        label: Some("hello".into()),
     })
 }
 

--- a/xtask/src/snapshots.rs
+++ b/xtask/src/snapshots.rs
@@ -81,6 +81,9 @@ fn renderer_dimensions(renderer: &str) -> (u16, u16) {
         "chart_histogram" => (40, 6),
         "chart_pie" => (40, 10),
         "media_image" => (40, 5),
+        // Canonical PixelArt sample is a 4x4 smiley (2 cells wide × 2 cells tall) with a
+        // one-line caption; (20, 5) gives breathing room without dwarfing the sprite.
+        "media_pixel" => (20, 5),
         "grid_calendar" => (28, 10),
         "grid_heatmap" => (40, 6),
         "list_timeline" => (50, 8),
@@ -228,6 +231,7 @@ mod tests {
             ("chart_histogram", (40, 6)),
             ("chart_pie", (40, 10)),
             ("media_image", (40, 5)),
+            ("media_pixel", (20, 5)),
             ("grid_calendar", (28, 10)),
             ("grid_heatmap", (40, 6)),
             ("list_timeline", (50, 8)),

--- a/xtask/src/snapshots.rs
+++ b/xtask/src/snapshots.rs
@@ -146,6 +146,7 @@ fn representative_fetcher(shape: Shape, fetchers: &FetcherRegistry) -> String {
         Shape::PointSeries => "weather",
         Shape::Bars => "github_languages",
         Shape::Image => "github_avatar",
+        Shape::PixelArt => "weather",
         Shape::Calendar => "clock",
         Shape::Heatmap => "git_blame_heatmap",
         Shape::Badge => "github_action_status",


### PR DESCRIPTION
Implements #259.

## Summary

- New `PixelArt` shape (`payload::PixelArtData`, row-major RGBA grid + optional label) + `media_pixel` renderer that draws each cell as a truecolor `▀` half-block. Distinct from `Image` / `media_image`: works in any 24-bit-colour terminal, no kitty / sixel / iTerm2 protocol dependency.
- `weather` fetcher gains a `PixelArt` shape variant. Eight bundled 16x16 sprites cover the WMO buckets (clear, mostly_clear, partly_cloudy, overcast, fog, rain, snow, thunderstorm); unknown codes fall back to overcast.
- `basic_read_store` learns `PixelArt` so users can drop their own sprite JSON at `$HOME/.splashboard/store/<id>.json` without depending on a network fetcher.

Sprites are authored as ASCII grids with per-sprite palettes in `weather/sprites.rs`, decoded once via `OnceLock`. PR diff stays text-only.

Two pixel rows pack into one terminal cell, so a 16x16 sprite renders as 16 columns × 8 rows. Honours `align` / `max_width` / `max_height`; jagged rows surface an in-band error; the shared `is_empty_body` placeholder catches zero-row grids.

After merge: tick the `media_pixel` checkbox on [#61](https://github.com/unhappychoice/splashboard/issues/61) and update the `weather` entry on [#68](https://github.com/unhappychoice/splashboard/issues/68).

## `media_pixel` reference (mirror of `/reference/renderers/media/media_pixel/`)

Draws a small pixel-art sprite cell-by-cell with truecolor half-blocks. Works in any terminal with 24-bit colour. Two stacked pixels fit into one cell, so a 16x16 sprite renders as 16 columns × 8 rows. Transparent pixels (`a = 0`) blend with the theme background.

| Accepts | Animates |
| --- | --- |
| `pixel_art` | no |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `align` | "left" \| "center" \| "right" | no | "left" | Horizontal placement of the sprite within the available cell. |
| `max_width` | cells (u16) | no | area width | Upper bound on the rendered sprite width in cells. Overflow is clipped from the right. |
| `max_height` | cells (u16) | no | area height | Upper bound on the rendered sprite height in cells (each cell = 2 pixel rows). Overflow is clipped from the bottom. |

### Theme tokens

| Key | Description |
| --- | --- |
| `bg` | Used to fill transparent (`a = 0`) pixels. |
| `text` | Used for the optional caption rendered under the sprite. |

### Compatible fetchers

| Shape | Fetchers |
| --- | --- |
| `pixel_art` | [`basic_read_store`](https://splashboard.unhappychoice.com/reference/fetchers/basic/basic_read_store/), [`weather`](https://splashboard.unhappychoice.com/reference/fetchers/weather/weather/) |

## Test plan

- [x] `cargo test --lib` — 3245 pass, 0 fail
- [x] `cargo test -p xtask` — 2 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run --bin splashboard -- catalog renderer media_pixel` — option schema + compatible fetchers list correct
- [x] Smoke test: `basic_read_store` widget consumes all 8 weather sprite JSONs over a 4×2 grid; eight buckets render in truecolor, transparent regions blend with theme bg, captions appear below each sprite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline PixelArt payload and truecolor pixel-art support, a terminal renderer drawing sprites with half-blocks, weather provider offering PixelArt shape, sample pixel-art sprite, and read-store support for PixelArt payloads.

* **Tests**
  * Added comprehensive tests for sprite dimensions, palettes, label mapping, rendering behavior (transparency, alignment, captions), format roundtrips, and shape registration.

* **Chores**
  * Updated snapshot/documentation sizes and registry mappings for the new renderer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->