### PR TITLE
feat(clock,system): PixelArt sprites for clock_derived + system_monitor_{battery,cpu}

### DIFF
--- a/src/fetcher/clock/derived.rs
+++ b/src/fetcher/clock/derived.rs
@@ -10,8 +10,9 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::common;
+use super::sprites;
 
-const SHAPES: &[Shape] = &[Shape::Text];
+const SHAPES: &[Shape] = &[Shape::Text, Shape::PixelArt];
 
 pub struct ClockDerivedFetcher;
 
@@ -70,6 +71,9 @@ impl RealtimeFetcher for ClockDerivedFetcher {
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         match shape {
             Shape::Text => Some(samples::text("day 113 of 2026")),
+            // Pick the most recognizable sprite (Full moon) so docs previews lead with a
+            // visually striking sample rather than an empty New-moon disk.
+            Shape::PixelArt => Some(Body::PixelArt(sprites::moon_sprite(4, "Full"))),
             _ => None,
         }
     }
@@ -79,11 +83,17 @@ impl RealtimeFetcher for ClockDerivedFetcher {
             Err(msg) => return common::placeholder(&msg),
         };
         let now = common::now_in(opts.timezone.as_deref());
-        let line = invoke(
-            &now,
-            opts.kind.unwrap_or(Kind::TimeOfDay),
-            opts.hemisphere.unwrap_or_default(),
-        );
+        let kind = opts.kind.unwrap_or(Kind::TimeOfDay);
+        let hemisphere = opts.hemisphere.unwrap_or_default();
+        if matches!(ctx.shape, Some(Shape::PixelArt)) {
+            return Payload {
+                icon: None,
+                status: None,
+                format: None,
+                body: Body::PixelArt(sprite_for_kind(&now, kind, hemisphere)),
+            };
+        }
+        let line = invoke(&now, kind, hemisphere);
         Payload {
             icon: None,
             status: None,
@@ -92,6 +102,52 @@ impl RealtimeFetcher for ClockDerivedFetcher {
         }
     }
 }
+
+/// Pick a sprite for the kind the user configured. Only moon-phase and season have visual
+/// translations today; numeric / textual kinds (`iso_week`, `day_of_year`, `julian_day`,
+/// `unix_epoch`, `time_of_day`, `rokuyou`, `jp_season`, `zodiac`, `chinese_zodiac`) fall
+/// through to a labelled placeholder so the misconfiguration is visible rather than silent.
+fn sprite_for_kind(
+    now: &DateTime<FixedOffset>,
+    kind: Kind,
+    hemisphere: Hemisphere,
+) -> crate::payload::PixelArtData {
+    match kind {
+        Kind::MoonPhase => {
+            let idx = moon_phase_index(now);
+            sprites::moon_sprite(idx, MOON_LABELS[idx])
+        }
+        Kind::Season => sprites::season_sprite(&season(now, hemisphere)),
+        other => sprites::placeholder(kind_label(other)),
+    }
+}
+
+fn kind_label(k: Kind) -> &'static str {
+    match k {
+        Kind::TimeOfDay => "time_of_day",
+        Kind::MoonPhase => "moon_phase",
+        Kind::Zodiac => "zodiac",
+        Kind::ChineseZodiac => "chinese_zodiac",
+        Kind::Season => "season",
+        Kind::JpSeason => "jp_season",
+        Kind::Rokuyou => "rokuyou",
+        Kind::IsoWeek => "iso_week",
+        Kind::DayOfYear => "day_of_year",
+        Kind::JulianDay => "julian_day",
+        Kind::UnixEpoch => "unix_epoch",
+    }
+}
+
+const MOON_LABELS: [&str; 8] = [
+    "New",
+    "Waxing Crescent",
+    "First Quarter",
+    "Waxing Gibbous",
+    "Full",
+    "Waning Gibbous",
+    "Last Quarter",
+    "Waning Crescent",
+];
 
 /// Dispatch a single kind against an already-resolved `now`. Shared with the
 /// `clock_almanac` rollup so both fetchers stay in sync on formatting.
@@ -120,8 +176,10 @@ fn time_of_day(now: &DateTime<FixedOffset>) -> &'static str {
     }
 }
 
-fn moon_phase(now: &DateTime<FixedOffset>) -> String {
-    // Conway's moon-phase approximation. Accuracy ±1 day, adequate for a splash widget.
+/// Conway's moon-phase approximation expressed as an index 0..=7. Shared with the
+/// `PixelArt` shape so the sprite stays consistent with the text label. ±1 day accuracy,
+/// adequate for a splash widget.
+pub(crate) fn moon_phase_index(now: &DateTime<FixedOffset>) -> usize {
     let (mut year, month, day) = (now.year(), now.month() as i32, now.day() as i32);
     let m = if month < 3 {
         year -= 1;
@@ -136,18 +194,13 @@ fn moon_phase(now: &DateTime<FixedOffset>) -> String {
         + c
         - 37.5;
     let phase = ((jdn - 2_451_550.1) / 29.530_588_853).rem_euclid(1.0);
-    let idx = (phase * 8.0).floor() as usize % 8;
-    let (glyph, name) = match idx {
-        0 => ("🌑", "New"),
-        1 => ("🌒", "Waxing Crescent"),
-        2 => ("🌓", "First Quarter"),
-        3 => ("🌔", "Waxing Gibbous"),
-        4 => ("🌕", "Full"),
-        5 => ("🌖", "Waning Gibbous"),
-        6 => ("🌗", "Last Quarter"),
-        _ => ("🌘", "Waning Crescent"),
-    };
-    format!("{glyph} {name}")
+    (phase * 8.0).floor() as usize % 8
+}
+
+fn moon_phase(now: &DateTime<FixedOffset>) -> String {
+    let idx = moon_phase_index(now);
+    let glyph = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"][idx];
+    format!("{glyph} {}", MOON_LABELS[idx])
 }
 
 fn zodiac(now: &DateTime<FixedOffset>) -> String {
@@ -476,5 +529,70 @@ mod tests {
         if let Body::Text(d) = p.body {
             assert!(!d.value.is_empty());
         }
+    }
+
+    fn pixel_ctx(opts: &str) -> FetchContext {
+        FetchContext {
+            widget_id: "d".into(),
+            timeout: Duration::from_secs(1),
+            shape: Some(Shape::PixelArt),
+            options: Some(toml::from_str(opts).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pixel_art_moon_phase_emits_16x16_sprite_with_label() {
+        let p = ClockDerivedFetcher.compute(&pixel_ctx("kind = \"moon_phase\""));
+        let Body::PixelArt(d) = p.body else {
+            panic!("expected PixelArt");
+        };
+        assert_eq!(d.pixels.len(), 16);
+        assert_eq!(d.pixels[0].len(), 16);
+        let label = d.label.expect("sprite carries phase label");
+        assert!(MOON_LABELS.contains(&label.as_str()), "{label}");
+    }
+
+    #[test]
+    fn pixel_art_season_uses_hemisphere_to_pick_sprite() {
+        let p =
+            ClockDerivedFetcher.compute(&pixel_ctx("kind = \"season\"\nhemisphere = \"south\""));
+        let Body::PixelArt(d) = p.body else {
+            panic!("expected PixelArt");
+        };
+        assert_eq!(d.pixels.len(), 16);
+        let label = d.label.unwrap();
+        assert!(["Spring", "Summer", "Autumn", "Winter"].contains(&label.as_str()));
+    }
+
+    #[test]
+    fn pixel_art_unsupported_kind_falls_back_to_labelled_placeholder() {
+        let p = ClockDerivedFetcher.compute(&pixel_ctx("kind = \"iso_week\""));
+        let Body::PixelArt(d) = p.body else {
+            panic!("expected PixelArt");
+        };
+        // 1×1 transparent placeholder; the meaningful signal is in the label.
+        assert_eq!(d.pixels.len(), 1);
+        assert_eq!(d.pixels[0].len(), 1);
+        let label = d.label.unwrap();
+        assert!(label.contains("iso_week"), "label = {label}");
+    }
+
+    #[test]
+    fn moon_phase_index_matches_text_label_table_indices() {
+        let now = at(2026, 1, 21, 0);
+        let idx = moon_phase_index(&now);
+        let text = moon_phase(&now);
+        assert!(text.contains(MOON_LABELS[idx]));
+    }
+
+    #[test]
+    fn sample_body_for_pixel_art_returns_full_moon_sprite() {
+        let body = ClockDerivedFetcher.sample_body(Shape::PixelArt).unwrap();
+        let Body::PixelArt(d) = body else {
+            panic!("expected PixelArt");
+        };
+        assert_eq!(d.label.as_deref(), Some("Full"));
+        assert_eq!(d.pixels.len(), 16);
     }
 }

--- a/src/fetcher/clock/mod.rs
+++ b/src/fetcher/clock/mod.rs
@@ -9,6 +9,7 @@ mod common;
 pub mod countdown;
 pub mod derived;
 pub mod ratio;
+pub(crate) mod sprites;
 pub mod state;
 pub mod sunrise;
 pub mod timezones;

--- a/src/fetcher/clock/sprites.rs
+++ b/src/fetcher/clock/sprites.rs
@@ -1,0 +1,481 @@
+//! Pixel-art sprites for `clock_derived`'s `PixelArt` shape. Same authoring pattern as
+//! `weather/sprites.rs`: ASCII grids paired with a palette, decoded once into
+//! [`PixelArtData`] and stashed in a `OnceLock` for the lifetime of the process.
+//!
+//! Only kinds with a natural visual translation are supported here. Numeric / textual kinds
+//! (`iso_week`, `day_of_year`, `julian_day`, `unix_epoch`, `time_of_day`, `rokuyou`,
+//! `jp_season`) fall through to a placeholder so a misconfigured widget surfaces a clear
+//! "no sprite for kind" hint rather than a blank frame.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use crate::payload::{PixelArtData, PixelColor};
+
+pub const SPRITE_SIZE: usize = 16;
+
+// ── Public catalog API ─────────────────────────────────────────────
+
+pub fn moon_sprite(phase_idx: usize, label: &str) -> PixelArtData {
+    let catalog = moon_catalog();
+    let mut sprite = catalog[phase_idx % 8].clone();
+    sprite.label = Some(label.into());
+    sprite
+}
+
+pub fn season_sprite(name: &str) -> PixelArtData {
+    let c = season_catalog();
+    let mut sprite = match name {
+        "Spring" => c.spring.clone(),
+        "Summer" => c.summer.clone(),
+        "Autumn" => c.autumn.clone(),
+        _ => c.winter.clone(),
+    };
+    sprite.label = Some(name.into());
+    sprite
+}
+
+pub fn placeholder(kind_label: &str) -> PixelArtData {
+    PixelArtData {
+        pixels: vec![vec![PixelColor::TRANSPARENT; 1]],
+        label: Some(format!("no sprite: {kind_label}")),
+    }
+}
+
+// ── Catalogs ───────────────────────────────────────────────────────
+
+fn moon_catalog() -> &'static [PixelArtData; 8] {
+    static CATALOG: OnceLock<[PixelArtData; 8]> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        let pal = palette_moon();
+        [
+            decode(MOON_NEW, &pal),
+            decode(MOON_WAXING_CRESCENT, &pal),
+            decode(MOON_FIRST_QUARTER, &pal),
+            decode(MOON_WAXING_GIBBOUS, &pal),
+            decode(MOON_FULL, &pal),
+            decode(MOON_WANING_GIBBOUS, &pal),
+            decode(MOON_LAST_QUARTER, &pal),
+            decode(MOON_WANING_CRESCENT, &pal),
+        ]
+    })
+}
+
+struct SeasonCatalog {
+    spring: PixelArtData,
+    summer: PixelArtData,
+    autumn: PixelArtData,
+    winter: PixelArtData,
+}
+
+fn season_catalog() -> &'static SeasonCatalog {
+    static CATALOG: OnceLock<SeasonCatalog> = OnceLock::new();
+    CATALOG.get_or_init(|| SeasonCatalog {
+        spring: decode(SPRING, &palette_spring()),
+        summer: decode(SUMMER, &palette_summer()),
+        autumn: decode(AUTUMN, &palette_autumn()),
+        winter: decode(WINTER, &palette_winter()),
+    })
+}
+
+fn decode(grid: &[&str], palette: &HashMap<char, PixelColor>) -> PixelArtData {
+    let pixels = grid
+        .iter()
+        .map(|row| {
+            row.chars()
+                .map(|c| palette.get(&c).copied().unwrap_or(PixelColor::TRANSPARENT))
+                .collect()
+        })
+        .collect();
+    PixelArtData {
+        pixels,
+        label: None,
+    }
+}
+
+// ── Palettes ───────────────────────────────────────────────────────
+
+const MOON_DARK: PixelColor = PixelColor::opaque(57, 62, 70);
+const MOON_LIT: PixelColor = PixelColor::opaque(245, 232, 199);
+const CHERRY_PETAL: PixelColor = PixelColor::opaque(255, 182, 193);
+const CHERRY_CORE: PixelColor = PixelColor::opaque(255, 105, 180);
+const CHERRY_POLLEN: PixelColor = PixelColor::opaque(255, 235, 59);
+const LEAF_GREEN: PixelColor = PixelColor::opaque(76, 175, 80);
+const STEM_BROWN: PixelColor = PixelColor::opaque(121, 85, 72);
+const SUN_RIM: PixelColor = PixelColor::opaque(255, 213, 79);
+const SUN_CORE: PixelColor = PixelColor::opaque(255, 152, 0);
+const MAPLE_RED: PixelColor = PixelColor::opaque(229, 57, 53);
+const MAPLE_ORANGE: PixelColor = PixelColor::opaque(255, 152, 0);
+const SNOW_WHITE: PixelColor = PixelColor::opaque(245, 245, 245);
+const SKY_BLUE: PixelColor = PixelColor::opaque(176, 224, 230);
+
+fn palette_moon() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('D', MOON_DARK),
+        ('L', MOON_LIT),
+    ])
+}
+
+fn palette_spring() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('P', CHERRY_PETAL),
+        ('p', CHERRY_CORE),
+        ('Y', CHERRY_POLLEN),
+        ('G', LEAF_GREEN),
+        ('T', STEM_BROWN),
+    ])
+}
+
+fn palette_summer() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('Y', SUN_RIM),
+        ('O', SUN_CORE),
+    ])
+}
+
+fn palette_autumn() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('R', MAPLE_RED),
+        ('O', MAPLE_ORANGE),
+        ('T', STEM_BROWN),
+    ])
+}
+
+fn palette_winter() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('S', SNOW_WHITE),
+        ('B', SKY_BLUE),
+    ])
+}
+
+// ── Moon-phase sprites (idx 0..=7 in standard astronomical order) ──
+
+const MOON_NEW: &[&str] = &[
+    "......DDDD......",
+    "....DDDDDDDD....",
+    "...DDDDDDDDDD...",
+    "..DDDDDDDDDDDD..",
+    "..DDDDDDDDDDDD..",
+    ".DDDDDDDDDDDDDD.",
+    ".DDDDDDDDDDDDDD.",
+    ".DDDDDDDDDDDDDD.",
+    ".DDDDDDDDDDDDDD.",
+    ".DDDDDDDDDDDDDD.",
+    ".DDDDDDDDDDDDDD.",
+    "..DDDDDDDDDDDD..",
+    "..DDDDDDDDDDDD..",
+    "...DDDDDDDDDD...",
+    "....DDDDDDDD....",
+    "......DDDD......",
+];
+
+const MOON_WAXING_CRESCENT: &[&str] = &[
+    "......DDDD......",
+    "....DDDDDDDD....",
+    "...DDDDDDDDDL...",
+    "..DDDDDDDDDDLL..",
+    "..DDDDDDDDDDLL..",
+    ".DDDDDDDDDDDLLL.",
+    ".DDDDDDDDDDDLLL.",
+    ".DDDDDDDDDDDLLL.",
+    ".DDDDDDDDDDDLLL.",
+    ".DDDDDDDDDDDLLL.",
+    ".DDDDDDDDDDDLLL.",
+    "..DDDDDDDDDDLL..",
+    "..DDDDDDDDDDLL..",
+    "...DDDDDDDDDL...",
+    "....DDDDDDDD....",
+    "......DDDD......",
+];
+
+const MOON_FIRST_QUARTER: &[&str] = &[
+    "......DDLL......",
+    "....DDDDLLLL....",
+    "...DDDDDLLLLL...",
+    "..DDDDDDLLLLLL..",
+    "..DDDDDDLLLLLL..",
+    ".DDDDDDDLLLLLLL.",
+    ".DDDDDDDLLLLLLL.",
+    ".DDDDDDDLLLLLLL.",
+    ".DDDDDDDLLLLLLL.",
+    ".DDDDDDDLLLLLLL.",
+    ".DDDDDDDLLLLLLL.",
+    "..DDDDDDLLLLLL..",
+    "..DDDDDDLLLLLL..",
+    "...DDDDDLLLLL...",
+    "....DDDDLLLL....",
+    "......DDLL......",
+];
+
+const MOON_WAXING_GIBBOUS: &[&str] = &[
+    "......LLLL......",
+    "....LLLLLLLL....",
+    "...DLLLLLLLLL...",
+    "..DDLLLLLLLLLL..",
+    "..DDLLLLLLLLLL..",
+    ".DDDLLLLLLLLLLL.",
+    ".DDDLLLLLLLLLLL.",
+    ".DDDLLLLLLLLLLL.",
+    ".DDDLLLLLLLLLLL.",
+    ".DDDLLLLLLLLLLL.",
+    ".DDDLLLLLLLLLLL.",
+    "..DDLLLLLLLLLL..",
+    "..DDLLLLLLLLLL..",
+    "...DLLLLLLLLL...",
+    "....LLLLLLLL....",
+    "......LLLL......",
+];
+
+const MOON_FULL: &[&str] = &[
+    "......LLLL......",
+    "....LLLLLLLL....",
+    "...LLLLLLLLLL...",
+    "..LLLLLLLLLLLL..",
+    "..LLLLLLLLLLLL..",
+    ".LLLLLLLLLLLLLL.",
+    ".LLLLLLLLLLLLLL.",
+    ".LLLLLLLLLLLLLL.",
+    ".LLLLLLLLLLLLLL.",
+    ".LLLLLLLLLLLLLL.",
+    ".LLLLLLLLLLLLLL.",
+    "..LLLLLLLLLLLL..",
+    "..LLLLLLLLLLLL..",
+    "...LLLLLLLLLL...",
+    "....LLLLLLLL....",
+    "......LLLL......",
+];
+
+const MOON_WANING_GIBBOUS: &[&str] = &[
+    "......LLLL......",
+    "....LLLLLLLL....",
+    "...LLLLLLLLLD...",
+    "..LLLLLLLLLLDD..",
+    "..LLLLLLLLLLDD..",
+    ".LLLLLLLLLLLDDD.",
+    ".LLLLLLLLLLLDDD.",
+    ".LLLLLLLLLLLDDD.",
+    ".LLLLLLLLLLLDDD.",
+    ".LLLLLLLLLLLDDD.",
+    ".LLLLLLLLLLLDDD.",
+    "..LLLLLLLLLLDD..",
+    "..LLLLLLLLLLDD..",
+    "...LLLLLLLLLD...",
+    "....LLLLLLLL....",
+    "......LLLL......",
+];
+
+const MOON_LAST_QUARTER: &[&str] = &[
+    "......LLDD......",
+    "....LLLLDDDD....",
+    "...LLLLLDDDDD...",
+    "..LLLLLLDDDDDD..",
+    "..LLLLLLDDDDDD..",
+    ".LLLLLLLDDDDDDD.",
+    ".LLLLLLLDDDDDDD.",
+    ".LLLLLLLDDDDDDD.",
+    ".LLLLLLLDDDDDDD.",
+    ".LLLLLLLDDDDDDD.",
+    ".LLLLLLLDDDDDDD.",
+    "..LLLLLLDDDDDD..",
+    "..LLLLLLDDDDDD..",
+    "...LLLLLDDDDD...",
+    "....LLLLDDDD....",
+    "......LLDD......",
+];
+
+const MOON_WANING_CRESCENT: &[&str] = &[
+    "......DDDD......",
+    "....DDDDDDDD....",
+    "...LDDDDDDDDD...",
+    "..LLDDDDDDDDDD..",
+    "..LLDDDDDDDDDD..",
+    ".LLLDDDDDDDDDDD.",
+    ".LLLDDDDDDDDDDD.",
+    ".LLLDDDDDDDDDDD.",
+    ".LLLDDDDDDDDDDD.",
+    ".LLLDDDDDDDDDDD.",
+    ".LLLDDDDDDDDDDD.",
+    "..LLDDDDDDDDDD..",
+    "..LLDDDDDDDDDD..",
+    "...LDDDDDDDDD...",
+    "....DDDDDDDD....",
+    "......DDDD......",
+];
+
+// ── Season sprites ─────────────────────────────────────────────────
+
+const SPRING: &[&str] = &[
+    "................",
+    "................",
+    "....PP....PP....",
+    "...PpPP..PPpP...",
+    "...PPPP..PPPP...",
+    "....PPPYPPP.....",
+    "....PPYYYPP.....",
+    "....PPPYPPP.....",
+    "...PPPP..PPPP...",
+    "...PpPP..PPpP...",
+    "....PP....PP....",
+    ".......TT.......",
+    ".......TT.......",
+    "......GTTG......",
+    ".....GGTTGG.....",
+    "................",
+];
+
+const SUMMER: &[&str] = &[
+    "................",
+    "......YYYY......",
+    ".....YYYYYY.....",
+    "....YYOOOOYY....",
+    "...YYOOOOOOYY...",
+    "..YYOOOOOOOOYY..",
+    ".YYOOOOOOOOOOYY.",
+    ".YOOOOOOOOOOOOY.",
+    ".YOOOOOOOOOOOOY.",
+    ".YYOOOOOOOOOOYY.",
+    "..YYOOOOOOOOYY..",
+    "...YYOOOOOOYY...",
+    "....YYOOOOYY....",
+    ".....YYYYYY.....",
+    "......YYYY......",
+    "................",
+];
+
+const AUTUMN: &[&str] = &[
+    "................",
+    "......RRR.......",
+    ".....RRRRR......",
+    "...RRORRRORRR...",
+    "..RROOOORRROORR.",
+    "..ROOOROOORROOR.",
+    "...ROORRRROORR..",
+    "....RROORROOR...",
+    "....RROORROOR...",
+    "...RROORRRROORR.",
+    "..ROOOROOORROOR.",
+    "..RROOOORRROORR.",
+    "...RRORRRORRR...",
+    ".....RRRRR......",
+    "......RTR.......",
+    ".......T........",
+];
+
+const WINTER: &[&str] = &[
+    "................",
+    ".......S........",
+    "...S...S...S....",
+    "...SS.SBS.SS....",
+    "....SSSBSSSS....",
+    ".....SSBSSS.....",
+    ".SSSSSSBSSSSSS..",
+    ".....SSBSSS.....",
+    ".SSSSSSBSSSSSS..",
+    "....SSSBSSSS....",
+    "...SS.SBS.SS....",
+    "....SS.S.SS.....",
+    "...S...S...S....",
+    ".......S........",
+    "................",
+    "................",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_16x16(grid: &[&str]) {
+        assert_eq!(grid.len(), SPRITE_SIZE, "row count");
+        for (i, row) in grid.iter().enumerate() {
+            assert_eq!(row.chars().count(), SPRITE_SIZE, "row {i} width");
+        }
+    }
+
+    #[test]
+    fn moon_grids_are_16x16() {
+        for g in [
+            MOON_NEW,
+            MOON_WAXING_CRESCENT,
+            MOON_FIRST_QUARTER,
+            MOON_WAXING_GIBBOUS,
+            MOON_FULL,
+            MOON_WANING_GIBBOUS,
+            MOON_LAST_QUARTER,
+            MOON_WANING_CRESCENT,
+        ] {
+            assert_16x16(g);
+        }
+    }
+
+    #[test]
+    fn season_grids_are_16x16() {
+        for g in [SPRING, SUMMER, AUTUMN, WINTER] {
+            assert_16x16(g);
+        }
+    }
+
+    #[test]
+    fn moon_sprite_label_round_trips() {
+        let s = moon_sprite(4, "Full");
+        assert_eq!(s.label.as_deref(), Some("Full"));
+        assert_eq!(s.pixels.len(), SPRITE_SIZE);
+    }
+
+    #[test]
+    fn moon_sprite_phase_wraps() {
+        // phase_idx is modulo'd so 8 → idx 0, matching how the Conway approximation could
+        // theoretically overshoot if the day boundary jitters.
+        let s0 = moon_sprite(0, "");
+        let s8 = moon_sprite(8, "");
+        assert_eq!(s0.pixels, s8.pixels);
+    }
+
+    #[test]
+    fn season_sprite_picks_winter_for_unknown_name() {
+        let s = season_sprite("???");
+        assert_eq!(s.pixels, season_catalog().winter.pixels);
+        assert_eq!(s.label.as_deref(), Some("???"));
+    }
+
+    #[test]
+    fn placeholder_is_single_transparent_pixel_with_label() {
+        let s = placeholder("zodiac");
+        assert_eq!(s.pixels.len(), 1);
+        assert_eq!(s.pixels[0].len(), 1);
+        assert!(s.pixels[0][0].is_transparent());
+        assert_eq!(s.label.as_deref(), Some("no sprite: zodiac"));
+    }
+
+    #[test]
+    fn every_palette_character_is_declared() {
+        let cases: &[(&[&str], HashMap<char, PixelColor>)] = &[
+            (MOON_NEW, palette_moon()),
+            (MOON_WAXING_CRESCENT, palette_moon()),
+            (MOON_FIRST_QUARTER, palette_moon()),
+            (MOON_WAXING_GIBBOUS, palette_moon()),
+            (MOON_FULL, palette_moon()),
+            (MOON_WANING_GIBBOUS, palette_moon()),
+            (MOON_LAST_QUARTER, palette_moon()),
+            (MOON_WANING_CRESCENT, palette_moon()),
+            (SPRING, palette_spring()),
+            (SUMMER, palette_summer()),
+            (AUTUMN, palette_autumn()),
+            (WINTER, palette_winter()),
+        ];
+        for (grid, palette) in cases {
+            for (y, row) in grid.iter().enumerate() {
+                for (x, ch) in row.chars().enumerate() {
+                    assert!(
+                        palette.contains_key(&ch),
+                        "char {ch:?} at ({x},{y}) missing palette entry"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/fetcher/system/mod.rs
+++ b/src/fetcher/system/mod.rs
@@ -656,7 +656,7 @@ mod tests {
         assert_realtime_contract(
             &SystemMonitorCpu::default(),
             "system_monitor_cpu",
-            &[Shape::Ratio, Shape::Text],
+            &[Shape::Ratio, Shape::Text, Shape::PixelArt],
             Shape::Ratio,
             Shape::Entries,
             0,

--- a/src/fetcher/system/mod.rs
+++ b/src/fetcher/system/mod.rs
@@ -36,6 +36,7 @@ mod monitor_load;
 mod monitor_memory;
 mod monitor_processes;
 mod monitor_uptime;
+pub(crate) mod sprites;
 
 pub use info_bios::SystemInfoBios;
 pub use info_board::SystemInfoBoard;

--- a/src/fetcher/system/mod.rs
+++ b/src/fetcher/system/mod.rs
@@ -696,7 +696,13 @@ mod tests {
         assert_realtime_contract(
             &SystemMonitorBattery::default(),
             "system_monitor_battery",
-            &[Shape::Ratio, Shape::Text, Shape::Entries, Shape::Badge],
+            &[
+                Shape::Ratio,
+                Shape::Text,
+                Shape::Entries,
+                Shape::Badge,
+                Shape::PixelArt,
+            ],
             Shape::Ratio,
             Shape::Bars,
             2,

--- a/src/fetcher/system/monitor_battery.rs
+++ b/src/fetcher/system/monitor_battery.rs
@@ -15,6 +15,7 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, RealtimeFetcher, Safety};
+use super::sprites;
 use super::{entry, format_uptime, options_placeholder, parse_options, payload};
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -111,7 +112,13 @@ impl RealtimeFetcher for SystemMonitorBattery {
         "Charge level and state of the primary (or `index`-selected) battery. `Ratio` drives gauges, `Text` formats a summary line whose field is picked by `kind`, and `Entries` rolls up charge / state / time-left / cycles / health. Hosts without a battery render a steady `\"AC\"` placeholder."
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio, Shape::Text, Shape::Entries, Shape::Badge]
+        &[
+            Shape::Ratio,
+            Shape::Text,
+            Shape::Entries,
+            Shape::Badge,
+            Shape::PixelArt,
+        ]
     }
     fn option_schemas(&self) -> &[OptionSchema] {
         OPTION_SCHEMAS
@@ -128,6 +135,7 @@ impl RealtimeFetcher for SystemMonitorBattery {
                 ("health", "97%"),
             ]),
             Shape::Badge => samples::badge(Status::Ok, "87% · Charging"),
+            Shape::PixelArt => Body::PixelArt(sprites::battery_sprite(0.87, "87% · Charging")),
             _ => return None,
         })
     }
@@ -146,6 +154,10 @@ impl RealtimeFetcher for SystemMonitorBattery {
                 items: battery_entries(&snap),
             })),
             (Some(snap), Shape::Badge) => payload(Body::Badge(battery_badge(&snap))),
+            (Some(snap), Shape::PixelArt) => payload(Body::PixelArt(sprites::battery_sprite(
+                snap.charge,
+                &format!("{} · {}", format_percent(snap.charge), snap.state.label()),
+            ))),
             (Some(snap), _) => payload(Body::Ratio(RatioData {
                 value: snap.charge,
                 label: Some(format!(
@@ -275,6 +287,9 @@ pub(crate) fn no_battery_payload(shape: Shape, kind: BatteryTextKind) -> Payload
             status: Status::Ok,
             label: "AC".into(),
         })),
+        // Render the AC-power case as a "full" sprite — a host without a battery is, from a
+        // glance perspective, always topped up.
+        Shape::PixelArt => payload(Body::PixelArt(sprites::battery_sprite(1.0, "AC"))),
         _ => payload(Body::Ratio(RatioData {
             value: 1.0,
             label: Some("AC".into()),
@@ -327,6 +342,22 @@ mod tests {
             Some(Body::Badge(badge))
                 if badge.status == Status::Ok && badge.label == "87% · Charging"
         ));
+        let pixel = fetcher.sample_body(Shape::PixelArt).unwrap();
+        let Body::PixelArt(d) = pixel else {
+            panic!("expected PixelArt sample body");
+        };
+        assert_eq!(d.pixels.len(), 16);
+        assert_eq!(d.label.as_deref(), Some("87% · Charging"));
+    }
+
+    #[test]
+    fn no_battery_payload_pixel_art_returns_full_sprite() {
+        let payload = no_battery_payload(Shape::PixelArt, BatteryTextKind::Summary);
+        let Body::PixelArt(d) = payload.body else {
+            panic!("expected PixelArt body for AC host");
+        };
+        assert_eq!(d.label.as_deref(), Some("AC"));
+        assert_eq!(d.pixels.len(), 16);
     }
 
     #[test]

--- a/src/fetcher/system/monitor_cpu.rs
+++ b/src/fetcher/system/monitor_cpu.rs
@@ -10,6 +10,7 @@ use crate::samples;
 
 use super::super::{FetchContext, RealtimeFetcher, Safety};
 use super::payload;
+use super::sprites;
 
 pub struct SystemMonitorCpu {
     state: Mutex<System>,
@@ -42,12 +43,13 @@ impl RealtimeFetcher for SystemMonitorCpu {
         "Aggregated CPU usage across all cores, sampled every frame. Pair with a gauge renderer for a live meter or use the `Text` shape for a plain percentage."
     }
     fn shapes(&self) -> &[Shape] {
-        &[Shape::Ratio, Shape::Text]
+        &[Shape::Ratio, Shape::Text, Shape::PixelArt]
     }
     fn sample_body(&self, shape: Shape) -> Option<Body> {
         Some(match shape {
             Shape::Ratio => samples::ratio(0.42, "cpu"),
             Shape::Text => samples::text("42%"),
+            Shape::PixelArt => Body::PixelArt(sprites::cpu_sprite(0.42, "42%")),
             _ => return None,
         })
     }
@@ -59,6 +61,7 @@ impl RealtimeFetcher for SystemMonitorCpu {
         let label = format!("{pct:.0}%");
         match ctx.shape.unwrap_or(Shape::Ratio) {
             Shape::Text => payload(Body::Text(TextData { value: label })),
+            Shape::PixelArt => payload(Body::PixelArt(sprites::cpu_sprite(ratio, &label))),
             _ => payload(Body::Ratio(RatioData {
                 value: ratio,
                 label: Some(label),
@@ -83,5 +86,35 @@ mod tests {
     fn cpu_load_emits_text_when_requested() {
         let p = SystemMonitorCpu::new().compute(&ctx_with_shape(Some(Shape::Text)));
         assert!(matches!(p.body, Body::Text(_)));
+    }
+
+    #[test]
+    fn cpu_load_emits_pixel_art_when_requested() {
+        let p = SystemMonitorCpu::new().compute(&ctx_with_shape(Some(Shape::PixelArt)));
+        let Body::PixelArt(d) = p.body else {
+            panic!("expected PixelArt body");
+        };
+        assert_eq!(d.pixels.len(), 16);
+        let label = d.label.unwrap();
+        assert!(label.ends_with('%'), "label = {label}");
+    }
+
+    #[test]
+    fn sample_body_covers_every_supported_shape() {
+        let fetcher = SystemMonitorCpu::new();
+        assert!(matches!(
+            fetcher.sample_body(Shape::Ratio),
+            Some(Body::Ratio(_))
+        ));
+        assert!(matches!(
+            fetcher.sample_body(Shape::Text),
+            Some(Body::Text(_))
+        ));
+        let pixel = fetcher.sample_body(Shape::PixelArt).unwrap();
+        let Body::PixelArt(d) = pixel else {
+            panic!("expected PixelArt sample body");
+        };
+        assert_eq!(d.label.as_deref(), Some("42%"));
+        assert!(fetcher.sample_body(Shape::Entries).is_none());
     }
 }

--- a/src/fetcher/system/sprites.rs
+++ b/src/fetcher/system/sprites.rs
@@ -1,0 +1,418 @@
+//! Pixel-art sprites for the `system_monitor_*` family. Battery and CPU each share an
+//! outline; the bucket meaning is conveyed through the colour and length of the inner fill,
+//! not through faces (an earlier draft used emoticon faces; it didn't read as ambient).
+//!
+//! Following the `weather/sprites.rs` pattern: ASCII grids + palette, decoded once via
+//! `OnceLock`.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use crate::payload::{PixelArtData, PixelColor};
+
+pub const SPRITE_SIZE: usize = 16;
+
+// ── Public API ─────────────────────────────────────────────────────
+
+pub fn battery_sprite(ratio: f64, label: &str) -> PixelArtData {
+    let bucket = bucket_index(ratio);
+    let mut sprite = battery_catalog()[bucket].clone();
+    sprite.label = Some(label.into());
+    sprite
+}
+
+pub fn cpu_sprite(ratio: f64, label: &str) -> PixelArtData {
+    let bucket = bucket_index(ratio);
+    let mut sprite = cpu_catalog()[bucket].clone();
+    sprite.label = Some(label.into());
+    sprite
+}
+
+/// Map a ratio in `[0, 1]` to one of five buckets used by every body sprite. `0..0.2` →
+/// critical, `0.2..0.4` → low, `0.4..0.6` → mid, `0.6..0.8` → good, `0.8..=1.0` → full.
+/// Values outside the range clamp at the nearest end.
+fn bucket_index(ratio: f64) -> usize {
+    let r = ratio.clamp(0.0, 1.0);
+    match r {
+        r if r < 0.2 => 0,
+        r if r < 0.4 => 1,
+        r if r < 0.6 => 2,
+        r if r < 0.8 => 3,
+        _ => 4,
+    }
+}
+
+// ── Catalogs ───────────────────────────────────────────────────────
+
+fn battery_catalog() -> &'static [PixelArtData; 5] {
+    static CATALOG: OnceLock<[PixelArtData; 5]> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        let pal = palette();
+        [
+            decode(BATTERY_CRITICAL, &pal),
+            decode(BATTERY_LOW, &pal),
+            decode(BATTERY_MID, &pal),
+            decode(BATTERY_GOOD, &pal),
+            decode(BATTERY_FULL, &pal),
+        ]
+    })
+}
+
+fn cpu_catalog() -> &'static [PixelArtData; 5] {
+    static CATALOG: OnceLock<[PixelArtData; 5]> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        let pal = palette();
+        [
+            decode(CPU_SLEEPY, &pal),
+            decode(CPU_RELAXED, &pal),
+            decode(CPU_NORMAL, &pal),
+            decode(CPU_BUSY, &pal),
+            decode(CPU_OVERHEATING, &pal),
+        ]
+    })
+}
+
+fn decode(grid: &[&str], palette: &HashMap<char, PixelColor>) -> PixelArtData {
+    let pixels = grid
+        .iter()
+        .map(|row| {
+            row.chars()
+                .map(|c| palette.get(&c).copied().unwrap_or(PixelColor::TRANSPARENT))
+                .collect()
+        })
+        .collect();
+    PixelArtData {
+        pixels,
+        label: None,
+    }
+}
+
+// ── Shared palette ─────────────────────────────────────────────────
+
+const SHELL: PixelColor = PixelColor::opaque(207, 216, 220);
+const SHELL_EDGE: PixelColor = PixelColor::opaque(96, 125, 139);
+const CHIP: PixelColor = PixelColor::opaque(38, 50, 56);
+const CHIP_EDGE: PixelColor = PixelColor::opaque(15, 20, 25);
+const PIN: PixelColor = PixelColor::opaque(189, 195, 199);
+const RED: PixelColor = PixelColor::opaque(244, 67, 54);
+const ORANGE: PixelColor = PixelColor::opaque(255, 152, 0);
+const YELLOW: PixelColor = PixelColor::opaque(255, 235, 59);
+const LIME: PixelColor = PixelColor::opaque(139, 195, 74);
+const GREEN: PixelColor = PixelColor::opaque(76, 175, 80);
+const BLUE: PixelColor = PixelColor::opaque(52, 152, 219);
+const FLAME: PixelColor = PixelColor::opaque(255, 87, 34);
+
+fn palette() -> HashMap<char, PixelColor> {
+    HashMap::from([
+        ('.', PixelColor::TRANSPARENT),
+        ('S', SHELL),
+        ('E', SHELL_EDGE),
+        ('C', CHIP),
+        ('D', CHIP_EDGE),
+        ('P', PIN),
+        ('R', RED),
+        ('O', ORANGE),
+        ('Y', YELLOW),
+        ('L', LIME),
+        ('G', GREEN),
+        ('B', BLUE),
+        ('f', FLAME),
+    ])
+}
+
+// ── Battery sprites ───────────────────────────────────────────────
+// Horizontal cell with a + terminal on the right. The inner bar grows left → right with the
+// bucket; colour shifts critical (R) → low (O) → mid (Y) → good (L) → full (G).
+
+const BATTERY_CRITICAL: &[&str] = &[
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    ".EEEEEEEEEEEEE..",
+    ".ESRR........SE.",
+    ".ESRR........SEE",
+    ".ESRR........SEE",
+    ".ESRR........SE.",
+    ".ESSSSSSSSSSSSE.",
+    ".EEEEEEEEEEEEE..",
+    "................",
+    "................",
+    "................",
+    "................",
+];
+
+const BATTERY_LOW: &[&str] = &[
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    ".EEEEEEEEEEEEE..",
+    ".ESOOOO......SE.",
+    ".ESOOOO......SEE",
+    ".ESOOOO......SEE",
+    ".ESOOOO......SE.",
+    ".ESSSSSSSSSSSSE.",
+    ".EEEEEEEEEEEEE..",
+    "................",
+    "................",
+    "................",
+    "................",
+];
+
+const BATTERY_MID: &[&str] = &[
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    ".EEEEEEEEEEEEE..",
+    ".ESYYYYYYY...SE.",
+    ".ESYYYYYYY...SEE",
+    ".ESYYYYYYY...SEE",
+    ".ESYYYYYYY...SE.",
+    ".ESSSSSSSSSSSSE.",
+    ".EEEEEEEEEEEEE..",
+    "................",
+    "................",
+    "................",
+    "................",
+];
+
+const BATTERY_GOOD: &[&str] = &[
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    ".EEEEEEEEEEEEE..",
+    ".ESLLLLLLLLL.SE.",
+    ".ESLLLLLLLLL.SEE",
+    ".ESLLLLLLLLL.SEE",
+    ".ESLLLLLLLLL.SE.",
+    ".ESSSSSSSSSSSSE.",
+    ".EEEEEEEEEEEEE..",
+    "................",
+    "................",
+    "................",
+    "................",
+];
+
+const BATTERY_FULL: &[&str] = &[
+    "................",
+    "................",
+    "................",
+    "................",
+    "................",
+    ".EEEEEEEEEEEEE..",
+    ".ESGGGGGGGGGGGE.",
+    ".ESGGGGGGGGGGGEE",
+    ".ESGGGGGGGGGGGEE",
+    ".ESGGGGGGGGGGGE.",
+    ".ESSSSSSSSSSSSE.",
+    ".EEEEEEEEEEEEE..",
+    "................",
+    "................",
+    "................",
+    "................",
+];
+
+// ── CPU sprites ───────────────────────────────────────────────────
+// Chip silhouette with top/bottom pin rows and small left/right pins. The 6x4 core in the
+// middle is what changes colour with load: cool blue when sleepy through warm red when
+// overheating. Overheating adds small flame tufts above the chip package.
+
+const CPU_SLEEPY: &[&str] = &[
+    "................",
+    "................",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "..DDDDDDDDDDDD..",
+    "..DCCCCCCCCCCD..",
+    "..DCCBBBBBBCCD..",
+    "..DCCBBBBBBCCD..",
+    "..DCCBBBBBBCCD..",
+    "..DCCBBBBBBCCD..",
+    "..DCCCCCCCCCCD..",
+    "..DDDDDDDDDDDD..",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "................",
+    "................",
+];
+
+const CPU_RELAXED: &[&str] = &[
+    "................",
+    "................",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "..DDDDDDDDDDDD..",
+    "..DCCCCCCCCCCD..",
+    "..DCCLLLLLLCCD..",
+    "..DCCLLLLLLCCD..",
+    "..DCCLLLLLLCCD..",
+    "..DCCLLLLLLCCD..",
+    "..DCCCCCCCCCCD..",
+    "..DDDDDDDDDDDD..",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "................",
+    "................",
+];
+
+const CPU_NORMAL: &[&str] = &[
+    "................",
+    "................",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "..DDDDDDDDDDDD..",
+    "..DCCCCCCCCCCD..",
+    "..DCCYYYYYYCCD..",
+    "..DCCYYYYYYCCD..",
+    "..DCCYYYYYYCCD..",
+    "..DCCYYYYYYCCD..",
+    "..DCCCCCCCCCCD..",
+    "..DDDDDDDDDDDD..",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "................",
+    "................",
+];
+
+const CPU_BUSY: &[&str] = &[
+    "................",
+    "................",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "..DDDDDDDDDDDD..",
+    "..DCCCCCCCCCCD..",
+    "..DCCOOOOOOCCD..",
+    "..DCCOOOOOOCCD..",
+    "..DCCOOOOOOCCD..",
+    "..DCCOOOOOOCCD..",
+    "..DCCCCCCCCCCD..",
+    "..DDDDDDDDDDDD..",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "................",
+    "................",
+];
+
+const CPU_OVERHEATING: &[&str] = &[
+    "................",
+    "................",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "..DDDDDDDDDDDD..",
+    "..DCCCCCCCCCCD..",
+    "..DCCRRRRRRCCD..",
+    "..DCCRRRRRRCCD..",
+    "..DCCRRRRRRCCD..",
+    "..DCCRRRRRRCCD..",
+    "..DCCCCCCCCCCD..",
+    "..DDDDDDDDDDDD..",
+    "...P..P..P..P...",
+    "...P..P..P..P...",
+    "................",
+    "................",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_16x16(grid: &[&str]) {
+        assert_eq!(grid.len(), SPRITE_SIZE, "row count");
+        for (i, row) in grid.iter().enumerate() {
+            assert_eq!(row.chars().count(), SPRITE_SIZE, "row {i} width");
+        }
+    }
+
+    #[test]
+    fn battery_grids_are_16x16() {
+        for g in [
+            BATTERY_CRITICAL,
+            BATTERY_LOW,
+            BATTERY_MID,
+            BATTERY_GOOD,
+            BATTERY_FULL,
+        ] {
+            assert_16x16(g);
+        }
+    }
+
+    #[test]
+    fn cpu_grids_are_16x16() {
+        for g in [
+            CPU_SLEEPY,
+            CPU_RELAXED,
+            CPU_NORMAL,
+            CPU_BUSY,
+            CPU_OVERHEATING,
+        ] {
+            assert_16x16(g);
+        }
+    }
+
+    #[test]
+    fn bucket_thresholds_match_documentation() {
+        for (ratio, expected) in [
+            (0.0, 0),
+            (0.19, 0),
+            (0.2, 1),
+            (0.39, 1),
+            (0.4, 2),
+            (0.59, 2),
+            (0.6, 3),
+            (0.79, 3),
+            (0.8, 4),
+            (1.0, 4),
+            (-0.5, 0),
+            (5.0, 4),
+        ] {
+            assert_eq!(bucket_index(ratio), expected, "ratio = {ratio}");
+        }
+    }
+
+    #[test]
+    fn battery_sprite_label_round_trips() {
+        let s = battery_sprite(0.5, "55%");
+        assert_eq!(s.label.as_deref(), Some("55%"));
+        assert_eq!(s.pixels.len(), SPRITE_SIZE);
+    }
+
+    #[test]
+    fn cpu_sprite_label_round_trips() {
+        let s = cpu_sprite(0.95, "overheating");
+        assert_eq!(s.label.as_deref(), Some("overheating"));
+        assert_eq!(s.pixels.len(), SPRITE_SIZE);
+    }
+
+    #[test]
+    fn every_palette_character_is_declared() {
+        let pal = palette();
+        for grid in [
+            BATTERY_CRITICAL,
+            BATTERY_LOW,
+            BATTERY_MID,
+            BATTERY_GOOD,
+            BATTERY_FULL,
+            CPU_SLEEPY,
+            CPU_RELAXED,
+            CPU_NORMAL,
+            CPU_BUSY,
+            CPU_OVERHEATING,
+        ] {
+            for (y, row) in grid.iter().enumerate() {
+                for (x, ch) in row.chars().enumerate() {
+                    assert!(
+                        pal.contains_key(&ch),
+                        "char {ch:?} at ({x},{y}) missing palette entry"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements #261. Stacks on top of #260 (`feat/pixel-art-shape`) — merge that first.

## Summary

Extends three existing fetchers with the `PixelArt` shape now that the renderer is in place:

- **`clock_derived`** — eight 16×16 moon-phase sprites (new → waxing crescent → first quarter → waxing gibbous → full → waning gibbous → last quarter → waning crescent) and four season sprites (spring cherry blossom, summer sun, autumn maple, winter snowflake — hemisphere-aware). Unsupported `kind`s (zodiac, iso_week, day_of_year, …) fall back to a 1×1 placeholder labelled with the kind name so the misconfiguration is visible.
- **`system_monitor_battery`** — horizontal battery silhouette with terminal cap and an inner ratio bar that grows + colour-shifts (red → orange → yellow → lime → green) across the 5 buckets. AC hosts render the full-tier sprite labelled "AC".
- **`system_monitor_cpu`** — chip silhouette with four symmetric pins (cols 3, 6, 9, 12) above and below the package and a 6×4 core whose colour tracks load (blue → lime → yellow → orange → red).

Sprites live in `src/fetcher/{clock,system}/sprites.rs`, authored as ASCII grids + palette decoded once via `OnceLock`. Same pattern as `weather/sprites.rs`.

After merge: tick the relevant rows on #62 (System / clock fetchers); the renderer roadmap (#61) already gets ticked by #260.

## Out of scope

- `kind = "zodiac"` (12 sprites) and `kind = "chinese_zodiac"` (12 sprites) — animal / constellation art deserves a dedicated PR's worth of drawing time.

## `clock_derived` reference (mirror of `/reference/fetchers/clock/clock_derived/`)

A single value derived from today's date, picked by `kind`. New shape entry:

| Shape | Behaviour |
| --- | --- |
| `pixel_art` | Returns a 16×16 sprite when `kind = "moon_phase"` or `kind = "season"`; other kinds fall back to a 1×1 placeholder labelled with the kind name. |

Compatible renderer: [`media_pixel`](https://splashboard.unhappychoice.com/reference/renderers/media/media_pixel/).

## `system_monitor_battery` reference

| Shape | Behaviour |
| --- | --- |
| `pixel_art` | Five buckets at 20% steps, label format `"42% · Discharging"`. AC hosts render the full-tier sprite labelled `"AC"`. |

## `system_monitor_cpu` reference

| Shape | Behaviour |
| --- | --- |
| `pixel_art` | Five buckets at 20% steps (sleepy → relaxed → normal → busy → overheating), label is the formatted percent. |

## Test plan

- [x] `cargo test --lib` — 3264 pass, 0 fail
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Smoke test: `basic_read_store` widget reads 16 of the 22 generated sprites over a 4×4 grid (moon × 4, season × 4, battery × 4, cpu × 4). All buckets render with the expected colour transitions and labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clock widget now supports PixelArt display showing moon phases with animated sprites based on the lunar cycle.
  * System monitor widgets (CPU and battery) now support PixelArt visualization for enhanced visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->