### PR TITLE
feat(fetcher): add net_vpn and net_listening_ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.11.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +466,17 @@ dependencies = [
  "parse-zoneinfo",
  "phf 0.11.3",
  "phf_codegen",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2784,6 +2824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,7 +3065,7 @@ dependencies = [
  "libc",
  "mac-addr",
  "ndk-context",
- "netlink-packet-core",
+ "netlink-packet-core 0.8.1",
  "netlink-packet-route",
  "netlink-sys",
  "objc2",
@@ -3026,6 +3076,17 @@ dependencies = [
  "once_cell",
  "plist",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
 ]
 
 [[package]]
@@ -3046,7 +3107,34 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.8.1",
+]
+
+[[package]]
+name = "netlink-packet-sock-diag"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a495cb1de50560a7cd12fdcf023db70eec00e340df81be31cedbbfd4aadd6b76"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-utils",
+ "smallvec",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3058,6 +3146,24 @@ dependencies = [
  "bytes",
  "libc",
  "log",
+]
+
+[[package]]
+name = "netstat2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496f264d3ead4870d6b366deb9d20597592d64aac2a907f3e7d07c2325ba4663"
+dependencies = [
+ "bindgen",
+ "bitflags 2.11.1",
+ "byteorder",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-sock-diag",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "num-derive 0.3.3",
+ "num-traits",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3124,6 +3230,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-derive"
@@ -4533,6 +4650,7 @@ dependencies = [
  "gix",
  "image",
  "netdev",
+ "netstat2",
  "ratatui",
  "ratatui-image",
  "regex",
@@ -4832,7 +4950,7 @@ dependencies = [
  "log",
  "memmem",
  "nix 0.29.0",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "ordered-float 4.6.0",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ chrono-tz = { version = "0.10", default-features = false }
 sysinfo = "0.39.3"
 starship-battery = "0.11"
 netdev = "0.44"
+netstat2 = "0.11"
 gix = { version = "0.84", default-features = false, features = ["revision", "status", "blob-diff", "max-performance-safe", "comfort", "sha1"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
 url = "2"

--- a/src/fetcher/net/listening_ports.rs
+++ b/src/fetcher/net/listening_ports.rs
@@ -1,0 +1,558 @@
+//! `net_listening_ports` — sockets the host is currently accepting connections on.
+//!
+//! Per-directory value: after `cd` into a project, the splash answers "is my dev server up?"
+//! and "what ports am I exposing right now?" without a separate `lsof -i -P -n | grep LISTEN`.
+
+use std::collections::{BTreeSet, HashMap};
+use std::net::IpAddr;
+
+use async_trait::async_trait;
+use netstat2::{
+    AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo, SocketInfo, TcpState, get_sockets_info,
+};
+use serde::Deserialize;
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
+use crate::options::OptionSchema;
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status, TextBlockData,
+    TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{cache_key, options_placeholder, parse_options, payload};
+
+const SHAPES: &[Shape] = &[
+    Shape::Entries,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Badge,
+];
+
+const DEFAULT_LIMIT: usize = 10;
+const MAX_LIMIT: usize = 50;
+
+const OPTION_SCHEMAS: &[OptionSchema] = &[
+    OptionSchema {
+        name: "protocol",
+        type_hint: "\"tcp\" | \"udp\" | \"both\"",
+        required: false,
+        default: Some("\"tcp\""),
+        description: "Which transport protocols to include. Default `tcp` because LISTEN is a TCP-specific state; UDP sockets are simply bound, with no equivalent concept of accepting connections.",
+    },
+    OptionSchema {
+        name: "family",
+        type_hint: "\"v4\" | \"v6\" | \"both\"",
+        required: false,
+        default: Some("\"both\""),
+        description: "Restrict the result to IPv4-bound or IPv6-bound sockets.",
+    },
+    OptionSchema {
+        name: "exclude_loopback",
+        type_hint: "bool",
+        required: false,
+        default: Some("false"),
+        description: "Drop sockets bound only to `127.0.0.1` / `::1`. Useful when you only care about externally-reachable services.",
+    },
+    OptionSchema {
+        name: "limit",
+        type_hint: "1..=50",
+        required: false,
+        default: Some("10"),
+        description: "Cap the number of listed sockets in multi-row shapes (`Entries` / `Text` preview / `TextBlock` / `MarkdownTextBlock`). `Badge` always reports the unclamped total.",
+    },
+];
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortsOptions {
+    #[serde(default)]
+    pub protocol: Option<Protocol>,
+    #[serde(default)]
+    pub family: Option<Family>,
+    #[serde(default)]
+    pub exclude_loopback: bool,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Protocol {
+    #[default]
+    Tcp,
+    Udp,
+    Both,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Family {
+    V4,
+    V6,
+    #[default]
+    Both,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SocketProtocol {
+    Tcp,
+    Udp,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ListeningSocket {
+    pub port: u16,
+    pub protocol: SocketProtocol,
+    pub addr: IpAddr,
+    pub pid: Option<u32>,
+    pub process: Option<String>,
+}
+
+pub struct NetListeningPorts;
+
+#[async_trait]
+impl Fetcher for NetListeningPorts {
+    fn name(&self) -> &str {
+        "net_listening_ports"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Sockets the host is currently accepting connections on, with the owning process. `Entries` \
+         (default) maps port to process; `Text` headlines the count and the leading port list; \
+         `TextBlock` / `MarkdownTextBlock` list one row per socket; `Badge` is a count tier. Useful \
+         per-directory for confirming a dev server actually came up after `cd`. `protocol` (default \
+         `tcp` — LISTEN is TCP-specific), `family`, `exclude_loopback`, and `limit` (1..=50) filter \
+         the result."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn option_schemas(&self) -> &[OptionSchema] {
+        OPTION_SCHEMAS
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        cache_key(self.name(), ctx)
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_sockets(), shape, DEFAULT_LIMIT)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let opts: PortsOptions = match parse_options(ctx.options.as_ref()) {
+            Ok(o) => o,
+            Err(msg) => return Ok(options_placeholder(&msg)),
+        };
+        let sockets = match collect_sockets(&opts) {
+            Ok(s) => s,
+            Err(msg) => return Ok(options_placeholder(&msg)),
+        };
+        let shape = ctx.shape.unwrap_or(Shape::Entries);
+        let limit = resolved_limit(&opts);
+        Ok(payload(
+            body_for_shape(&sockets, shape, limit).unwrap_or_else(|| entries_body(&sockets, limit)),
+        ))
+    }
+}
+
+fn resolved_limit(opts: &PortsOptions) -> usize {
+    opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
+}
+
+fn collect_sockets(opts: &PortsOptions) -> Result<Vec<ListeningSocket>, String> {
+    let af = match opts.family.unwrap_or_default() {
+        Family::V4 => AddressFamilyFlags::IPV4,
+        Family::V6 => AddressFamilyFlags::IPV6,
+        Family::Both => AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6,
+    };
+    let proto = match opts.protocol.unwrap_or_default() {
+        Protocol::Tcp => ProtocolFlags::TCP,
+        Protocol::Udp => ProtocolFlags::UDP,
+        Protocol::Both => ProtocolFlags::TCP | ProtocolFlags::UDP,
+    };
+    let raw = get_sockets_info(af, proto).map_err(|e| format!("netstat: {e}"))?;
+    let mut sockets: Vec<ListeningSocket> = raw
+        .into_iter()
+        .filter_map(|info| from_info(info, opts.exclude_loopback))
+        .collect();
+    sockets.sort_by(|a, b| a.port.cmp(&b.port).then(a.protocol.cmp(&b.protocol)));
+    resolve_process_names(&mut sockets);
+    Ok(sockets)
+}
+
+fn from_info(info: SocketInfo, exclude_loopback: bool) -> Option<ListeningSocket> {
+    let (protocol, addr, port, is_listening) = match info.protocol_socket_info {
+        ProtocolSocketInfo::Tcp(tcp) => (
+            SocketProtocol::Tcp,
+            tcp.local_addr,
+            tcp.local_port,
+            tcp.state == TcpState::Listen,
+        ),
+        // UDP has no LISTEN state — a bound UDP socket is always "accepting" datagrams.
+        ProtocolSocketInfo::Udp(udp) => (SocketProtocol::Udp, udp.local_addr, udp.local_port, true),
+    };
+    if !is_listening || (exclude_loopback && is_loopback(&addr)) {
+        return None;
+    }
+    Some(ListeningSocket {
+        port,
+        protocol,
+        addr,
+        pid: info.associated_pids.first().copied(),
+        process: None,
+    })
+}
+
+fn resolve_process_names(sockets: &mut [ListeningSocket]) {
+    let pid_set: BTreeSet<u32> = sockets.iter().filter_map(|s| s.pid).collect();
+    if pid_set.is_empty() {
+        return;
+    }
+    let pids: Vec<Pid> = pid_set.iter().map(|p| Pid::from_u32(*p)).collect();
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::Some(&pids), true);
+    let names: HashMap<u32, String> = pid_set
+        .iter()
+        .filter_map(|pid| {
+            sys.process(Pid::from_u32(*pid))
+                .map(|p| (*pid, p.name().to_string_lossy().to_string()))
+        })
+        .collect();
+    sockets.iter_mut().for_each(|s| {
+        if let Some(pid) = s.pid {
+            s.process = names.get(&pid).cloned();
+        }
+    });
+}
+
+fn is_loopback(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v) => v.is_loopback(),
+        IpAddr::V6(v) => v.is_loopback(),
+    }
+}
+
+fn is_unspecified(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v) => v.is_unspecified(),
+        IpAddr::V6(v) => v.is_unspecified(),
+    }
+}
+
+fn body_for_shape(sockets: &[ListeningSocket], shape: Shape, limit: usize) -> Option<Body> {
+    let mixed = has_mixed_protocols(sockets);
+    Some(match shape {
+        Shape::Entries => entries_body(sockets, limit),
+        Shape::Text => Body::Text(TextData {
+            value: headline(sockets, limit),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: sockets
+                .iter()
+                .take(limit)
+                .map(|s| row_line(s, mixed))
+                .collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: sockets
+                .iter()
+                .take(limit)
+                .map(|s| format!("- **{}** {}", port_label(s, mixed), process_label(s)))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Badge => Body::Badge(count_badge(sockets.len())),
+        _ => return None,
+    })
+}
+
+fn entries_body(sockets: &[ListeningSocket], limit: usize) -> Body {
+    let mixed = has_mixed_protocols(sockets);
+    Body::Entries(EntriesData {
+        items: sockets
+            .iter()
+            .take(limit)
+            .map(|s| Entry {
+                key: port_label(s, mixed),
+                value: Some(process_label(s)),
+                status: None,
+            })
+            .collect(),
+    })
+}
+
+fn has_mixed_protocols(sockets: &[ListeningSocket]) -> bool {
+    let mut tcp = false;
+    let mut udp = false;
+    for s in sockets {
+        match s.protocol {
+            SocketProtocol::Tcp => tcp = true,
+            SocketProtocol::Udp => udp = true,
+        }
+        if tcp && udp {
+            return true;
+        }
+    }
+    false
+}
+
+fn headline(sockets: &[ListeningSocket], limit: usize) -> String {
+    if sockets.is_empty() {
+        return "no listening ports".into();
+    }
+    let preview: Vec<_> = sockets
+        .iter()
+        .take(limit)
+        .map(|s| s.port.to_string())
+        .collect();
+    format!("{} listening · {}", sockets.len(), preview.join(", "))
+}
+
+fn row_line(s: &ListeningSocket, mixed: bool) -> String {
+    format!("{}  {}", port_label(s, mixed), process_label(s))
+}
+
+fn port_label(s: &ListeningSocket, mixed: bool) -> String {
+    if mixed {
+        format!(
+            "{}/{}",
+            s.port,
+            match s.protocol {
+                SocketProtocol::Tcp => "tcp",
+                SocketProtocol::Udp => "udp",
+            }
+        )
+    } else {
+        s.port.to_string()
+    }
+}
+
+fn process_label(s: &ListeningSocket) -> String {
+    let body = match (&s.process, s.pid) {
+        (Some(name), Some(pid)) => format!("{name} (pid {pid})"),
+        (Some(name), None) => name.clone(),
+        (None, Some(pid)) => format!("pid {pid}"),
+        (None, None) => "—".into(),
+    };
+    if is_loopback(&s.addr) {
+        format!("{body} · localhost")
+    } else if !is_unspecified(&s.addr) {
+        format!("{body} · {}", s.addr)
+    } else {
+        body
+    }
+}
+
+fn count_badge(count: usize) -> BadgeData {
+    let (status, label) = if count == 0 {
+        (Status::Ok, "no ports".to_string())
+    } else if count <= 10 {
+        (Status::Ok, format!("{count} listening"))
+    } else {
+        (Status::Warn, format!("{count} listening"))
+    };
+    BadgeData { status, label }
+}
+
+fn sample_sockets() -> Vec<ListeningSocket> {
+    vec![
+        ListeningSocket {
+            port: 22,
+            protocol: SocketProtocol::Tcp,
+            addr: "0.0.0.0".parse().unwrap(),
+            pid: Some(842),
+            process: Some("sshd".into()),
+        },
+        ListeningSocket {
+            port: 3000,
+            protocol: SocketProtocol::Tcp,
+            addr: "127.0.0.1".parse().unwrap(),
+            pid: Some(9123),
+            process: Some("node".into()),
+        },
+        ListeningSocket {
+            port: 5432,
+            protocol: SocketProtocol::Tcp,
+            addr: "127.0.0.1".parse().unwrap(),
+            pid: Some(2410),
+            process: Some("postgres".into()),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sock(port: u16, addr: &str, process: Option<&str>) -> ListeningSocket {
+        ListeningSocket {
+            port,
+            protocol: SocketProtocol::Tcp,
+            addr: addr.parse().unwrap(),
+            pid: process.map(|_| 12345),
+            process: process.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let snap = sample_sockets();
+        for &shape in SHAPES {
+            let body = body_for_shape(&snap, shape, DEFAULT_LIMIT).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&snap, Shape::Ratio, DEFAULT_LIMIT).is_none());
+        assert!(body_for_shape(&snap, Shape::Bars, DEFAULT_LIMIT).is_none());
+        assert!(body_for_shape(&snap, Shape::Timeline, DEFAULT_LIMIT).is_none());
+    }
+
+    #[test]
+    fn entries_default_drops_protocol_suffix_when_all_rows_share_protocol() {
+        let snap = vec![sock(8080, "0.0.0.0", Some("rails"))];
+        let Body::Entries(e) = entries_body(&snap, DEFAULT_LIMIT) else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items[0].key, "8080");
+    }
+
+    #[test]
+    fn port_label_adds_protocol_suffix_when_tcp_and_udp_mix() {
+        let snap = vec![
+            sock(8080, "0.0.0.0", Some("rails")),
+            ListeningSocket {
+                port: 53,
+                protocol: SocketProtocol::Udp,
+                addr: "0.0.0.0".parse().unwrap(),
+                pid: None,
+                process: Some("dnsmasq".into()),
+            },
+        ];
+        let Body::Entries(e) = entries_body(&snap, DEFAULT_LIMIT) else {
+            panic!("expected entries");
+        };
+        let keys: Vec<_> = e.items.iter().map(|i| i.key.as_str()).collect();
+        assert!(keys.contains(&"8080/tcp"));
+        assert!(keys.contains(&"53/udp"));
+    }
+
+    #[test]
+    fn process_label_appends_localhost_or_bind_addr() {
+        let local = sock(3000, "127.0.0.1", Some("node"));
+        assert!(process_label(&local).ends_with("· localhost"));
+
+        let pinned = sock(5000, "192.168.1.10", Some("rails"));
+        assert!(process_label(&pinned).ends_with("· 192.168.1.10"));
+
+        let any = sock(22, "0.0.0.0", Some("sshd"));
+        assert_eq!(process_label(&any), "sshd (pid 12345)");
+
+        let unknown = ListeningSocket {
+            port: 9999,
+            protocol: SocketProtocol::Tcp,
+            addr: "0.0.0.0".parse().unwrap(),
+            pid: None,
+            process: None,
+        };
+        assert_eq!(process_label(&unknown), "—");
+    }
+
+    #[test]
+    fn limit_clamps_into_one_to_max() {
+        assert_eq!(resolved_limit(&PortsOptions::default()), DEFAULT_LIMIT);
+        assert_eq!(
+            resolved_limit(&PortsOptions {
+                limit: Some(0),
+                ..Default::default()
+            }),
+            1
+        );
+        assert_eq!(
+            resolved_limit(&PortsOptions {
+                limit: Some(999),
+                ..Default::default()
+            }),
+            MAX_LIMIT
+        );
+    }
+
+    #[test]
+    fn headline_includes_count_and_preview_ports() {
+        let snap = sample_sockets();
+        let h = headline(&snap, DEFAULT_LIMIT);
+        assert!(h.starts_with("3 listening · "));
+        assert!(h.contains("22"));
+        assert!(h.contains("3000"));
+        assert!(h.contains("5432"));
+
+        assert_eq!(headline(&[], DEFAULT_LIMIT), "no listening ports");
+    }
+
+    #[test]
+    fn count_badge_tiers() {
+        assert_eq!(count_badge(0).label, "no ports");
+        assert_eq!(count_badge(0).status, Status::Ok);
+        assert_eq!(count_badge(5).status, Status::Ok);
+        assert_eq!(count_badge(50).status, Status::Warn);
+    }
+
+    #[test]
+    fn options_parse_and_reject_unknown_keys() {
+        let toml = "protocol = \"both\"\nfamily = \"v4\"\nexclude_loopback = true\nlimit = 5";
+        let v: toml::Value = toml::from_str(toml).unwrap();
+        let opts: PortsOptions = parse_options(Some(&v)).unwrap();
+        assert_eq!(opts.protocol, Some(Protocol::Both));
+        assert_eq!(opts.family, Some(Family::V4));
+        assert!(opts.exclude_loopback);
+        assert_eq!(opts.limit, Some(5));
+
+        let bad: toml::Value = toml::from_str("bogus = 1").unwrap();
+        assert!(parse_options::<PortsOptions>(Some(&bad)).is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_invalid_options_to_placeholder() {
+        let ctx = FetchContext {
+            shape: Some(Shape::Entries),
+            options: Some(toml::from_str("protocol = \"bogus\"").unwrap()),
+            ..Default::default()
+        };
+        let Body::Text(t) = NetListeningPorts.fetch(&ctx).await.unwrap().body else {
+            panic!("expected text placeholder");
+        };
+        assert!(t.value.starts_with("⚠"));
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetListeningPorts.name(), "net_listening_ports");
+        assert_eq!(NetListeningPorts.safety(), Safety::Safe);
+        assert_eq!(NetListeningPorts.default_shape(), Shape::Entries);
+        assert_eq!(NetListeningPorts.option_schemas().len(), 4);
+        let description = NetListeningPorts.description();
+        assert!(description.contains("Sockets"), "{description}");
+        assert!(description.contains("`Entries`"), "{description}");
+        assert!(description.contains("`Badge`"), "{description}");
+        for &shape in SHAPES {
+            assert!(NetListeningPorts.sample_body(shape).is_some());
+        }
+        assert!(NetListeningPorts.sample_body(Shape::Ratio).is_none());
+        let base = FetchContext {
+            shape: Some(Shape::Entries),
+            ..Default::default()
+        };
+        let other = FetchContext {
+            options: Some(toml::from_str("limit = 5").unwrap()),
+            ..base.clone()
+        };
+        assert_ne!(
+            NetListeningPorts.cache_key(&base),
+            NetListeningPorts.cache_key(&other)
+        );
+    }
+}

--- a/src/fetcher/net/mod.rs
+++ b/src/fetcher/net/mod.rs
@@ -21,6 +21,7 @@ use super::{FetchContext, Fetcher, RealtimeFetcher};
 mod gateway;
 mod interfaces;
 mod ip;
+mod listening_ports;
 mod mac;
 mod proxy;
 mod speedtest;
@@ -29,6 +30,7 @@ mod vpn;
 pub use gateway::NetGateway;
 pub use interfaces::NetInterfaces;
 pub use ip::NetIp;
+pub use listening_ports::NetListeningPorts;
 pub use mac::NetMac;
 pub use proxy::NetProxy;
 pub use speedtest::NetSpeedtest;
@@ -42,6 +44,7 @@ pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(NetGateway),
         Arc::new(NetSpeedtest),
         Arc::new(NetVpn),
+        Arc::new(NetListeningPorts),
     ]
 }
 
@@ -229,6 +232,7 @@ mod tests {
                 "net_gateway",
                 "net_speedtest",
                 "net_vpn",
+                "net_listening_ports",
             ]
         );
         assert_eq!(realtime, vec!["net_proxy"]);

--- a/src/fetcher/net/mod.rs
+++ b/src/fetcher/net/mod.rs
@@ -24,6 +24,7 @@ mod ip;
 mod mac;
 mod proxy;
 mod speedtest;
+mod vpn;
 
 pub use gateway::NetGateway;
 pub use interfaces::NetInterfaces;
@@ -31,6 +32,7 @@ pub use ip::NetIp;
 pub use mac::NetMac;
 pub use proxy::NetProxy;
 pub use speedtest::NetSpeedtest;
+pub use vpn::NetVpn;
 
 pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
     vec![
@@ -39,6 +41,7 @@ pub fn cached_fetchers() -> Vec<Arc<dyn Fetcher>> {
         Arc::new(NetMac),
         Arc::new(NetGateway),
         Arc::new(NetSpeedtest),
+        Arc::new(NetVpn),
     ]
 }
 
@@ -225,6 +228,7 @@ mod tests {
                 "net_mac",
                 "net_gateway",
                 "net_speedtest",
+                "net_vpn",
             ]
         );
         assert_eq!(realtime, vec!["net_proxy"]);

--- a/src/fetcher/net/vpn.rs
+++ b/src/fetcher/net/vpn.rs
@@ -1,0 +1,346 @@
+//! `net_vpn` — host VPN connection state.
+//!
+//! An interface is treated as a VPN tunnel when its `netdev` type is `Tunnel` / `Ppp`, or its
+//! name starts with one of the common VPN-driver prefixes (`tun` / `utun` / `wg` / `ipsec` / …).
+//! Name-prefix detection is the load-bearing path on Linux because WireGuard and OpenVPN-tun
+//! devices report as `Ether`, not `Tunnel`, in `/sys/class/net` and would otherwise slip past
+//! the `if_type` check.
+
+use async_trait::async_trait;
+
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status, TextBlockData,
+    TextData,
+};
+use crate::render::Shape;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::{NetIface, payload, snapshot};
+
+const SHAPES: &[Shape] = &[
+    Shape::Badge,
+    Shape::Text,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Entries,
+];
+
+/// Interface-name prefixes that identify a VPN tunnel even when `netdev` doesn't classify the
+/// `if_type` as `Tunnel`. Covers the userspace tun drivers (`tun*` / `utun*`) plus the kernel
+/// modules from the major commercial / FOSS VPN stacks.
+const VPN_NAME_PREFIXES: &[&str] = &[
+    "tun", "utun", "wg", "ipsec", "nordlynx", "proton", "tap", "gpd", "cscotun",
+];
+
+pub struct NetVpn;
+
+#[async_trait]
+impl Fetcher for NetVpn {
+    fn name(&self) -> &str {
+        "net_vpn"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Whether this host is currently routing through a VPN tunnel. `Badge` (default) is a \
+         connected / disconnected pill — `disconnected` is `Warn`, since the widget exists \
+         because the user wants to know when the tunnel is *down*. `Text` names the active VPN \
+         interface and its address; `TextBlock` / `MarkdownTextBlock` / `Entries` list every \
+         active tunnel. Detects `netdev` `Tunnel` / `Ppp` types plus name-prefix fallback for \
+         WireGuard, OpenVPN-tun, IPsec, NordLynx, ProtonVPN, Cisco AnyConnect, and GlobalProtect."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        body_for_shape(&sample_snapshot(), shape)
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let ifaces = snapshot();
+        let shape = ctx.shape.unwrap_or(Shape::Badge);
+        Ok(payload(
+            body_for_shape(&ifaces, shape).unwrap_or_else(|| Body::Badge(vpn_badge(&[]))),
+        ))
+    }
+}
+
+fn body_for_shape(ifaces: &[NetIface], shape: Shape) -> Option<Body> {
+    let vpns = active_vpns(ifaces);
+    Some(match shape {
+        Shape::Badge => Body::Badge(vpn_badge(&vpns)),
+        Shape::Text => Body::Text(TextData {
+            value: headline(&vpns),
+        }),
+        Shape::TextBlock => Body::TextBlock(TextBlockData {
+            lines: vpns.iter().map(|i| row_line(i)).collect(),
+        }),
+        Shape::MarkdownTextBlock => Body::MarkdownTextBlock(MarkdownTextBlockData {
+            value: vpns
+                .iter()
+                .map(|i| format!("- **{}** {}", i.name, addr_summary(i)))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }),
+        Shape::Entries => Body::Entries(EntriesData {
+            items: vpns
+                .iter()
+                .map(|i| Entry {
+                    key: i.name.clone(),
+                    value: Some(addr_summary(i)),
+                    status: Some(Status::Ok),
+                })
+                .collect(),
+        }),
+        _ => return None,
+    })
+}
+
+fn active_vpns(ifaces: &[NetIface]) -> Vec<&NetIface> {
+    ifaces
+        .iter()
+        .filter(|i| is_vpn(i) && i.up && (!i.ipv4.is_empty() || !i.ipv6.is_empty()))
+        .collect()
+}
+
+fn is_vpn(i: &NetIface) -> bool {
+    if i.loopback {
+        return false;
+    }
+    if i.kind == "Tunnel" || i.kind == "Ppp" {
+        return true;
+    }
+    VPN_NAME_PREFIXES.iter().any(|p| i.name.starts_with(p))
+}
+
+fn headline(vpns: &[&NetIface]) -> String {
+    match vpns.first() {
+        None => "VPN: off".into(),
+        Some(i) => format!("VPN: {} · {}", i.name, addr_summary(i)),
+    }
+}
+
+fn row_line(i: &NetIface) -> String {
+    format!("{}  {}", i.name, addr_summary(i))
+}
+
+fn addr_summary(i: &NetIface) -> String {
+    [
+        i.ipv4.first().map(ToString::to_string),
+        i.ipv6.first().map(ToString::to_string),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(" · ")
+}
+
+/// `disconnected` is `Warn`, not `Ok`: a user who configured this widget cares about the tunnel
+/// being up, so the absence is the noteworthy state worth a glance flag (mirrors `net_proxy`'s
+/// "proxied is the surprise" stance, with the direction flipped).
+fn vpn_badge(vpns: &[&NetIface]) -> BadgeData {
+    if vpns.is_empty() {
+        BadgeData {
+            status: Status::Warn,
+            label: "disconnected".into(),
+        }
+    } else if vpns.len() == 1 {
+        BadgeData {
+            status: Status::Ok,
+            label: format!("connected · {}", vpns[0].name),
+        }
+    } else {
+        BadgeData {
+            status: Status::Ok,
+            label: format!("connected · {} tunnels", vpns.len()),
+        }
+    }
+}
+
+fn sample_snapshot() -> Vec<NetIface> {
+    vec![
+        NetIface {
+            name: "lo".into(),
+            kind: "Loopback".into(),
+            mac: None,
+            ipv4: vec![std::net::Ipv4Addr::LOCALHOST],
+            ipv6: vec![],
+            up: true,
+            loopback: true,
+            is_default: false,
+            mtu: Some(65536),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+        NetIface {
+            name: "eth0".into(),
+            kind: "Ethernet".into(),
+            mac: Some("aa:bb:cc:dd:ee:ff".into()),
+            ipv4: vec![std::net::Ipv4Addr::new(192, 168, 1, 24)],
+            ipv6: vec![],
+            up: true,
+            loopback: false,
+            is_default: true,
+            mtu: Some(1500),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+        NetIface {
+            name: "tun0".into(),
+            kind: "Tunnel".into(),
+            mac: None,
+            ipv4: vec![std::net::Ipv4Addr::new(10, 8, 0, 5)],
+            ipv6: vec![],
+            up: true,
+            loopback: false,
+            is_default: false,
+            mtu: Some(1380),
+            rx_bytes: 0,
+            tx_bytes: 0,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::iface;
+    use super::*;
+
+    fn vpn_iface(name: &str, kind: &str, ipv4: &[&str]) -> NetIface {
+        let mut i = iface(name, ipv4, true);
+        i.kind = kind.into();
+        i.loopback = false;
+        i
+    }
+
+    #[test]
+    fn body_for_shape_covers_every_supported_shape() {
+        let snap = sample_snapshot();
+        for &shape in SHAPES {
+            let body = body_for_shape(&snap, shape).unwrap();
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+        assert!(body_for_shape(&snap, Shape::Ratio).is_none());
+        assert!(body_for_shape(&snap, Shape::Bars).is_none());
+        assert!(body_for_shape(&snap, Shape::Timeline).is_none());
+    }
+
+    #[test]
+    fn is_vpn_recognises_kind_and_name_prefixes() {
+        assert!(is_vpn(&vpn_iface("tun0", "Ethernet", &["10.0.0.1"])));
+        assert!(is_vpn(&vpn_iface("utun3", "Ethernet", &["10.0.0.1"])));
+        assert!(is_vpn(&vpn_iface("wg0", "Ethernet", &["10.0.0.1"])));
+        assert!(is_vpn(&vpn_iface("ipsec0", "Ethernet", &["10.0.0.1"])));
+        assert!(is_vpn(&vpn_iface("nordlynx", "Ethernet", &["10.0.0.1"])));
+        assert!(is_vpn(&vpn_iface("anything", "Tunnel", &["10.0.0.1"])));
+        assert!(is_vpn(&vpn_iface("anything", "Ppp", &["10.0.0.1"])));
+
+        assert!(!is_vpn(&vpn_iface("eth0", "Ethernet", &["10.0.0.1"])));
+        assert!(!is_vpn(&vpn_iface(
+            "wlan0",
+            "Wireless IEEE 802.11",
+            &["10.0.0.1"]
+        )));
+        let lo = iface("lo", &["127.0.0.1"], true);
+        assert!(!is_vpn(&lo));
+    }
+
+    #[test]
+    fn active_vpns_requires_up_and_addressed() {
+        let down_vpn = {
+            let mut i = vpn_iface("tun0", "Tunnel", &["10.8.0.5"]);
+            i.up = false;
+            i
+        };
+        let no_addr_vpn = vpn_iface("wg0", "Ethernet", &[]);
+        let live = vpn_iface("utun1", "Ethernet", &["10.99.0.2"]);
+        let snap = vec![down_vpn, no_addr_vpn, live];
+        let vpns = active_vpns(&snap);
+        assert_eq!(vpns.len(), 1);
+        assert_eq!(vpns[0].name, "utun1");
+    }
+
+    #[test]
+    fn badge_distinguishes_disconnected_single_and_multi() {
+        let none: Vec<&NetIface> = vec![];
+        let b0 = vpn_badge(&none);
+        assert_eq!(b0.status, Status::Warn);
+        assert_eq!(b0.label, "disconnected");
+
+        let one = vpn_iface("tun0", "Tunnel", &["10.0.0.1"]);
+        let b1 = vpn_badge(&[&one]);
+        assert_eq!(b1.status, Status::Ok);
+        assert!(b1.label.contains("tun0"));
+
+        let a = vpn_iface("tun0", "Tunnel", &["10.0.0.1"]);
+        let b = vpn_iface("wg0", "Ethernet", &["10.99.0.2"]);
+        let b2 = vpn_badge(&[&a, &b]);
+        assert!(b2.label.contains("2 tunnels"));
+    }
+
+    #[test]
+    fn headline_names_first_active_tunnel_then_falls_back_to_off() {
+        let snap = sample_snapshot();
+        let vpns = active_vpns(&snap);
+        let h = headline(&vpns);
+        assert!(h.starts_with("VPN: tun0"));
+        assert!(h.contains("10.8.0.5"));
+
+        let nothing = vec![iface("eth0", &["10.0.0.1"], true)];
+        let vpns_none = active_vpns(&nothing);
+        assert_eq!(headline(&vpns_none), "VPN: off");
+    }
+
+    #[test]
+    fn entries_carry_status_ok_for_every_active_tunnel() {
+        let snap = vec![
+            vpn_iface("tun0", "Tunnel", &["10.8.0.5"]),
+            vpn_iface("wg0", "Ethernet", &["10.99.0.2"]),
+        ];
+        let Body::Entries(e) = body_for_shape(&snap, Shape::Entries).unwrap() else {
+            panic!("expected entries");
+        };
+        assert_eq!(e.items.len(), 2);
+        assert!(e.items.iter().all(|i| i.status == Some(Status::Ok)));
+    }
+
+    #[test]
+    fn addr_summary_joins_v4_and_v6_when_both_present() {
+        let mut i = vpn_iface("tun0", "Tunnel", &["10.0.0.1"]);
+        i.ipv6 = vec!["fd00::1".parse().unwrap()];
+        let s = addr_summary(&i);
+        assert!(s.contains("10.0.0.1"));
+        assert!(s.contains("fd00::1"));
+    }
+
+    #[tokio::test]
+    async fn fetch_emits_the_requested_shape() {
+        for &shape in SHAPES {
+            let ctx = FetchContext {
+                shape: Some(shape),
+                ..Default::default()
+            };
+            let body = NetVpn.fetch(&ctx).await.unwrap().body;
+            // On a CI host with no VPN, every shape still resolves — just empty multi-row shapes.
+            assert_eq!(crate::render::shape_of(&body), shape);
+        }
+    }
+
+    #[test]
+    fn fetcher_contract_metadata() {
+        assert_eq!(NetVpn.name(), "net_vpn");
+        assert_eq!(NetVpn.safety(), Safety::Safe);
+        assert_eq!(NetVpn.default_shape(), Shape::Badge);
+        assert!(NetVpn.option_schemas().is_empty());
+        let description = NetVpn.description();
+        assert!(description.contains("Badge"), "{description}");
+        assert!(description.contains("VPN"), "{description}");
+        for &shape in SHAPES {
+            assert!(NetVpn.sample_body(shape).is_some());
+        }
+        assert!(NetVpn.sample_body(Shape::Ratio).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Two new local-only, cache-backed `net_*` fetchers. Both `Safety::Safe`. Same family helpers (`snapshot()` / `parse_options` / `cache_key` / `options_placeholder`) as the rest of `src/fetcher/net/`.

- `net_vpn` — flags whether the host is currently routing through a VPN tunnel. Built on the existing `netdev` snapshot; per-frame additional cost is zero.
- `net_listening_ports` — sockets the host is currently accepting connections on, with the owning process. Cross-platform via the new `netstat2` dep (Linux procfs / macOS native syscall / Windows GetExtendedTcpTable); PID→name resolved through the existing `sysinfo` dep, scoped to just the PIDs that actually own a socket.

Both ticked checkboxes on #62 (`net_*`).

## net_vpn

> Whether this host is currently routing through a VPN tunnel. `Badge` (default) is a connected / disconnected pill — `disconnected` is `Warn`, since the widget exists because the user wants to know when the tunnel is *down*. `Text` names the active VPN interface and its address; `TextBlock` / `MarkdownTextBlock` / `Entries` list every active tunnel. Detects `netdev` `Tunnel` / `Ppp` types plus name-prefix fallback for WireGuard, OpenVPN-tun, IPsec, NordLynx, ProtonVPN, Cisco AnyConnect, and GlobalProtect.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `badge`, `text`, `text_block`, `markdown_text_block`, `entries` |

### Options

_No options._

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| `badge` | [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/) + the five animated wrappers |
| `text` | [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`animated_figlet_morph`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_figlet_morph/), [`animated_typewriter`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_typewriter/) + the five animated wrappers |
| `text_block` | [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) + the five animated wrappers |
| `markdown_text_block` | [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/) |
| `entries` | [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/) + the five animated wrappers |

## net_listening_ports

> Sockets the host is currently accepting connections on, with the owning process. `Entries` (default) maps port to process; `Text` headlines the count and the leading port list; `TextBlock` / `MarkdownTextBlock` list one row per socket; `Badge` is a count tier. Useful per-directory for confirming a dev server actually came up after `cd`. `protocol` (default `tcp` — LISTEN is TCP-specific), `family`, `exclude_loopback`, and `limit` (1..=50) filter the result.

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `entries`, `text`, `text_block`, `markdown_text_block`, `badge` |

### Options

| Option | Type | Required | Default | Description |
| --- | --- | --- | --- | --- |
| `protocol` | `"tcp" \| "udp" \| "both"` | no | `"tcp"` | Which transport protocols to include. Default `tcp` because LISTEN is a TCP-specific state; UDP sockets are simply bound, with no equivalent concept of accepting connections. |
| `family` | `"v4" \| "v6" \| "both"` | no | `"both"` | Restrict the result to IPv4-bound or IPv6-bound sockets. |
| `exclude_loopback` | `bool` | no | `false` | Drop sockets bound only to `127.0.0.1` / `::1`. Useful when you only care about externally-reachable services. |
| `limit` | `1..=50` | no | `10` | Cap the number of listed sockets in multi-row shapes. `Badge` always reports the unclamped total. |

The port label drops its protocol suffix when every row shares a protocol, and reappears as `8080/tcp`-style only when tcp and udp mix in the result — so the default `tcp`-only view stays uncluttered.

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| `entries` | [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/) + the five animated wrappers |
| `text` | [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/) + the five animated wrappers |
| `text_block` | [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) + the five animated wrappers |
| `markdown_text_block` | [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/) |
| `badge` | [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/) + the five animated wrappers |

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — 3283 passed, 0 failed (17 ignored, unchanged from main)
- [x] \`cargo run --bin splashboard -- catalog fetcher net_vpn\` lists 5 shapes + no options
- [x] \`cargo run --bin splashboard -- catalog fetcher net_listening_ports\` lists 5 shapes + 4 options
- [x] Manual smoke test on Linux (WSL2): `net_vpn` correctly renders `disconnected` Warn pill when no tunnel is up; `net_listening_ports` Entries grid shows port → process with localhost / bind-addr suffixes; mixed tcp+udp run shows `53/udp` style labels; loopback-excluded variant drops `127.0.0.1` rows

## Catalog ticks

- #62 — `net_listening_ports` (`net_*` section, "open listening sockets")
- #62 — `net_vpn` (`net_*` section, "VPN status")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added listening ports monitoring to display active network services and their associated processes with filtering by protocol (TCP/UDP) and address family (IPv4/IPv6).
  * Added VPN status detection to identify active VPN tunnels and display connectivity status with network interface information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->