### PR TITLE
feat(fetcher): add `project_manifest` for nearest manifest metadata

### DIFF
--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -36,6 +36,7 @@ pub mod lobsters;
 pub mod nasa_apod;
 pub mod net;
 pub mod news;
+pub mod project;
 pub mod random_cat;
 pub mod random_dog;
 pub mod random_fortune;
@@ -421,6 +422,9 @@ impl Registry {
             r.register(f);
         }
         for f in code::fetchers() {
+            r.register(f);
+        }
+        for f in project::fetchers() {
             r.register(f);
         }
         for f in basic::realtime_fetchers() {

--- a/src/fetcher/project/detect.rs
+++ b/src/fetcher/project/detect.rs
@@ -1,0 +1,344 @@
+//! Walk-up manifest detection — tries each known manifest format in priority order, returning
+//! the first one found by ascending from the process CWD.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default)]
+pub struct ManifestData {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub description: Option<String>,
+    pub license: Option<String>,
+    pub ecosystem: &'static str,
+}
+
+pub fn detect_manifest() -> Option<ManifestData> {
+    let cwd = std::env::current_dir().ok()?;
+    walk_up(&cwd)
+}
+
+pub fn cwd_cache_component() -> String {
+    std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default()
+}
+
+fn walk_up(start: &Path) -> Option<ManifestData> {
+    let mut cur: &Path = start;
+    loop {
+        if let Some(d) = try_in_dir(cur) {
+            return Some(d);
+        }
+        cur = cur.parent()?;
+    }
+}
+
+fn try_in_dir(dir: &Path) -> Option<ManifestData> {
+    try_cargo(dir)
+        .or_else(|| try_package_json(dir))
+        .or_else(|| try_pyproject(dir))
+        .or_else(|| try_go_mod(dir))
+        .or_else(|| try_composer(dir))
+}
+
+// ── Cargo.toml ──────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct CargoToml {
+    package: Option<CargoPackage>,
+}
+
+#[derive(Deserialize)]
+struct CargoPackage {
+    name: Option<String>,
+    version: Option<toml::Value>,
+    description: Option<String>,
+    license: Option<String>,
+}
+
+fn try_cargo(dir: &Path) -> Option<ManifestData> {
+    let text = read_file(dir.join("Cargo.toml"))?;
+    let t: CargoToml = toml::from_str(&text).ok()?;
+    let pkg = t.package?;
+    Some(ManifestData {
+        name: pkg.name,
+        version: toml_string(pkg.version),
+        description: pkg.description,
+        license: pkg.license,
+        ecosystem: "cargo",
+    })
+}
+
+fn toml_string(v: Option<toml::Value>) -> Option<String> {
+    match v? {
+        toml::Value::String(s) => Some(s),
+        toml::Value::Table(t) => t
+            .get("version")
+            .and_then(|v| v.as_str().map(str::to_string)),
+        _ => None,
+    }
+}
+
+// ── package.json ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PackageJson {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    license: Option<serde_json::Value>,
+}
+
+fn try_package_json(dir: &Path) -> Option<ManifestData> {
+    let text = read_file(dir.join("package.json"))?;
+    let p: PackageJson = serde_json::from_str(&text).ok()?;
+    Some(ManifestData {
+        name: p.name,
+        version: p.version,
+        description: p.description,
+        license: p.license.and_then(json_license),
+        ecosystem: "npm",
+    })
+}
+
+fn json_license(v: serde_json::Value) -> Option<String> {
+    match v {
+        serde_json::Value::String(s) => Some(s),
+        serde_json::Value::Object(m) => m.get("type").and_then(|v| v.as_str().map(str::to_string)),
+        _ => None,
+    }
+}
+
+// ── pyproject.toml ───────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PyprojectToml {
+    project: Option<PyprojectProject>,
+    tool: Option<PyprojectTool>,
+}
+
+#[derive(Deserialize)]
+struct PyprojectProject {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    license: Option<toml::Value>,
+}
+
+#[derive(Deserialize)]
+struct PyprojectTool {
+    poetry: Option<PoetryProject>,
+}
+
+#[derive(Deserialize)]
+struct PoetryProject {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    license: Option<String>,
+}
+
+fn try_pyproject(dir: &Path) -> Option<ManifestData> {
+    let text = read_file(dir.join("pyproject.toml"))?;
+    let t: PyprojectToml = toml::from_str(&text).ok()?;
+    if let Some(p) = t.project {
+        return Some(ManifestData {
+            name: p.name,
+            version: p.version,
+            description: p.description,
+            license: pyproject_license(p.license),
+            ecosystem: "python",
+        });
+    }
+    if let Some(poetry) = t.tool.and_then(|t| t.poetry) {
+        return Some(ManifestData {
+            name: poetry.name,
+            version: poetry.version,
+            description: poetry.description,
+            license: poetry.license,
+            ecosystem: "python",
+        });
+    }
+    None
+}
+
+fn pyproject_license(v: Option<toml::Value>) -> Option<String> {
+    match v? {
+        toml::Value::String(s) => Some(s),
+        toml::Value::Table(t) => t
+            .get("text")
+            .or_else(|| t.get("expression"))
+            .and_then(|v| v.as_str().map(str::to_string)),
+        _ => None,
+    }
+}
+
+// ── go.mod ───────────────────────────────────────────────────────────────────
+
+fn try_go_mod(dir: &Path) -> Option<ManifestData> {
+    let text = read_file(dir.join("go.mod"))?;
+    let name = text
+        .lines()
+        .find(|l| l.starts_with("module "))?
+        .strip_prefix("module ")?
+        .trim()
+        .to_string();
+    Some(ManifestData {
+        name: Some(name),
+        version: None,
+        description: None,
+        license: None,
+        ecosystem: "go",
+    })
+}
+
+// ── composer.json ────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ComposerJson {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    license: Option<serde_json::Value>,
+}
+
+fn try_composer(dir: &Path) -> Option<ManifestData> {
+    let text = read_file(dir.join("composer.json"))?;
+    let c: ComposerJson = serde_json::from_str(&text).ok()?;
+    Some(ManifestData {
+        name: c.name,
+        version: c.version,
+        description: c.description,
+        license: c.license.and_then(|v| match v {
+            serde_json::Value::String(s) => Some(s),
+            serde_json::Value::Array(arr) => arr
+                .into_iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .reduce(|a, b| format!("{a}/{b}")),
+            _ => None,
+        }),
+        ecosystem: "php",
+    })
+}
+
+// ── I/O helper ───────────────────────────────────────────────────────────────
+
+fn read_file(path: PathBuf) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_cargo_toml() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"myapp\"\nversion = \"1.2.3\"\ndescription = \"A tool\"\nlicense = \"MIT\"\n",
+        )
+        .unwrap();
+        let d = try_in_dir(dir.path()).unwrap();
+        assert_eq!(d.name.as_deref(), Some("myapp"));
+        assert_eq!(d.version.as_deref(), Some("1.2.3"));
+        assert_eq!(d.description.as_deref(), Some("A tool"));
+        assert_eq!(d.license.as_deref(), Some("MIT"));
+        assert_eq!(d.ecosystem, "cargo");
+    }
+
+    #[test]
+    fn detects_package_json() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"myapp","version":"0.1.0","description":"My app","license":"ISC"}"#,
+        )
+        .unwrap();
+        let d = try_in_dir(dir.path()).unwrap();
+        assert_eq!(d.name.as_deref(), Some("myapp"));
+        assert_eq!(d.version.as_deref(), Some("0.1.0"));
+        assert_eq!(d.ecosystem, "npm");
+    }
+
+    #[test]
+    fn detects_pyproject_pep621() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nname = \"mypkg\"\nversion = \"3.0.0\"\ndescription = \"Python thing\"\n",
+        )
+        .unwrap();
+        let d = try_in_dir(dir.path()).unwrap();
+        assert_eq!(d.name.as_deref(), Some("mypkg"));
+        assert_eq!(d.version.as_deref(), Some("3.0.0"));
+        assert_eq!(d.ecosystem, "python");
+    }
+
+    #[test]
+    fn detects_pyproject_poetry() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            "[tool.poetry]\nname = \"poem\"\nversion = \"0.5.0\"\ndescription = \"Verse\"\nlicense = \"Apache-2.0\"\n",
+        )
+        .unwrap();
+        let d = try_in_dir(dir.path()).unwrap();
+        assert_eq!(d.name.as_deref(), Some("poem"));
+        assert_eq!(d.ecosystem, "python");
+    }
+
+    #[test]
+    fn detects_go_mod() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("go.mod"),
+            "module github.com/user/repo\n\ngo 1.21\n",
+        )
+        .unwrap();
+        let d = try_in_dir(dir.path()).unwrap();
+        assert_eq!(d.name.as_deref(), Some("github.com/user/repo"));
+        assert_eq!(d.ecosystem, "go");
+    }
+
+    #[test]
+    fn walk_up_finds_manifest_in_parent() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"parent\"\nversion = \"0.0.1\"\n",
+        )
+        .unwrap();
+        let child = dir.path().join("src").join("lib");
+        fs::create_dir_all(&child).unwrap();
+        let d = walk_up(&child).unwrap();
+        assert_eq!(d.name.as_deref(), Some("parent"));
+    }
+
+    #[test]
+    fn returns_none_when_no_manifest_found() {
+        let dir = tempdir().unwrap();
+        assert!(try_in_dir(dir.path()).is_none());
+    }
+
+    #[test]
+    fn cargo_takes_priority_over_package_json() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"rust-app\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"js-app","version":"2.0.0"}"#,
+        )
+        .unwrap();
+        let d = try_in_dir(dir.path()).unwrap();
+        assert_eq!(d.ecosystem, "cargo");
+    }
+}

--- a/src/fetcher/project/manifest.rs
+++ b/src/fetcher/project/manifest.rs
@@ -1,20 +1,30 @@
 //! `project_manifest` — reads version, description, name, and license from the nearest
 //! project manifest file (Cargo.toml › package.json › pyproject.toml › go.mod › composer.json)
-//! walking up from the process CWD. `Text` emits the version string (or module path for Go);
-//! `Entries` delivers all available fields as key/value rows; `TextBlock` lists them as
-//! human-readable lines.
+//! walking up from the process CWD. `Text` emits the version string; `Entries` delivers all
+//! available fields as key/value rows; `TextBlock` lists them as human-readable lines;
+//! `MarkdownTextBlock` formats name / description / version / license as a styled block;
+//! `Badge` shows the version with a tone derived from license permissiveness.
 
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
-use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TextData};
+use crate::payload::{
+    BadgeData, Body, EntriesData, Entry, MarkdownTextBlockData, Payload, Status, TextBlockData,
+    TextData,
+};
 use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
 use super::detect::{ManifestData, cwd_cache_component, detect_manifest};
 
-const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries, Shape::TextBlock];
+const SHAPES: &[Shape] = &[
+    Shape::Text,
+    Shape::Entries,
+    Shape::TextBlock,
+    Shape::MarkdownTextBlock,
+    Shape::Badge,
+];
 
 pub struct ProjectManifest;
 
@@ -31,7 +41,9 @@ impl Fetcher for ProjectManifest {
          process CWD — Cargo.toml, package.json, pyproject.toml, go.mod, or composer.json. \
          `Text` emits the version string (useful as a hero subtitle); `Entries` delivers \
          name / version / description / license as key/value rows; `TextBlock` lists the \
-         same fields as human-readable lines."
+         same fields as human-readable lines; `MarkdownTextBlock` formats them as a styled \
+         block; `Badge` shows the version with a tone derived from license permissiveness \
+         (permissive → ok, copyleft → warn, unknown → warn)."
     }
     fn refresh_interval(&self) -> u64 {
         60 * 5
@@ -61,6 +73,10 @@ impl Fetcher for ProjectManifest {
             Shape::TextBlock => {
                 samples::text_block(&["splashboard 1.4.2", "Terminal splash dashboard", "MIT"])
             }
+            Shape::MarkdownTextBlock => {
+                samples::markdown("# splashboard\n\n_Terminal splash dashboard_\n\n**1.4.2** · MIT")
+            }
+            Shape::Badge => samples::badge(Status::Ok, "v1.4.2"),
             _ => return None,
         })
     }
@@ -80,6 +96,8 @@ fn render_body(data: &ManifestData, shape: Shape) -> Body {
     match shape {
         Shape::Text => text_body(data),
         Shape::TextBlock => text_block_body(data),
+        Shape::MarkdownTextBlock => markdown_body(data),
+        Shape::Badge => badge_body(data),
         _ => entries_body(data),
     }
 }
@@ -106,6 +124,59 @@ fn text_block_body(data: &ManifestData) -> Body {
         lines.push(lic.clone());
     }
     Body::TextBlock(TextBlockData { lines })
+}
+
+fn markdown_body(data: &ManifestData) -> Body {
+    let mut sections: Vec<String> = Vec::new();
+    if let Some(name) = &data.name {
+        sections.push(format!("# {name}"));
+    }
+    if let Some(desc) = &data.description {
+        sections.push(format!("_{desc}_"));
+    }
+    let footer = match (&data.version, &data.license) {
+        (Some(v), Some(l)) => Some(format!("**{v}** · {l}")),
+        (Some(v), None) => Some(format!("**{v}**")),
+        (None, Some(l)) => Some(l.clone()),
+        (None, None) => None,
+    };
+    if let Some(f) = footer {
+        sections.push(f);
+    }
+    Body::MarkdownTextBlock(MarkdownTextBlockData {
+        value: sections.join("\n\n"),
+    })
+}
+
+fn badge_body(data: &ManifestData) -> Body {
+    match (&data.version, &data.name) {
+        (Some(v), _) => Body::Badge(BadgeData {
+            status: license_status(data.license.as_deref()),
+            label: format!("v{v}"),
+        }),
+        (None, Some(n)) => Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: n.clone(),
+        }),
+        (None, None) => Body::Badge(BadgeData {
+            status: Status::Warn,
+            label: String::new(),
+        }),
+    }
+}
+
+fn license_status(license: Option<&str>) -> Status {
+    match license {
+        None => Status::Warn,
+        Some(s) => {
+            let lower = s.to_ascii_lowercase();
+            if lower.contains("agpl") || lower.contains("gpl") {
+                Status::Warn
+            } else {
+                Status::Ok
+            }
+        }
+    }
 }
 
 fn entries_body(data: &ManifestData) -> Body {
@@ -205,6 +276,75 @@ mod tests {
                 value: String::new()
             })
         );
+    }
+
+    #[test]
+    fn markdown_body_composes_heading_description_footer() {
+        let Body::MarkdownTextBlock(md) = render_body(&manifest(), Shape::MarkdownTextBlock) else {
+            panic!("expected MarkdownTextBlock");
+        };
+        assert_eq!(md.value, "# myapp\n\n_A cool app_\n\n**1.0.0** · MIT");
+    }
+
+    #[test]
+    fn markdown_body_skips_missing_sections() {
+        let data = ManifestData {
+            name: Some("bare".into()),
+            version: None,
+            description: None,
+            license: None,
+            ecosystem: "go",
+        };
+        let Body::MarkdownTextBlock(md) = render_body(&data, Shape::MarkdownTextBlock) else {
+            panic!("expected MarkdownTextBlock");
+        };
+        assert_eq!(md.value, "# bare");
+    }
+
+    #[test]
+    fn badge_body_labels_version_with_license_tone() {
+        assert_eq!(
+            render_body(&manifest(), Shape::Badge),
+            Body::Badge(BadgeData {
+                status: Status::Ok,
+                label: "v1.0.0".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn badge_body_warns_on_copyleft_license() {
+        let data = ManifestData {
+            license: Some("GPL-3.0".into()),
+            ..manifest()
+        };
+        let Body::Badge(b) = render_body(&data, Shape::Badge) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.status, Status::Warn);
+    }
+
+    #[test]
+    fn badge_body_falls_back_to_name_when_version_missing() {
+        let data = ManifestData {
+            version: None,
+            ..manifest()
+        };
+        let Body::Badge(b) = render_body(&data, Shape::Badge) else {
+            panic!("expected Badge");
+        };
+        assert_eq!(b.label, "myapp");
+        assert_eq!(b.status, Status::Warn);
+    }
+
+    #[test]
+    fn license_status_classifies_permissive_and_copyleft() {
+        assert_eq!(license_status(Some("MIT")), Status::Ok);
+        assert_eq!(license_status(Some("Apache-2.0")), Status::Ok);
+        assert_eq!(license_status(Some("ISC")), Status::Ok);
+        assert_eq!(license_status(Some("GPL-3.0")), Status::Warn);
+        assert_eq!(license_status(Some("AGPL-3.0-only")), Status::Warn);
+        assert_eq!(license_status(None), Status::Warn);
     }
 
     #[test]

--- a/src/fetcher/project/manifest.rs
+++ b/src/fetcher/project/manifest.rs
@@ -1,0 +1,318 @@
+//! `project_manifest` — reads version, description, name, and license from the nearest
+//! project manifest file (Cargo.toml › package.json › pyproject.toml › go.mod › composer.json)
+//! walking up from the process CWD. `Text` emits the version string (or module path for Go);
+//! `Entries` delivers all available fields as key/value rows; `TextBlock` lists them as
+//! human-readable lines.
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::payload::{Body, EntriesData, Entry, Payload, TextBlockData, TextData};
+use crate::render::Shape;
+use crate::samples;
+
+use super::super::{FetchContext, FetchError, Fetcher, Safety};
+use super::detect::{ManifestData, cwd_cache_component, detect_manifest};
+
+const SHAPES: &[Shape] = &[Shape::Text, Shape::Entries, Shape::TextBlock];
+
+pub struct ProjectManifest;
+
+#[async_trait]
+impl Fetcher for ProjectManifest {
+    fn name(&self) -> &str {
+        "project_manifest"
+    }
+    fn safety(&self) -> Safety {
+        Safety::Safe
+    }
+    fn description(&self) -> &'static str {
+        "Reads project metadata from the nearest manifest file found by walking up from the \
+         process CWD — Cargo.toml, package.json, pyproject.toml, go.mod, or composer.json. \
+         `Text` emits the version string (useful as a hero subtitle); `Entries` delivers \
+         name / version / description / license as key/value rows; `TextBlock` lists the \
+         same fields as human-readable lines."
+    }
+    fn refresh_interval(&self) -> u64 {
+        60 * 5
+    }
+    fn shapes(&self) -> &[Shape] {
+        SHAPES
+    }
+    fn default_shape(&self) -> Shape {
+        Shape::Entries
+    }
+    fn cache_key(&self, ctx: &FetchContext) -> String {
+        let shape = ctx.shape.map(|s| s.as_str()).unwrap_or("default");
+        let raw = format!("{}|{}|{}", self.name(), shape, cwd_cache_component());
+        let digest = Sha256::digest(raw.as_bytes());
+        let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+        format!("{}-{hex}", self.name())
+    }
+    fn sample_body(&self, shape: Shape) -> Option<Body> {
+        Some(match shape {
+            Shape::Text => samples::text("1.4.2"),
+            Shape::Entries => samples::entries(&[
+                ("name", "splashboard"),
+                ("version", "1.4.2"),
+                ("description", "Terminal splash dashboard"),
+                ("license", "MIT"),
+            ]),
+            Shape::TextBlock => {
+                samples::text_block(&["splashboard 1.4.2", "Terminal splash dashboard", "MIT"])
+            }
+            _ => return None,
+        })
+    }
+    async fn fetch(&self, ctx: &FetchContext) -> Result<Payload, FetchError> {
+        let data = detect_manifest().unwrap_or_default();
+        let shape = ctx.shape.unwrap_or(Shape::Entries);
+        Ok(Payload {
+            icon: None,
+            status: None,
+            format: None,
+            body: render_body(&data, shape),
+        })
+    }
+}
+
+fn render_body(data: &ManifestData, shape: Shape) -> Body {
+    match shape {
+        Shape::Text => text_body(data),
+        Shape::TextBlock => text_block_body(data),
+        _ => entries_body(data),
+    }
+}
+
+fn text_body(data: &ManifestData) -> Body {
+    Body::Text(TextData {
+        value: data.version.clone().unwrap_or_default(),
+    })
+}
+
+fn text_block_body(data: &ManifestData) -> Body {
+    let mut lines = Vec::new();
+    if let Some(name) = &data.name {
+        let header = match &data.version {
+            Some(v) => format!("{name} {v}"),
+            None => name.clone(),
+        };
+        lines.push(header);
+    }
+    if let Some(desc) = &data.description {
+        lines.push(desc.clone());
+    }
+    if let Some(lic) = &data.license {
+        lines.push(lic.clone());
+    }
+    Body::TextBlock(TextBlockData { lines })
+}
+
+fn entries_body(data: &ManifestData) -> Body {
+    let fields: &[(&str, &Option<String>)] = &[
+        ("name", &data.name),
+        ("version", &data.version),
+        ("description", &data.description),
+        ("license", &data.license),
+    ];
+    Body::Entries(EntriesData {
+        items: fields
+            .iter()
+            .filter_map(|(key, val)| {
+                val.as_ref().map(|v| Entry {
+                    key: key.to_string(),
+                    value: Some(v.clone()),
+                    status: None,
+                })
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::future::Future;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::render::Shape;
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    fn ctx(shape: Shape) -> FetchContext {
+        FetchContext {
+            widget_id: "w".into(),
+            shape: Some(shape),
+            ..Default::default()
+        }
+    }
+
+    fn manifest() -> ManifestData {
+        ManifestData {
+            name: Some("myapp".into()),
+            version: Some("1.0.0".into()),
+            description: Some("A cool app".into()),
+            license: Some("MIT".into()),
+            ecosystem: "cargo",
+        }
+    }
+
+    #[test]
+    fn fetcher_contract() {
+        assert_eq!(ProjectManifest.name(), "project_manifest");
+        assert!(matches!(ProjectManifest.safety(), Safety::Safe));
+        assert_eq!(ProjectManifest.default_shape(), Shape::Entries);
+        assert_eq!(ProjectManifest.shapes(), SHAPES);
+        let key_a = ProjectManifest.cache_key(&ctx(Shape::Text));
+        let key_b = ProjectManifest.cache_key(&ctx(Shape::Entries));
+        assert_ne!(key_a, key_b);
+        assert!(key_a.starts_with("project_manifest-"));
+    }
+
+    #[test]
+    fn samples_cover_all_shapes() {
+        SHAPES.iter().copied().for_each(|s| {
+            let body = ProjectManifest.sample_body(s).expect("sample body");
+            assert_eq!(crate::render::shape_of(&body), s);
+        });
+        assert!(ProjectManifest.sample_body(Shape::Ratio).is_none());
+    }
+
+    #[test]
+    fn text_body_returns_version() {
+        assert_eq!(
+            render_body(&manifest(), Shape::Text),
+            Body::Text(TextData {
+                value: "1.0.0".into()
+            })
+        );
+    }
+
+    #[test]
+    fn text_body_empty_when_no_version() {
+        let data = ManifestData::default();
+        assert_eq!(
+            render_body(&data, Shape::Text),
+            Body::Text(TextData {
+                value: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn text_block_body_combines_name_and_version() {
+        let block = render_body(&manifest(), Shape::TextBlock);
+        assert_eq!(
+            block,
+            Body::TextBlock(TextBlockData {
+                lines: vec!["myapp 1.0.0".into(), "A cool app".into(), "MIT".into(),]
+            })
+        );
+    }
+
+    #[test]
+    fn text_block_body_skips_missing_fields() {
+        let data = ManifestData {
+            name: Some("bare".into()),
+            version: None,
+            description: None,
+            license: None,
+            ecosystem: "go",
+        };
+        assert_eq!(
+            render_body(&data, Shape::TextBlock),
+            Body::TextBlock(TextBlockData {
+                lines: vec!["bare".into()]
+            })
+        );
+    }
+
+    #[test]
+    fn entries_body_filters_none_values() {
+        let data = ManifestData {
+            name: Some("myapp".into()),
+            version: Some("2.0.0".into()),
+            description: None,
+            license: None,
+            ecosystem: "npm",
+        };
+        let Body::Entries(entries) = render_body(&data, Shape::Entries) else {
+            panic!("expected Entries");
+        };
+        assert_eq!(entries.items.len(), 2);
+        assert_eq!(entries.items[0].key, "name");
+        assert_eq!(entries.items[1].key, "version");
+    }
+
+    #[test]
+    fn fetch_from_splashboard_repo_returns_cargo_entries() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let payload = run_async(ProjectManifest.fetch(&ctx(Shape::Entries))).unwrap();
+        let Body::Entries(entries) = payload.body else {
+            panic!("expected Entries");
+        };
+        assert!(entries.items.iter().any(|e| e.key == "name"));
+        assert!(
+            entries
+                .items
+                .iter()
+                .any(|e| e.key == "version" && e.value.is_some())
+        );
+    }
+
+    #[test]
+    fn fetch_text_from_tmpdir_returns_empty_string() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let payload = run_async(ProjectManifest.fetch(&ctx(Shape::Text))).unwrap();
+        std::env::set_current_dir(prev).unwrap();
+        let Body::Text(t) = payload.body else {
+            panic!("expected Text");
+        };
+        assert_eq!(t.value, "");
+    }
+
+    #[test]
+    fn fetch_reads_package_json_in_cwd() {
+        let _lock = crate::paths::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"demo","version":"5.0.0","description":"Demo","license":"Apache-2.0"}"#,
+        )
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let payload = run_async(ProjectManifest.fetch(&ctx(Shape::Entries))).unwrap();
+        std::env::set_current_dir(prev).unwrap();
+        let Body::Entries(e) = payload.body else {
+            panic!("expected Entries");
+        };
+        assert!(
+            e.items
+                .iter()
+                .any(|i| i.key == "name" && i.value.as_deref() == Some("demo"))
+        );
+        assert!(
+            e.items
+                .iter()
+                .any(|i| i.key == "version" && i.value.as_deref() == Some("5.0.0"))
+        );
+    }
+}

--- a/src/fetcher/project/mod.rs
+++ b/src/fetcher/project/mod.rs
@@ -1,0 +1,17 @@
+//! Project manifest fetchers — read project metadata (name, version, description, license)
+//! from the nearest manifest file discovered by walking up from the process CWD.
+//! Supports Cargo.toml, package.json, pyproject.toml, go.mod, and composer.json.
+//! All fetchers are `Safety::Safe` (local file reads only).
+
+use std::sync::Arc;
+
+use super::Fetcher;
+
+mod detect;
+mod manifest;
+
+pub use manifest::ProjectManifest;
+
+pub fn fetchers() -> Vec<Arc<dyn Fetcher>> {
+    vec![Arc::new(ProjectManifest)]
+}


### PR DESCRIPTION
## Summary

- New `project_manifest` fetcher reads name / version / description / license from the nearest manifest found by walking up from CWD. Supports Cargo.toml, package.json, pyproject.toml (PEP 621 + Poetry), go.mod, and composer.json in that priority order.
- All five output shapes covered: `Text` (version), `Entries` (key/value), `TextBlock` (readable lines), `MarkdownTextBlock` (styled block), `Badge` (version label with license-derived tone — permissive → ok, copyleft → warn).
- Cache key includes CWD so two projects don't share entries. `Safety::Safe` (local file reads only). Catalog parity verified via `splashboard catalog fetcher project_manifest`.

## Reference

| Kind | Safety | Shapes |
| --- | --- | --- |
| cached | Safe | `text`, `entries`, `text_block`, `markdown_text_block`, `badge` |

### Options

_No options._

### Compatible renderers

| Shape | Renderers |
| --- | --- |
| `text` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_figlet_morph`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_figlet_morph/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_typewriter`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_typewriter/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`text_ascii`](https://splashboard.unhappychoice.com/reference/renderers/text/text_ascii/), [`text_plain`](https://splashboard.unhappychoice.com/reference/renderers/text/text_plain/) |
| `entries` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`grid_table`](https://splashboard.unhappychoice.com/reference/renderers/grid/grid_table/) |
| `text_block` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`list_plain`](https://splashboard.unhappychoice.com/reference/renderers/list/list_plain/) |
| `markdown_text_block` | [`text_markdown`](https://splashboard.unhappychoice.com/reference/renderers/text/text_markdown/) |
| `badge` | [`animated_boot`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_boot/), [`animated_postfx`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_postfx/), [`animated_scanlines`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_scanlines/), [`animated_splitflap`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_splitflap/), [`animated_wave`](https://splashboard.unhappychoice.com/reference/renderers/animated/animated_wave/), [`status_badge`](https://splashboard.unhappychoice.com/reference/renderers/status/status_badge/) |

## Test plan

- [x] `cargo test --lib fetcher::project` — 24 tests pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo xtask` regenerates the reference page without errors
- [x] Smoke-tested in the splashboard repo: reads its own Cargo.toml (name: splashboard, version: 2.9.0, license: ISC)
- [x] Smoke-tested with package.json / go.mod / empty dirs

Ticks the `project_manifest` checkbox on #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic project manifest detection that scans common configuration files (Cargo.toml, package.json, pyproject.toml, go.mod, composer.json) and extracts project metadata including name, version, description, and license
  * Support for multiple output formats including text, badges, and markdown blocks
  * License classification with automatic status indicators for common open source licenses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->