### PR TITLE
feat(github): support GitHub Enterprise Server via GH_HOST / GITHUB_HOST

### DIFF
--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -1,8 +1,11 @@
-//! `github_avatar` — download a github.com avatar PNG and expose it as `Body::Image`.
+//! `github_avatar` — download an avatar PNG and expose it as `Body::Image`.
 //!
-//! Safety::Safe: the host is hardcoded (`github.com/<user>.png`), so config can't redirect
-//! traffic to a different origin. No auth is needed — the endpoint is public — so we do not
-//! attach `GH_TOKEN`, avoiding accidental token exposure along the redirect chain.
+//! - github.com: keeps the original public shortcut (`https://github.com/<user>.png`).
+//! - GHE: the public shortcut redirects to `/login`, so we indirect through
+//!   `/users/<login>` to get the server-signed `avatar_url`.
+//!
+//! Safety::Safe: the host is resolved via `client::host()` (env-var-only), so a malicious
+//! `.splashboard.toml` cannot redirect traffic to an attacker-chosen origin.
 //!
 //! Caching: the PNG is written to `$SPLASHBOARD_HOME/cache/avatars/<user>-<size>.png`. The
 //! fetcher framework already gates re-downloads via `refresh_interval`; we default to one day
@@ -19,10 +22,9 @@ use crate::payload::{Body, ImageData, Payload};
 use crate::render::Shape;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::client::{http, resolve_authenticated_user};
+use super::client::{host, http, rest_get, resolve_authenticated_user, web_base};
 use super::common::cache_key;
 
-const AVATAR_BASE: &str = "https://github.com";
 const DEFAULT_SIZE: u32 = 200;
 
 const OPTION_SCHEMAS: &[OptionSchema] = &[
@@ -103,7 +105,11 @@ async fn download_avatar(user: &str, size: u32) -> Result<PathBuf, FetchError> {
         .ok_or_else(|| FetchError::Failed("$HOME not available for avatar cache".into()))?;
     std::fs::create_dir_all(&out_dir)
         .map_err(|e| FetchError::Failed(format!("create avatar cache dir: {e}")))?;
-    let url = format!("{AVATAR_BASE}/{user}.png?size={size}");
+    let url = if host().eq_ignore_ascii_case("github.com") {
+        format!("{}/{user}.png?size={size}", web_base())
+    } else {
+        resolve_ghe_avatar_url(user, size).await?
+    };
     let res = http()
         .get(&url)
         .send()
@@ -124,6 +130,19 @@ async fn download_avatar(user: &str, size: u32) -> Result<PathBuf, FetchError> {
     let path = out_dir.join(format!("{user}-{size}.{ext}"));
     std::fs::write(&path, &bytes).map_err(|e| FetchError::Failed(format!("write avatar: {e}")))?;
     Ok(path)
+}
+
+#[derive(Debug, Deserialize)]
+struct UserAvatar {
+    avatar_url: String,
+}
+
+/// GHE-only: resolve the server-signed avatar URL via `/users/<login>` and append a size
+/// query so the source is small enough for the media_image renderer.
+async fn resolve_ghe_avatar_url(user: &str, size: u32) -> Result<String, FetchError> {
+    let me: UserAvatar = rest_get(&format!("/users/{user}")).await?;
+    let sep = if me.avatar_url.contains('?') { '&' } else { '?' };
+    Ok(format!("{}{sep}s={size}", me.avatar_url))
 }
 
 fn image_extension(bytes: &[u8]) -> &'static str {

--- a/src/fetcher/github/avatar.rs
+++ b/src/fetcher/github/avatar.rs
@@ -22,7 +22,7 @@ use crate::payload::{Body, ImageData, Payload};
 use crate::render::Shape;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::client::{host, http, rest_get, resolve_authenticated_user, web_base};
+use super::client::{host, http, resolve_authenticated_user, rest_get, web_base};
 use super::common::cache_key;
 
 const DEFAULT_SIZE: u32 = 200;
@@ -141,7 +141,11 @@ struct UserAvatar {
 /// query so the source is small enough for the media_image renderer.
 async fn resolve_ghe_avatar_url(user: &str, size: u32) -> Result<String, FetchError> {
     let me: UserAvatar = rest_get(&format!("/users/{user}")).await?;
-    let sep = if me.avatar_url.contains('?') { '&' } else { '?' };
+    let sep = if me.avatar_url.contains('?') {
+        '&'
+    } else {
+        '?'
+    };
     Ok(format!("{}{sep}s={size}", me.avatar_url))
 }
 

--- a/src/fetcher/github/client.rs
+++ b/src/fetcher/github/client.rs
@@ -1,7 +1,9 @@
 //! Shared HTTP client + auth for the `github_*` fetcher family. Reads `GH_TOKEN` or
-//! `GITHUB_TOKEN` (in that order) once per process. Every fetcher talks to `api.github.com`
-//! only — there is no config-controlled host, so leaking a user's token to an attacker-chosen
-//! origin is not possible by design.
+//! `GITHUB_TOKEN` (in that order) once per process. The host defaults to `github.com` but
+//! can be redirected to a GitHub Enterprise Server via `GH_HOST` / `GITHUB_HOST` (and
+//! optionally `GH_API_URL` / `GH_GRAPHQL_URL` for older `<host>/api/v3` deployments). Host
+//! selection is env-var-only — a `.splashboard.toml` cannot redirect traffic to an
+//! attacker-chosen origin, so the token cannot leak by design.
 //!
 //! The rest helpers accept a path like `"/user"` or `"/repos/foo/bar"`; the base URL is joined
 //! here so fetchers stay free of URL plumbing. GraphQL goes through a single POST helper.
@@ -19,10 +21,16 @@ const DEFAULT_HOST: &str = "github.com";
 const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
 
 fn read_env(var: &str) -> Option<String> {
-    std::env::var(var)
-        .ok()
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
+    std::env::var(var).ok().and_then(|raw| normalize_env(&raw))
+}
+
+/// Trim whitespace and a trailing `/` so callers can rely on host / URL values being free of
+/// surface-level user typos like `GH_API_URL=https://ghe.example.com/api/v3/`. Returns `None`
+/// when the value collapses to empty after normalization so the caller can fall back to the
+/// default.
+fn normalize_env(raw: &str) -> Option<String> {
+    let v = raw.trim().trim_end_matches('/');
+    (!v.is_empty()).then(|| v.to_owned())
 }
 
 pub(crate) fn host() -> &'static str {
@@ -73,6 +81,7 @@ pub(crate) fn api_repos_prefix() -> &'static str {
     static API_REPOS_PREFIX: OnceLock<String> = OnceLock::new();
     API_REPOS_PREFIX.get_or_init(|| format!("{}/repos/", api_base()))
 }
+
 const ACCEPT: &str = "application/vnd.github+json";
 const API_VERSION: &str = "2022-11-28";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -268,6 +277,34 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn normalize_env_strips_trailing_slash() {
+        assert_eq!(
+            normalize_env("https://ghe.example.com/api/v3/").as_deref(),
+            Some("https://ghe.example.com/api/v3")
+        );
+    }
+
+    #[test]
+    fn normalize_env_handles_whitespace_and_empty() {
+        assert_eq!(
+            normalize_env("  github.com  ").as_deref(),
+            Some("github.com")
+        );
+        assert_eq!(normalize_env("   ").as_deref(), None);
+        assert_eq!(normalize_env("").as_deref(), None);
+        assert_eq!(normalize_env("/").as_deref(), None);
+    }
+
+    #[test]
+    fn normalize_env_preserves_clean_values() {
+        assert_eq!(
+            normalize_env("https://ghe.example.com/api/v3").as_deref(),
+            Some("https://ghe.example.com/api/v3")
+        );
+        assert_eq!(normalize_env("github.com").as_deref(), Some("github.com"));
     }
 
     #[test]

--- a/src/fetcher/github/client.rs
+++ b/src/fetcher/github/client.rs
@@ -15,9 +15,64 @@ use serde::de::DeserializeOwned;
 
 use crate::fetcher::FetchError;
 
-const API_BASE: &str = "https://api.github.com";
-const GRAPHQL_URL: &str = "https://api.github.com/graphql";
+const DEFAULT_HOST: &str = "github.com";
 const USER_AGENT: &str = concat!("splashboard/", env!("CARGO_PKG_VERSION"));
+
+fn read_env(var: &str) -> Option<String> {
+    std::env::var(var)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+pub(crate) fn host() -> &'static str {
+    static HOST: OnceLock<String> = OnceLock::new();
+    HOST.get_or_init(|| {
+        read_env("GH_HOST")
+            .or_else(|| read_env("GITHUB_HOST"))
+            .unwrap_or_else(|| DEFAULT_HOST.into())
+            // Normalize to lowercase so SCP-style remote parsing (`git@<host>:`) and
+            // `eq_ignore_ascii_case` checks against `"github.com"` stay consistent when
+            // the user types `GH_HOST=GitHub.com`. DNS is case-insensitive so this
+            // doesn't affect URL composition.
+            .to_ascii_lowercase()
+    })
+    .as_str()
+}
+
+/// REST API base URL. Defaults to `https://api.<host>` (github.com and modern GHE).
+/// Override via `GH_API_URL` / `GITHUB_API_URL` for older `<host>/api/v3` GHE deployments
+/// (the env var name matches GitHub Actions' standard `GITHUB_API_URL`).
+pub(crate) fn api_base() -> &'static str {
+    static API_BASE: OnceLock<String> = OnceLock::new();
+    API_BASE.get_or_init(|| {
+        read_env("GH_API_URL")
+            .or_else(|| read_env("GITHUB_API_URL"))
+            .unwrap_or_else(|| format!("https://api.{}", host()))
+    })
+}
+
+/// GraphQL endpoint. Defaults to `https://api.<host>/graphql`. Override via
+/// `GH_GRAPHQL_URL` / `GITHUB_GRAPHQL_URL` for older `<host>/api/graphql` GHE deployments
+/// (matches GitHub Actions' standard `GITHUB_GRAPHQL_URL` env var).
+pub(crate) fn graphql_url() -> &'static str {
+    static GRAPHQL_URL: OnceLock<String> = OnceLock::new();
+    GRAPHQL_URL.get_or_init(|| {
+        read_env("GH_GRAPHQL_URL")
+            .or_else(|| read_env("GITHUB_GRAPHQL_URL"))
+            .unwrap_or_else(|| format!("https://api.{}/graphql", host()))
+    })
+}
+
+pub(crate) fn web_base() -> &'static str {
+    static WEB_BASE: OnceLock<String> = OnceLock::new();
+    WEB_BASE.get_or_init(|| format!("https://{}", host()))
+}
+
+pub(crate) fn api_repos_prefix() -> &'static str {
+    static API_REPOS_PREFIX: OnceLock<String> = OnceLock::new();
+    API_REPOS_PREFIX.get_or_init(|| format!("{}/repos/", api_base()))
+}
 const ACCEPT: &str = "application/vnd.github+json";
 const API_VERSION: &str = "2022-11-28";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -76,7 +131,7 @@ pub(crate) fn clear_authenticated_user_cache() {
 /// are both actionable.
 pub async fn rest_get<T: DeserializeOwned>(path: &str) -> Result<T, FetchError> {
     let token = resolve_token()?;
-    let url = format!("{API_BASE}{path}");
+    let url = format!("{}{path}", api_base());
     let res = http()
         .get(&url)
         .bearer_auth(&token)
@@ -96,7 +151,7 @@ pub async fn graphql<T: DeserializeOwned>(
     let token = resolve_token()?;
     let body = serde_json::json!({ "query": query, "variables": variables });
     let res = http()
-        .post(GRAPHQL_URL)
+        .post(graphql_url())
         .bearer_auth(&token)
         .header("Accept", ACCEPT)
         .header("X-GitHub-Api-Version", API_VERSION)

--- a/src/fetcher/github/common.rs
+++ b/src/fetcher/github/common.rs
@@ -117,30 +117,58 @@ fn remote_slug(repo: &gix::Repository) -> Option<RepoSlug> {
     slug_from_url(&url.to_bstring().to_string())
 }
 
-/// Parses the github URL shapes splashboard supports:
-/// - `git@github.com:owner/name(.git)?`
-/// - `https://github.com/owner/name(.git)?`
-/// - `https://<user>(:<token>)?@github.com/owner/name(.git)?`
-/// - `ssh://git@github.com/owner/name(.git)?`
+/// Parses the github URL shapes splashboard supports against the configured host:
+/// - `<user>@<host>:owner/name(.git)?` (SCP-style; `<user>` is conventionally `git` on
+///   github.com but can be anything — Microsoft GHE uses `microsoft@...`, for instance)
+/// - `https://<host>/owner/name(.git)?`
+/// - `https://<user>(:<token>)?@<host>/owner/name(.git)?`
+/// - `ssh://<user>@<host>/owner/name(.git)?`
 ///
-/// Anything that isn't github.com returns `None` — splashboard's github fetchers target the
-/// github.com API and silently accepting a gitlab remote would be misleading.
+/// When `GH_HOST` is set, the configured host wins; we also try github.com as a fallback so
+/// a user with a GHE shell can still parse github.com remotes.
 pub fn slug_from_url(url: &str) -> Option<RepoSlug> {
-    let rest = url
-        .strip_prefix("git@github.com:")
-        .or_else(|| strip_https_github_prefix(url))
-        .or_else(|| url.strip_prefix("ssh://git@github.com/"))?;
+    let host = super::client::host();
+    parse_with_host(host, url).or_else(|| {
+        if host.eq_ignore_ascii_case("github.com") {
+            None
+        } else {
+            parse_with_host("github.com", url)
+        }
+    })
+}
+
+fn parse_with_host(host: &str, url: &str) -> Option<RepoSlug> {
+    let rest = strip_scp_prefix(host, url)
+        .or_else(|| strip_https_prefix(host, url))
+        .or_else(|| strip_ssh_prefix(host, url))?;
     let rest = rest.strip_suffix(".git").unwrap_or(rest);
     RepoSlug::parse(rest)
 }
 
-fn strip_https_github_prefix(url: &str) -> Option<&str> {
+fn strip_scp_prefix<'a>(host: &str, url: &'a str) -> Option<&'a str> {
+    let (userinfo, rest) = url.split_once('@')?;
+    if userinfo.is_empty() || userinfo.contains([':', '/']) {
+        return None;
+    }
+    rest.strip_prefix(&format!("{host}:")[..])
+}
+
+fn strip_https_prefix<'a>(host: &str, url: &'a str) -> Option<&'a str> {
     let after_scheme = url.strip_prefix("https://")?;
     let after_userinfo = match after_scheme.split_once('@') {
         Some((userinfo, rest)) if !userinfo.contains('/') => rest,
         _ => after_scheme,
     };
-    after_userinfo.strip_prefix("github.com/")
+    after_userinfo.strip_prefix(&format!("{host}/")[..])
+}
+
+fn strip_ssh_prefix<'a>(host: &str, url: &'a str) -> Option<&'a str> {
+    let after_scheme = url.strip_prefix("ssh://")?;
+    let (userinfo, rest) = after_scheme.split_once('@')?;
+    if userinfo.is_empty() || userinfo.contains([':', '/']) {
+        return None;
+    }
+    rest.strip_prefix(&format!("{host}/")[..])
 }
 
 #[allow(dead_code)]

--- a/src/fetcher/github/common.rs
+++ b/src/fetcher/github/common.rs
@@ -274,6 +274,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_host_handles_ghe_https() {
+        let s =
+            parse_with_host("ghe.example.com", "https://ghe.example.com/owner/repo.git").unwrap();
+        assert_eq!(s.owner, "owner");
+        assert_eq!(s.name, "repo");
+    }
+
+    #[test]
+    fn parse_with_host_handles_ghe_scp() {
+        let s = parse_with_host("ghe.example.com", "git@ghe.example.com:owner/repo.git").unwrap();
+        assert_eq!(s.owner, "owner");
+        assert_eq!(s.name, "repo");
+    }
+
+    #[test]
+    fn parse_with_host_handles_ghe_ssh_scheme() {
+        let s = parse_with_host(
+            "ghe.example.com",
+            "ssh://git@ghe.example.com/owner/repo.git",
+        )
+        .unwrap();
+        assert_eq!(s.owner, "owner");
+        assert_eq!(s.name, "repo");
+    }
+
+    #[test]
+    fn parse_with_host_accepts_non_git_scp_user() {
+        let s = parse_with_host(
+            "ghe.microsoft.com",
+            "microsoft@ghe.microsoft.com:org/repo.git",
+        )
+        .unwrap();
+        assert_eq!(s.owner, "org");
+        assert_eq!(s.name, "repo");
+    }
+
+    #[test]
+    fn parse_with_host_rejects_other_host() {
+        assert!(parse_with_host("ghe.example.com", "https://github.com/owner/repo").is_none());
+        assert!(parse_with_host("ghe.example.com", "git@github.com:owner/repo.git").is_none());
+    }
+
+    #[test]
     fn parse_timestamp_reads_rfc3339() {
         let ts = parse_timestamp("2026-04-22T10:15:30Z");
         assert_eq!(ts, 1_776_852_930);

--- a/src/fetcher/github/items.rs
+++ b/src/fetcher/github/items.rs
@@ -12,6 +12,7 @@ use crate::fetcher::forge_items::{self, ForgeRow};
 use crate::payload::Body;
 use crate::render::Shape;
 
+use super::client::api_repos_prefix;
 use super::common::{RepoSlug, parse_timestamp};
 
 #[derive(Debug, Deserialize, Default)]
@@ -47,10 +48,10 @@ pub struct SearchResult {
     pub items: Vec<IssueItem>,
 }
 
-/// Extracts `owner/name` from a GitHub API repository URL
-/// (`https://api.github.com/repos/owner/name`).
+/// Extracts `owner/name` from a GitHub API repository URL. The prefix tracks the configured
+/// host via `client::api_repos_prefix()`.
 pub fn repo_from_url(url: &str) -> Option<RepoSlug> {
-    let rest = url.strip_prefix("https://api.github.com/repos/")?;
+    let rest = url.strip_prefix(api_repos_prefix())?;
     RepoSlug::parse(rest)
 }
 

--- a/src/fetcher/github/notifications.rs
+++ b/src/fetcher/github/notifications.rs
@@ -13,7 +13,7 @@ use crate::render::Shape;
 use crate::samples;
 
 use super::super::{FetchContext, FetchError, Fetcher, Safety};
-use super::client::rest_get;
+use super::client::{api_repos_prefix, rest_get, web_base};
 use super::common::{cache_key, parse_options, parse_timestamp, payload};
 
 const SHAPES: &[Shape] = &[
@@ -222,8 +222,8 @@ fn short_repo(full: &str) -> String {
 /// or doesn't match the expected prefix; callers fall back to leaving the row unlinked.
 fn subject_html_url(n: &Notification) -> Option<String> {
     let url = n.subject.url.as_deref()?;
-    let rest = url.strip_prefix("https://api.github.com/repos/")?;
-    Some(format!("https://github.com/{rest}"))
+    let rest = url.strip_prefix(api_repos_prefix())?;
+    Some(format!("{}/{rest}", web_base()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I use this local configuration to point splashboard to GHE, feel free to merge if you think it would be a wanted addition to the project, otherwise feel free to close.

Screenshot of it working

<img width="1917" height="1069" alt="image" src="https://github.com/user-attachments/assets/6fbe5520-1cc1-49ca-b089-9506c94214b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub avatar loading across GitHub.com and GitHub Enterprise.
  * Updated repository and notification links to use the configured GitHub host and the correct browser/API URL formats.
  * Improved support for parsing remote repository URLs across SCP, HTTPS, and SSH forms for the configured host.

* **New Features**
  * GitHub URL building now honors custom API and web endpoint settings via environment configuration.

* **Tests**
  * Added coverage for environment value normalization and host-aware URL parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->