### PR TITLE
chore(ci): use personal git identity for automated commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
 
       - name: Create temporary tag
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "unhappychoice@gmail.com"
+          git config --local user.name "Yuji Ueki"
           git add Cargo.toml Cargo.lock flake.nix
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git tag ${{ steps.version.outputs.new_version }}
@@ -251,8 +251,8 @@ jobs:
       - name: Commit and push changes
         run: |
           VERSION=${{ needs.release.outputs.new_version }}
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "unhappychoice@gmail.com"
+          git config --local user.name "Yuji Ueki"
           git add flake.nix flake.lock
           git commit -m "chore: update flake.nix hashes for $VERSION" || echo "No changes to commit"
           git push origin main
@@ -310,8 +310,8 @@ jobs:
           FOURTH_SHA_LINE=$(grep -n 'sha256 "' Formula/splashboard.rb | head -4 | tail -1 | cut -d: -f1)
           sed -i "${FOURTH_SHA_LINE}s/sha256 \"[a-f0-9]\+\"/sha256 \"$LINUX_ARM_SHA\"/" Formula/splashboard.rb
 
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "unhappychoice@gmail.com"
+          git config --local user.name "Yuji Ueki"
           git add Formula/splashboard.rb
           git commit -m "chore: update splashboard to $VERSION"
           git push

--- a/.github/workflows/sync-llm-pricing.yml
+++ b/.github/workflows/sync-llm-pricing.yml
@@ -75,6 +75,8 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          author: Yuji Ueki <unhappychoice@gmail.com>
+          committer: Yuji Ueki <unhappychoice@gmail.com>
           branch: chore/sync-llm-pricing
           title: 'chore: sync llm pricing from LiteLLM'
           commit-message: |


### PR DESCRIPTION
Automated commits made by GitHub Actions in this repository were authored as a bot (or under an inconsistent name). This switches them to `Yuji Ueki <unhappychoice@gmail.com>` so the history and contribution graph reflect the actual author.

Workflow logic is unchanged — only the configured commit identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved attribution consistency for automated release and maintenance updates.
  * Refresh pull requests generated by pricing synchronization now use a consistent author identity.
  * No changes to application functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->